### PR TITLE
Implemented Ball class

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -204,4 +204,13 @@ if (CATKIN_ENABLE_TESTING)
 
     target_link_libraries(ball_test ${catkin_LIBRARIES})
 
+    catkin_add_gtest(ros_message_util_test
+            test/util/ros_messages.cpp
+            util/ros_messages.cpp
+            ai/world/ball.cpp
+            geom/point.h
+            geom/angle.h)
+
+    target_link_libraries(ros_message_util_test ${catkin_LIBRARIES})
+
 endif()

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -163,7 +163,7 @@ if (CATKIN_ENABLE_TESTING)
     target_link_libraries(geom_point_test ${catkin_LIBRARIES})
 
     catkin_add_gtest(field_test
-            test/field/field.cpp
+            test/world/field.cpp
             ai/world/field.cpp
             )
     target_link_libraries(field_test ${catkin_LIBRARIES})

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -78,6 +78,7 @@ file(GLOB_RECURSE BACKEND_INPUT_SRC LIST_DIRECTORIES false CONFIGURE_DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/geom/*.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/geom/*.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ai/world/team.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/ai/world/ball.*
         ${CMAKE_CURRENT_SOURCE_DIR}/util/*.h
         ${CMAKE_CURRENT_SOURCE_DIR}/util/*.cpp
         )

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -196,4 +196,12 @@ if (CATKIN_ENABLE_TESTING)
 
     target_link_libraries(shared_util_test ${catkin_LIBRARIES})
 
+    catkin_add_gtest(ball_test
+            test/world/ball.cpp
+            ai/world/ball.cpp
+            geom/point.h
+            geom/angle.h)
+
+    target_link_libraries(ball_test ${catkin_LIBRARIES})
+
 endif()

--- a/src/thunderbots/software/ai/ai.cpp
+++ b/src/thunderbots/software/ai/ai.cpp
@@ -22,9 +22,9 @@ std::vector<std::unique_ptr<Primitive>> AI::getPrimitives(
     return assignedPrimitives;
 }
 
-void AI::updateWorldBallState(const thunderbots_msgs::Ball &new_ball_msg)
+void AI::updateWorldBallState(const Ball &new_ball_data)
 {
-    world.updateBallState(new_ball_msg);
+    world.updateBallState(new_ball_data);
 }
 
 void AI::updateWorldFieldState(const thunderbots_msgs::Field &new_field_msg)

--- a/src/thunderbots/software/ai/ai.h
+++ b/src/thunderbots/software/ai/ai.h
@@ -4,7 +4,6 @@
 #include "ai/navigator/rrt/rrt.h"
 #include "ai/primitive/primitive.h"
 #include "ai/world/world.h"
-#include "thunderbots_msgs/Ball.h"
 #include "thunderbots_msgs/Field.h"
 #include "thunderbots_msgs/Team.h"
 #include "util/timestamp.h"
@@ -34,12 +33,11 @@ class AI final
         const AITimestamp& timestamp) const;
 
     /**
-     * Given a message containing new ball state, updates the state of the ball
-     * in the world
+     * Updates the state of the ball in the AI's world with the new ball data
      *
-     * @param new_ball_msg The message containing new ball information
+     * @param new_ball_data A Ball containing new ball information
      */
-    void updateWorldBallState(const thunderbots_msgs::Ball& new_ball_msg);
+    void updateWorldBallState(const Ball& new_ball_data);
 
     /**
      * Given a message containing new field geometry, update the geometry of the

--- a/src/thunderbots/software/ai/main.cpp
+++ b/src/thunderbots/software/ai/main.cpp
@@ -6,6 +6,7 @@
 #include "thunderbots_msgs/PrimitiveArray.h"
 #include "thunderbots_msgs/Team.h"
 #include "util/constants.h"
+#include "util/ros_messages.h"
 #include "util/timestamp.h"
 
 // Variables we need to maintain state
@@ -28,7 +29,9 @@ void ballUpdateCallback(const thunderbots_msgs::Ball::ConstPtr &msg)
 {
     thunderbots_msgs::Ball ball_msg = *msg;
 
-    ai.updateWorldBallState(ball_msg);
+    Ball ball = Util::ROSMessages::createBallFromROSMessage(ball_msg);
+
+    ai.updateWorldBallState(ball);
 }
 
 void friendlyTeamUpdateCallback(const thunderbots_msgs::Team::ConstPtr &msg)

--- a/src/thunderbots/software/ai/world/ball.cpp
+++ b/src/thunderbots/software/ai/world/ball.cpp
@@ -1,16 +1,15 @@
 #include "ball.h"
 
-Ball::Ball() : position_(Point()), velocity_(Vector())
+Ball::Ball(Point position, Vector velocity) : position_(position), velocity_(velocity)
 {
 }
 
-void Ball::update(const thunderbots_msgs::Ball &ball_msg)
+void Ball::update(const Ball &new_ball_data)
 {
-    position_ = Point(ball_msg.position.x, ball_msg.position.y);
-    velocity_ = Vector(ball_msg.velocity.x, ball_msg.velocity.y);
+    update(new_ball_data.position(), new_ball_data.velocity());
 }
 
-void Ball::update(Point &new_position, Vector &new_velocity)
+void Ball::update(const Point &new_position, const Vector &new_velocity)
 {
     position_ = new_position;
     velocity_ = new_velocity;
@@ -18,10 +17,26 @@ void Ball::update(Point &new_position, Vector &new_velocity)
 
 Point Ball::position(double time_delta) const
 {
-    return position_;
+    // TODO: This is a simple linear implementation that does not necessarily reflect
+    // real-world behavior. Position prediction should be improved as outlined in
+    // https://github.com/UBC-Thunderbots/Software/issues/47
+    return position_ + (velocity_.norm(time_delta * velocity_.len()));
 }
 
 Vector Ball::velocity(double time_delta) const
 {
-    return velocity_;
+    // TODO: This is a implementation with an empirically determined time constant that
+    // does not necessarily reflect real-world behavior. Velocity prediction should be
+    // improved as outlined in https://github.com/UBC-Thunderbots/Software/issues/47
+    return velocity_ * exp(-0.1 * time_delta);
+}
+
+bool Ball::operator==(const Ball &other) const
+{
+    return this->position_ == other.position_ && this->velocity_ == other.velocity_;
+}
+
+bool Ball::operator!=(const Ball &other) const
+{
+    return !(*this == other);
 }

--- a/src/thunderbots/software/ai/world/ball.h
+++ b/src/thunderbots/software/ai/world/ball.h
@@ -1,15 +1,18 @@
 #pragma once
 
-#include <thunderbots_msgs/Ball.h>
 #include "geom/point.h"
 
 class Ball final
 {
    public:
     /**
-     * Creates a new ball
+     * Creates a new ball with the given position and velocity
+     *
+     * @param position The position of the ball, with coordinates in metres.
+     * Default is (0, 0)
+     * @param velocity The velocity of the ball, in metres per second. Default is (0, 0)
      */
-    explicit Ball();
+    explicit Ball(Point position = Point(), Vector velocity = Vector());
 
     /**
      * Updates the ball with new data, updating the current data as well as the predictive
@@ -18,15 +21,15 @@ class Ball final
      * @param new_position the new position of the ball, defined in metres
      * @param new_velocity the new velocity of the ball, defined in metres per second
      */
-    void update(Point &new_position, Vector &new_velocity);
+    void update(const Point& new_position, const Vector& new_velocity);
 
     /**
-     * Updates the ball with new data from a Ball message. This updates the current data
-     * as well as the predictive models
+     * Updates the ball with new data, updating the current data as well as the predictive
+     * model
      *
-     * @param ball_msg The message containing the new data to update the Ball with
+     * @param new_ball_data A ball containing new ball data
      */
-    void update(const thunderbots_msgs::Ball &ball_msg);
+    void update(const Ball& new_ball_data);
 
     /**
      * Get the predicted position of the ball at a time relative to the current time.
@@ -48,7 +51,26 @@ class Ball final
      */
     Vector velocity(double time_delta = 0.0) const;
 
+    /**
+     * Defines the equality operator for a Ball. Balls are equal if their positions and
+     * velocities are the same
+     *
+     * @param other The Ball to compare against for equality
+     * @return True if the other ball is equal to this ball, and false otherwise
+     */
+    bool operator==(const Ball& other) const;
+
+    /**
+     * Defines the inequality operator for a Ball.
+     *
+     * @param other The ball to compare against for inequality
+     * @return True if the other ball is not equal to this ball, and false otherwise
+     */
+    bool operator!=(const Ball& other) const;
+
    private:
+    // The current position of the ball, with coordinates in metres
     Point position_;
+    // The current velocity of the ball, in metres per second
     Vector velocity_;
 };

