### PR TITLE
Create simple backend_input

### DIFF
--- a/src/thunderbots/CMakeLists.txt
+++ b/src/thunderbots/CMakeLists.txt
@@ -67,3 +67,24 @@ add_executable (backend_input
 add_dependencies(backend_input ${catkin_EXPORTED_TARGETS})
 target_link_libraries(backend_input ${catkin_LIBRARIES}
         ${PROTOBUF_LIBRARIES})
+
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+if (CATKIN_ENABLE_TESTING)
+    #gtest
+    catkin_add_gtest(geom_angle_test
+            geom/test/angle.cpp
+            geom/angle.h
+            )
+    target_link_libraries(geom_angle_test ${catkin_LIBRARIES})
+
+    catkin_add_gtest(geom_point_test
+            geom/test/point.cpp
+            geom/point.h
+            )
+    target_link_libraries(geom_point_test ${catkin_LIBRARIES})
+endif()

--- a/src/thunderbots/CMakeLists.txt
+++ b/src/thunderbots/CMakeLists.txt
@@ -59,6 +59,10 @@ add_executable (backend_input
         backend_input/vision_client/netraw_util.h
         backend_input/vision_client/robocup_ssl_client.cpp
         backend_input/vision_client/robocup_ssl_client.h
+        backend_input/message_util.cpp
+        backend_input/message_util.h
+        backend_input/filter/ball_filter.cpp
+        backend_input/filter/ball_filter.h
         geom/point.h
         geom/angle.h
         )

--- a/src/thunderbots/CMakeLists.txt
+++ b/src/thunderbots/CMakeLists.txt
@@ -63,6 +63,10 @@ add_executable (backend_input
         backend_input/message_util.h
         backend_input/filter/ball_filter.cpp
         backend_input/filter/ball_filter.h
+        backend_input/filter/robot_filter.cpp
+        backend_input/filter/robot_filter.h
+        backend_input/filter/robot_team_filter.cpp
+        backend_input/filter/robot_team_filter.h
         geom/point.h
         geom/angle.h
         )

--- a/src/thunderbots/CMakeLists.txt
+++ b/src/thunderbots/CMakeLists.txt
@@ -59,6 +59,8 @@ add_executable (backend_input
         backend_input/vision_client/netraw_util.h
         backend_input/vision_client/robocup_ssl_client.cpp
         backend_input/vision_client/robocup_ssl_client.h
+        geom/point.h
+        geom/angle.h
         )
 # Depend on exported targets (other packages) so that the messages in our thunderbots_msgs package are built first.
 # This way the message headers are always generated before they are used in compilation here.

--- a/src/thunderbots/backend_input/filter/ball_filter.cpp
+++ b/src/thunderbots/backend_input/filter/ball_filter.cpp
@@ -1,0 +1,27 @@
+#include "ball_filter.h"
+
+BallFilter::BallFilter()
+{
+    current_ball_position = Point();
+    current_ball_velocity = Point();
+}
+
+void BallFilter::update(std::vector<SSLBallData> new_ball_data)
+{
+    if (!new_ball_data.empty())
+    {
+        Point old_position    = current_ball_position;
+        current_ball_position = new_ball_data[0].position;
+        current_ball_velocity = current_ball_position - old_position;
+    }
+}
+
+Point BallFilter::getBallPosition()
+{
+    return current_ball_position;
+}
+
+Point BallFilter::getBallVelocity()
+{
+    return current_ball_velocity;
+}

--- a/src/thunderbots/backend_input/filter/ball_filter.h
+++ b/src/thunderbots/backend_input/filter/ball_filter.h
@@ -1,0 +1,55 @@
+#ifndef BACKEND_INPUT_BALL_FILTER_H_
+#define BACKEND_INPUT_BALL_FILTER_H_
+
+#include <vector>
+#include "geom/point.h"
+
+/**
+ * A lightweight datatype used to input new data into the filter.
+ * We do this rather than taking the SSL_DetectionBall directly
+ * so we can make this module more generic and abstract away
+ * the protobuf for testing
+ */
+typedef struct
+{
+    Point position;
+    double confidence;
+} SSLBallData;
+
+/**
+ * Given ball data from SSL Vision, filters for and returns the position/velocity of the
+ * "real" ball
+ */
+class BallFilter
+{
+   public:
+    /**
+     * Creates a new Ball Filter
+     */
+    explicit BallFilter();
+
+    /**
+     * Updates the filter given a new set of data
+     */
+    void update(std::vector<SSLBallData> new_ball_data);
+
+    /**
+     * Returns the filtered position of the ball
+     *
+     * @return the filtered position of the ball
+     */
+    Point getBallPosition();
+
+    /**
+     * Returns the filtered velocity of the ball
+     *
+     * @return the filtered velocity of the ball
+     */
+    Point getBallVelocity();
+
+   private:
+    Point current_ball_position;
+    Point current_ball_velocity;
+};
+
+#endif  // BACKEND_INPUT_BALL_FILTER_H_

--- a/src/thunderbots/backend_input/filter/robot_filter.cpp
+++ b/src/thunderbots/backend_input/filter/robot_filter.cpp
@@ -1,0 +1,43 @@
+#include "robot_filter.h"
+#include <ros/console.h>
+
+RobotFilter::RobotFilter(unsigned int id)
+    : current_robot_position(Point()),
+      current_robot_velocity(Point()),
+      current_robot_orientation(Angle::zero()),
+      robot_id(id)
+{
+}
+
+void RobotFilter::update(const SSLRobotData &new_robot_data)
+{
+    if (new_robot_data.id != robot_id)
+    {
+        ROS_DEBUG("Error: Different robot data given to robot filter");
+    }
+
+    Point previous_position   = current_robot_position;
+    current_robot_position    = new_robot_data.position;
+    current_robot_velocity    = current_robot_position - previous_position;
+    current_robot_orientation = new_robot_data.orientation;
+}
+
+Point RobotFilter::getRobotPosition()
+{
+    return current_robot_position;
+}
+
+Point RobotFilter::getRobotVelocity()
+{
+    return current_robot_velocity;
+}
+
+Angle RobotFilter::getRobotOrientation()
+{
+    return current_robot_orientation;
+}
+
+unsigned int RobotFilter::getRobotId()
+{
+    return robot_id;
+}

--- a/src/thunderbots/backend_input/filter/robot_filter.h
+++ b/src/thunderbots/backend_input/filter/robot_filter.h
@@ -1,0 +1,74 @@
+#ifndef BACKEND_INPUT_ROBOT_FILTER_H_
+#define BACKEND_INPUT_ROBOT_FILTER_H_
+
+#include "geom/angle.h"
+#include "geom/point.h"
+
+/**
+ * A lightweight datatype used to input new data into the filter.
+ * We do this rather than taking the SSL_Detection data directly
+ * so we can make this module more generic and abstract away
+ * the protobuf for testing
+ */
+typedef struct
+{
+    unsigned int id;
+    Point position;
+    Angle orientation;
+    double confidence;
+} SSLRobotData;
+
+class RobotFilter
+{
+   public:
+    /**
+     * Creates a new robot filter
+     *
+     * @param id the id of the robot to filter
+     */
+    explicit RobotFilter(unsigned int id);
+
+    /**
+     * Updates the filter given a new set of data
+     */
+    // TODO: Could this accept a vector? Are we likely to get multiple robot detections at
+    // once?
+    void update(const SSLRobotData &new_robot_data);
+
+    /**
+     * Returns the filtered position of the robot
+     *
+     * @return the filtered position of the robot
+     */
+    Point getRobotPosition();
+
+    /**
+     * Returns the filtered velocity of the robot
+     *
+     * @return the filtered velocity of the robot
+     */
+    Point getRobotVelocity();
+
+    /**
+     * Gets the filtered orientation of the robot
+     *
+     * @return the filtered orientation of the robot
+     */
+    Angle getRobotOrientation();
+
+    /**
+     * Gets the id of the robot
+     *
+     * @return the id of the robot
+     */
+    unsigned int getRobotId();
+
+   private:
+    unsigned int robot_id;
+    Point current_robot_position;
+    Point current_robot_velocity;
+    Angle current_robot_orientation;
+};
+
+
+#endif  // BACKEND_INPUT_ROBOT_FILTER_H_

--- a/src/thunderbots/backend_input/filter/robot_team_filter.cpp
+++ b/src/thunderbots/backend_input/filter/robot_team_filter.cpp
@@ -1,0 +1,76 @@
+#include "robot_team_filter.h"
+#include <algorithm>
+#include <vector>
+#include "robot_filter.h"
+
+RobotTeamFilter::RobotTeamFilter()
+{
+    robot_filters = std::map<unsigned int, RobotFilter>();
+}
+
+void RobotTeamFilter::update(std::vector<SSLRobotData> new_team_data)
+{
+    // Go through each existing robot filter. If there is new robot data with a matching
+    // id to that filter
+    // (ie. new data for that robot), then update that filter. If an existing filter does
+    // not receive new data,
+    // we assume the robot must have disappeared from vision (perhaps it was moved off the
+    // field) and remove
+    // its filter.
+    for (auto it = robot_filters.begin(); it != robot_filters.end(); it++)
+    {
+        RobotFilter robot_filter = it->second;
+
+        // Get an iterator to new data with a matching id. We use this to figure out if
+        // new data
+        // exists for each robot
+        unsigned int robot_id = robot_filter.getRobotId();
+        auto new_data_it      = std::find_if(
+            new_team_data.begin(),
+            new_team_data.end(), [& id = robot_id](const SSLRobotData& d)->bool {
+                return id == d.id;
+            });
+
+        if (new_data_it != new_team_data.end())
+        {
+            // There is new data for this filter. Update it.
+            robot_filter.update(*new_data_it);
+            // Remove the new data once we are done with it.
+            new_team_data.erase(new_data_it);
+        }
+        else
+        {
+            // There is no new data for this filter. The robot must have disappeared from
+            // vision, so remove its filter.
+            robot_filters.erase(robot_id);
+        }
+    }
+
+    // Add all the remaining data that did not already have an entry in the filter map
+    for (SSLRobotData robot_data : new_team_data)
+    {
+        RobotFilter filter = RobotFilter(robot_data.id);
+        filter.update(robot_data);
+        robot_filters.insert(std::pair<unsigned int, RobotFilter>(robot_data.id, filter));
+    }
+}
+
+std::vector<FilteredRobotData> RobotTeamFilter::getFilteredTeamData()
+{
+    std::vector<FilteredRobotData> filtered_team_data;
+
+    // Iterate through all entries in the filter map
+    for (auto it = robot_filters.begin(); it != robot_filters.end(); it++)
+    {
+        FilteredRobotData filtered_robot_data;
+        RobotFilter robot_filter        = it->second;
+        filtered_robot_data.id          = robot_filter.getRobotId();
+        filtered_robot_data.position    = robot_filter.getRobotPosition();
+        filtered_robot_data.velocity    = robot_filter.getRobotVelocity();
+        filtered_robot_data.orientation = robot_filter.getRobotOrientation();
+
+        filtered_team_data.emplace_back(filtered_robot_data);
+    }
+
+    return filtered_team_data;
+}

--- a/src/thunderbots/backend_input/filter/robot_team_filter.h
+++ b/src/thunderbots/backend_input/filter/robot_team_filter.h
@@ -1,0 +1,44 @@
+#ifndef BACKEND_INPUT_ROBOT_TEAM_FILTER_H_
+#define BACKEND_INPUT_ROBOT_TEAM_FILTER_H_
+
+#include <map>
+#include <vector>
+#include "geom/angle.h"
+#include "geom/point.h"
+#include "robot_filter.h"
+
+typedef struct
+{
+    unsigned int id;
+    Point position;
+    Point velocity;
+    Angle orientation;
+} FilteredRobotData;
+
+class RobotTeamFilter
+{
+   public:
+    /**
+     * Creates a new Robot Team Filter
+     */
+    explicit RobotTeamFilter();
+
+    /**
+     * Given a list of new robot data, updates the filter for this team of robots
+     *
+     * @param new_team_data a vector of new robot data for the team
+     */
+    void update(std::vector<SSLRobotData> new_team_data);
+
+    /**
+     * Gets the latest filtered team data.
+     *
+     * @return the latest filtered data for every robot on the team
+     */
+    std::vector<FilteredRobotData> getFilteredTeamData();
+
+   private:
+    std::map<unsigned int, RobotFilter> robot_filters;
+};
+
+#endif  // BACKEND_INPUT_ROBOT_TEAM_FILTER_H_

--- a/src/thunderbots/backend_input/main.cpp
+++ b/src/thunderbots/backend_input/main.cpp
@@ -1,11 +1,16 @@
 #include <ros/ros.h>
 #include <iostream>
 #include "backend_input/filter/ball_filter.h"
+#include "backend_input/filter/robot_filter.h"
 #include "backend_input/message_util.h"
 #include "backend_input/vision_client/robocup_ssl_client.h"
 #include "geom/point.h"
 #include "thunderbots_msgs/Ball.h"
 #include "thunderbots_msgs/Field.h"
+#include "thunderbots_msgs/Team.h"
+
+// TODO: Make a real constant
+#define FRIENDLY_COLOR_YELLOW true
 
 int main(int argc, char **argv)
 {
@@ -18,6 +23,10 @@ int main(int argc, char **argv)
         n.advertise<thunderbots_msgs::Ball>("backend/ball", 1);
     ros::Publisher field_publisher =
         n.advertise<thunderbots_msgs::Field>("backend/field", 1);
+    ros::Publisher friendly_team_publisher =
+        n.advertise<thunderbots_msgs::Team>("backend/friendly_team", 1);
+    ros::Publisher enemy_team_publisher =
+        n.advertise<thunderbots_msgs::Team>("backend/friendly_team", 1);
 
     // Set up the SSL Client to receive data over the network
     RoboCupSSLClient vision_client = RoboCupSSLClient(10020, "224.5.23.2");
@@ -25,7 +34,9 @@ int main(int argc, char **argv)
     SSL_WrapperPacket packet;
 
     // Set up any filters for the incoming data
-    BallFilter ball_filter = BallFilter();
+    BallFilter ball_filter               = BallFilter();
+    RobotTeamFilter friendly_team_filter = RobotTeamFilter();
+    RobotTeamFilter enemy_team_filter    = RobotTeamFilter();
 
     // Main loop
     while (ros::ok())
@@ -60,6 +71,62 @@ int main(int argc, char **argv)
                 thunderbots_msgs::Ball ball_msg =
                     VisionUtil::createBallMsg(new_ball_position, new_ball_velocity);
                 ball_publisher.publish(ball_msg);
+
+
+                // Handle Robot filtering, and updating the friendly and enemy teams
+                std::vector<SSLRobotData> friendly_team_robot_data =
+                    std::vector<SSLRobotData>();
+                std::vector<SSLRobotData> enemy_team_robot_data =
+                    std::vector<SSLRobotData>();
+
+                for (const SSL_DetectionRobot &yellow_robot : detection.robots_yellow())
+                {
+                    SSLRobotData new_robot_data;
+                    new_robot_data.id       = yellow_robot.robot_id();
+                    new_robot_data.position = Point(yellow_robot.x(), yellow_robot.y());
+                    new_robot_data.orientation =
+                        Angle::ofRadians(yellow_robot.orientation());
+                    new_robot_data.confidence = yellow_robot.confidence();
+
+                    if (FRIENDLY_COLOR_YELLOW)
+                    {
+                        friendly_team_robot_data.emplace_back(new_robot_data);
+                    }
+                    else
+                    {
+                        enemy_team_robot_data.emplace_back(new_robot_data);
+                    }
+                }
+
+                for (const SSL_DetectionRobot &blue_robot : detection.robots_blue())
+                {
+                    SSLRobotData new_robot_data;
+                    new_robot_data.id       = blue_robot.robot_id();
+                    new_robot_data.position = Point(blue_robot.x(), blue_robot.y());
+                    new_robot_data.orientation =
+                        Angle::ofRadians(blue_robot.orientation());
+                    new_robot_data.confidence = blue_robot.confidence();
+
+                    if (FRIENDLY_COLOR_YELLOW)
+                    {
+                        enemy_team_robot_data.emplace_back(new_robot_data);
+                    }
+                    else
+                    {
+                        friendly_team_robot_data.emplace_back(new_robot_data);
+                    }
+                }
+
+                friendly_team_filter.update(friendly_team_robot_data);
+                enemy_team_filter.update(enemy_team_robot_data);
+
+                thunderbots_msgs::Team friendly_team_msg =
+                    VisionUtil::createTeamMsg(friendly_team_filter.getFilteredTeamData());
+                thunderbots_msgs::Team enemy_team_msg =
+                    VisionUtil::createTeamMsg(enemy_team_filter.getFilteredTeamData());
+
+                friendly_team_publisher.publish(friendly_team_msg);
+                enemy_team_publisher.publish(enemy_team_msg);
             }
         }
 

