### PR TITLE
Parameter and constant tweaks

### DIFF
--- a/src/thunderbots/shared/constants.h
+++ b/src/thunderbots/shared/constants.h
@@ -9,6 +9,8 @@
 const double BALL_MAX_SPEED = 6.5;
 // The max allowed radius of the robots, in metres
 const double ROBOT_MAX_RADIUS = 0.09;
+// The approximate radius of the ball according to the SSL rulebook
+const double BALL_MAX_RADIUS = 0.0215;
 
 /* Robot Attributes */
 // The maximum speed achievable by our robots, in metres per second.
@@ -19,8 +21,15 @@ const double ROBOT_MAX_SPEED = 2.0;
 const double ROBOT_MAX_ACCELERATION = 3.0;
 
 /* Unit Conversion */
-const double METERS_PER_MILLIMETER = 1.0 / 1000.0;
 const double MILLIMETERS_PER_METER = 1000.0;
+const double METERS_PER_MILLIMETER = 1.0 / 1000.0;
 
-const double RADIANS_PER_CENTIRADIAN = 1.0 / 100.0;
 const double CENTIRADIANS_PER_RADIAN = 100.0;
+const double RADIANS_PER_CENTIRADIAN = 1.0 / 100.0;
+
+const double MICROSECONDS_PER_MILLISECOND = 1000.0;
+const double MICROSECONDS_PER_SECOND      = 1000000.0;
+const double MILLISECONDS_PER_SECOND      = 1000.0;
+const double SECONDS_PER_MICROSECOND      = 1.0 / 1000000.0;
+const double SECONDS_PER_MILLISECOND      = 1.0 / 1000.0;
+const double MILLISECONDS_PER_MICROSECOND = 1.0 / 1000.0;

--- a/src/thunderbots/software/ai/world/ball.h
+++ b/src/thunderbots/software/ai/world/ball.h
@@ -6,9 +6,6 @@
 class Ball final
 {
    public:
-    // The approximate radius of the ball according to the SSL rulebook
-    static constexpr double MAX_RADIUS = 0.0215;
-
     /**
      * Creates a new ball
      */

--- a/src/thunderbots/software/util/parameter/dynamic_parameters.cpp
+++ b/src/thunderbots/software/util/parameter/dynamic_parameters.cpp
@@ -14,27 +14,16 @@ namespace DynamicParameters
         Parameter<std::vector<std::string>>::updateAllParametersFromROSParameterServer();
     }
 
-    const extern Parameter<int> param1("/thunderbots/parameters/param1", 7);
-
     namespace Navigator
     {
         // Default avoid distance around robots.
-        const Parameter<double> default_avoid_dist(
-            "/thunderbots/parameters/default_avoid_dist", 0.15);
+        Parameter<double> default_avoid_dist("/thunderbots/parameters/default_avoid_dist",
+                                             0.15);
 
         // Scaling factor for collision avoidance.
         // TODO this is arbitrary for now; could be determined as part of
         // #23: https://github.com/UBC-Thunderbots/Software/issues/23
-        const Parameter<double> collision_avoid_velocity_scale(
+        Parameter<double> collision_avoid_velocity_scale(
             "/thunderbots/parameters/collision_avoid_velocity_scale", 2.0);
-    }
-
-    namespace HL
-    {
-        namespace STP
-        {
-            const Parameter<std::vector<std::string>> param3(
-                "/thunderbots/parameters/param3", {"MovePlay", "IdlePlay"});
-        }
     }
 }

--- a/src/thunderbots/software/util/parameter/dynamic_parameters.h
+++ b/src/thunderbots/software/util/parameter/dynamic_parameters.h
@@ -14,21 +14,9 @@ namespace DynamicParameters
      */
     void updateAllParametersFromROSParameterServer();
 
-    // These are currently placeholders to provide an example of how parameters are
-    // created an initialized. Parameters can be organized in (nested) namespaces.
-    const extern Parameter<int> param1;
-
     namespace Navigator
     {
-        const extern Parameter<double> default_avoid_dist;
-        const extern Parameter<double> collision_avoid_velocity_scale;
-    }
-
-    namespace HL
-    {
-        namespace STP
-        {
-            const extern Parameter<std::vector<std::string>> param3;
-        }
+        extern Parameter<double> default_avoid_dist;
+        extern Parameter<double> collision_avoid_velocity_scale;
     }
 }

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -31,7 +31,7 @@ class Parameter
         this->ros_parameter_path = ros_parameter_path;
         value_                   = default_value;
 
-        Parameter<T>::registerParameter(std::unique_ptr<Parameter<T>>(this));
+        Parameter<T>::registerParameter(std::make_unique<Parameter<T>>(*this));
     }
 
     /**
@@ -64,13 +64,25 @@ class Parameter
     }
 
     /**
-     * Sets the parameter value in the ROS Parameter Server to the new value
+     * Sets the parameter value in the ROS Parameter Server to the new value.
      *
      * @param new_value The new value to be set
      */
     void setValueInParameterServer(T new_value)
     {
         ros::param::set(getROSParameterPath(), new_value);
+    }
+
+    /**
+     * Sets the local value of the parameter to the new value. This is primarily useful
+     * for unit testing, so that parameters can be adjusted without needing the ROS
+     * Parameter server
+     *
+     * @param new_value The new value to be set
+     */
+    void setValueLocally(T new_value)
+    {
+        value_ = new_value;
     }
 
     /**

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -68,21 +68,9 @@ class Parameter
      *
      * @param new_value The new value to be set
      */
-    void setValueInParameterServer(T new_value)
+    void setValueInROSParameterServer(T new_value)
     {
         ros::param::set(getROSParameterPath(), new_value);
-    }
-
-    /**
-     * Sets the local value of the parameter to the new value. This is primarily useful
-     * for unit testing, so that parameters can be adjusted without needing the ROS
-     * Parameter server
-     *
-     * @param new_value The new value to be set
-     */
-    void setValueLocally(T new_value)
-    {
-        value_ = new_value;
     }
 
     /**


### PR DESCRIPTION
Tweaks to the dynamic parameters so they can be set properly, and used locally for unit testing without the ROS Parameter Server running.

Added more constants for unit conversion and moved the BALL_RADIUS constant to be a shared constant.