--- a/src/thunderbots/software/ai/world/field.cpp
+++ b/src/thunderbots/software/ai/world/field.cpp
@@ -138,22 +138,22 @@ Point Field::enemyCornerNeg() const
 
 Point Field::friendlyGoalpostPos() const
 {
-    return Point(friendlyGoal().x(), defenseAreaWidth() / 2.0);
+    return Point(friendlyGoal().x(), goalWidth() / 2.0);
 }
 
 Point Field::friendlyGoalpostNeg() const
 {
-    return Point(friendlyGoal().x(), -defenseAreaWidth() / 2.0);
+    return Point(friendlyGoal().x(), -goalWidth() / 2.0);
 }
 
 Point Field::enemyGoalpostPos() const
 {
-    return Point(enemyGoal().x(), defenseAreaWidth() / 2.0);
+    return Point(enemyGoal().x(), goalWidth() / 2.0);
 }
 
 Point Field::enemyGoalpostNeg() const
 {
-    return Point(enemyGoal().x(), -defenseAreaWidth() / 2.0);
+    return Point(enemyGoal().x(), -goalWidth() / 2.0);
 }
 
 std::pair<Point, Point> Field::friendlyGoalposts() const

--- a/src/thunderbots/software/ai/world/field.h
+++ b/src/thunderbots/software/ai/world/field.h
@@ -28,16 +28,16 @@ class Field
      *
      * @param field_length the length of the playing area (along the x-axis)
      * @param field_width the width of the playing area (along the y-axis)
