### PR TITLE
Move Shared Utils Globbing to Top Level CMake

### DIFF
--- a/src/thunderbots/CMakeLists.txt
+++ b/src/thunderbots/CMakeLists.txt
@@ -9,4 +9,13 @@
 cmake_minimum_required(VERSION 3.8.2)
 project(thunderbots_all)
 
+# Create a list of files from the shared folder
+# This is put at top level since shared files may be used across software and firmware. Removes need for relative paths
+# (i.e. paths with .. in them)
+file(GLOB_RECURSE SHARED_UTIL_SRC LIST_DIRECTORIES false CONFIGURE_DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/shared/*.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/shared/*.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/shared/*.h
+        )
+
 add_subdirectory(software)

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -34,14 +34,6 @@ set(CMAKE_CXX_FLAGS "-Wnon-virtual-dtor")
 # Call our CMake file to include and build protobuf
 include("${CMAKE_CURRENT_SOURCE_DIR}/proto/build_proto.cmake")
 
-# Create a list of files from the shared folder
-file(GLOB_RECURSE SHARED_UTIL_SRC LIST_DIRECTORIES false CONFIGURE_DEPENDS
-        ${CMAKE_CURRENT_SOURCE_DIR}/../shared/*.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../shared/*.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/../shared/*.h
-        )
-
-
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
         roscpp


### PR DESCRIPTION
Proposal to move the GLOB_RECURSE for SHARED_UTIL_SRC to the top level CMakeLists.txt under `thunderbots/` since these files will be used in firmware and software. This removes the need for hard-coding paths with ".." in them, since they are not full proof if we move stuff around.