--- a/src/thunderbots/backend_input/main.cpp
+++ b/src/thunderbots/backend_input/main.cpp
@@ -1,6 +1,10 @@
 #include <ros/ros.h>
 #include <iostream>
+#include "backend_input/filter/ball_filter.h"
 #include "backend_input/vision_client/robocup_ssl_client.h"
+#include "backend_input/message_util.h"
+#include "geom/point.h"
+#include "thunderbots_msgs/Ball.h"
 
 int main(int argc, char **argv)
 {
@@ -8,10 +12,17 @@ int main(int argc, char **argv)
     ros::init(argc, argv, "backend_input");
     ros::NodeHandle n;
 
+    // Create publishers
+    ros::Publisher ball_publisher =
+        n.advertise<thunderbots_msgs::Ball>("backend/ball", 1);
+
     // Set up the SSL Client to receive data over the network
     RoboCupSSLClient vision_client = RoboCupSSLClient(10020, "224.5.23.2");
     vision_client.open(true);
     SSL_WrapperPacket packet;
+
+    // Set up any filters for the incoming data
+    BallFilter ball_filter = BallFilter();
 
     // Main loop
     while (ros::ok())
@@ -29,8 +40,23 @@ int main(int argc, char **argv)
             if (packet.has_detection())
             {
                 const SSL_DetectionFrame &detection = packet.detection();
-                std::cout << "Number of balls detected: " << detection.balls_size()
-                          << std::endl;
+
+                // Handle ball detection, filtering, and message updates
+                std::vector<SSLBallData> ball_detections = std::vector<SSLBallData>();
+                for (const SSL_DetectionBall &ball : detection.balls())
+                {
+                    SSLBallData ball_data;
+                    ball_data.position   = Point(ball.x(), ball.y());
+                    ball_data.confidence = ball.confidence();
+                    ball_detections.push_back(ball_data);
+                }
+
+                ball_filter.update(ball_detections);
+                Point new_ball_position = ball_filter.getBallPosition();
+                Point new_ball_velocity = ball_filter.getBallVelocity();
+                thunderbots_msgs::Ball ball_msg =
+                    VisionUtil::createBallMsg(new_ball_position, new_ball_velocity);
+                ball_publisher.publish(ball_msg);
             }
         }
 