-     * @param goal_width the width of the goal (along the y-axis)
      * @param defense_length the length of the defense area (along the x-axis)
      * @param defense_width the width of the defense area (along the y-axis)
+     * @param goal_width the width of the goal (along the y-axis)
      * @param boundary_width the width/size of the boundary area between the edge of the
      * playing area and the physical border/perimeter of the field
      * @param center_circle_radius the radius of the center circle
      */
-    void updateDimensions(double field_length, double field_width, double goal_width,
-                          double defense_length, double defense_width,
-                          double boundary_width, double center_circle_radius);
+    void updateDimensions(double field_length, double field_width, double defense_length,
+                          double defense_width, double goal_width, double boundary_width,
+                          double center_circle_radius);
 
     /**
      * Checks if the field data is valid yet.

--- a/src/thunderbots/software/ai/world/world.cpp
+++ b/src/thunderbots/software/ai/world/world.cpp
@@ -15,9 +15,9 @@ void World::updateFieldGeometry(const thunderbots_msgs::Field &new_field_msg)
     field_.updateDimensions(new_field_msg);
 }
 
-void World::updateBallState(const thunderbots_msgs::Ball &new_ball_msg)
+void World::updateBallState(const Ball &new_ball_data)
 {
-    ball_.update(new_ball_msg);
+    ball_.update(new_ball_data);
 }
 
 void World::updateFriendlyTeam(const thunderbots_msgs::Team &new_friendly_team_msg)

--- a/src/thunderbots/software/ai/world/world.h
+++ b/src/thunderbots/software/ai/world/world.h
@@ -39,12 +39,11 @@ class World final
     void updateFieldGeometry(const thunderbots_msgs::Field& new_field_msg);
 
     /**
-     * Given a message containing new ball state, updates the state of the ball
-     * in the world
+     * Updates the state of the ball in the world with the new ball data
      *
-     * @param new_ball_msg The message containing new ball information
+     * @param new_ball_data A Ball containing new ball information
      */
