### PR TITLE
Implement robot class

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -216,6 +216,7 @@ if (CATKIN_ENABLE_TESTING)
             test/util/ros_messages.cpp
             util/ros_messages.cpp
             ai/world/ball.cpp
+            ai/world/robot.cpp
             geom/point.h
             geom/angle.h)
 

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -77,8 +77,8 @@ file(GLOB_RECURSE BACKEND_INPUT_SRC LIST_DIRECTORIES false CONFIGURE_DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/backend_input/*.h
         ${CMAKE_CURRENT_SOURCE_DIR}/geom/*.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/geom/*.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/ai/world/team.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/ai/world/ball.*
+        ${CMAKE_CURRENT_SOURCE_DIR}/ai/world/*.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ai/world/*.h
         ${CMAKE_CURRENT_SOURCE_DIR}/util/*.h
         ${CMAKE_CURRENT_SOURCE_DIR}/util/*.cpp
         )

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -204,6 +204,14 @@ if (CATKIN_ENABLE_TESTING)
 
     target_link_libraries(ball_test ${catkin_LIBRARIES})
 
+    catkin_add_gtest(robot_test
+            test/world/robot.cpp
+            ai/world/robot.cpp
+            geom/point.h
+            geom/angle.h)
+
+    target_link_libraries(robot_test ${catkin_LIBRARIES})
+
     catkin_add_gtest(ros_message_util_test
             test/util/ros_messages.cpp
             util/ros_messages.cpp

--- a/src/thunderbots/software/ai/world/ball.cpp
+++ b/src/thunderbots/software/ai/world/ball.cpp
@@ -15,7 +15,12 @@ void Ball::update(const Point &new_position, const Vector &new_velocity)
     velocity_ = new_velocity;
 }
 
-Point Ball::position(double time_delta) const
+Point Ball::position() const
+{
+    return position_;
+}
+
+Point Ball::estimatePositionAtFutureTime(double time_delta) const
 {
     // TODO: This is a simple linear implementation that does not necessarily reflect
     // real-world behavior. Position prediction should be improved as outlined in
@@ -23,7 +28,12 @@ Point Ball::position(double time_delta) const
     return position_ + (velocity_.norm(time_delta * velocity_.len()));
 }
 
-Vector Ball::velocity(double time_delta) const
+Vector Ball::velocity() const
+{
+    return velocity_;
+}
+
+Vector Ball::estimateVelocityAtFutureTime(double time_delta) const
 {
     // TODO: This is a implementation with an empirically determined time constant that
     // does not necessarily reflect real-world behavior. Velocity prediction should be

--- a/src/thunderbots/software/ai/world/ball.h
+++ b/src/thunderbots/software/ai/world/ball.h
@@ -32,24 +32,44 @@ class Ball final
     void update(const Ball& new_ball_data);
 
     /**
-     * Get the predicted position of the ball at a time relative to the current time.
-     * Using the default of 0 will give the current position of the ball.
+     * Returns the current position of the ball
      *
-     * @param time_delta the amount of time in seconds forward to predict
-     *
-     * @return the predicted position of the ball, defined in metres
+     * @return the current position of the ball
      */
-    Point position(double time_delta = 0.0) const;
+    Point position() const;
 
     /**
-     * Get the predicted velocity of the ball at a time relative to the current time.
-     * Using the default of 0 will give the current velocity of the ball.
+     * Returns the estimated position of the ball at a future time, relative to the
+     * current time
      *
-     * @param time_delta the amount of time in seconds forwards to predict
+     * @param time_delta The relative amount of time in the future (in seconds) at which
+     * to predict the ball's position. For example, a value of 1.5 would return the
+     * estimated position of the ball 1.5s in the future.
      *
-     * @return the predicted velocity of the ball, defined in metres per second
+     * @return the estimated position of the ball at a future time.
+     * Coordinates are in metres.
      */
-    Vector velocity(double time_delta = 0.0) const;
+    Point estimatePositionAtFutureTime(double time_delta = 0.0) const;
+
+    /**
+     * Returns the current velocity of the ball
+     *
+     * @return the current velocity of the ball
+     */
+    Vector velocity() const;
+
+    /**
+     * Returns the estimated velocity of the ball at a future time, relative to the
+     * current time
+     *
+     * @param time_delta The relative amount of time in the future (in seconds) at which
+     * to predict the ball's velocity. For example, a value of 1.5 would return the
+     * estimated velocity of the ball 1.5s in the future.
+     *
+     * @return the estimated velocity of the ball at a future time.
+     * Coordinates are in metres.
+     */
+    Vector estimateVelocityAtFutureTime(double time_delta = 0.0) const;
 
     /**
      * Defines the equality operator for a Ball. Balls are equal if their positions and

--- a/src/thunderbots/software/ai/world/robot.cpp
+++ b/src/thunderbots/software/ai/world/robot.cpp
@@ -11,11 +11,11 @@ Robot::Robot(const unsigned int id)
 
 Robot::Robot(unsigned int id, const Point &position, const Vector &velocity,
              const Angle &orientation, const AngularVelocity &angular_velocity)
-        : id_(id),
-          position_(position),
-          velocity_(velocity),
-          orientation_(orientation),
-          angularVelocity_(angular_velocity)
+    : id_(id),
+      position_(position),
+      velocity_(velocity),
+      orientation_(orientation),
+      angularVelocity_(angular_velocity)
 {
 }
 
@@ -29,16 +29,20 @@ void Robot::update(const Point &new_position, const Vector &new_velocity,
     angularVelocity_ = new_angular_velocity;
 }
 
-void Robot::update(const Robot &new_robot_data) {
-    if(new_robot_data.id() != id()) {
+void Robot::update(const Robot &new_robot_data)
+{
+    if (new_robot_data.id() != id())
+    {
         // TODO: Throw a proper exception here. We should not update a robot using a robot
         // with a different id (a different robot)
         // https://github.com/UBC-Thunderbots/Software/issues/16
-        std::cerr << "Error: Robot updated using a robot with a mismatched id" << std::endl;
+        std::cerr << "Error: Robot updated using a robot with a mismatched id"
+                  << std::endl;
         exit(1);
     }
 
-    update(new_robot_data.position(), new_robot_data.velocity(), new_robot_data.orientation(), new_robot_data.angularVelocity());
+    update(new_robot_data.position(), new_robot_data.velocity(),
+           new_robot_data.orientation(), new_robot_data.angularVelocity());
 }
 
 unsigned int Robot::id() const

--- a/src/thunderbots/software/ai/world/robot.cpp
+++ b/src/thunderbots/software/ai/world/robot.cpp
@@ -50,7 +50,12 @@ unsigned int Robot::id() const
     return id_;
 }
 
-Point Robot::position(const double time_delta) const
+Point Robot::position() const
+{
+    return position_;
+}
+
+Point Robot::estimatePositionAtFutureTime(double time_delta) const
 {
     // TODO: This is a simple linear implementation that does not necessarily reflect
     // real-world behavior. Position prediction should be improved as outlined in
@@ -58,7 +63,12 @@ Point Robot::position(const double time_delta) const
     return position_ + velocity_.norm(velocity_.len() * time_delta);
 }
 
-Vector Robot::velocity(const double time_delta) const
+Vector Robot::velocity() const
+{
+    return velocity_;
+}
+
+Vector Robot::estimateVelocityAtFutureTime(double time_delta) const
 {
     // TODO: This simple implementation that assumes the robot maintains the same velocity
     // and does not necessarily reflect real-world behavior. Velocity prediction should be
@@ -66,7 +76,12 @@ Vector Robot::velocity(const double time_delta) const
     return velocity_;
 }
 
-Angle Robot::orientation(const double time_delta) const
+Angle Robot::orientation() const
+{
+    return orientation_;
+}
+
+Angle Robot::estimateOrientationAtFutureTime(double time_delta) const
 {
     // TODO: This is a simple linear implementation that does not necessarily reflect
     // real-world behavior. Orientation prediction should be improved as outlined in
@@ -74,7 +89,12 @@ Angle Robot::orientation(const double time_delta) const
     return orientation_ + angularVelocity_ * time_delta;
 }
 
-AngularVelocity Robot::angularVelocity(const double time_delta) const
+AngularVelocity Robot::angularVelocity() const
+{
+    return angularVelocity_;
+}
+
+AngularVelocity Robot::estimateAngularVelocityAtFutureTime(double time_delta) const
 {
     // TODO: This simple implementation that assumes the robot maintains the same
     // angular velocity and does not necessarily reflect real-world behavior. Angular

--- a/src/thunderbots/software/ai/world/robot.cpp
+++ b/src/thunderbots/software/ai/world/robot.cpp
@@ -9,6 +9,16 @@ Robot::Robot(const unsigned int id)
 {
 }
 
+Robot::Robot(unsigned int id, const Point &position, const Vector &velocity,
+             const Angle &orientation, const AngularVelocity &angular_velocity)
+        : id_(id),
+          position_(position),
+          velocity_(velocity),
+          orientation_(orientation),
+          angularVelocity_(angular_velocity)
+{
+}
+
 void Robot::update(const Point &new_position, const Vector &new_velocity,
                    const Angle &new_orientation,
                    const AngularVelocity &new_angular_velocity)
@@ -19,16 +29,16 @@ void Robot::update(const Point &new_position, const Vector &new_velocity,
     angularVelocity_ = new_angular_velocity;
 }
 
-void Robot::update(const thunderbots_msgs::Robot &robot_msg)
-{
-    assert(robot_msg.id == id_);
+void Robot::update(const Robot &new_robot_data) {
+    if(new_robot_data.id() != id()) {
+        // TODO: Throw a proper exception here. We should not update a robot using a robot
+        // with a different id (a different robot)
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+        std::cerr << "Error: Robot updated using a robot with a mismatched id" << std::endl;
+        exit(1);
+    }
 
-    Point position         = Point(robot_msg.position.x, robot_msg.position.y);
-    Point velocity         = Vector(robot_msg.velocity.x, robot_msg.velocity.y);
-    Angle orientation      = Angle::ofRadians(robot_msg.orientation);
-    Angle angular_velocity = AngularVelocity::ofRadians(robot_msg.angular_velocity);
-
-    update(position, velocity, orientation, angular_velocity);
+    update(new_robot_data.position(), new_robot_data.velocity(), new_robot_data.orientation(), new_robot_data.angularVelocity());
 }
 
 unsigned int Robot::id() const
@@ -38,20 +48,46 @@ unsigned int Robot::id() const
 
 Point Robot::position(const double time_delta) const
 {
-    return position_;
+    // TODO: This is a simple linear implementation that does not necessarily reflect
+    // real-world behavior. Position prediction should be improved as outlined in
+    // https://github.com/UBC-Thunderbots/Software/issues/50
+    return position_ + velocity_.norm(velocity_.len() * time_delta);
 }
 
 Vector Robot::velocity(const double time_delta) const
 {
+    // TODO: This simple implementation that assumes the robot maintains the same velocity
+    // and does not necessarily reflect real-world behavior. Velocity prediction should be
+    // improved as outlined in https://github.com/UBC-Thunderbots/Software/issues/50
     return velocity_;
 }
 
 Angle Robot::orientation(const double time_delta) const
 {
-    return orientation_;
+    // TODO: This is a simple linear implementation that does not necessarily reflect
+    // real-world behavior. Orientation prediction should be improved as outlined in
+    // https://github.com/UBC-Thunderbots/Software/issues/50
+    return orientation_ + angularVelocity_ * time_delta;
 }
 
 AngularVelocity Robot::angularVelocity(const double time_delta) const
 {
+    // TODO: This simple implementation that assumes the robot maintains the same
+    // angular velocity and does not necessarily reflect real-world behavior. Angular
+    // velocity prediction should be improved as outlined in
+    // https://github.com/UBC-Thunderbots/Software/issues/50
     return angularVelocity_;
+}
+
+bool Robot::operator==(const Robot &other) const
+{
+    return this->id_ == other.id_ && this->position_ == other.position_ &&
+           this->velocity_ == other.velocity_ &&
+           this->orientation_ == other.orientation_ &&
+           this->angularVelocity_ == other.angularVelocity_;
+}
+
+bool Robot::operator!=(const Robot &other) const
+{
+    return !(*this == other);
 }

--- a/src/thunderbots/software/ai/world/robot.h
+++ b/src/thunderbots/software/ai/world/robot.h
@@ -58,48 +58,84 @@ class Robot
     unsigned int id() const;
 
     /**
-     * Get the predicted position of the robot at a time relative to the current time.
-     * Using the default of 0 will give the current position of the robot.
+     * Returns the current position of the robot
      *
-     * @param time_delta The relative amount of time in the future (in seconds) at which
-     * to predict the robot's position.
-     *
-     * @return the predicted position of the robot. Coordinates are in metres.
+     * @return the current position of the robot
      */
-    Point position(double time_delta = 0.0) const;
+    Point position() const;
 
     /**
-     * Get the predicted velocity of the robot at a time relative to the current time.
-     * Using the default of 0 will give the current velocity of the robot.
+     * Returns the estimated position of the robot at a future time, relative to the
+     * current time
      *
      * @param time_delta The relative amount of time in the future (in seconds) at which
-     * to predict the robot's position.
+     * to predict the robot's position. For example, a value of 1.5 would return the
+     * estimated position of the robot 1.5s in the future.
      *
-     * @return the predicted velocity of the robot, in metres / second.
+     * @return the estimated position of the robot at a future time.
+     * Coordinates are in metres.
      */
-    Vector velocity(double time_delta = 0.0) const;
+    Point estimatePositionAtFutureTime(double time_delta = 0.0) const;
 
     /**
-     * Get the predicted orientation of the robot at a time relative to the current time.
-     * Using the default of 0 will give the current orientation of the robot.
+     * Returns the current velocity of the robot
      *
-     * @param time_delta The relative amount of time in the future (in seconds) at which
-     * to predict the robot's position.
-     *
-     * @return the predicted orientation of the robot, in Radians.
+     * @return the current velocity of the robot
      */
-    Angle orientation(double time_delta = 0.0) const;
+    Vector velocity() const;
 
     /**
-     * Get the predicted angular velocity of the robot at a time relative to the current
-     * time. Using the default of 0 will give the current orientation of the robot.
+     * Returns the estimated velocity of the robot at a future time, relative to the
+     * current time
      *
      * @param time_delta The relative amount of time in the future (in seconds) at which
-     * to predict the robot's position.
+     * to predict the robot's velocity. For example, a value of 1.5 would return the
+     * estimated velocity of the robot 1.5s in the future.
      *
-     * @return the predicted angular velocity of the robot, in Radians / second.
+     * @return the estimated velocity of the robot at a future time.
+     * Coordinates are in metres.
      */
-    AngularVelocity angularVelocity(double time_delta = 0.0) const;
+    Vector estimateVelocityAtFutureTime(double time_delta = 0.0) const;
+
+    /**
+     * Returns the current orientation of the robot
+     *
+     * @return the current orientation of the robot
+     */
+    Angle orientation() const;
+
+    /**
+     * Returns the estimated orientation of the robot at a future time, relative to the
+     * current time
+     *
+     * @param time_delta The relative amount of time in the future (in seconds) at which
+     * to predict the robot's orientation. For example, a value of 1.5 would return the
+     * estimated orientation of the robot 1.5s in the future.
+     *
+     * @return the estimated orientation of the robot at a future time.
+     * Coordinates are in metres.
+     */
+    Angle estimateOrientationAtFutureTime(double time_delta = 0.0) const;
+
+    /**
+     * Returns the current angular velocity of the robot
+     *
+     * @return the current angular velocity of the robot
+     */
+    AngularVelocity angularVelocity() const;
+
+    /**
+     * Returns the estimated angular velocity of the robot at a future time, relative to
+     * the current time
+     *
+     * @param time_delta The relative amount of time in the future (in seconds) at which
+     * to predict the robot's angular velocity. For example, a value of 1.5 would return
+     * the estimated angular velocity of the robot 1.5s in the future.
+     *
+     * @return the estimated angular velocity of the robot at a future time.
+     * Coordinates are in metres.
+     */
+    AngularVelocity estimateAngularVelocityAtFutureTime(double time_delta = 0.0) const;
 
     /**
      * Defines the equality operator for a Robot. Robots are equal if their IDs and

--- a/src/thunderbots/software/ai/world/robot.h
+++ b/src/thunderbots/software/ai/world/robot.h
@@ -2,7 +2,6 @@
 
 #include "geom/angle.h"
 #include "geom/point.h"
-#include "thunderbots_msgs/Robot.h"
 
 /**
  * Defines an SSL robot
@@ -12,8 +11,23 @@ class Robot
    public:
     /**
      * Creates a new robot given a pattern id
+     *
+     * @param id The id of the robot to create
      */
     explicit Robot(unsigned int id);
+
+    /**
+     * Creates a new robot given robot data
+     *
+     * @param id The id of the robot to create
+     * @param position the new position of the robot. Coordinates are in metres.
+     * @param velocity the new velocity of the robot, in metres / second.
+     * @param orientation the new orientation of the robot, in Radians.
+     * @param angular_velocity the new angular velocity of the robot, in Radians
+     * per second
+     */
+    explicit Robot(unsigned int id, const Point& position, const Vector& velocity,
+                   const Angle& orientation, const AngularVelocity& angular_velocity);
 
     /**
      * Updates the state of the robot.
@@ -29,11 +43,12 @@ class Robot
                 const AngularVelocity& new_angular_velocity);
 
     /**
-     * Updates the state of the robot.
+     * Updates the robot with new data, updating the current state as well as the
+     * predictive model
      *
-     * @param robot_msg the Robot message containing the new data to update with
+     * @param new_robot_data A robot containing new robot data
      */
-    void update(const thunderbots_msgs::Robot& robot_msg);
+    void update(const Robot& new_robot_data);
 
     /**
      * Returns the id of the robot
@@ -86,10 +101,32 @@ class Robot
      */
     AngularVelocity angularVelocity(double time_delta = 0.0) const;
 
+    /**
+     * Defines the equality operator for a Robot. Robots are equal if their IDs and
+     * all other parameters (position, orientation, etc) are equal
+     *
+     * @param other The robot to compare against for equality
+     * @return True if the other robot is equal to this robot, and false otherwise
+     */
+    bool operator==(const Robot& other) const;
+
+    /**
+     * Defines the inequality operator for a Robot.
+     *
+     * @param other The robot to compare against for inequality
+     * @return True if the other robot is not equal to this robots, and false otherwise
+     */
+    bool operator!=(const Robot& other) const;
+
    private:
+    // The id of this robot
     const unsigned int id_;
+    // The current position of the robot, with coordinates in metres
     Point position_;
+    // The current velocity of the robot, in metres per second
     Vector velocity_;
+    // The current orientation of the robot, in radians
     Angle orientation_;
+    // The current angular velocity of the robot, in radians per second
     AngularVelocity angularVelocity_;
 };