--- a/src/thunderbots/backend_input/main.cpp
+++ b/src/thunderbots/backend_input/main.cpp
@@ -1,10 +1,11 @@
 #include <ros/ros.h>
 #include <iostream>
 #include "backend_input/filter/ball_filter.h"
-#include "backend_input/vision_client/robocup_ssl_client.h"
 #include "backend_input/message_util.h"
+#include "backend_input/vision_client/robocup_ssl_client.h"
 #include "geom/point.h"
 #include "thunderbots_msgs/Ball.h"
+#include "thunderbots_msgs/Field.h"
 
 int main(int argc, char **argv)
 {
@@ -15,6 +16,8 @@ int main(int argc, char **argv)
     // Create publishers
     ros::Publisher ball_publisher =
         n.advertise<thunderbots_msgs::Ball>("backend/ball", 1);
+    ros::Publisher field_publisher =
+        n.advertise<thunderbots_msgs::Field>("backend/field", 1);
 
     // Set up the SSL Client to receive data over the network
     RoboCupSSLClient vision_client = RoboCupSSLClient(10020, "224.5.23.2");
@@ -33,8 +36,8 @@ int main(int argc, char **argv)
             {
                 const SSL_GeometryData &geom       = packet.geometry();
                 const SSL_GeometryFieldSize &field = geom.field();
-                std::cout << "Field boundary width is: " << field.boundary_width()
-                          << std::endl;
+                thunderbots_msgs::Field field_msg  = VisionUtil::createFieldMsg(field);
+                field_publisher.publish(field_msg);
             }
 
             if (packet.has_detection())

--- a/src/thunderbots/backend_input/message_util.cpp
+++ b/src/thunderbots/backend_input/message_util.cpp
@@ -1,5 +1,85 @@
 #include "message_util.h"
 
+// TODO: Create unit conversion functions
+#define MILLIMETERS_TO_METERS_FLOAT 1000.0
+
+thunderbots_msgs::Field VisionUtil::createFieldMsg(
+    const SSL_GeometryFieldSize &field_data)
+{
+    // We can't guarantee the order that any geometry elements are passed to us in, so
+    // We map the name of each line/arc to the actual object so we can refer to them
+    // consistantly
+    std::map<std::string, SSL_FieldCicularArc> ssl_circular_arcs;
+    std::map<std::string, SSL_FieldLineSegment> ssl_field_lines;
+
+    // Circular arcs
+    //
+    // Arc names:
+    // CenterCircle
+    for (int i = 0; i < field_data.field_arcs_size(); i++)
+    {
+        const SSL_FieldCicularArc &arc = field_data.field_arcs(i);
+        std::string arc_name           = arc.name();
+        ssl_circular_arcs[arc_name]    = arc;
+    }
+
+    // Field Lines
+    //
+    // Line names:
+    // TopTouchLine
+    // BottomTouchLine
+    // LeftGoalLine
+    // RightGoalLine
+    // HalfwayLine
+    // CenterLine
+    // LeftPenaltyStretch
+    // RightPenaltyStretch
+    // RightGoalTopLine
+    // RightGoalBottomLine
+    // RightGoalDepthLine
+    // LeftGoalTopLine
+    // LeftGoalBottomLine
+    // LeftGoalDepthLine
+    // LeftFieldLeftPenaltyStretch
+    // LeftFieldRightPenaltyStretch
+    // RightFieldLeftPenaltyStretch
+    // RightFieldRightPenaltyStretch
+    for (int i = 0; i < field_data.field_lines_size(); i++)
+    {
+        const SSL_FieldLineSegment &line = field_data.field_lines(i);
+        std::string line_name            = line.name();
+        ssl_field_lines[line_name]       = line;
+    }
+
+    thunderbots_msgs::Field field_msg;
+
+    // Make sure we convert ALL fields into meters before returning
+    field_msg.field_length  = field_data.field_length() / MILLIMETERS_TO_METERS_FLOAT;
+    field_msg.field_width   = field_data.field_width() / MILLIMETERS_TO_METERS_FLOAT;
+    Point defense_length_p1 = Point(
+        ssl_field_lines["LeftFieldLeftPenaltyStretch"].p1().x(),
+        ssl_field_lines["LeftFieldLeftPenaltyStretch"].p1().y());
+    Point defense_length_p2 = Point(
+        ssl_field_lines["LeftFieldLeftPenaltyStretch"].p2().x(),
+        ssl_field_lines["LeftFieldLeftPenaltyStretch"].p2().y());
+    field_msg.defense_length =
+        (defense_length_p2 - defense_length_p1).len() / MILLIMETERS_TO_METERS_FLOAT;
+    Point defense_width_p1 = Point(
+        ssl_field_lines["LeftPenaltyStretch"].p1().x(),
+        ssl_field_lines["LeftPenaltyStretch"].p1().y());
+    Point defense_width_p2 = Point(
+        ssl_field_lines["LeftPenaltyStretch"].p2().x(),
+        ssl_field_lines["LeftPenaltyStretch"].p2().y());
+    field_msg.defense_width =
+        (defense_width_p1 - defense_width_p2).len() / MILLIMETERS_TO_METERS_FLOAT;
+    field_msg.goal_width     = field_data.goalwidth() / MILLIMETERS_TO_METERS_FLOAT;
+    field_msg.boundary_width = field_data.boundary_width() / MILLIMETERS_TO_METERS_FLOAT;
+    field_msg.center_circle_radius =
+        ssl_circular_arcs["CenterCircle"].radius() / MILLIMETERS_TO_METERS_FLOAT;
+
+    return field_msg;
+}
+
 thunderbots_msgs::Ball VisionUtil::createBallMsg(
     const Point &position, const Point &velocity)
 {

--- a/src/thunderbots/backend_input/message_util.cpp
+++ b/src/thunderbots/backend_input/message_util.cpp
@@ -93,3 +93,35 @@ thunderbots_msgs::Ball VisionUtil::createBallMsg(
 
     return ball_msg;
 }
+
+thunderbots_msgs::Robot VisionUtil::createRobotMsg(const FilteredRobotData &robot_data)
+{
+    thunderbots_msgs::Robot robot_msg;
+
+    robot_msg.id = robot_data.id;
+
+    robot_msg.position.x = robot_data.position.x();
+    robot_msg.position.y = robot_data.position.y();
+
+    robot_msg.velocity.x = robot_data.velocity.x();
+    robot_msg.velocity.y = robot_data.velocity.y();
+
+    robot_msg.orientation = robot_data.orientation.toRadians();
+
+    return robot_msg;
+}
+
+thunderbots_msgs::Team VisionUtil::createTeamMsg(
+    const std::vector<FilteredRobotData> &team_data)
+{
+    thunderbots_msgs::Team team_msg;
+    team_msg.robots.clear();
+
+    for (FilteredRobotData filtered_robot_data : team_data)
+    {
+        thunderbots_msgs::Robot robot_msg = createRobotMsg(filtered_robot_data);
+        team_msg.robots.emplace_back(robot_msg);
+    }
+
+    return team_msg;
+}

--- a/src/thunderbots/backend_input/message_util.cpp
+++ b/src/thunderbots/backend_input/message_util.cpp
@@ -1,0 +1,15 @@
+#include "message_util.h"
+
+thunderbots_msgs::Ball VisionUtil::createBallMsg(
+    const Point &position, const Point &velocity)
+{
+    thunderbots_msgs::Ball ball_msg;
+
+    ball_msg.position.x = position.x();
+    ball_msg.position.y = position.y();
+
+    ball_msg.velocity.x = velocity.x();
+    ball_msg.velocity.y = velocity.y();
+
+    return ball_msg;
+}

--- a/src/thunderbots/backend_input/message_util.h
+++ b/src/thunderbots/backend_input/message_util.h
@@ -1,5 +1,5 @@
-#ifndef THUNDERBOTS_VISION_UTIL_H
-#define THUNDERBOTS_VISION_UTIL_H
+#ifndef BACKEND_INPUT_MESSAGE_UTIL_H_
+#define BACKEND_INPUT_MESSAGE_UTIL_H_
 
 #include <backend_input/filter/robot_team_filter.h>
 #include "geom/point.h"
@@ -53,4 +53,4 @@ class VisionUtil
         const std::vector<FilteredRobotData> &team_data);
 };
 