-    void updateBallState(const thunderbots_msgs::Ball& new_ball_msg);
+    void updateBallState(const Ball& new_ball_data);
 
     /**
      * Given a message containing new information about the friendly team, updates

--- a/src/thunderbots/software/test/util/ros_messages.cpp
+++ b/src/thunderbots/software/test/util/ros_messages.cpp
@@ -1,0 +1,23 @@
+#include "util/ros_messages.h"
+#include <gtest/gtest.h>
+
+TEST(ROSMessageUtilTest, create_ball_from_ros_message)
+{
+    thunderbots_msgs::Ball ball_msg;
+
+    ball_msg.position.x = 1.2;
+    ball_msg.position.y = -8.07;
+    ball_msg.velocity.x = 0;
+    ball_msg.velocity.y = 3;
+
+    Ball ball = Util::ROSMessages::createBallFromROSMessage(ball_msg);
+
+    EXPECT_EQ(Ball(Point(1.2, -8.07), Vector(0, 3)), ball);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/world/ball.cpp
+++ b/src/thunderbots/software/test/world/ball.cpp
@@ -1,0 +1,162 @@
+#include "ai/world/ball.h"
+#include <gtest/gtest.h>
+
+TEST(BallTest, construct_with_no_params)
+{
+    Ball ball = Ball();
+
+    EXPECT_EQ(Point(), ball.position());
+    EXPECT_EQ(Vector(), ball.velocity());
+}
+
+TEST(BallTest, construct_with_params)
+{
+    Ball ball = Ball(Point(1, 2.3), Vector(-0.04, 0.0));
+
+    EXPECT_EQ(Point(1, 2.3), ball.position());
+    EXPECT_EQ(Vector(-0.04, 0.0), ball.velocity());
+}
+
+TEST(BallTest, update_all_values)
+{
+    Ball ball = Ball();
+
+    ball.update(Point(-4.23, 1.07), Vector(1, 2));
+
+    EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(1, 2)), ball);
+}
+
+TEST(BallTest, update_position_only)
+{
+    Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2));
+
+    ball.update(Point(0.01, -99.8), ball.velocity());
+
+    EXPECT_EQ(Ball(Point(0.01, -99.8), Vector(1, 2)), ball);
+}
+
+TEST(BallTest, update_velocity_only)
+{
+    Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2));
+
+    ball.update(ball.position(), Vector(-0.0, -9.433));
+
+    EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(-0.0, -9.433)), ball);
+}
+
+TEST(BallTest, update_with_new_ball)
+{
+    Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2));
+
+    ball.update(Ball(Point(), Vector(-4.89, 3.1)));
+
+    EXPECT_EQ(Ball(Point(), Vector(-4.89, 3.1)), ball);
+}
+
+TEST(BallTest, get_position_at_current_time)
+{
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+
+    EXPECT_EQ(Point(3, 7), ball.position());
+    EXPECT_EQ(Point(3, 7), ball.position(0));
+}
+
+TEST(BallTest, predict_future_position)
+{
+    Ball ball = Ball(Point(), Vector(1, 2));
+
+    EXPECT_EQ(Point(1, 2), ball.position(1));
+    EXPECT_EQ(Point(2, 4), ball.position(2));
+    EXPECT_EQ(Point(0.15, 0.3), ball.position(0.15));
+
+    ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+
+    EXPECT_EQ(Point(-1.5, 6.88), ball.position(1));
+    EXPECT_EQ(Point(-6, 6.76), ball.position(2));
+    EXPECT_EQ(Point(2.325, 6.982), ball.position(0.15));
+}
+
+TEST(BallTest, predict_past_position)
+{
+    Ball ball = Ball(Point(), Vector(1, 2));
+
+    EXPECT_EQ(Point(-1, -2), ball.position(-1));
+    EXPECT_EQ(Point(-2, -4), ball.position(-2));
+    EXPECT_EQ(Point(-0.15, -0.3), ball.position(-0.15));
+
+    ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+
+    EXPECT_EQ(Point(7.5, 7.12), ball.position(-1));
+    EXPECT_EQ(Point(12, 7.24), ball.position(-2));
+    EXPECT_EQ(Point(3.675, 7.018), ball.position(-0.15));
+}
+
+TEST(BallTest, get_velocity_at_current_time)
+{
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+
+    EXPECT_EQ(Vector(-4.5, -0.12), ball.velocity());
+    EXPECT_EQ(Vector(-4.5, -0.12), ball.velocity(0));
+}
+
+TEST(BallTest, predict_future_velocity)
+{
+    Ball ball = Ball(Point(), Vector(1, 2));
+
+    // A small distance to check that values are approximately equal
+    double EPSILON = 1e-4;
+
+    EXPECT_TRUE(Vector(0.9851, 1.9702).isClose(ball.velocity(0.15), EPSILON));
+    EXPECT_TRUE(Vector(0.9048, 1.8097).isClose(ball.velocity(1), EPSILON));
+    EXPECT_TRUE(Vector(0.8187, 1.6375).isClose(ball.velocity(2), EPSILON));
+
+    ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+
+    EXPECT_TRUE(Vector(-4.4330, -0.1182).isClose(ball.velocity(0.15), EPSILON));
+    EXPECT_TRUE(Vector(-4.0717, -0.1086).isClose(ball.velocity(1), EPSILON));
+    EXPECT_TRUE(Vector(-3.6843, -0.0982).isClose(ball.velocity(2), EPSILON));
+}
+
+TEST(BallTest, predict_past_velocity)
+{
+    Ball ball = Ball(Point(), Vector(1, 2));
+
+    // A small distance to check that values are approximately equal
+    double EPSILON = 1e-4;
+
+    EXPECT_TRUE(Vector(1.0151, 2.0302).isClose(ball.velocity(-0.15), EPSILON));
+    EXPECT_TRUE(Vector(1.1052, 2.2103).isClose(ball.velocity(-1), EPSILON));
+    EXPECT_TRUE(Vector(1.2214, 2.4428).isClose(ball.velocity(-2), EPSILON));
+
+    ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+
+    EXPECT_TRUE(Vector(-4.5680, -0.1218).isClose(ball.velocity(-0.15), EPSILON));
+    EXPECT_TRUE(Vector(-4.9733, -0.1326).isClose(ball.velocity(-1), EPSILON));
+    EXPECT_TRUE(Vector(-5.4963, -0.1466).isClose(ball.velocity(-2), EPSILON));
+}
+
+TEST(BallTest, equality_operators)
+{
+    Ball ball_0 = Ball();
+
+    Ball ball_1 = Ball(Point(0.01, -0.0), Vector());
+
+    Ball ball_2 = Ball(Point(2, -3), Vector(0, 1));
+
+    Ball ball_3 = Ball(Point(0.01, -0.0), Vector());
+
+    EXPECT_EQ(ball_0, ball_0);
+    EXPECT_NE(ball_0, ball_1);
+    EXPECT_NE(ball_0, ball_2);
+    EXPECT_EQ(ball_1, ball_1);
+    EXPECT_NE(ball_1, ball_2);
+    EXPECT_EQ(ball_1, ball_3);
+    EXPECT_NE(ball_2, ball_3);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/world/field.cpp
+++ b/src/thunderbots/software/test/world/field.cpp
@@ -25,22 +25,22 @@ TEST(FieldTest, update_and_accessors)
     double boundary_width       = 0.3;
     double center_circle_radius = 0.5;
 
-    field.updateDimensions(length, width, defense_length, defense_width, goal_width,
+    field.updateDimensions(length, width, goal_width, defense_length, defense_width,
                            boundary_width, center_circle_radius);
 
     EXPECT_TRUE(field.valid());
 
     EXPECT_DOUBLE_EQ(9.6, field.totalLength());
     EXPECT_DOUBLE_EQ(6.6, field.totalWidth());
-    EXPECT_DOUBLE_EQ(0.3, boundary_width);
+    EXPECT_DOUBLE_EQ(0.3, field.boundaryWidth());
 
     EXPECT_EQ(Point(-4.5, 0.0), field.friendlyGoal());
     EXPECT_EQ(Point(4.5, 0.0), field.enemyGoal());
 
-    EXPECT_EQ(Point(-4.5, 1.0), field.friendlyGoalpostPos());
-    EXPECT_EQ(Point(-4.5, -1.0), field.friendlyGoalpostNeg());
-    EXPECT_EQ(Point(4.5, 1.0), field.enemyGoalpostPos());
-    EXPECT_EQ(Point(4.5, -1.0), field.enemyGoalpostNeg());
+    EXPECT_EQ(Point(-4.5, 0.5), field.friendlyGoalpostPos());
+    EXPECT_EQ(Point(-4.5, -0.5), field.friendlyGoalpostNeg());
+    EXPECT_EQ(Point(4.5, 0.5), field.enemyGoalpostPos());
+    EXPECT_EQ(Point(4.5, -0.5), field.enemyGoalpostNeg());
 
     EXPECT_EQ(Rect(Point(-4.5, 1.0), Point(-3.5, -1.0)), field.friendlyDefenseArea());
     EXPECT_EQ(Rect(Point(4.5, 1.0), Point(3.5, -1.0)), field.enemyDefenseArea());
@@ -74,6 +74,8 @@ TEST(FieldTest, equality_operators)
     field_other.updateDimensions(length, width, goal_width, defense_length, defense_width,
                                  boundary_width, center_circle_radius);
 
+    // field and field_other have been updated with the same dimensions, so
+    // should be equal
     EXPECT_EQ(invalid_field, invalid_field);
     EXPECT_NE(invalid_field, field);
     EXPECT_NE(invalid_field, field_other);

--- a/src/thunderbots/software/test/world/field.cpp
+++ b/src/thunderbots/software/test/world/field.cpp
@@ -25,7 +25,7 @@ TEST(FieldTest, update_and_accessors)
     double boundary_width       = 0.3;
     double center_circle_radius = 0.5;
 
-    field.updateDimensions(length, width, goal_width, defense_length, defense_width,
+    field.updateDimensions(length, width, defense_length, defense_width, goal_width,
                            boundary_width, center_circle_radius);
 
     EXPECT_TRUE(field.valid());
@@ -67,11 +67,11 @@ TEST(FieldTest, equality_operators)
     Field invalid_field = Field();
 
     Field field = Field();
-    field.updateDimensions(length, width, goal_width, defense_length, defense_width,
+    field.updateDimensions(length, width, defense_length, defense_width, goal_width,
                            boundary_width, center_circle_radius);
 
     Field field_other = Field();
-    field_other.updateDimensions(length, width, goal_width, defense_length, defense_width,
+    field_other.updateDimensions(length, width, defense_length, defense_width, goal_width,
                                  boundary_width, center_circle_radius);
 
     // field and field_other have been updated with the same dimensions, so
@@ -83,7 +83,7 @@ TEST(FieldTest, equality_operators)
     EXPECT_EQ(field, field);
 
     // Update with the same dimensions as above, except for a slightly larger length
-    field_other.updateDimensions(length + 0.02, width, goal_width, defense_length,
+    field_other.updateDimensions(length + 0.02, width, defense_length, goal_width,
                                  defense_width, boundary_width, center_circle_radius);
 
     EXPECT_NE(field, field_other);

--- a/src/thunderbots/software/util/ros_messages.cpp
+++ b/src/thunderbots/software/util/ros_messages.cpp
@@ -1,0 +1,17 @@
+#include "util/ros_messages.h"
+
+namespace Util
+{
+    namespace ROSMessages
+    {
+        Ball createBallFromROSMessage(const thunderbots_msgs::Ball& ball_msg)
+        {
+            Point ball_position  = Point(ball_msg.position.x, ball_msg.position.y);
+            Vector ball_velocity = Vector(ball_msg.velocity.x, ball_msg.velocity.y);
+
+            Ball ball = Ball(ball_position, ball_velocity);
+
+            return ball;
+        }
+    }
+}

--- a/src/thunderbots/software/util/ros_messages.h
+++ b/src/thunderbots/software/util/ros_messages.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ai/world/ball.h"
+#include "thunderbots_msgs/Ball.h"
+
+namespace Util
+{
+    /**
+     * Functions in this namespace provide functions that assist in converting between
+     * a ROS message and its equivalent class
+     */
+    namespace ROSMessages
+    {
+        /**
+         * Given a Ball message, constructs and returns a Ball object
+         *
+         * @param ball_msg The message containing the ball message data
+         * @return A Ball object created with the given ball message data
+         */
+        Ball createBallFromROSMessage(const thunderbots_msgs::Ball& ball_msg);
+    }
+}


### PR DESCRIPTION
Added an implementation for the Ball class
* `update` function with the ROS message removed as per @jordanzliu 's suggestion in #45 to keep our datastructures indepdendent of ROS. Utility methods to convert between messages and object are used instead at the highest level

Part of #41 