--- a/src/thunderbots/software/geom/angle.h
+++ b/src/thunderbots/software/geom/angle.h
@@ -12,6 +12,16 @@
 class Angle final
 {
    public:
+    // Due to internal representation of doubles being slightly less accurate/consistent
+    // with some numbers and operations, we consider angles that are very close together
+    // to be equal (since they likely are, just possibly slightly misrepresented by the
+    // system/compiler). We use this EPSILON as a threshold for comparison. 1e-15 was
+    // chosen as a value because doubles have about 16 consistent significant figures.
+    // Comparing numbers with 15 significant figures gives us a
+    // small buffer while remaining as accurate as possible.
+    // http://www.cplusplus.com/forum/beginner/95128/
+    static constexpr double EPSILON = 1e-15;
+
     /**
      * The zero angle.
      */
@@ -345,8 +355,7 @@ constexpr bool operator<=(Angle x, Angle y);
 constexpr bool operator>=(Angle x, Angle y);
 
 /**
- * Compares two angles for equality. Angles are considered equal if their difference is no
- * greater than 1e-15 radians
+ * Compares two angles for equality
  *
  * @param x the first angle.
  * @param y the second angle.
@@ -578,15 +587,7 @@ inline constexpr bool operator>=(Angle x, Angle y)
 
 inline bool operator==(Angle x, Angle y)
 {
-    // Due to internal representation of doubles being slightly less accurate/consistent
-    // with some numbers and operations, we consider angles that are very close together
-    // to be equal (since they likely are, just possibly slightly misrepresented by the
-    // system/compiler). 1e-15 was chosen as a value because doubles have about 16 digits
-    // of precision. Comparing numbers with 15 digits of precision gives us a small buffer
-    // while remaining as accurate as possible.
-    // http://www.cplusplus.com/forum/beginner/95128/
-    double EPS = 1e-15;
-    return (std::fabs(x.toRadians() - y.toRadians()) <= EPS);
+    return (std::fabs(x.toRadians() - y.toRadians()) <= Angle::EPSILON);
 }
 
 inline constexpr bool operator!=(Angle x, Angle y)

--- a/src/thunderbots/software/geom/angle.h
+++ b/src/thunderbots/software/geom/angle.h
@@ -345,14 +345,15 @@ constexpr bool operator<=(Angle x, Angle y);
 constexpr bool operator>=(Angle x, Angle y);
 
 /**
- * Compares two angles for equality.
+ * Compares two angles for equality. Angles are considered equal if their difference is no
+ * greater than 1e-15 radians
  *
  * @param x the first angle.
  * @param y the second angle.
  *
  * @return true if x is equal to y, and false otherwise.
  */
-constexpr bool operator==(Angle x, Angle y);
+bool operator==(Angle x, Angle y);
 
 /**
  * Compares two angles for inequality.
@@ -575,9 +576,17 @@ inline constexpr bool operator>=(Angle x, Angle y)
     return x.toRadians() >= y.toRadians();
 }
 
-inline constexpr bool operator==(Angle x, Angle y)
+inline bool operator==(Angle x, Angle y)
 {
-    return x.toRadians() == y.toRadians();
+    // Due to internal representation of doubles being slightly less accurate/consistent
+    // with some numbers and operations, we consider angles that are very close together
+    // to be equal (since they likely are, just possibly slightly misrepresented by the
+    // system/compiler). 1e-15 was chosen as a value because doubles have about 16 digits
+    // of precision. Comparing numbers with 15 digits of precision gives us a small buffer
+    // while remaining as accurate as possible.
+    // http://www.cplusplus.com/forum/beginner/95128/
+    double EPS = 1e-15;
+    return (std::fabs(x.toRadians() - y.toRadians()) <= EPS);
 }
 
 inline constexpr bool operator!=(Angle x, Angle y)

--- a/src/thunderbots/software/geom/point.h
+++ b/src/thunderbots/software/geom/point.h
@@ -327,7 +327,8 @@ Point &operator/=(Point &p, double s);
 inline std::ostream &operator<<(std::ostream &os, const Point &p);
 
 /**
- * Compares two vectors for equality
+ * Compares two Points for equality. Points are considered equal if they
+ * are within a distance of 1e-15 from each other.
  *
  * @param p the first Point
  * @param q the second Point
@@ -513,7 +514,15 @@ inline std::ostream &operator<<(std::ostream &os, const Point &p)
 
 inline constexpr bool operator==(const Point &p, const Point &q)
 {
-    return p.x() == q.x() && p.y() == q.y();
+    // Due to internal representation of doubles being slightly less accurate/consistent
+    // with some numbers and operations, we consider points that are very close together
+    // to be equal (since they likely are, just possibly slightly misrepresented by the
+    // system/compiler). 1e-15 was chosen as a value because doubles have about 16 digits
+    // of precision. Comparing numbers with 15 digits of precision gives us a small buffer
+    // while remaining as accurate as possible.
+    // http://www.cplusplus.com/forum/beginner/95128/
+    double EPS = 1e-15;
+    return p.isClose(q, EPS);
 }
 
 inline constexpr bool operator!=(const Point &p, const Point &q)

--- a/src/thunderbots/software/geom/point.h
+++ b/src/thunderbots/software/geom/point.h
@@ -14,6 +14,16 @@
 class Point final
 {
    public:
+    // Due to internal representation of doubles being slightly less accurate/consistent
+    // with some numbers and operations, we consider points that are very close together
+    // to be equal (since they likely are, just possibly slightly misrepresented by the
+    // system/compiler). We use this EPSILON as a threshold for comparison. 1e-15 was
+    // chosen as a value because doubles have about 16 consistent significant figures.
+    // Comparing numbers with 15 significant figures gives us a
+    // small buffer while remaining as accurate as possible.
+    // http://www.cplusplus.com/forum/beginner/95128/
+    static constexpr double EPSILON = 1e-15;
+
     /**
      * Creates a Point at the origin (0, 0).
      */
@@ -327,8 +337,7 @@ Point &operator/=(Point &p, double s);
 inline std::ostream &operator<<(std::ostream &os, const Point &p);
 
 /**
- * Compares two Points for equality. Points are considered equal if they
- * are within a distance of 1e-15 from each other.
+ * Compares two Points for equality
  *
  * @param p the first Point
  * @param q the second Point
@@ -514,15 +523,7 @@ inline std::ostream &operator<<(std::ostream &os, const Point &p)
 
 inline constexpr bool operator==(const Point &p, const Point &q)
 {
-    // Due to internal representation of doubles being slightly less accurate/consistent
-    // with some numbers and operations, we consider points that are very close together
-    // to be equal (since they likely are, just possibly slightly misrepresented by the
-    // system/compiler). 1e-15 was chosen as a value because doubles have about 16 digits
-    // of precision. Comparing numbers with 15 digits of precision gives us a small buffer
-    // while remaining as accurate as possible.
-    // http://www.cplusplus.com/forum/beginner/95128/
-    double EPS = 1e-15;
-    return p.isClose(q, EPS);
+    return p.isClose(q, Point::EPSILON);
 }
 
 inline constexpr bool operator!=(const Point &p, const Point &q)

--- a/src/thunderbots/software/test/util/ros_messages.cpp
+++ b/src/thunderbots/software/test/util/ros_messages.cpp
@@ -15,6 +15,29 @@ TEST(ROSMessageUtilTest, create_ball_from_ros_message)
     EXPECT_EQ(Ball(Point(1.2, -8.07), Vector(0, 3)), ball);
 }
 
+TEST(ROSMessageUtilTest, create_robot_from_ros_message)
+{
+    unsigned int id                  = 2;
+    Point position                   = Point(1.2, -8.07);
+    Vector velocity                  = Vector(0, 3);
+    Angle orientation                = Angle::ofRadians(1.16);
+    AngularVelocity angular_velocity = AngularVelocity::ofRadians(-0.85);
+
+    thunderbots_msgs::Robot robot_msg;
+
+    robot_msg.id               = id;
+    robot_msg.position.x       = position.x();
+    robot_msg.position.y       = position.y();
+    robot_msg.velocity.x       = velocity.x();
+    robot_msg.velocity.y       = velocity.y();
+    robot_msg.orientation      = orientation.toRadians();
+    robot_msg.angular_velocity = angular_velocity.toRadians();
+
+    Robot robot = Util::ROSMessages::createRobotFromROSMessage(robot_msg);
+
+    EXPECT_EQ(Robot(id, position, velocity, orientation, angular_velocity), robot);
+}
+
 int main(int argc, char **argv)
 {
     std::cout << argv[0] << std::endl;

--- a/src/thunderbots/software/test/world/ball.cpp
+++ b/src/thunderbots/software/test/world/ball.cpp
@@ -58,37 +58,21 @@ TEST(BallTest, get_position_at_current_time)
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
 
     EXPECT_EQ(Point(3, 7), ball.position());
-    EXPECT_EQ(Point(3, 7), ball.position(0));
 }
 
 TEST(BallTest, predict_future_position)
 {
     Ball ball = Ball(Point(), Vector(1, 2));
 
-    EXPECT_EQ(Point(1, 2), ball.position(1));
-    EXPECT_EQ(Point(2, 4), ball.position(2));
-    EXPECT_EQ(Point(0.15, 0.3), ball.position(0.15));
+    EXPECT_EQ(Point(1, 2), ball.estimatePositionAtFutureTime(1));
+    EXPECT_EQ(Point(2, 4), ball.estimatePositionAtFutureTime(2));
+    EXPECT_EQ(Point(0.15, 0.3), ball.estimatePositionAtFutureTime(0.15));
 
     ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
 
-    EXPECT_EQ(Point(-1.5, 6.88), ball.position(1));
-    EXPECT_EQ(Point(-6, 6.76), ball.position(2));
-    EXPECT_EQ(Point(2.325, 6.982), ball.position(0.15));
-}
-
-TEST(BallTest, predict_past_position)
-{
-    Ball ball = Ball(Point(), Vector(1, 2));
-
-    EXPECT_EQ(Point(-1, -2), ball.position(-1));
-    EXPECT_EQ(Point(-2, -4), ball.position(-2));
-    EXPECT_EQ(Point(-0.15, -0.3), ball.position(-0.15));
-
-    ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
-
-    EXPECT_EQ(Point(7.5, 7.12), ball.position(-1));
-    EXPECT_EQ(Point(12, 7.24), ball.position(-2));
-    EXPECT_EQ(Point(3.675, 7.018), ball.position(-0.15));
+    EXPECT_EQ(Point(-1.5, 6.88), ball.estimatePositionAtFutureTime(1));
+    EXPECT_EQ(Point(-6, 6.76), ball.estimatePositionAtFutureTime(2));
+    EXPECT_EQ(Point(2.325, 6.982), ball.estimatePositionAtFutureTime(0.15));
 }
 
 TEST(BallTest, get_velocity_at_current_time)
@@ -96,7 +80,6 @@ TEST(BallTest, get_velocity_at_current_time)
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
 
     EXPECT_EQ(Vector(-4.5, -0.12), ball.velocity());
-    EXPECT_EQ(Vector(-4.5, -0.12), ball.velocity(0));
 }
 
 TEST(BallTest, predict_future_velocity)
@@ -106,33 +89,21 @@ TEST(BallTest, predict_future_velocity)
     // A small distance to check that values are approximately equal
     double EPSILON = 1e-4;
 
-    EXPECT_TRUE(Vector(0.9851, 1.9702).isClose(ball.velocity(0.15), EPSILON));
-    EXPECT_TRUE(Vector(0.9048, 1.8097).isClose(ball.velocity(1), EPSILON));
-    EXPECT_TRUE(Vector(0.8187, 1.6375).isClose(ball.velocity(2), EPSILON));
+    EXPECT_TRUE(
+        Vector(0.9851, 1.9702).isClose(ball.estimateVelocityAtFutureTime(0.15), EPSILON));
+    EXPECT_TRUE(
+        Vector(0.9048, 1.8097).isClose(ball.estimateVelocityAtFutureTime(1), EPSILON));
+    EXPECT_TRUE(
+        Vector(0.8187, 1.6375).isClose(ball.estimateVelocityAtFutureTime(2), EPSILON));
 
     ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
 
-    EXPECT_TRUE(Vector(-4.4330, -0.1182).isClose(ball.velocity(0.15), EPSILON));
-    EXPECT_TRUE(Vector(-4.0717, -0.1086).isClose(ball.velocity(1), EPSILON));
-    EXPECT_TRUE(Vector(-3.6843, -0.0982).isClose(ball.velocity(2), EPSILON));
-}
-
-TEST(BallTest, predict_past_velocity)
-{
-    Ball ball = Ball(Point(), Vector(1, 2));
-
-    // A small distance to check that values are approximately equal
-    double EPSILON = 1e-4;
-
-    EXPECT_TRUE(Vector(1.0151, 2.0302).isClose(ball.velocity(-0.15), EPSILON));
-    EXPECT_TRUE(Vector(1.1052, 2.2103).isClose(ball.velocity(-1), EPSILON));
-    EXPECT_TRUE(Vector(1.2214, 2.4428).isClose(ball.velocity(-2), EPSILON));
-
-    ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
-
-    EXPECT_TRUE(Vector(-4.5680, -0.1218).isClose(ball.velocity(-0.15), EPSILON));
-    EXPECT_TRUE(Vector(-4.9733, -0.1326).isClose(ball.velocity(-1), EPSILON));
-    EXPECT_TRUE(Vector(-5.4963, -0.1466).isClose(ball.velocity(-2), EPSILON));
+    EXPECT_TRUE(Vector(-4.4330, -0.1182)
+                    .isClose(ball.estimateVelocityAtFutureTime(0.15), EPSILON));
+    EXPECT_TRUE(
+        Vector(-4.0717, -0.1086).isClose(ball.estimateVelocityAtFutureTime(1), EPSILON));
+    EXPECT_TRUE(
+        Vector(-3.6843, -0.0982).isClose(ball.estimateVelocityAtFutureTime(2), EPSILON));
 }
 
 TEST(BallTest, equality_operators)

--- a/src/thunderbots/software/test/world/robot.cpp
+++ b/src/thunderbots/software/test/world/robot.cpp
@@ -1,0 +1,233 @@
+#include "ai/world/robot.h"
+#include <gtest/gtest.h>
+
+TEST(RobotTest, construct_with_id_only)
+{
+    Robot robot = Robot(0);
+
+    EXPECT_EQ(0, robot.id());
+    EXPECT_EQ(Point(), robot.position());
+    EXPECT_EQ(Vector(), robot.velocity());
+    EXPECT_EQ(Angle::zero(), robot.orientation());
+    EXPECT_EQ(AngularVelocity::zero(), robot.angularVelocity());
+}
+
+TEST(RobotTest, construct_with_all_params)
+{
+    Robot robot = Robot(3, Point(1, 1), Vector(-0.3, 0), Angle::ofRadians(2.2), AngularVelocity::ofRadians(-0.6));
+
+    EXPECT_EQ(3, robot.id());
+    EXPECT_EQ(Point(1, 1), robot.position());
+    EXPECT_EQ(Vector(-0.3, 0), robot.velocity());
+    EXPECT_EQ(Angle::ofRadians(2.2), robot.orientation());
+    EXPECT_EQ(AngularVelocity::ofRadians(-0.6), robot.angularVelocity());
+}
+
+TEST(RobotTest, update_with_all_params)
+{
+    Robot robot = Robot(0);
+
+    robot.update(Point(-1.2, 3), Vector(2.2, -0.05), Angle::quarter(),
+                 AngularVelocity::ofRadians(1.1));
+
+    EXPECT_EQ(0, robot.id());
+    EXPECT_EQ(Point(-1.2, 3), robot.position());
+    EXPECT_EQ(Vector(2.2, -0.05), robot.velocity());
+    EXPECT_EQ(Angle::quarter(), robot.orientation());
+    EXPECT_EQ(AngularVelocity::ofRadians(1.1), robot.angularVelocity());
+}
+
+TEST(RobotTest, update_specific_params)
+{
+    Robot robot = Robot(0);
+
+    // Only update certain parameters and leave the rest as their previous values
+    robot.update(robot.position(), Vector(2.2, -0.05), robot.orientation(),
+                 AngularVelocity::ofRadians(1.1));
+
+    EXPECT_EQ(0, robot.id());
+    EXPECT_EQ(Point(), robot.position());
+    EXPECT_EQ(Vector(2.2, -0.05), robot.velocity());
+    EXPECT_EQ(Angle::zero(), robot.orientation());
+    EXPECT_EQ(AngularVelocity::ofRadians(1.1), robot.angularVelocity());
+
+    // Repeat with a different combination of parameters
+    robot.update(Point(-1.2, 3), robot.velocity(), Angle::quarter(),
+                 robot.angularVelocity());
+
+    EXPECT_EQ(0, robot.id());
+    EXPECT_EQ(Point(-1.2, 3), robot.position());
+    EXPECT_EQ(Vector(2.2, -0.05), robot.velocity());
+    EXPECT_EQ(Angle::quarter(), robot.orientation());
+    EXPECT_EQ(AngularVelocity::ofRadians(1.1), robot.angularVelocity());
+}
+
+TEST(RobotTest, update_with_new_robot)
+{
+    Robot robot = Robot(0);
+
+    Robot update_robot = Robot(0, Point(-1.2, 3), robot.velocity(), Angle::quarter(),
+                               robot.angularVelocity());
+
+    robot.update(update_robot);
+
+    EXPECT_EQ(robot, update_robot);
+
+    // TODO: Update this test to also test for a thrown exception once
+    // https://github.com/UBC-Thunderbots/Software/issues/16
+    // is completed. If a robot is updated using a robot with a different id, an
+    // exception should be thrown
+}
+
+TEST(RobotTest, get_position_at_current_time)
+{
+    Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
+                        AngularVelocity::ofRadians(0.7));
+
+    EXPECT_EQ(Point(-1.2, 3), robot.position());
+    EXPECT_EQ(Point(-1.2, 3), robot.position(0.0));
+}
+
+TEST(RobotTest, get_position_at_future_time)
+{
+    Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
+                        AngularVelocity::ofRadians(0.7));
+
+    EXPECT_EQ(Point(-1.4, 4.04), robot.position(0.4));
+    EXPECT_EQ(Point(-1.7, 5.6), robot.position(1));
+    EXPECT_EQ(Point(-2.7, 10.8), robot.position(3));
+
+    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                  AngularVelocity::ofRadians(2));
+
+    EXPECT_EQ(Point(2.4, -1.6), robot_other.position(0.4));
+    EXPECT_EQ(Point(4.5, -1), robot_other.position(1));
+    EXPECT_EQ(Point(11.5, 1), robot_other.position(3));
+}
+
+TEST(RobotTest, get_velocity_at_current_time)
+{
+    Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
+                        AngularVelocity::ofRadians(0.7));
+
+    EXPECT_EQ(Vector(-0.5, 2.6), robot.velocity());
+    EXPECT_EQ(Vector(-0.5, 2.6), robot.velocity(0.0));
+}
+
+TEST(RobotTest, get_velocity_at_future_time)
+{
+    Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
+                        AngularVelocity::ofRadians(0.7));
+
+    EXPECT_EQ(Point(-0.5, 2.6), robot.velocity(0.4));
+    EXPECT_EQ(Point(-0.5, 2.6), robot.velocity(1));
+    EXPECT_EQ(Point(-0.5, 2.6), robot.velocity(3));
+
+    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                              AngularVelocity::ofRadians(2));
+
+    EXPECT_EQ(Point(3.5, 1), robot_other.velocity(0.4));
+    EXPECT_EQ(Point(3.5, 1), robot_other.velocity(1));
+    EXPECT_EQ(Point(3.5, 1), robot_other.velocity(3));
+}
+
+TEST(RobotTest, get_orientation_at_current_time)
+{
+    Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
+                        AngularVelocity::ofRadians(0.7));
+
+    EXPECT_EQ(Angle::quarter(), robot.orientation());
+    EXPECT_EQ(Angle::quarter(), robot.orientation(0.0));
+}
+
+TEST(RobotTest, get_orientation_at_future_time)
+{
+    Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
+                        AngularVelocity::ofRadians(0.7));
+
+    EXPECT_EQ(Angle::quarter() + Angle::ofRadians(0.28), robot.orientation(0.4));
+    EXPECT_EQ(Angle::quarter() + Angle::ofRadians(0.7), robot.orientation(1));
+    EXPECT_EQ(Angle::quarter() + Angle::ofRadians(2.1), robot.orientation(3));
+
+    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                              AngularVelocity::ofRadians(2));
+
+    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(0.8), robot_other.orientation(0.4));
+    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(2), robot_other.orientation(1));
+    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(6), robot_other.orientation(3));
+}
+
+TEST(RobotTest, get_angular_velocity_at_current_time)
+{
+    Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
+                        AngularVelocity::ofRadians(0.7));
+
+    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity());
+    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity(0.0));
+}
+
+TEST(RobotTest, get_angularVelocity_at_future_time)
+{
+    Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
+                        AngularVelocity::ofRadians(0.7));
+
+    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity(0.4));
+    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity(1));
+    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity(3));
+
+    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                              AngularVelocity::ofRadians(2));
+
+    EXPECT_EQ(AngularVelocity::ofRadians(2), robot_other.angularVelocity(0.4));
+    EXPECT_EQ(AngularVelocity::ofRadians(2), robot_other.angularVelocity(1));
+    EXPECT_EQ(AngularVelocity::ofRadians(2), robot_other.angularVelocity(3));
+}
+
+TEST(RobotTest, equality_operators)
+{
+    Robot robot_0_0 = Robot(0);
+    robot_0_0.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
+                     AngularVelocity::ofDegrees(30));
+
+    Robot robot_0_1 = Robot(0);
+    robot_0_1.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
+                     AngularVelocity::ofDegrees(-30));
+
+    Robot robot_1 = Robot(1);
+    robot_1.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
+                   AngularVelocity::ofDegrees(30));
+
+    Robot robot_2 = Robot(2);
+    robot_2.update(Point(3, 1.2), Vector(3, 1), Angle::ofDegrees(0),
+                   AngularVelocity::ofDegrees(25));
+
+    EXPECT_EQ(robot_0_0, robot_0_0);
+    EXPECT_NE(robot_0_0, robot_0_1);
+    EXPECT_NE(robot_0_0, robot_1);
+    EXPECT_NE(robot_0_0, robot_2);
+
+    EXPECT_EQ(robot_1, robot_1);
+    EXPECT_NE(robot_1, robot_2);
+
+    EXPECT_NE(robot_0_1, robot_1);
+    EXPECT_NE(robot_0_1, robot_2);
+
+    // Update robot_2 to be the same as robot_1 (except for the robot id)
+    robot_2.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
+                   AngularVelocity::ofDegrees(30));
+
+    EXPECT_NE(robot_1, robot_2);
+
+    // Update robot_0_1 to be the same as robot_0
+    robot_0_1.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
+                   AngularVelocity::ofDegrees(30));
+
+    EXPECT_EQ(robot_0_0, robot_0_1);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/world/robot.cpp
+++ b/src/thunderbots/software/test/world/robot.cpp
@@ -86,7 +86,6 @@ TEST(RobotTest, get_position_at_current_time)
                         AngularVelocity::ofRadians(0.7));
 
     EXPECT_EQ(Point(-1.2, 3), robot.position());
-    EXPECT_EQ(Point(-1.2, 3), robot.position(0.0));
 }
 
 TEST(RobotTest, get_position_at_future_time)
@@ -94,16 +93,16 @@ TEST(RobotTest, get_position_at_future_time)
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
                         AngularVelocity::ofRadians(0.7));
 
-    EXPECT_EQ(Point(-1.4, 4.04), robot.position(0.4));
-    EXPECT_EQ(Point(-1.7, 5.6), robot.position(1));
-    EXPECT_EQ(Point(-2.7, 10.8), robot.position(3));
+    EXPECT_EQ(Point(-1.4, 4.04), robot.estimatePositionAtFutureTime(0.4));
+    EXPECT_EQ(Point(-1.7, 5.6), robot.estimatePositionAtFutureTime(1));
+    EXPECT_EQ(Point(-2.7, 10.8), robot.estimatePositionAtFutureTime(3));
 
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2));
 
-    EXPECT_EQ(Point(2.4, -1.6), robot_other.position(0.4));
-    EXPECT_EQ(Point(4.5, -1), robot_other.position(1));
-    EXPECT_EQ(Point(11.5, 1), robot_other.position(3));
+    EXPECT_EQ(Point(2.4, -1.6), robot_other.estimatePositionAtFutureTime(0.4));
+    EXPECT_EQ(Point(4.5, -1), robot_other.estimatePositionAtFutureTime(1));
+    EXPECT_EQ(Point(11.5, 1), robot_other.estimatePositionAtFutureTime(3));
 }
 
 TEST(RobotTest, get_velocity_at_current_time)
@@ -112,7 +111,6 @@ TEST(RobotTest, get_velocity_at_current_time)
                         AngularVelocity::ofRadians(0.7));
 
     EXPECT_EQ(Vector(-0.5, 2.6), robot.velocity());
-    EXPECT_EQ(Vector(-0.5, 2.6), robot.velocity(0.0));
 }
 
 TEST(RobotTest, get_velocity_at_future_time)
@@ -120,16 +118,16 @@ TEST(RobotTest, get_velocity_at_future_time)
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
                         AngularVelocity::ofRadians(0.7));
 
-    EXPECT_EQ(Point(-0.5, 2.6), robot.velocity(0.4));
-    EXPECT_EQ(Point(-0.5, 2.6), robot.velocity(1));
-    EXPECT_EQ(Point(-0.5, 2.6), robot.velocity(3));
+    EXPECT_EQ(Point(-0.5, 2.6), robot.estimateVelocityAtFutureTime(0.4));
+    EXPECT_EQ(Point(-0.5, 2.6), robot.estimateVelocityAtFutureTime(1));
+    EXPECT_EQ(Point(-0.5, 2.6), robot.estimateVelocityAtFutureTime(3));
 
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2));
 
-    EXPECT_EQ(Point(3.5, 1), robot_other.velocity(0.4));
-    EXPECT_EQ(Point(3.5, 1), robot_other.velocity(1));
-    EXPECT_EQ(Point(3.5, 1), robot_other.velocity(3));
+    EXPECT_EQ(Point(3.5, 1), robot_other.estimateVelocityAtFutureTime(0.4));
+    EXPECT_EQ(Point(3.5, 1), robot_other.estimateVelocityAtFutureTime(1));
+    EXPECT_EQ(Point(3.5, 1), robot_other.estimateVelocityAtFutureTime(3));
 }
 
 TEST(RobotTest, get_orientation_at_current_time)
@@ -138,7 +136,6 @@ TEST(RobotTest, get_orientation_at_current_time)
                         AngularVelocity::ofRadians(0.7));
 
     EXPECT_EQ(Angle::quarter(), robot.orientation());
-    EXPECT_EQ(Angle::quarter(), robot.orientation(0.0));
 }
 
 TEST(RobotTest, get_orientation_at_future_time)
@@ -146,17 +143,22 @@ TEST(RobotTest, get_orientation_at_future_time)
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
                         AngularVelocity::ofRadians(0.7));
 
-    EXPECT_EQ(Angle::quarter() + Angle::ofRadians(0.28), robot.orientation(0.4));
-    EXPECT_EQ(Angle::quarter() + Angle::ofRadians(0.7), robot.orientation(1));
-    EXPECT_EQ(Angle::quarter() + Angle::ofRadians(2.1), robot.orientation(3));
+    EXPECT_EQ(Angle::quarter() + Angle::ofRadians(0.28),
+              robot.estimateOrientationAtFutureTime(0.4));
+    EXPECT_EQ(Angle::quarter() + Angle::ofRadians(0.7),
+              robot.estimateOrientationAtFutureTime(1));
+    EXPECT_EQ(Angle::quarter() + Angle::ofRadians(2.1),
+              robot.estimateOrientationAtFutureTime(3));
 
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2));
 
     EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(0.8),
-              robot_other.orientation(0.4));
-    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(2), robot_other.orientation(1));
-    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(6), robot_other.orientation(3));
+              robot_other.estimateOrientationAtFutureTime(0.4));
+    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(2),
+              robot_other.estimateOrientationAtFutureTime(1));
+    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(6),
+              robot_other.estimateOrientationAtFutureTime(3));
 }
 
 TEST(RobotTest, get_angular_velocity_at_current_time)
@@ -165,7 +167,6 @@ TEST(RobotTest, get_angular_velocity_at_current_time)
                         AngularVelocity::ofRadians(0.7));
 
     EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity());
-    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity(0.0));
 }
 
 TEST(RobotTest, get_angularVelocity_at_future_time)
@@ -173,16 +174,22 @@ TEST(RobotTest, get_angularVelocity_at_future_time)
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
                         AngularVelocity::ofRadians(0.7));
 
-    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity(0.4));
-    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity(1));
-    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity(3));
+    EXPECT_EQ(AngularVelocity::ofRadians(0.7),
+              robot.estimateAngularVelocityAtFutureTime(0.4));
+    EXPECT_EQ(AngularVelocity::ofRadians(0.7),
+              robot.estimateAngularVelocityAtFutureTime(1));
+    EXPECT_EQ(AngularVelocity::ofRadians(0.7),
+              robot.estimateAngularVelocityAtFutureTime(3));
 
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2));
 
-    EXPECT_EQ(AngularVelocity::ofRadians(2), robot_other.angularVelocity(0.4));
-    EXPECT_EQ(AngularVelocity::ofRadians(2), robot_other.angularVelocity(1));
-    EXPECT_EQ(AngularVelocity::ofRadians(2), robot_other.angularVelocity(3));
+    EXPECT_EQ(AngularVelocity::ofRadians(2),
+              robot_other.estimateAngularVelocityAtFutureTime(0.4));
+    EXPECT_EQ(AngularVelocity::ofRadians(2),
+              robot_other.estimateAngularVelocityAtFutureTime(1));
+    EXPECT_EQ(AngularVelocity::ofRadians(2),
+              robot_other.estimateAngularVelocityAtFutureTime(3));
 }
 
 TEST(RobotTest, equality_operators)

--- a/src/thunderbots/software/test/world/robot.cpp
+++ b/src/thunderbots/software/test/world/robot.cpp
@@ -14,7 +14,8 @@ TEST(RobotTest, construct_with_id_only)
 
 TEST(RobotTest, construct_with_all_params)
 {
-    Robot robot = Robot(3, Point(1, 1), Vector(-0.3, 0), Angle::ofRadians(2.2), AngularVelocity::ofRadians(-0.6));
+    Robot robot = Robot(3, Point(1, 1), Vector(-0.3, 0), Angle::ofRadians(2.2),
+                        AngularVelocity::ofRadians(-0.6));
 
     EXPECT_EQ(3, robot.id());
     EXPECT_EQ(Point(1, 1), robot.position());
@@ -98,7 +99,7 @@ TEST(RobotTest, get_position_at_future_time)
     EXPECT_EQ(Point(-2.7, 10.8), robot.position(3));
 
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
-                  AngularVelocity::ofRadians(2));
+                              AngularVelocity::ofRadians(2));
 
     EXPECT_EQ(Point(2.4, -1.6), robot_other.position(0.4));
     EXPECT_EQ(Point(4.5, -1), robot_other.position(1));
@@ -152,7 +153,8 @@ TEST(RobotTest, get_orientation_at_future_time)
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2));
 
-    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(0.8), robot_other.orientation(0.4));
+    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(0.8),
+              robot_other.orientation(0.4));
     EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(2), robot_other.orientation(1));
     EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(6), robot_other.orientation(3));
 }
@@ -220,7 +222,7 @@ TEST(RobotTest, equality_operators)
 
     // Update robot_0_1 to be the same as robot_0
     robot_0_1.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
-                   AngularVelocity::ofDegrees(30));
+                     AngularVelocity::ofDegrees(30));
 
     EXPECT_EQ(robot_0_0, robot_0_1);
 }

--- a/src/thunderbots/software/util/ros_messages.cpp
+++ b/src/thunderbots/software/util/ros_messages.cpp
@@ -13,5 +13,20 @@ namespace Util
 
             return ball;
         }
+
+        Robot createRobotFromROSMessage(const thunderbots_msgs::Robot& robot_msg)
+        {
+            unsigned int robot_id   = robot_msg.id;
+            Point robot_position    = Point(robot_msg.position.x, robot_msg.position.y);
+            Vector robot_velocity   = Vector(robot_msg.velocity.x, robot_msg.velocity.y);
+            Angle robot_orientation = Angle::ofRadians(robot_msg.orientation);
+            AngularVelocity robot_angular_velocity =
+                Angle::ofRadians(robot_msg.angular_velocity);
+
+            Robot robot = Robot(robot_id, robot_position, robot_velocity,
+                                robot_orientation, robot_angular_velocity);
+
+            return robot;
+        }
     }
 }

--- a/src/thunderbots/software/util/ros_messages.h
+++ b/src/thunderbots/software/util/ros_messages.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "ai/world/ball.h"
+#include "ai/world/robot.h"
 #include "thunderbots_msgs/Ball.h"
+#include "thunderbots_msgs/Robot.h"
 
 namespace Util
 {
@@ -18,5 +20,13 @@ namespace Util
          * @return A Ball object created with the given ball message data
          */
         Ball createBallFromROSMessage(const thunderbots_msgs::Ball& ball_msg);
+
+        /**
+         * Given a Robot message, constructs and returns a Robot object
+         *
+         * @param robot_msg The message containing the robot message data
+         * @return A Robot object created with the given robot message data
+         */
+        Robot createRobotFromROSMessage(const thunderbots_msgs::Robot& robot_msg);
     }
 }


### PR DESCRIPTION
Implemented the Robot class
* Removed the update function that accepted a ROS message to keep ROS abstracted away from our datatypes

The reason there are no unit tests for predicting "negative time" values is because I think that is not generally useful to us, and should be removed. I plan to make that change in a PR very soon, likely alongside #49 , and the change is being tracked in #52

Partially resolves #41 