-#endif  // THUNDERBOTS_VISION_UTIL_H
+#endif  // BACKEND_INPUT_MESSAGE_UTIL_H_

--- a/src/thunderbots/backend_input/message_util.h
+++ b/src/thunderbots/backend_input/message_util.h
@@ -2,11 +2,23 @@
 #define THUNDERBOTS_VISION_UTIL_H
 
 #include "geom/point.h"
+#include "proto/messages_robocup_ssl_geometry.pb.h"
 #include "thunderbots_msgs/Ball.h"
+#include "thunderbots_msgs/Field.h"
 
 class VisionUtil
 {
    public:
+    /**
+     * Creates a Field msg given raw SSL Field Geometry data
+     *
+     * @param field_data the SSL Geometry packet containing field geometry data
+     *
+     * @return a Field message containing the field geometry information
+     */
+    static thunderbots_msgs::Field createFieldMsg(
+        const SSL_GeometryFieldSize &field_data);
+
     /**
      * Creates a Ball msg given the position and velocity of a ball
      *

--- a/src/thunderbots/backend_input/message_util.h
+++ b/src/thunderbots/backend_input/message_util.h
@@ -1,10 +1,13 @@
 #ifndef THUNDERBOTS_VISION_UTIL_H
 #define THUNDERBOTS_VISION_UTIL_H
 
+#include <backend_input/filter/robot_team_filter.h>
 #include "geom/point.h"
 #include "proto/messages_robocup_ssl_geometry.pb.h"
 #include "thunderbots_msgs/Ball.h"
 #include "thunderbots_msgs/Field.h"
+#include "thunderbots_msgs/Robot.h"
+#include "thunderbots_msgs/Team.h"
 
 class VisionUtil
 {
@@ -29,6 +32,25 @@ class VisionUtil
      */
     static thunderbots_msgs::Ball createBallMsg(
         const Point &position, const Point &velocity);
+
+    /**
+     * Creates a Robot msg given the Filtered Data for a robot
+     *
+     * @param robot_data the Filtered Data for a robot
+     *
+     * @return a Robot message containing the robot's information
+     */
+    static thunderbots_msgs::Robot createRobotMsg(const FilteredRobotData &robot_data);
+
+    /**
+     * Creates a Team msg given team data
+     *
+     * @param team_data A vector of robot data representing a team
+     *
+     * @return a Team message containing the information for the team
+     */
+    static thunderbots_msgs::Team createTeamMsg(
+        const std::vector<FilteredRobotData> &team_data);
 };
 
 #endif  // THUNDERBOTS_VISION_UTIL_H

--- a/src/thunderbots/backend_input/message_util.h
+++ b/src/thunderbots/backend_input/message_util.h
@@ -1,0 +1,22 @@
+#ifndef THUNDERBOTS_VISION_UTIL_H
+#define THUNDERBOTS_VISION_UTIL_H
+
+#include "geom/point.h"
+#include "thunderbots_msgs/Ball.h"
+
+class VisionUtil
+{
+   public:
+    /**
+     * Creates a Ball msg given the position and velocity of a ball
+     *
+     * @param position the position of the ball
+     * @param velocity the velocity of the ball
+     *
+     * @return a Ball message containing the ball information
+     */
+    static thunderbots_msgs::Ball createBallMsg(
+        const Point &position, const Point &velocity);
+};
+
+#endif  // THUNDERBOTS_VISION_UTIL_H

