### PR TITLE
Improve Ball timestamping and prediction

### DIFF
--- a/src/thunderbots/software/ai/world/ball.cpp
+++ b/src/thunderbots/software/ai/world/ball.cpp
@@ -1,18 +1,45 @@
 #include "ball.h"
 
-Ball::Ball(Point position, Vector velocity) : position_(position), velocity_(velocity)
+Ball::Ball(Point position, Vector velocity, std::chrono::time_point<std::chrono::steady_clock> last_update_timestamp) : position_(position), velocity_(velocity), last_update_timestamp(last_update_timestamp)
 {
 }
 
 void Ball::update(const Ball &new_ball_data)
 {
-    update(new_ball_data.position(), new_ball_data.velocity());
+    update(new_ball_data.position(), new_ball_data.velocity(), new_ball_data.lastUpdateTimestamp());
 }
 
-void Ball::update(const Point &new_position, const Vector &new_velocity)
+void Ball::update(const Point &new_position, const Vector &new_velocity, std::chrono::time_point<std::chrono::steady_clock> timestamp)
 {
+    if (timestamp < last_update_timestamp) {
+        // TODO: Error. We should never be updating with times from the past
+        // TODO: Throw a proper exception here
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+        exit(1);
+    }
+
     position_ = new_position;
     velocity_ = new_velocity;
+    last_update_timestamp = timestamp;
+}
+
+void Ball::updateState(std::chrono::time_point<std::chrono::steady_clock> timestamp) {
+    if (timestamp < last_update_timestamp) {
+        // TODO: Error. We should never be updating with times from the past
+        // TODO: Throw a proper exception here
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+        exit(1);
+    }
+
+    auto milliseconds_in_future = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp - last_update_timestamp);
+    Point new_position = estimatePositionAtFutureTime(milliseconds_in_future);
+    Point new_velocity = estimateVelocityAtFutureTime(milliseconds_in_future);
+
+    update(new_position, new_velocity, timestamp);
+}
+
+std::chrono::time_point<std::chrono::steady_clock> Ball::lastUpdateTimestamp() const {
+    return last_update_timestamp;
 }
 
 Point Ball::position() const
@@ -20,12 +47,20 @@ Point Ball::position() const
     return position_;
 }
 
-Point Ball::estimatePositionAtFutureTime(double time_delta) const
+Point Ball::estimatePositionAtFutureTime(const std::chrono::milliseconds& milliseconds_in_future) const
 {
+    if (milliseconds_in_future < std::chrono::milliseconds(0)) {
+        // TODO: Error. We should never be updating with times from the past
+        // TODO: Throw a proper exception here
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+    }
+
     // TODO: This is a simple linear implementation that does not necessarily reflect
     // real-world behavior. Position prediction should be improved as outlined in
     // https://github.com/UBC-Thunderbots/Software/issues/47
-    return position_ + (velocity_.norm(time_delta * velocity_.len()));
+    typedef std::chrono::duration<double> double_seconds;
+    double seconds_in_future = std::chrono::duration_cast<double_seconds>(milliseconds_in_future).count();
+    return position_ + (velocity_.norm(seconds_in_future * velocity_.len()));
 }
 
 Vector Ball::velocity() const
@@ -33,12 +68,20 @@ Vector Ball::velocity() const
     return velocity_;
 }
 
-Vector Ball::estimateVelocityAtFutureTime(double time_delta) const
+Vector Ball::estimateVelocityAtFutureTime(const std::chrono::milliseconds& milliseconds_in_future) const
 {
+    if (milliseconds_in_future < std::chrono::milliseconds(0)) {
+        // TODO: Error. We should never be updating with times from the past
+        // TODO: Throw a proper exception here
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+    }
+
     // TODO: This is a implementation with an empirically determined time constant that
     // does not necessarily reflect real-world behavior. Velocity prediction should be
     // improved as outlined in https://github.com/UBC-Thunderbots/Software/issues/47
-    return velocity_ * exp(-0.1 * time_delta);
+    typedef std::chrono::duration<double> double_seconds;
+    double seconds_in_future = std::chrono::duration_cast<double_seconds>(milliseconds_in_future).count();
+    return velocity_ * exp(-0.1 * seconds_in_future);
 }
 
 bool Ball::operator==(const Ball &other) const

--- a/src/thunderbots/software/ai/world/ball.cpp
+++ b/src/thunderbots/software/ai/world/ball.cpp
@@ -1,7 +1,7 @@
 #include "ball.h"
 
 Ball::Ball(Point position, Vector velocity,
-           std::chrono::time_point<std::chrono::steady_clock> timestamp)
+           std::chrono::steady_clock::time_point timestamp)
     : position_(position), velocity_(velocity), last_update_timestamp(timestamp)
 {
 }