--- a/src/thunderbots/geom/angle.h
+++ b/src/thunderbots/geom/angle.h
@@ -1,0 +1,581 @@
+#ifndef GEOM_ANGLE_H
+#define GEOM_ANGLE_H
+
+#include <cmath>
+#include <ostream>
+
+/**
+ * A typesafe representation of an angle.
+ *
+ * This class helps prevent accidentally combining values in degrees and radians
+ * without proper conversion.
+ */
+class Angle final
+{
+   public:
+    /**
+     * The zero angle.
+     */
+    static constexpr Angle zero();
+
+    /**
+     * The quarter-turn angle (90°).
+     */
+    static constexpr Angle quarter();
+
+    /**
+     * The half-turn angle (180°).
+     */
+    static constexpr Angle half();
+
+    /**
+     * The three-quarter turn angle (270°).
+     */
+    static constexpr Angle threeQuarter();
+
+    /**
+     * The full-turn angle (360°).
+     */
+    static constexpr Angle full();
+
+    /**
+     * Constructs an angle from a value in radians.
+     *
+     * @param rad the angle in radians.
+     *
+     * @return the constructed angle
+     */
+    static constexpr Angle ofRadians(double rad);
+
+    /**
+     * Constructs an angle from a value in degrees.
+     *
+     * @param deg the angle in degrees
+     *
+     * @return the constructed angle
+     */
+    static constexpr Angle ofDegrees(double deg);
+
+    /**
+     * Computes the arc sine of a value.
+     *
+     * @param x the value.
+     *
+     * @return the angle.
+     */
+    static Angle asin(double x);
+
+    /**
+     * Computes the arc cosine of a value.
+     *
+     * @param x the value.
+     *
+     * @return the angle.
+     */
+    static Angle acos(double x);
+
+    /**
+     * Computes the arc tangent of a value.
+     *
+     * @param x the value.
+     *
+     * @return the angle.
+     */
+    static Angle atan(double x);
+
+    /**
+     * Constructs the "zero" angle.
+     */
+    explicit constexpr Angle();
+
+    /**
+     * Converts this angle to a value in radians.
+     *
+     * @return the number of radians in this angle in the range [0, 2PI)
+     */
+    constexpr double toRadians() const;
+
+    /**
+     * Converts this angle to a value in degrees.
+     *
+     * @return the number of degrees in this angle in the range [0,360)
+     */
+    constexpr double toDegrees() const;
+
+    /**
+     * Computes the modulus of a division between this angle and another
+     * angle.
+     *
+     * @param divisor the divisor.
+     *
+     * @return the modulus of this Angle ÷ divisor.
+     */
+    constexpr Angle mod(Angle divisor) const;
+
+    /**
+     * Computes the remainder of a division between this angle and
+     * another angle.
+     *
+     * @param divisor the divisor.
+     *
+     * @return the remainder of this Angle ÷ divisor.
+     */
+    constexpr Angle remainder(Angle divisor) const;
+
+    /**
+     * Returns the absolute value of this angle.
+     *
+     * @return the absolute value of this angle.
+     */
+    constexpr Angle abs() const;
+
+    /**
+     * Checks whether the angle is finite.
+     *
+     * @return true if the angle is finite, and false if it is ±∞ or NaN.
+     */
+    bool isFinite() const;
+
+    /**
+     * Computes the sine of this angle.
+     *
+     * @return the sine of this angle.
+     */
+    double sin() const;
+
+    /**
+     * Computes the cosine of this angle.
+     *
+     * @return the cosine of this angle.
+     */
+    double cos() const;
+
+    /**
+     * Computes the tangent of this angle.
+     *
+     * @return the tangent of this angle.
+     */
+    double tan() const;
+
+    /**
+     * Limits this angle to [−π, π].
+     *
+     * The angle is rotated by a multiple of 2π until it lies within the target
+     * interval.
+     *
+     * @return the clamped angle.
+     */
+    constexpr Angle clamp() const;
+
+    /**
+     * Returns the smallest possible rotational difference between this angle
+     * and another angle.
+     *
+     * @param other the second angle.
+     *
+     * @return the angle between this Angle and other, in the range [0, π].
+     */
+    constexpr Angle diff(Angle other) const;
+
+   private:
+    double rads;
+
+    explicit constexpr Angle(double rads);
+};
+
+/**
+ * Negates an angle.
+ *
+ * @param angle the angle to negate.
+ *
+ * @return the negated angle
+ */
+constexpr Angle operator-(Angle angle);
+
+/**
+ * Adds two angles.
+ *
+ * @param x the first addend.
+ * @param y the second addend.
+ *
+ * @return the sum of the angles
+ */
+constexpr Angle operator+(Angle x, Angle y);
+
+/**
+ * Subtracts two angles.
+ *
+ * @param x the minuend.
+ *
+ * @param y the subtrahend.
+ *
+ * @return the difference between the minuend and subtrahend.
+ */
+constexpr Angle operator-(Angle x, Angle y);
+
+/**
+ * Multiplies an angle by a scalar factor.
+ *
+ * @param angle the angle.
+ * @param scale the scalar factor.
+ *
+ * @return the product of the angle and the scalar factor
+ */
+constexpr Angle operator*(Angle angle, double scale);
+
+/**
+ * Multiplies an angle by a scalar factor.
+ *
+ * @param scale the scalar factor.
+ * @param angle the angle.
+ *
+ * @return the product of the angle and the scalar factor
+ */
+constexpr Angle operator*(double scale, Angle angle);
+
+/**
+ * Divides an angle by a scalar divisor.
+ *
+ * @param angle the angle.
+ * @param divisor the scalar divisor.
+ *
+ * @return the quotient of this Angle ÷ the divisor.
+ */
+constexpr Angle operator/(Angle angle, double divisor);
+
+/**
+ * Divides two angles.
+ *
+ * @param x the divident.
+ * @param y the divisor.
+ *
+ * @return the quotient of the divident ÷ the divisor.
+ */
+constexpr double operator/(Angle x, Angle y);
+
+/**
+ * Adds an angle to another angle.
+ *
+ * @param x the angle to add to.
+ * @param y the angle to add.
+ *
+ * @return the new angle x
+ */
+Angle &operator+=(Angle &x, Angle y);
+
+/**
+ * Subtracts an angle from an angle.
+ *
+ * @param x the angle to subtract from.
+ * @param y the angle to subtract.
+ *
+ * @return the new angle x
+ */
+Angle &operator-=(Angle &x, Angle y);
+
+/**
+ * Scales an angle by a factor.
+ *
+ * @param angle the angle to scale.
+ * @param scale the scalar factor.
+ *
+ * @return the scaled angle.
+ */
+Angle &operator*=(Angle &angle, double scale);
+
+/**
+ * Divides an angle by a scalar divisor.
+ *
+ * @param angle the angle to scale.
+ *
+ * @param divisor the scalar divisor.
+ *
+ * @return the scaled angle.
+ */
+Angle &operator/=(Angle &angle, double divisor);
+
+/**
+ * Compares two angles.
+ *
+ * @param x the first angle.
+ *
+ * @param y the second angle.
+ *
+ * @return true if x is strictly less than y, and false otherwise
+ */
+constexpr bool operator<(Angle x, Angle y);
+
+/**
+ * Compares two angles.
+ *
+ * @param x the first angle.
+ * @param y the second angle.
+ *
+ * @return true if x is strictly greater than y, and false otherwise.
+ */
+constexpr bool operator>(Angle x, Angle y);
+
+/**
+ * Compares two angles.
+ *
+ * @param x the first angle.
+ * @param y the second angle.
+ *
+ * @return true if x is less than or equal to y, and false otherwise.
+ */
+constexpr bool operator<=(Angle x, Angle y);
+
+/**
+ * Compares two angles.
+ *
+ * @param x the first angle.
+ * @param y the second angle.
+ *
+ * @return true if x is greater than or equal to y, and false otherwise.
+ */
+constexpr bool operator>=(Angle x, Angle y);
+
+/**
+ * Compares two angles for equality.
+ *
+ * @param x the first angle.
+ * @param y the second angle.
+ *
+ * @return true if x is equal to y, and false otherwise.
+ */
+constexpr bool operator==(Angle x, Angle y);
+
+/**
+ * Compares two angles for inequality.
+ *
+ * @param x the first angle.
+ * @param y the second angle.
+ *
+ * @return true if x is not equal to y, and false otherwise
+ */
+constexpr bool operator!=(Angle x, Angle y);
+
+/**
+ * Prints an Angle to a stream
+ *
+ * @param os the stream to print to
+ * @param a the Point to print
+ *
+ * @return the stream with the Angle printed
+ */
+inline std::ostream &operator<<(std::ostream &os, const Angle &a);
+
+inline constexpr Angle Angle::zero()
+{
+    return Angle();
+}
+
+inline constexpr Angle Angle::quarter()
+{
+    return Angle(M_PI / 2.0);
+}
+
+inline constexpr Angle Angle::half()
+{
+    return Angle(M_PI);
+}
+
+inline constexpr Angle Angle::threeQuarter()
+{
+    return Angle(3.0 / 2.0 * M_PI);
+}
+
+inline constexpr Angle Angle::full()
+{
+    return Angle(2.0 * M_PI);
+}
+
+inline constexpr Angle Angle::ofRadians(double rad)
+{
+    return Angle(rad);
+}
+
+inline constexpr Angle Angle::ofDegrees(double deg)
+{
+    return Angle(deg / 180.0 * M_PI);
+}
+
+inline Angle Angle::asin(double x)
+{
+    return Angle::ofRadians(std::asin(x));
+}
+
+inline Angle Angle::acos(double x)
+{
+    return ofRadians(std::acos(x));
+}
+
+inline Angle Angle::atan(double x)
+{
+    return Angle::ofRadians(std::atan(x));
+}
+
+inline constexpr Angle::Angle() : rads(0.0)
+{
+}
+
+inline constexpr double Angle::toRadians() const
+{
+    return rads;
+}
+
+inline constexpr double Angle::toDegrees() const
+{
+    return rads / M_PI * 180.0;
+}
+
+inline constexpr Angle Angle::mod(Angle divisor) const
+{
+    return Angle::ofRadians(
+        toRadians() -
+        static_cast<double>(static_cast<long>(toRadians() / divisor.toRadians())) *
+            divisor.toRadians());
+}
+
+inline constexpr Angle Angle::remainder(Angle divisor) const
+{
+    return Angle::ofRadians(
+        toRadians() -
+        static_cast<double>(static_cast<long>(
+            (toRadians() / divisor.toRadians()) >= 0
+                ? (toRadians() / divisor.toRadians() + 0.5)
+                : (toRadians() / divisor.toRadians() - 0.5))) *
+            divisor.toRadians());
+}
+
+inline constexpr Angle Angle::abs() const
+{
+    return Angle::ofRadians(toRadians() < 0 ? -toRadians() : toRadians());
+}
+
+inline bool Angle::isFinite() const
+{
+    return std::isfinite(toRadians());
+}
+
+inline double Angle::sin() const
+{
+    return std::sin(toRadians());
+}
+
+inline double Angle::cos() const
+{
+    return std::cos(toRadians());
+}
+
+inline double Angle::tan() const
+{
+    return std::tan(toRadians());
+}
+
+inline constexpr Angle Angle::clamp() const
+{
+    return remainder(Angle::full());
+}
+
+inline constexpr Angle Angle::diff(Angle other) const
+{
+    return (*this - other).clamp().abs();
+}
+
+inline constexpr Angle::Angle(double rads) : rads(rads)
+{
+}
+
+inline constexpr Angle operator-(Angle angle)
+{
+    return Angle::ofRadians(-angle.toRadians());
+}
+
+inline constexpr Angle operator+(Angle x, Angle y)
+{
+    return Angle::ofRadians(x.toRadians() + y.toRadians());
+}
+
+inline constexpr Angle operator-(Angle x, Angle y)
+{
+    return Angle::ofRadians(x.toRadians() - y.toRadians());
+}
+
+inline constexpr Angle operator*(Angle angle, double scale)
+{
+    return Angle::ofRadians(angle.toRadians() * scale);
+}
+
+inline constexpr Angle operator*(double scale, Angle angle)
+{
+    return Angle::ofRadians(scale * angle.toRadians());
+}
+
+inline constexpr Angle operator/(Angle angle, double divisor)
+{
+    return Angle::ofRadians(angle.toRadians() / divisor);
+}
+
+inline constexpr double operator/(Angle x, Angle y)
+{
+    return x.toRadians() / y.toRadians();
+}
+
+inline Angle &operator+=(Angle &x, Angle y)
+{
+    return x = x + y;
+}
+
+inline Angle &operator-=(Angle &x, Angle y)
+{
+    return x = x - y;
+}
+
+inline Angle &operator*=(Angle &angle, double scale)
+{
+    return angle = angle * scale;
+}
+
+inline Angle &operator/=(Angle &angle, double divisor)
+{
+    return angle = angle / divisor;
+}
+
+inline constexpr bool operator<(Angle x, Angle y)
+{
+    return x.toRadians() < y.toRadians();
+}
+
+inline constexpr bool operator>(Angle x, Angle y)
+{
+    return x.toRadians() > y.toRadians();
+}
+
+inline constexpr bool operator<=(Angle x, Angle y)
+{
+    return x.toRadians() <= y.toRadians();
+}
+
+inline constexpr bool operator>=(Angle x, Angle y)
+{
+    return x.toRadians() >= y.toRadians();
+}
+
+inline constexpr bool operator==(Angle x, Angle y)
+{
+    return x.toRadians() == y.toRadians();
+}
+
+inline constexpr bool operator!=(Angle x, Angle y)
+{
+    return x.toRadians() != y.toRadians();
+}
+
+inline std::ostream &operator<<(std::ostream &os, const Angle &a)
+{
+    os << a.toRadians() << "R";
+    return os;
+}
+
+#endif