@@ -13,7 +13,7 @@ void Ball::updateState(const Ball &new_ball_data)
 }
 
 void Ball::updateState(const Point &new_position, const Vector &new_velocity,
-                       std::chrono::time_point<std::chrono::steady_clock> timestamp)
+                       std::chrono::steady_clock::time_point timestamp)
 {
     if (timestamp < last_update_timestamp)
     {
@@ -28,8 +28,7 @@ void Ball::updateState(const Point &new_position, const Vector &new_velocity,
     last_update_timestamp = timestamp;
 }
 
-void Ball::updateStateToPredictedState(
-    std::chrono::time_point<std::chrono::steady_clock> timestamp)
+void Ball::updateStateToPredictedState(std::chrono::steady_clock::time_point timestamp)
 {
     if (timestamp < last_update_timestamp)
     {
@@ -47,7 +46,7 @@ void Ball::updateStateToPredictedState(
     updateState(new_position, new_velocity, timestamp);
 }
 
-std::chrono::time_point<std::chrono::steady_clock> Ball::lastUpdateTimestamp() const
+std::chrono::steady_clock::time_point Ball::lastUpdateTimestamp() const
 {
     return last_update_timestamp;
 }

--- a/src/thunderbots/software/ai/world/ball.cpp
+++ b/src/thunderbots/software/ai/world/ball.cpp
@@ -1,44 +1,55 @@
 #include "ball.h"
 
-Ball::Ball(Point position, Vector velocity, std::chrono::time_point<std::chrono::steady_clock> last_update_timestamp) : position_(position), velocity_(velocity), last_update_timestamp(last_update_timestamp)
+Ball::Ball(Point position, Vector velocity,
+           std::chrono::time_point<std::chrono::steady_clock> last_update_timestamp)
+    : position_(position),
+      velocity_(velocity),
+      last_update_timestamp(last_update_timestamp)
 {
 }
 
 void Ball::update(const Ball &new_ball_data)
 {
-    update(new_ball_data.position(), new_ball_data.velocity(), new_ball_data.lastUpdateTimestamp());
+    update(new_ball_data.position(), new_ball_data.velocity(),
+           new_ball_data.lastUpdateTimestamp());
 }
 
-void Ball::update(const Point &new_position, const Vector &new_velocity, std::chrono::time_point<std::chrono::steady_clock> timestamp)
+void Ball::update(const Point &new_position, const Vector &new_velocity,
+                  std::chrono::time_point<std::chrono::steady_clock> timestamp)
 {
-    if (timestamp < last_update_timestamp) {
+    if (timestamp < last_update_timestamp)
+    {
         // TODO: Error. We should never be updating with times from the past
         // TODO: Throw a proper exception here
         // https://github.com/UBC-Thunderbots/Software/issues/16
         exit(1);
     }
 
-    position_ = new_position;
-    velocity_ = new_velocity;
+    position_             = new_position;
+    velocity_             = new_velocity;
     last_update_timestamp = timestamp;
 }
 
-void Ball::updateState(std::chrono::time_point<std::chrono::steady_clock> timestamp) {
-    if (timestamp < last_update_timestamp) {
+void Ball::updateState(std::chrono::time_point<std::chrono::steady_clock> timestamp)
+{
+    if (timestamp < last_update_timestamp)
+    {
         // TODO: Error. We should never be updating with times from the past
         // TODO: Throw a proper exception here
         // https://github.com/UBC-Thunderbots/Software/issues/16
         exit(1);
     }
 
-    auto milliseconds_in_future = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp - last_update_timestamp);
+    auto milliseconds_in_future = std::chrono::duration_cast<std::chrono::milliseconds>(
+        timestamp - last_update_timestamp);
     Point new_position = estimatePositionAtFutureTime(milliseconds_in_future);
     Point new_velocity = estimateVelocityAtFutureTime(milliseconds_in_future);
 
     update(new_position, new_velocity, timestamp);
 }
 
-std::chrono::time_point<std::chrono::steady_clock> Ball::lastUpdateTimestamp() const {
+std::chrono::time_point<std::chrono::steady_clock> Ball::lastUpdateTimestamp() const
+{
     return last_update_timestamp;
 }
 
@@ -47,9 +58,11 @@ Point Ball::position() const
     return position_;
 }
 
-Point Ball::estimatePositionAtFutureTime(const std::chrono::milliseconds& milliseconds_in_future) const
+Point Ball::estimatePositionAtFutureTime(
+    const std::chrono::milliseconds &milliseconds_in_future) const
 {
-    if (milliseconds_in_future < std::chrono::milliseconds(0)) {
+    if (milliseconds_in_future < std::chrono::milliseconds(0))
+    {
         // TODO: Error. We should never be updating with times from the past
         // TODO: Throw a proper exception here
         // https://github.com/UBC-Thunderbots/Software/issues/16
@@ -59,7 +72,8 @@ Point Ball::estimatePositionAtFutureTime(const std::chrono::milliseconds& millis
     // real-world behavior. Position prediction should be improved as outlined in
     // https://github.com/UBC-Thunderbots/Software/issues/47
     typedef std::chrono::duration<double> double_seconds;
-    double seconds_in_future = std::chrono::duration_cast<double_seconds>(milliseconds_in_future).count();
+    double seconds_in_future =
+        std::chrono::duration_cast<double_seconds>(milliseconds_in_future).count();
     return position_ + (velocity_.norm(seconds_in_future * velocity_.len()));
 }
 
@@ -68,9 +82,11 @@ Vector Ball::velocity() const
     return velocity_;
 }
 
-Vector Ball::estimateVelocityAtFutureTime(const std::chrono::milliseconds& milliseconds_in_future) const
+Vector Ball::estimateVelocityAtFutureTime(
+    const std::chrono::milliseconds &milliseconds_in_future) const
 {
-    if (milliseconds_in_future < std::chrono::milliseconds(0)) {
+    if (milliseconds_in_future < std::chrono::milliseconds(0))
+    {
         // TODO: Error. We should never be updating with times from the past
         // TODO: Throw a proper exception here
         // https://github.com/UBC-Thunderbots/Software/issues/16
@@ -80,7 +96,8 @@ Vector Ball::estimateVelocityAtFutureTime(const std::chrono::milliseconds& milli
     // does not necessarily reflect real-world behavior. Velocity prediction should be
     // improved as outlined in https://github.com/UBC-Thunderbots/Software/issues/47
     typedef std::chrono::duration<double> double_seconds;
-    double seconds_in_future = std::chrono::duration_cast<double_seconds>(milliseconds_in_future).count();
+    double seconds_in_future =
+        std::chrono::duration_cast<double_seconds>(milliseconds_in_future).count();
     return velocity_ * exp(-0.1 * seconds_in_future);
 }
 

--- a/src/thunderbots/software/ai/world/ball.cpp
+++ b/src/thunderbots/software/ai/world/ball.cpp
@@ -1,21 +1,19 @@
 #include "ball.h"
 
 Ball::Ball(Point position, Vector velocity,
-           std::chrono::time_point<std::chrono::steady_clock> last_update_timestamp)
-    : position_(position),
-      velocity_(velocity),
-      last_update_timestamp(last_update_timestamp)
+           std::chrono::time_point<std::chrono::steady_clock> timestamp)
+    : position_(position), velocity_(velocity), last_update_timestamp(timestamp)
 {
 }
 
-void Ball::update(const Ball &new_ball_data)
+void Ball::updateState(const Ball &new_ball_data)
 {
-    update(new_ball_data.position(), new_ball_data.velocity(),
-           new_ball_data.lastUpdateTimestamp());
+    updateState(new_ball_data.position(), new_ball_data.velocity(),
+                new_ball_data.lastUpdateTimestamp());
 }
 
-void Ball::update(const Point &new_position, const Vector &new_velocity,
-                  std::chrono::time_point<std::chrono::steady_clock> timestamp)
+void Ball::updateState(const Point &new_position, const Vector &new_velocity,
+                       std::chrono::time_point<std::chrono::steady_clock> timestamp)
 {
     if (timestamp < last_update_timestamp)
     {
@@ -30,7 +28,8 @@ void Ball::update(const Point &new_position, const Vector &new_velocity,
     last_update_timestamp = timestamp;
 }
 
-void Ball::updateState(std::chrono::time_point<std::chrono::steady_clock> timestamp)
+void Ball::updateStateToPredictedState(
+    std::chrono::time_point<std::chrono::steady_clock> timestamp)
 {
     if (timestamp < last_update_timestamp)
     {
@@ -45,7 +44,7 @@ void Ball::updateState(std::chrono::time_point<std::chrono::steady_clock> timest
     Point new_position = estimatePositionAtFutureTime(milliseconds_in_future);
     Point new_velocity = estimateVelocityAtFutureTime(milliseconds_in_future);
 
-    update(new_position, new_velocity, timestamp);
+    updateState(new_position, new_velocity, timestamp);
 }
 
 std::chrono::time_point<std::chrono::steady_clock> Ball::lastUpdateTimestamp() const

--- a/src/thunderbots/software/ai/world/ball.h
+++ b/src/thunderbots/software/ai/world/ball.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "geom/point.h"
+#include <chrono>
 
 class Ball final
 {
@@ -11,8 +12,10 @@ class Ball final
      * @param position The position of the ball, with coordinates in metres.
      * Default is (0, 0)
      * @param velocity The velocity of the ball, in metres per second. Default is (0, 0)
+     * @paragraph last_update_timestamp A timestamp of when this ball's information was
+     * last updated. Default is the current time.
      */
-    explicit Ball(Point position = Point(), Vector velocity = Vector());
+    explicit Ball(Point position = Point(), Vector velocity = Vector(), std::chrono::time_point<std::chrono::steady_clock> last_update_timestamp = std::chrono::steady_clock::now());
 
     /**
      * Updates the ball with new data, updating the current data as well as the predictive
@@ -20,8 +23,10 @@ class Ball final
      *
      * @param new_position the new position of the ball, defined in metres
      * @param new_velocity the new velocity of the ball, defined in metres per second
+     * @param timestamp The timestamp for the time at which this update is taking place.
+     * The timestamp must be >= the ball's latest update timestamp
      */
-    void update(const Point& new_position, const Vector& new_velocity);
+    void update(const Point& new_position, const Vector& new_velocity, std::chrono::time_point<std::chrono::steady_clock> timestamp);
 
     /**
      * Updates the ball with new data, updating the current data as well as the predictive
@@ -32,6 +37,21 @@ class Ball final
     void update(const Ball& new_ball_data);
 
     /**
+     * Updates the ball's state to match what it would be at the given timestamp. The
+     * timestamp must be >= the ball's last update timestamp.
+     *
+     * @param timestamp The timestamp at which to update the ball's state to
+     */
+    void updateState(std::chrono::time_point<std::chrono::steady_clock> timestamp);
+
+    /**
+     * Returns the timestamp for when this ball's data was last updated
+     *
+     * @return the timestamp for when this ball's data was last updated
+     */
+    std::chrono::time_point<std::chrono::steady_clock> lastUpdateTimestamp() const;
+
+    /**
      * Returns the current position of the ball
      *
      * @return the current position of the ball
@@ -39,17 +59,18 @@ class Ball final
     Point position() const;
 
     /**
-     * Returns the estimated position of the ball at a future time, relative to the
-     * current time
+     * Returns the estimated position of the ball at a future time, relative to when the
+     * ball was last updated.
      *
-     * @param time_delta The relative amount of time in the future (in seconds) at which
-     * to predict the ball's position. For example, a value of 1.5 would return the
-     * estimated position of the ball 1.5s in the future.
+     * @param milliseconds_in_future The relative amount of time in the future
+     * (in milliseconds) at which to predict the ball's position. Value must be >= 0.
+     * For example, a value of 1500 would return the estimated position of the ball
+     * 1.5 seconds in the future.
      *
-     * @return the estimated position of the ball at a future time.
-     * Coordinates are in metres.
+     * @return the estimated position of the ball at the given number of milliseconds
+     * in the future. Coordinates are in metres.
      */
-    Point estimatePositionAtFutureTime(double time_delta = 0.0) const;
+    Point estimatePositionAtFutureTime(const std::chrono::milliseconds& milliseconds_in_future) const;
 
     /**
      * Returns the current velocity of the ball
@@ -59,17 +80,18 @@ class Ball final
     Vector velocity() const;
 
     /**
-     * Returns the estimated velocity of the ball at a future time, relative to the
-     * current time
+     * Returns the estimated velocity of the ball at a future time, relative to when the
+     * ball was last updated
      *
-     * @param time_delta The relative amount of time in the future (in seconds) at which
-     * to predict the ball's velocity. For example, a value of 1.5 would return the
-     * estimated velocity of the ball 1.5s in the future.
+     * @param milliseconds_in_future The relative amount of time in the future
+     * (in milliseconds) at which to predict the ball's velocity. Value must be >= 0.
+     * For example, a value of 1500 would return the estimated velocity of the ball
+     * 1.5 seconds in the future.
      *
-     * @return the estimated velocity of the ball at a future time.
-     * Coordinates are in metres.
+     * @return the estimated velocity of the ball at the given number of milliseconds
+     * in the future. Coordinates are in metres.
      */
-    Vector estimateVelocityAtFutureTime(double time_delta = 0.0) const;
+    Vector estimateVelocityAtFutureTime(const std::chrono::milliseconds& milliseconds_in_future) const;
 
     /**
      * Defines the equality operator for a Ball. Balls are equal if their positions and
@@ -93,4 +115,6 @@ class Ball final
     Point position_;
     // The current velocity of the ball, in metres per second
     Vector velocity_;
+    // The timestamp for when this ball was last updated
+    std::chrono::time_point<std::chrono::steady_clock> last_update_timestamp;
 };

--- a/src/thunderbots/software/ai/world/ball.h
+++ b/src/thunderbots/software/ai/world/ball.h
@@ -16,7 +16,7 @@ class Ball final
      * given position and velocity. Default is the current time.
      */
     explicit Ball(Point position = Point(), Vector velocity = Vector(),
-                  std::chrono::time_point<std::chrono::steady_clock> timestamp =
+                  std::chrono::steady_clock::time_point timestamp =
                       std::chrono::steady_clock::now());
 
     /**
@@ -29,7 +29,7 @@ class Ball final
      * position and velocity. The timestamp must be >= the ball's latest update timestamp
      */
     void updateState(const Point& new_position, const Vector& new_velocity,
-                     std::chrono::time_point<std::chrono::steady_clock> timestamp);
+                     std::chrono::steady_clock::time_point timestamp);
 
     /**
      * Updates the ball with new data, updating the current data as well as the predictive
@@ -46,15 +46,14 @@ class Ball final
      * @param timestamp The timestamp at which to update the ball's state to. Must
      * be >= the ball's last update timestamp
      */
-    void updateStateToPredictedState(
-        std::chrono::time_point<std::chrono::steady_clock> timestamp);
+    void updateStateToPredictedState(std::chrono::steady_clock::time_point timestamp);
 
     /**
      * Returns the timestamp for when this ball's data was last updated
      *
      * @return the timestamp for when this ball's data was last updated
      */
-    std::chrono::time_point<std::chrono::steady_clock> lastUpdateTimestamp() const;
+    std::chrono::steady_clock::time_point lastUpdateTimestamp() const;
 
     /**
      * Returns the current position of the ball
@@ -123,5 +122,5 @@ class Ball final
     // The current velocity of the ball, in metres per second
     Vector velocity_;
     // The timestamp for when this ball was last updated
-    std::chrono::time_point<std::chrono::steady_clock> last_update_timestamp;
+    std::chrono::steady_clock::time_point last_update_timestamp;
 };

--- a/src/thunderbots/software/ai/world/ball.h
+++ b/src/thunderbots/software/ai/world/ball.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "geom/point.h"
 #include <chrono>
+#include "geom/point.h"
 
 class Ball final
 {
@@ -15,7 +15,9 @@ class Ball final
      * @paragraph last_update_timestamp A timestamp of when this ball's information was
      * last updated. Default is the current time.
      */
-    explicit Ball(Point position = Point(), Vector velocity = Vector(), std::chrono::time_point<std::chrono::steady_clock> last_update_timestamp = std::chrono::steady_clock::now());
+    explicit Ball(Point position = Point(), Vector velocity = Vector(),
+                  std::chrono::time_point<std::chrono::steady_clock>
+                      last_update_timestamp = std::chrono::steady_clock::now());
 
     /**
      * Updates the ball with new data, updating the current data as well as the predictive
@@ -26,7 +28,8 @@ class Ball final
      * @param timestamp The timestamp for the time at which this update is taking place.
      * The timestamp must be >= the ball's latest update timestamp
      */
-    void update(const Point& new_position, const Vector& new_velocity, std::chrono::time_point<std::chrono::steady_clock> timestamp);
+    void update(const Point& new_position, const Vector& new_velocity,
+                std::chrono::time_point<std::chrono::steady_clock> timestamp);
 
     /**
      * Updates the ball with new data, updating the current data as well as the predictive
@@ -70,7 +73,8 @@ class Ball final
      * @return the estimated position of the ball at the given number of milliseconds
      * in the future. Coordinates are in metres.
      */
-    Point estimatePositionAtFutureTime(const std::chrono::milliseconds& milliseconds_in_future) const;
+    Point estimatePositionAtFutureTime(
+        const std::chrono::milliseconds& milliseconds_in_future) const;
 
     /**
      * Returns the current velocity of the ball
@@ -91,7 +95,8 @@ class Ball final
      * @return the estimated velocity of the ball at the given number of milliseconds
      * in the future. Coordinates are in metres.
      */
-    Vector estimateVelocityAtFutureTime(const std::chrono::milliseconds& milliseconds_in_future) const;
+    Vector estimateVelocityAtFutureTime(
+        const std::chrono::milliseconds& milliseconds_in_future) const;
 
     /**
      * Defines the equality operator for a Ball. Balls are equal if their positions and

--- a/src/thunderbots/software/ai/world/ball.h
+++ b/src/thunderbots/software/ai/world/ball.h
@@ -12,12 +12,12 @@ class Ball final
      * @param position The position of the ball, with coordinates in metres.
      * Default is (0, 0)
      * @param velocity The velocity of the ball, in metres per second. Default is (0, 0)
-     * @paragraph last_update_timestamp A timestamp of when this ball's information was
-     * last updated. Default is the current time.
+     * @param timestamp The timestamp at which the ball was observed to be at the
+     * given position and velocity. Default is the current time.
      */
     explicit Ball(Point position = Point(), Vector velocity = Vector(),
-                  std::chrono::time_point<std::chrono::steady_clock>
-                      last_update_timestamp = std::chrono::steady_clock::now());
+                  std::chrono::time_point<std::chrono::steady_clock> timestamp =
+                      std::chrono::steady_clock::now());
 
     /**
      * Updates the ball with new data, updating the current data as well as the predictive
@@ -25,11 +25,11 @@ class Ball final
      *
      * @param new_position the new position of the ball, defined in metres
      * @param new_velocity the new velocity of the ball, defined in metres per second
-     * @param timestamp The timestamp for the time at which this update is taking place.
-     * The timestamp must be >= the ball's latest update timestamp
+     * @param timestamp The timestamp at which the ball was observed to be at the given
+     * position and velocity. The timestamp must be >= the ball's latest update timestamp
      */
-    void update(const Point& new_position, const Vector& new_velocity,
-                std::chrono::time_point<std::chrono::steady_clock> timestamp);
+    void updateState(const Point& new_position, const Vector& new_velocity,
+                     std::chrono::time_point<std::chrono::steady_clock> timestamp);
 
     /**
      * Updates the ball with new data, updating the current data as well as the predictive
@@ -37,15 +37,17 @@ class Ball final
      *
      * @param new_ball_data A ball containing new ball data
      */
-    void update(const Ball& new_ball_data);
+    void updateState(const Ball& new_ball_data);
 
     /**
-     * Updates the ball's state to match what it would be at the given timestamp. The
-     * timestamp must be >= the ball's last update timestamp.
+     * Updates the ball's state to be its predicted state at the given timestamp.
+     * The timestamp must be >= the ball's last update timestamp
      *
-     * @param timestamp The timestamp at which to update the ball's state to
+     * @param timestamp The timestamp at which to update the ball's state to. Must
+     * be >= the ball's last update timestamp
      */
-    void updateState(std::chrono::time_point<std::chrono::steady_clock> timestamp);
+    void updateStateToPredictedState(
+        std::chrono::time_point<std::chrono::steady_clock> timestamp);
 
     /**
      * Returns the timestamp for when this ball's data was last updated

--- a/src/thunderbots/software/ai/world/world.cpp
+++ b/src/thunderbots/software/ai/world/world.cpp
@@ -17,7 +17,7 @@ void World::updateFieldGeometry(const Field &new_field_data)
 
 void World::updateBallState(const Ball &new_ball_data)
 {
-    ball_.update(new_ball_data);
+    ball_.updateState(new_ball_data);
 }
 
 void World::updateFriendlyTeam(const thunderbots_msgs::Team &new_friendly_team_msg)

--- a/src/thunderbots/software/test/world/ball.cpp
+++ b/src/thunderbots/software/test/world/ball.cpp
@@ -3,7 +3,30 @@
 
 using namespace std::chrono;
 
-TEST(BallTest, construct_with_no_params)
+class BallTest : public ::testing::Test
+{
+   protected:
+    void SetUp() override
+    {
+        auto epoch = time_point<std::chrono::steady_clock>();
+        // An arbitrary fixed point in time. 10000 seconds after the epoch
+        auto since_epoch = std::chrono::seconds(10000);
+
+        current_time                          = epoch + since_epoch;
+        one_hundred_fifty_milliseconds_future = current_time + milliseconds(150);
+        half_second_future                    = current_time + milliseconds(500);
+        one_second_future                     = current_time + seconds(1);
+        nine_seconds_future                   = current_time + seconds(9);
+    }
+
+    steady_clock::time_point current_time;
+    steady_clock::time_point half_second_future;
+    steady_clock::time_point one_second_future;
+    steady_clock::time_point nine_seconds_future;
+    steady_clock::time_point one_hundred_fifty_milliseconds_future;
+};
+
+TEST_F(BallTest, construct_with_no_params)
 {
     Ball ball = Ball();
 
@@ -15,10 +38,8 @@ TEST(BallTest, construct_with_no_params)
     // makes the test dependant on the speed of the system executing it
 }
 
-TEST(BallTest, construct_with_params)
+TEST_F(BallTest, construct_with_params)
 {
-    auto current_time = steady_clock::now();
-
     Ball ball = Ball(Point(1, 2.3), Vector(-0.04, 0.0), current_time);
 
     EXPECT_EQ(Point(1, 2.3), ball.position());
@@ -26,66 +47,55 @@ TEST(BallTest, construct_with_params)
     EXPECT_EQ(current_time, ball.lastUpdateTimestamp());
 }
 
-TEST(BallTest, update_all_values)
+TEST_F(BallTest, update_all_values)
 {
-    Ball ball = Ball();
+    Ball ball = Ball(Point(), Vector(), current_time);
 
-    auto current_time = steady_clock::now();
+    ball.updateState(Point(-4.23, 1.07), Vector(1, 2), one_second_future);
 
-    ball.update(Point(-4.23, 1.07), Vector(1, 2), current_time);
-
-    EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(1, 2), current_time), ball);
+    EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(1, 2), one_second_future), ball);
 }
 
-TEST(BallTest, update_position_only)
+TEST_F(BallTest, update_position_only)
 {
-    auto current_time = steady_clock::now();
-
     Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2), current_time);
 
-    ball.update(Point(0.01, -99.8), ball.velocity(), current_time);
+    ball.updateState(Point(0.01, -99.8), ball.velocity(), current_time);
 
     EXPECT_EQ(Ball(Point(0.01, -99.8), Vector(1, 2), current_time), ball);
 }
 
-TEST(BallTest, update_velocity_only)
+TEST_F(BallTest, update_velocity_only)
 {
-    auto current_time = steady_clock::now();
-
     Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2), current_time);
 
-    ball.update(ball.position(), Vector(-0.0, -9.433), current_time);
+    ball.updateState(ball.position(), Vector(-0.0, -9.433), current_time);
 
     EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(-0.0, -9.433), current_time), ball);
 }
 
-TEST(BallTest, update_with_new_ball)
+TEST_F(BallTest, update_with_new_ball)
 {
-    auto current_time = steady_clock::now();
-
     Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2), current_time);
 
     Ball ball_update = Ball(Point(), Vector(-4.89, 3.1), current_time);
 
-    ball.update(ball_update);
+    ball.updateState(ball_update);
 
     EXPECT_EQ(ball_update, ball);
 }
 
-TEST(BallTest, update_values_with_past_timestamp)
+TEST_F(BallTest, update_values_with_past_timestamp)
 {
     // TODO: Add unit tests to check for thrown exceptions when past timestamps are used
     // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
 }
 
-TEST(BallTest, update_state_with_future_timestamp)
+TEST_F(BallTest, update_state_with_future_timestamp)
 {
-    auto current_time      = steady_clock::now();
-    auto one_second_future = current_time + seconds(1);
-
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
-    ball.updateState(one_second_future);
+    ball.updateStateToPredictedState(one_second_future);
 
     // A small distance to check that values are approximately equal
     double EPSILON = 1e-4;
@@ -95,70 +105,67 @@ TEST(BallTest, update_state_with_future_timestamp)
     EXPECT_EQ(one_second_future, ball.lastUpdateTimestamp());
 }
 
-TEST(BallTest, update_state_with_future_timestamp_2)
+TEST_F(BallTest, update_state_with_future_timestamp_2)
 {
-    auto current_time = steady_clock::now();
-    auto future_time  = current_time + milliseconds(150);
-
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
-    ball.updateState(future_time);
+    ball.updateStateToPredictedState(one_hundred_fifty_milliseconds_future);
 
     // A small distance to check that values are approximately equal
     double EPSILON = 1e-4;
 
     EXPECT_EQ(Point(2.325, 6.982), ball.position());
     EXPECT_TRUE(Vector(-4.4330, -0.1182).isClose(ball.velocity(), EPSILON));
-    EXPECT_EQ(future_time, ball.lastUpdateTimestamp());
+    EXPECT_EQ(one_hundred_fifty_milliseconds_future, ball.lastUpdateTimestamp());
 }
 
-TEST(BallTest, update_state_with_past_timestamp)
+TEST_F(BallTest, update_state_with_past_timestamp)
 {
     // TODO: Add unit tests to check for thrown exceptions when past timestamps are used
     // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
 }
 
-TEST(BallTest, get_position_at_current_time)
+TEST_F(BallTest, get_position_at_current_time)
 {
-    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
     EXPECT_EQ(Point(3, 7), ball.position());
 }
 
-TEST(BallTest, get_position_at_future_time)
+TEST_F(BallTest, get_position_at_future_time)
 {
-    Ball ball = Ball(Point(), Vector(1, 2));
+    Ball ball = Ball(Point(), Vector(1, 2), current_time);
 
     EXPECT_EQ(Point(0.15, 0.3), ball.estimatePositionAtFutureTime(milliseconds(150)));
     EXPECT_EQ(Point(1, 2), ball.estimatePositionAtFutureTime(milliseconds(1000)));
     EXPECT_EQ(Point(2, 4), ball.estimatePositionAtFutureTime(milliseconds(2000)));
 }
 
-TEST(BallTest, get_position_at_future_time_2)
+TEST_F(BallTest, get_position_at_future_time_2)
 {
-    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
     EXPECT_EQ(Point(2.325, 6.982), ball.estimatePositionAtFutureTime(milliseconds(150)));
     EXPECT_EQ(Point(-1.5, 6.88), ball.estimatePositionAtFutureTime(milliseconds(1000)));
     EXPECT_EQ(Point(-6, 6.76), ball.estimatePositionAtFutureTime(milliseconds(2000)));
 }
 
-TEST(BallTest, get_position_at_past_time)
+TEST_F(BallTest, get_position_at_past_time)
 {
     // TODO: Add unit tests to check for thrown exceptions when a negative value is passed
     // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
 }
 
-TEST(BallTest, get_velocity_at_current_time)
+TEST_F(BallTest, get_velocity_at_current_time)
 {
-    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
     EXPECT_EQ(Vector(-4.5, -0.12), ball.velocity());
 }
 
-TEST(BallTest, get_velocity_at_future_time)
+TEST_F(BallTest, get_velocity_at_future_time)
 {
-    Ball ball = Ball(Point(), Vector(1, 2));
+    Ball ball = Ball(Point(), Vector(1, 2), current_time);
 
     // A small distance to check that values are approximately equal
     double EPSILON = 1e-4;
@@ -174,12 +181,12 @@ TEST(BallTest, get_velocity_at_future_time)
             .isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
 }
 
-TEST(BallTest, get_velocity_at_future_time_2)
+TEST_F(BallTest, get_velocity_at_future_time_2)
 {
     // A small distance to check that values are approximately equal
     double EPSILON = 1e-4;
 
-    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
     EXPECT_TRUE(
         Vector(-4.4330, -0.1182)
@@ -192,52 +199,44 @@ TEST(BallTest, get_velocity_at_future_time_2)
             .isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
 }
 
-TEST(BallTest, get_velocity_at_past_time)
+TEST_F(BallTest, get_velocity_at_past_time)
 {
     // TODO: Add unit tests to check for thrown exceptions when a negative value is passed
     // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
 }
 
-TEST(BallTest, get_last_update_timestamp)
+TEST_F(BallTest, get_last_update_timestamp)
 {
-    auto current_time       = steady_clock::now();
-    auto half_second_future = current_time + milliseconds(500);
-
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
     EXPECT_EQ(current_time, ball.lastUpdateTimestamp());
 
-    ball.updateState(half_second_future);
+    ball.updateStateToPredictedState(half_second_future);
 
     EXPECT_EQ(half_second_future, ball.lastUpdateTimestamp());
 }
 
-TEST(BallTest, get_last_update_timestamp_2)
+TEST_F(BallTest, get_last_update_timestamp_2)
 {
-    auto current_time        = steady_clock::now();
-    auto nine_seconds_future = current_time + seconds(9);
-
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
     EXPECT_EQ(current_time, ball.lastUpdateTimestamp());
 
-    ball.updateState(nine_seconds_future);
+    ball.updateStateToPredictedState(nine_seconds_future);
 
     EXPECT_EQ(nine_seconds_future, ball.lastUpdateTimestamp());
 }
 
-TEST(BallTest, equality_operators)
+TEST_F(BallTest, equality_operators)
 {
-    auto current_time = steady_clock::now();
-    auto future_time  = current_time + milliseconds(123);
-
     Ball ball_0 = Ball();
 
     Ball ball_1 = Ball(Point(0.01, -0.0), Vector(), current_time);
 
-    Ball ball_2 = Ball(Point(2, -3), Vector(0, 1), future_time);
+    Ball ball_2 = Ball(Point(2, -3), Vector(0, 1), one_hundred_fifty_milliseconds_future);
 
-    Ball ball_3 = Ball(Point(0.01, -0.0), Vector(), future_time);
+    Ball ball_3 =
+        Ball(Point(0.01, -0.0), Vector(), one_hundred_fifty_milliseconds_future);
 
     EXPECT_EQ(ball_0, ball_0);
     EXPECT_NE(ball_0, ball_1);

--- a/src/thunderbots/software/test/world/ball.cpp
+++ b/src/thunderbots/software/test/world/ball.cpp
@@ -80,7 +80,7 @@ TEST(BallTest, update_values_with_past_timestamp)
 
 TEST(BallTest, update_state_with_future_timestamp)
 {
-    auto current_time = steady_clock::now();
+    auto current_time      = steady_clock::now();
     auto one_second_future = current_time + seconds(1);
 
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
@@ -98,7 +98,7 @@ TEST(BallTest, update_state_with_future_timestamp)
 TEST(BallTest, update_state_with_future_timestamp_2)
 {
     auto current_time = steady_clock::now();
-    auto future_time = current_time + milliseconds(150);
+    auto future_time  = current_time + milliseconds(150);
 
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
@@ -164,11 +164,14 @@ TEST(BallTest, get_velocity_at_future_time)
     double EPSILON = 1e-4;
 
     EXPECT_TRUE(
-        Vector(0.9851, 1.9702).isClose(ball.estimateVelocityAtFutureTime(milliseconds(150)), EPSILON));
+        Vector(0.9851, 1.9702)
+            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(150)), EPSILON));
     EXPECT_TRUE(
-        Vector(0.9048, 1.8097).isClose(ball.estimateVelocityAtFutureTime(milliseconds(1000)), EPSILON));
+        Vector(0.9048, 1.8097)
+            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(1000)), EPSILON));
     EXPECT_TRUE(
-        Vector(0.8187, 1.6375).isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
+        Vector(0.8187, 1.6375)
+            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
 }
 
 TEST(BallTest, get_velocity_at_future_time_2)
@@ -178,12 +181,15 @@ TEST(BallTest, get_velocity_at_future_time_2)
 
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
 
-    EXPECT_TRUE(Vector(-4.4330, -0.1182)
-                        .isClose(ball.estimateVelocityAtFutureTime(milliseconds(150)), EPSILON));
     EXPECT_TRUE(
-            Vector(-4.0717, -0.1086).isClose(ball.estimateVelocityAtFutureTime(milliseconds(1000)), EPSILON));
+        Vector(-4.4330, -0.1182)
+            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(150)), EPSILON));
     EXPECT_TRUE(
-            Vector(-3.6843, -0.0982).isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
+        Vector(-4.0717, -0.1086)
+            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(1000)), EPSILON));
+    EXPECT_TRUE(
+        Vector(-3.6843, -0.0982)
+            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
 }
 
 TEST(BallTest, get_velocity_at_past_time)
@@ -194,7 +200,7 @@ TEST(BallTest, get_velocity_at_past_time)
 
 TEST(BallTest, get_last_update_timestamp)
 {
-    auto current_time = steady_clock::now();
+    auto current_time       = steady_clock::now();
     auto half_second_future = current_time + milliseconds(500);
 
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
@@ -208,7 +214,7 @@ TEST(BallTest, get_last_update_timestamp)
 
 TEST(BallTest, get_last_update_timestamp_2)
 {
-    auto current_time = steady_clock::now();
+    auto current_time        = steady_clock::now();
     auto nine_seconds_future = current_time + seconds(9);
 
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
@@ -223,7 +229,7 @@ TEST(BallTest, get_last_update_timestamp_2)
 TEST(BallTest, equality_operators)
 {
     auto current_time = steady_clock::now();
-    auto future_time = current_time + milliseconds(123);
+    auto future_time  = current_time + milliseconds(123);
 
     Ball ball_0 = Ball();
 

--- a/src/thunderbots/software/test/world/ball.cpp
+++ b/src/thunderbots/software/test/world/ball.cpp
@@ -1,56 +1,121 @@
 #include "ai/world/ball.h"
 #include <gtest/gtest.h>
 
+using namespace std::chrono;
+
 TEST(BallTest, construct_with_no_params)
 {
     Ball ball = Ball();
 
     EXPECT_EQ(Point(), ball.position());
     EXPECT_EQ(Vector(), ball.velocity());
+    // Can't compare timestamp values here because the ball and the expected timestamp
+    // would not be createdx at the same time, and would not be equal. We could check
+    // that the timestamps are within a certain threshold, but that is not robust and
+    // makes the test dependant on the speed of the system executing it
 }
 
 TEST(BallTest, construct_with_params)
 {
-    Ball ball = Ball(Point(1, 2.3), Vector(-0.04, 0.0));
+    auto current_time = steady_clock::now();
+
+    Ball ball = Ball(Point(1, 2.3), Vector(-0.04, 0.0), current_time);
 
     EXPECT_EQ(Point(1, 2.3), ball.position());
     EXPECT_EQ(Vector(-0.04, 0.0), ball.velocity());
+    EXPECT_EQ(current_time, ball.lastUpdateTimestamp());
 }
 
 TEST(BallTest, update_all_values)
 {
     Ball ball = Ball();
 
-    ball.update(Point(-4.23, 1.07), Vector(1, 2));
+    auto current_time = steady_clock::now();
 
-    EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(1, 2)), ball);
+    ball.update(Point(-4.23, 1.07), Vector(1, 2), current_time);
+
+    EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(1, 2), current_time), ball);
 }
 
 TEST(BallTest, update_position_only)
 {
-    Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2));
+    auto current_time = steady_clock::now();
 
-    ball.update(Point(0.01, -99.8), ball.velocity());
+    Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2), current_time);
 
-    EXPECT_EQ(Ball(Point(0.01, -99.8), Vector(1, 2)), ball);
+    ball.update(Point(0.01, -99.8), ball.velocity(), current_time);
+
+    EXPECT_EQ(Ball(Point(0.01, -99.8), Vector(1, 2), current_time), ball);
 }
 
 TEST(BallTest, update_velocity_only)
 {
-    Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2));
+    auto current_time = steady_clock::now();
 
-    ball.update(ball.position(), Vector(-0.0, -9.433));
+    Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2), current_time);
 
-    EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(-0.0, -9.433)), ball);
+    ball.update(ball.position(), Vector(-0.0, -9.433), current_time);
+
+    EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(-0.0, -9.433), current_time), ball);
 }
 
 TEST(BallTest, update_with_new_ball)
 {
-    Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2));
+    auto current_time = steady_clock::now();
 
-    ball.update(Ball(Point(), Vector(-4.89, 3.1)));
+    Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2), current_time);
 
-    EXPECT_EQ(Ball(Point(), Vector(-4.89, 3.1)), ball);
+    Ball ball_update = Ball(Point(), Vector(-4.89, 3.1), current_time);
+
+    ball.update(ball_update);
+
+    EXPECT_EQ(ball_update, ball);
+}
+
+TEST(BallTest, update_values_with_past_timestamp)
+{
+    // TODO: Add unit tests to check for thrown exceptions when past timestamps are used
+    // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
+}
+
+TEST(BallTest, update_state_with_future_timestamp)
+{
+    auto current_time = steady_clock::now();
+    auto one_second_future = current_time + seconds(1);
+
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
+
+    ball.updateState(one_second_future);
+
+    // A small distance to check that values are approximately equal
+    double EPSILON = 1e-4;
+
+    EXPECT_EQ(Point(-1.5, 6.88), ball.position());
+    EXPECT_TRUE(Vector(-4.0717, -0.1086).isClose(ball.velocity(), EPSILON));
+    EXPECT_EQ(one_second_future, ball.lastUpdateTimestamp());
+}
+
+TEST(BallTest, update_state_with_future_timestamp_2)
+{
+    auto current_time = steady_clock::now();
+    auto future_time = current_time + milliseconds(150);
+
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
+
+    ball.updateState(future_time);
+
+    // A small distance to check that values are approximately equal
+    double EPSILON = 1e-4;
+
+    EXPECT_EQ(Point(2.325, 6.982), ball.position());
+    EXPECT_TRUE(Vector(-4.4330, -0.1182).isClose(ball.velocity(), EPSILON));
+    EXPECT_EQ(future_time, ball.lastUpdateTimestamp());
+}
+
+TEST(BallTest, update_state_with_past_timestamp)
+{
+    // TODO: Add unit tests to check for thrown exceptions when past timestamps are used
+    // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
 }
 
 TEST(BallTest, get_position_at_current_time)
@@ -60,19 +125,28 @@ TEST(BallTest, get_position_at_current_time)
     EXPECT_EQ(Point(3, 7), ball.position());
 }
 
-TEST(BallTest, predict_future_position)
+TEST(BallTest, get_position_at_future_time)
 {
     Ball ball = Ball(Point(), Vector(1, 2));
 
-    EXPECT_EQ(Point(1, 2), ball.estimatePositionAtFutureTime(1));
-    EXPECT_EQ(Point(2, 4), ball.estimatePositionAtFutureTime(2));
-    EXPECT_EQ(Point(0.15, 0.3), ball.estimatePositionAtFutureTime(0.15));
+    EXPECT_EQ(Point(0.15, 0.3), ball.estimatePositionAtFutureTime(milliseconds(150)));
+    EXPECT_EQ(Point(1, 2), ball.estimatePositionAtFutureTime(milliseconds(1000)));
+    EXPECT_EQ(Point(2, 4), ball.estimatePositionAtFutureTime(milliseconds(2000)));
+}
 
-    ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+TEST(BallTest, get_position_at_future_time_2)
+{
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
 
-    EXPECT_EQ(Point(-1.5, 6.88), ball.estimatePositionAtFutureTime(1));
-    EXPECT_EQ(Point(-6, 6.76), ball.estimatePositionAtFutureTime(2));
-    EXPECT_EQ(Point(2.325, 6.982), ball.estimatePositionAtFutureTime(0.15));
+    EXPECT_EQ(Point(2.325, 6.982), ball.estimatePositionAtFutureTime(milliseconds(150)));
+    EXPECT_EQ(Point(-1.5, 6.88), ball.estimatePositionAtFutureTime(milliseconds(1000)));
+    EXPECT_EQ(Point(-6, 6.76), ball.estimatePositionAtFutureTime(milliseconds(2000)));
+}
+
+TEST(BallTest, get_position_at_past_time)
+{
+    // TODO: Add unit tests to check for thrown exceptions when a negative value is passed
+    // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
 }
 
 TEST(BallTest, get_velocity_at_current_time)
@@ -82,7 +156,7 @@ TEST(BallTest, get_velocity_at_current_time)
     EXPECT_EQ(Vector(-4.5, -0.12), ball.velocity());
 }
 
-TEST(BallTest, predict_future_velocity)
+TEST(BallTest, get_velocity_at_future_time)
 {
     Ball ball = Ball(Point(), Vector(1, 2));
 
@@ -90,31 +164,74 @@ TEST(BallTest, predict_future_velocity)
     double EPSILON = 1e-4;
 
     EXPECT_TRUE(
-        Vector(0.9851, 1.9702).isClose(ball.estimateVelocityAtFutureTime(0.15), EPSILON));
+        Vector(0.9851, 1.9702).isClose(ball.estimateVelocityAtFutureTime(milliseconds(150)), EPSILON));
     EXPECT_TRUE(
-        Vector(0.9048, 1.8097).isClose(ball.estimateVelocityAtFutureTime(1), EPSILON));
+        Vector(0.9048, 1.8097).isClose(ball.estimateVelocityAtFutureTime(milliseconds(1000)), EPSILON));
     EXPECT_TRUE(
-        Vector(0.8187, 1.6375).isClose(ball.estimateVelocityAtFutureTime(2), EPSILON));
+        Vector(0.8187, 1.6375).isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
+}
 
-    ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
+TEST(BallTest, get_velocity_at_future_time_2)
+{
+    // A small distance to check that values are approximately equal
+    double EPSILON = 1e-4;
+
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12));
 
     EXPECT_TRUE(Vector(-4.4330, -0.1182)
-                    .isClose(ball.estimateVelocityAtFutureTime(0.15), EPSILON));
+                        .isClose(ball.estimateVelocityAtFutureTime(milliseconds(150)), EPSILON));
     EXPECT_TRUE(
-        Vector(-4.0717, -0.1086).isClose(ball.estimateVelocityAtFutureTime(1), EPSILON));
+            Vector(-4.0717, -0.1086).isClose(ball.estimateVelocityAtFutureTime(milliseconds(1000)), EPSILON));
     EXPECT_TRUE(
-        Vector(-3.6843, -0.0982).isClose(ball.estimateVelocityAtFutureTime(2), EPSILON));
+            Vector(-3.6843, -0.0982).isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
+}
+
+TEST(BallTest, get_velocity_at_past_time)
+{
+    // TODO: Add unit tests to check for thrown exceptions when a negative value is passed
+    // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
+}
+
+TEST(BallTest, get_last_update_timestamp)
+{
+    auto current_time = steady_clock::now();
+    auto half_second_future = current_time + milliseconds(500);
+
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
+
+    EXPECT_EQ(current_time, ball.lastUpdateTimestamp());
+
+    ball.updateState(half_second_future);
+
+    EXPECT_EQ(half_second_future, ball.lastUpdateTimestamp());
+}
+
+TEST(BallTest, get_last_update_timestamp_2)
+{
+    auto current_time = steady_clock::now();
+    auto nine_seconds_future = current_time + seconds(9);
+
+    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
+
+    EXPECT_EQ(current_time, ball.lastUpdateTimestamp());
+
+    ball.updateState(nine_seconds_future);
+
+    EXPECT_EQ(nine_seconds_future, ball.lastUpdateTimestamp());
 }
 
 TEST(BallTest, equality_operators)
 {
+    auto current_time = steady_clock::now();
+    auto future_time = current_time + milliseconds(123);
+
     Ball ball_0 = Ball();
 
-    Ball ball_1 = Ball(Point(0.01, -0.0), Vector());
+    Ball ball_1 = Ball(Point(0.01, -0.0), Vector(), current_time);
 
-    Ball ball_2 = Ball(Point(2, -3), Vector(0, 1));
+    Ball ball_2 = Ball(Point(2, -3), Vector(0, 1), future_time);
 
-    Ball ball_3 = Ball(Point(0.01, -0.0), Vector());
+    Ball ball_3 = Ball(Point(0.01, -0.0), Vector(), future_time);
 
     EXPECT_EQ(ball_0, ball_0);
     EXPECT_NE(ball_0, ball_1);

--- a/src/thunderbots/software/test/world/ball.cpp
+++ b/src/thunderbots/software/test/world/ball.cpp
@@ -47,7 +47,7 @@ TEST_F(BallTest, construct_with_params)
     EXPECT_EQ(current_time, ball.lastUpdateTimestamp());
 }
 
-TEST_F(BallTest, update_all_values)
+TEST_F(BallTest, update_state_with_all_values)
 {
     Ball ball = Ball(Point(), Vector(), current_time);
 
@@ -56,7 +56,7 @@ TEST_F(BallTest, update_all_values)
     EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(1, 2), one_second_future), ball);
 }
 
-TEST_F(BallTest, update_position_only)
+TEST_F(BallTest, update_state_with_position_only)
 {
     Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2), current_time);
 
@@ -65,7 +65,7 @@ TEST_F(BallTest, update_position_only)
     EXPECT_EQ(Ball(Point(0.01, -99.8), Vector(1, 2), current_time), ball);
 }
 
-TEST_F(BallTest, update_velocity_only)
+TEST_F(BallTest, update_state_with_velocity_only)
 {
     Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2), current_time);
 
@@ -74,7 +74,7 @@ TEST_F(BallTest, update_velocity_only)
     EXPECT_EQ(Ball(Point(-4.23, 1.07), Vector(-0.0, -9.433), current_time), ball);
 }
 
-TEST_F(BallTest, update_with_new_ball)
+TEST_F(BallTest, update_state_with_new_ball)
 {
     Ball ball = Ball(Point(-4.23, 1.07), Vector(1, 2), current_time);
 
@@ -85,13 +85,13 @@ TEST_F(BallTest, update_with_new_ball)
     EXPECT_EQ(ball_update, ball);
 }
 
-TEST_F(BallTest, update_values_with_past_timestamp)
+TEST_F(BallTest, update_state_with_past_timestamp)
 {
     // TODO: Add unit tests to check for thrown exceptions when past timestamps are used
     // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
 }
 
-TEST_F(BallTest, update_state_with_future_timestamp)
+TEST_F(BallTest, update_state_to_predicted_state_with_future_timestamp)
 {
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
@@ -105,7 +105,7 @@ TEST_F(BallTest, update_state_with_future_timestamp)
     EXPECT_EQ(one_second_future, ball.lastUpdateTimestamp());
 }
 
-TEST_F(BallTest, update_state_with_future_timestamp_2)
+TEST_F(BallTest, update_state_to_predicted_state_with_future_timestamp_2)
 {
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
@@ -119,7 +119,7 @@ TEST_F(BallTest, update_state_with_future_timestamp_2)
     EXPECT_EQ(one_hundred_fifty_milliseconds_future, ball.lastUpdateTimestamp());
 }
 
-TEST_F(BallTest, update_state_with_past_timestamp)
+TEST_F(BallTest, update_state_to_predicted_state_with_past_timestamp)
 {
     // TODO: Add unit tests to check for thrown exceptions when past timestamps are used
     // once https://github.com/UBC-Thunderbots/Software/issues/16 is done


### PR DESCRIPTION
Update the Ball class to use `std::chrono` for timestamps. Also added a new `updateState` function to update the Ball's state to a predicted future state. Useful for when the AI node runs several times without getting updates from vision, but we want to act with the most up-to-date/accurate information.

If anyone has naming suggestions to make the different `update` functions more clear I'm all ears.

I'm going to roll out a few timestamp changes before finishing the last `Team` and `World` implementations. This is the first part.

partially resolved #49 