--- a/src/thunderbots/geom/point.h
+++ b/src/thunderbots/geom/point.h
@@ -1,0 +1,546 @@
+#ifndef GEOM_POINT_H_
+#define GEOM_POINT_H_
+
+#include <cmath>
+#include <iostream>
+#include "geom/angle.h"
+
+/**
+ * A point or vector in 2D space.
+ *
+ * Here, point and vector are used interchangeably. A Point lies on the 2D x-y plane. The
+ * corresponding
+ * vector can be though of as a vector/line from the origin to the Point on the plane.
+ */
+class Point final
+{
+   public:
+    /**
+     * Creates a Point at the origin (0, 0).
+     */
+    explicit constexpr Point();
+
+    /**
+     * Creates a unit-magnitude Point from an angle.
+     *
+     * @param angle the angle
+     *
+     * @return Point the Point
+     */
+    static Point createFromAngle(Angle angle);
+
+    /**
+     * Creates a Point at arbitrary coordinates.
+     *
+     * @param x the <var>x</var> value of the Point
+     * @param y the <var>y</var> value of the Point
+     */
+    constexpr Point(double x, double y);
+
+    /**
+     * Creates a new Point that is a copy of the given Point
+     *
+     * @param the Point to duplicate
+     */
+    constexpr Point(const Point &p);
+
+    /**
+     * Returns the x coordinate of this Point
+     *
+     * @return the x coordinate of this Point
+     */
+    constexpr double x() const;
+
+    /**
+     * Returns the y coordinate of this Point
+     *
+     * @return the y coordinate of this Point
+     */
+    constexpr double y() const;
+
+    /**
+     * Sets the coordinates of this point to the new coordinates
+     *
+     * @param x the new x coordinate
+     * @param y the new y coordinate
+     */
+    void set(double x, double y);
+
+    /**
+     * Returns the square of the length of the Point
+     *
+     * @return the square of the length of the Point
+     */
+    constexpr double lensq() const;
+
+    /**
+     * Returns the length of the Point
+     *
+     * @return the length of the Point
+     */
+    double len() const;
+
+    /**
+     * Returns the unit vector in the same direction as this Point
+     *
+     * @return Point a unit vector in the same direction as this Point, or a
+     * zero-length Point if this Point is zero
+     */
+    Point norm() const;
+
+    /**
+     * Returns a scaled normalized vector in the same direction as this
+     * Point
+     *
+     * @param length the desired length of the resultant vector
+     *
+     * @return a vector in the same direction as this Point and with the given length,
+     * or a zero-length Point if this Point is zero
+     */
+    Point norm(double length) const;
+
+    /**
+     * Returns the vector perpendicular to this Point
+     *
+     * @return a vector perpendicular to this Point
+     */
+    constexpr Point perp() const;
+
+    /**
+     * Rotates this Point counterclockwise by an angle
+     *
+     * @param rot the angle to rotate the vector
+     *
+     * @return the Point rotated by rot
+     */
+    Point rotate(Angle rot) const;
+
+    /**
+     * Projects this vector onto another vector
+     *
+     * @param n the vector to project onto
+     *
+     * @return the component of this Point that is in the same direction as the given
+     * Point
+     */
+    constexpr Point project(const Point &other) const;
+
+    /**
+     * Takes the dot product of two vectors
+     *
+     * @param other the Point to dot against
+     *
+     * @return the dot product of the points
+     */
+    constexpr double dot(const Point &other) const;
+
+    /**
+     * Takes the cross product of two vectors
+     *
+     * @param other the Point to cross with
+     *
+     * @return the z component of the 3-dimensional cross product between this Point and
+     * the other point
+     */
+    constexpr double cross(const Point &other) const;
+
+    /**
+     * Returns the direction of this Point
+     *
+     * @return the direction of this Point, in the range [-π, π], with 0 being
+     * the positive x direction, π/2 being up (positive y), etc. like on a standary x-y
+     * plane
+     *
+     *              +
+     *              | Y
+     *              |
+     *              |
+     *      +---------------+
+     *       -X     |      X
+     *              |
+     *              | -Y
+     *              +
+     */
+    Angle orientation() const;
+
+    /**
+     * Checks whether this Point contains NaN in either coordinate
+     *
+     * @return true if either coordinate is NaN, and false otherwise
+     */
+    constexpr bool isnan() const;
+
+    /**
+     * Checks whether this Point is close to another Point, where “close”
+     * is defined as 1.0e-9
+     *
+     * @param other the other point to check against
+     *
+     * @return true if the other point is within a distance of 1.0e-9, not inclusive
+     */
+    constexpr bool isClose(const Point &other) const;
+
+    /**
+     * Checks whether this Point is close to another Point
+     *
+     * @param other the other point to check against
+     *
+     * @param dist the distance to check against
+     *
+     * @return true if the other point is within the given distance (not inclusive) of
+     * this Point
+     */
+    constexpr bool isClose(const Point &other, double dist) const;
+
+    /**
+    * Assigns one Point to another
+    *
+    * @param other the Point whose value should be copied into this Point
+    *
+    * @return this Point
+    */
+    Point &operator=(const Point &other);
+
+   private:
+    /**
+     * The X coordinate of the Point. The variable name starts with an underscore to
+     * prevent
+     * name conflicts with its accessor function.
+     */
+    double _x;
+
+    /**
+     * The Y coordinate of the Point. The variable name starts with an underscore to
+     * prevent
+     * name conflicts with its accessor function.
+     */
+    double _y;
+};
+
+// Vectors can be represented by points, and vice-versa, se we let points also be called
+// vectors
+typedef Point Vector2;
+
+/**
+ * Adds two points
+ *
+ * @param p the first Point
+ * @param q the second Point
+ *
+ * @return the vector-sum of the two points
+ */
+constexpr Point operator+(const Point &p, const Point &q);
+
+/**
+ * Adds an offset to a Point
+ *
+ * @param p the Point to add the offset to
+ * @param q the offset to add
+ *
+ * @return the new value of Point p
+ */
+Point &operator+=(Point &p, const Point &q);
+
+/**
+ * Negates a Point
+ *
+ * @param p the Point to negate
+ *
+ * @return the point with its coordinates negated
+ */
+constexpr Point operator-(const Point &p) __attribute__((warn_unused_result));
+
+/**
+ * Subtracts one Point from another
+ *
+ * @param p the Point to subtract from
+ * @param q the Point to subtract
+ *
+ * @return the vector-difference of the two points
+ */
+constexpr Point operator-(const Point &p, const Point &q)
+    __attribute__((warn_unused_result));
+
+/**
+ * Subtracts an offset from a Point
+ *
+ * @paramp the Point to subtract the offset from
+ * @param q the offset to subtract
+ *
+ * @return the new Point with the offest subtracted
+ */
+Point &operator-=(Point &p, const Point &q);
+
+/**
+ * Multiplies a vector by a scalar
+ *
+ * @param s the scaling factor
+ * @param p the vector to scale
+ *
+ * @return the scaled vector
+ */
+constexpr Point operator*(double s, const Point &p);
+
+/**
+ * Multiplies a vector by a scalar
+ *
+ * @param p the vector to scale
+ * @param s the scaling factor
+ *
+ * @return the scaled vector
+ */
+constexpr Point operator*(const Point &p, double s);
+
+/**
+ * Scales a vector by a scalar
+ *
+ * @param p the vector to scale
+ * @param s the scaling factor
+ *
+ * @return p scaled by the scaling factor
+ */
+Point &operator*=(Point &p, double s);
+
+/**
+ * Divides a vector by a scalar
+ *
+ * @param p the vector to scale
+ * @param s the scalar to divide by
+ *
+ * @return the scaled vector
+ */
+constexpr Point operator/(const Point &p, double s);
+
+/**
+ * Scales a vector by a scalar
+ *
+ * @param p the vector to scale
+ * @param s the sclaing factor
+ *
+ * @return p scaled by the scaling factor
+ */
+Point &operator/=(Point &p, double s);
+
+/**
+ * Prints a vector to a stream
+ *
+ * @param os the stream to print to
+ * @param p the Point to print
+ *
+ * @return the stream with the point printed
+ */
+inline std::ostream &operator<<(std::ostream &os, const Point &p);
+
+/**
+ * Compares two vectors for equality
+ *
+ * @param p the first Point
+ * @param q the second Point
+ *
+ * @return true if the two points represent the same point, and false otherwise
+ */
+constexpr bool operator==(const Point &p, const Point &q);
+
+/**
+ * Compares two vectors for inequality
+ *
+ * @param p the first Point
+ * @param q the second Point
+ *
+ * @return true if the two points represent different points, and false otherwise
+ */
+constexpr bool operator!=(const Point &p, const Point &q);
+
+inline Point Point::createFromAngle(Angle angle)
+{
+    return Point(angle.cos(), angle.sin());
+}
+
+inline constexpr Point::Point() : _x(0.0), _y(0.0)
+{
+}
+
+inline constexpr Point::Point(double x, double y) : _x(x), _y(y)
+{
+}
+
+inline constexpr Point::Point(const Point &p) : _x(p.x()), _y(p.y())
+{
+}
+
+inline constexpr double Point::x() const
+{
+    return _x;
+}
+
+inline constexpr double Point::y() const
+{
+    return _y;
+}
+
+inline void Point::set(double x, double y)
+{
+    this->_x = x;
+    this->_y = y;
+}
+
+inline constexpr double Point::lensq() const
+{
+    return _x * _x + _y * _y;
+}
+
+inline double Point::len() const
+{
+    return std::hypot(_x, _y);
+}
+
+inline Point Point::norm() const
+{
+    return len() < 1.0e-9 ? Point() : Point(_x / len(), _y / len());
+}
+
+inline Point Point::norm(double length) const
+{
+    return len() < 1.0e-9 ? Point() : Point(_x * length / len(), _y * length / len());
+}
+
+inline constexpr Point Point::perp() const
+{
+    return Point(-_y, _x);
+}
+
+inline Point Point::rotate(Angle rot) const
+{
+    return Point(_x * rot.cos() - _y * rot.sin(), _x * rot.sin() + _y * rot.cos());
+}
+
+inline constexpr Point Point::project(const Point &other) const
+{
+    return dot(other) / other.lensq() * other;
+}
+
+inline constexpr double Point::dot(const Point &other) const
+{
+    return _x * other.x() + _y * other.y();
+}
+
+inline constexpr double Point::cross(const Point &other) const
+{
+    return _x * other.y() - _y * other.x();
+}
+
+inline Point &Point::operator=(const Point &q)
+{
+    _x = q.x();
+    _y = q.y();
+    return *this;
+}
+
+inline Angle Point::orientation() const
+{
+    return Angle::ofRadians(std::atan2(_y, _x));
+}
+
+inline constexpr bool Point::isnan() const
+{
+    return std::isnan(_x) || std::isnan(_y);
+}
+
+inline constexpr bool Point::isClose(const Point &other) const
+{
+    return Point(_x - other.x(), _y - other.y()).lensq() < 1e-9;
+}
+
+inline constexpr bool Point::isClose(const Point &other, double dist) const
+{
+    return std::pow(_x - other.x(), 2) + std::pow(_y - other.y(), 2) < dist * dist;
+}
+
+inline constexpr Point operator+(const Point &p, const Point &q)
+{
+    return Point(p.x() + q.x(), p.y() + q.y());
+}
+
+inline Point &operator+=(Point &p, const Point &q)
+{
+    p.set(q.x(), q.y());
+    return p;
+}
+
+inline constexpr Point operator-(const Point &p)
+{
+    return Point(-p.x(), -p.y());
+}
+
+inline constexpr Point operator-(const Point &p, const Point &q)
+{
+    return Point(p.x() - q.x(), p.y() - q.y());
+}
+
+inline Point &operator-=(Point &p, const Point &q)
+{
+    p.set(q.x(), q.y());
+    return p;
+}
+
+inline constexpr Point operator*(double s, const Point &p)
+{
+    return Point(p.x() * s, p.y() * s);
+}
+
+inline constexpr Point operator*(const Point &p, double s)
+{
+    return Point(p.x() * s, p.y() * s);
+}
+
+inline Point &operator*=(Point &p, double s)
+{
+    p.set(p.x() * s, p.y() * s);
+    return p;
+}
+
+inline constexpr Point operator/(const Point &p, double s)
+{
+    return Point(p.x() / s, p.y() / s);
+}
+
+inline Point &operator/=(Point &p, double s)
+{
+    p.set(p.x() / s, p.y() / s);
+    return p;
+}
+
+inline std::ostream &operator<<(std::ostream &os, const Point &p)
+{
+    os << "(" << p.x() << ", " << p.y() << ")";
+    return os;
+}
+
+inline constexpr bool operator==(const Point &p, const Point &q)
+{
+    return p.x() == q.x() && p.y() == q.y();
+}
+
+inline constexpr bool operator!=(const Point &p, const Point &q)
+{
+    return !(p == q);
+}
+
+// We need to define a hash function so that the Point class can be used in unordered STL
+// containers
+// like unordered_set and unordered_map
+// https://prateekvjoshi.com/2014/06/05/using-hash-function-in-c-for-user-defined-classes/
+namespace std
+{
+template <>
+struct hash<Point> final
+{
+    size_t operator()(const Point &p) const
+    {
+        hash<double> h;
+        return h(p.x()) * 17 + h(p.y());
+    }
+};
+}
+
+#endif  // GEOM_POINT_H_

--- a/src/thunderbots/geom/test/angle.cpp
+++ b/src/thunderbots/geom/test/angle.cpp
@@ -1,0 +1,88 @@
+#include "geom/angle.h"
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(AngleTest, Statics)
+{
+    EXPECT_DOUBLE_EQ(0, Angle::zero().toDegrees());
+    EXPECT_DOUBLE_EQ(90, Angle::quarter().toDegrees());
+    EXPECT_DOUBLE_EQ(180, Angle::half().toDegrees());
+    EXPECT_DOUBLE_EQ(270, Angle::threeQuarter().toDegrees());
+    EXPECT_DOUBLE_EQ(360, Angle::full().toDegrees());
+
+    EXPECT_DOUBLE_EQ(0, Angle::zero().toRadians());
+    EXPECT_DOUBLE_EQ(M_PI_2, Angle::quarter().toRadians());
+    EXPECT_DOUBLE_EQ(M_PI, Angle::half().toRadians());
+    EXPECT_DOUBLE_EQ(3 * M_PI_2, Angle::threeQuarter().toRadians());
+    EXPECT_DOUBLE_EQ(2 * M_PI, Angle::full().toRadians());
+}
+
+TEST(AngleTest, Of_radians)
+{
+    EXPECT_DOUBLE_EQ(0, Angle::ofRadians(0).toDegrees());
+    EXPECT_DOUBLE_EQ(30, Angle::ofRadians(M_PI / 6).toDegrees());
+    EXPECT_DOUBLE_EQ(390, Angle::ofRadians(M_PI * 13 / 6).toDegrees());
+}
+
+TEST(AngleTest, Of_degrees)
+{
+    EXPECT_DOUBLE_EQ(0, Angle::ofDegrees(0).toRadians());
+    EXPECT_DOUBLE_EQ(M_PI / 3, Angle::ofDegrees(60).toRadians());
+    EXPECT_DOUBLE_EQ(M_PI, Angle::ofDegrees(180).toRadians());
+    EXPECT_DOUBLE_EQ(-M_PI, Angle::ofDegrees(-180).toRadians());
+}
+
+TEST(AngleTest, Angle_mod)
+{
+    EXPECT_DOUBLE_EQ(27, Angle::ofDegrees(27).clamp().toDegrees());
+    EXPECT_DOUBLE_EQ(27, Angle::ofDegrees(360 + 27).clamp().toDegrees());
+    EXPECT_DOUBLE_EQ(-27, Angle::ofDegrees(360 - 27).clamp().toDegrees());
+}
+
+TEST(AngleTest, Angle_remainder)
+{
+    EXPECT_DOUBLE_EQ(0, Angle::full().remainder(Angle::half()).toRadians());
+}
+
+TEST(AngleTest, Angle_abs)
+{
+    EXPECT_DOUBLE_EQ(90, (Angle::quarter() - Angle::half()).abs().toDegrees());
+}
+
+TEST(AngleTest, Angle_isFinite)
+{
+    // TODO: Add tests
+}
+
+TEST(AngleTest, Angle_diff)
+{
+    EXPECT_DOUBLE_EQ(27, Angle::ofDegrees(50).diff(Angle::ofDegrees(23)).toDegrees());
+    // We require a slightly larger tolerance for this test to pass
+    EXPECT_NEAR(
+        27, Angle::ofDegrees(360 + 13).diff(Angle::ofDegrees(-14)).toDegrees(), 1e-13);
+    EXPECT_DOUBLE_EQ(
+        27, Angle::ofDegrees(180 - 13).diff(Angle::ofDegrees(-180 + 14)).toDegrees());
+    EXPECT_DOUBLE_EQ(
+        27, Angle::ofDegrees(180 + 13).diff(Angle::ofDegrees(-180 - 14)).toDegrees());
+    EXPECT_DOUBLE_EQ(
+        27, Angle::ofDegrees(-180 + 13).diff(Angle::ofDegrees(180 - 14)).toDegrees());
+    EXPECT_DOUBLE_EQ(
+        27, Angle::ofDegrees(-180 - 13).diff(Angle::ofDegrees(180 + 14)).toDegrees());
+}
+
+TEST(AngleTest, asin)
+{
+    EXPECT_DOUBLE_EQ(0, Angle::asin(0).toRadians());
+    EXPECT_DOUBLE_EQ(M_PI / 2, Angle::asin(1).toRadians());
+    EXPECT_DOUBLE_EQ(-M_PI / 2, Angle::asin(-1).toRadians());
+    EXPECT_DOUBLE_EQ(30, Angle::asin(0.5).toDegrees());
+    EXPECT_NEAR(-2.865983983, Angle::asin(-0.05).toDegrees(), 1e-7);
+    EXPECT_NEAR(57.14011962, Angle::asin(0.84).toDegrees(), 1e-7);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/geom/test/point.cpp
+++ b/src/thunderbots/geom/test/point.cpp
@@ -1,0 +1,14 @@
+#include "geom/point.h"
+#include <gtest/gtest.h>
+
+TEST(AngleTest, accesors)
+{
+    EXPECT_DOUBLE_EQ(0, Point().x());
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR creates a simple `backend_input` node for the new system. The backend input is responsible for receiving incoming data (from whatever source, could be ssl-vision or grsim), filtering it, and publishing this data to some common interface. This will abstract the source of the data from the rest of the system and allows us to only maintain one version of our "logic" code.