### PR TITLE
improve robot timestamping and prediction

### DIFF
--- a/src/thunderbots/software/ai/world/robot.cpp
+++ b/src/thunderbots/software/ai/world/robot.cpp
@@ -1,35 +1,48 @@
 #include "robot.h"
 
-Robot::Robot(const unsigned int id)
+Robot::Robot(const unsigned int id, std::chrono::steady_clock::time_point timestamp)
     : id_(id),
       position_(Point()),
       velocity_(Vector()),
       orientation_(Angle::zero()),
-      angularVelocity_(AngularVelocity::zero())
+      angularVelocity_(AngularVelocity::zero()),
+      last_update_timestamp(timestamp)
 {
 }
 
 Robot::Robot(unsigned int id, const Point &position, const Vector &velocity,
-             const Angle &orientation, const AngularVelocity &angular_velocity)
+             const Angle &orientation, const AngularVelocity &angular_velocity,
+             std::chrono::steady_clock::time_point timestamp)
     : id_(id),
       position_(position),
       velocity_(velocity),
       orientation_(orientation),
-      angularVelocity_(angular_velocity)
+      angularVelocity_(angular_velocity),
+      last_update_timestamp(timestamp)
 {
 }
 
-void Robot::update(const Point &new_position, const Vector &new_velocity,
-                   const Angle &new_orientation,
-                   const AngularVelocity &new_angular_velocity)
+void Robot::updateState(const Point &new_position, const Vector &new_velocity,
+                        const Angle &new_orientation,
+                        const AngularVelocity &new_angular_velocity,
+                        std::chrono::steady_clock::time_point timestamp)
 {
-    position_        = new_position;
-    velocity_        = new_velocity;
-    orientation_     = new_orientation;
-    angularVelocity_ = new_angular_velocity;
+    if (timestamp < last_update_timestamp)
+    {
+        // TODO: Error. We should never be updating with times from the past
+        // TODO: Throw a proper exception here
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+        exit(1);
+    }
+
+    position_             = new_position;
+    velocity_             = new_velocity;
+    orientation_          = new_orientation;
+    angularVelocity_      = new_angular_velocity;
+    last_update_timestamp = timestamp;
 }
 
-void Robot::update(const Robot &new_robot_data)
+void Robot::updateState(const Robot &new_robot_data)
 {
     if (new_robot_data.id() != id())
     {
@@ -41,8 +54,36 @@ void Robot::update(const Robot &new_robot_data)
         exit(1);
     }
 
-    update(new_robot_data.position(), new_robot_data.velocity(),
-           new_robot_data.orientation(), new_robot_data.angularVelocity());
+    updateState(new_robot_data.position(), new_robot_data.velocity(),
+                new_robot_data.orientation(), new_robot_data.angularVelocity(),
+                new_robot_data.lastUpdateTimestamp());
+}
+
+void Robot::updateStateToPredictedState(std::chrono::steady_clock::time_point timestamp)
+{
+    if (timestamp < last_update_timestamp)
+    {
+        // TODO: Error. We should never be updating with times from the past
+        // TODO: Throw a proper exception here
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+        exit(1);
+    }
+
+    auto milliseconds_in_future = std::chrono::duration_cast<std::chrono::milliseconds>(
+        timestamp - last_update_timestamp);
+    Point new_position    = estimatePositionAtFutureTime(milliseconds_in_future);
+    Vector new_velocity   = estimateVelocityAtFutureTime(milliseconds_in_future);
+    Angle new_orientation = estimateOrientationAtFutureTime(milliseconds_in_future);
+    AngularVelocity new_angular_velocity =
+        estimateAngularVelocityAtFutureTime(milliseconds_in_future);
+
+    updateState(new_position, new_velocity, new_orientation, new_angular_velocity,
+                timestamp);
+}
+
+std::chrono::steady_clock::time_point Robot::lastUpdateTimestamp() const
+{
+    return last_update_timestamp;
 }
 
 unsigned int Robot::id() const
@@ -55,12 +96,23 @@ Point Robot::position() const
     return position_;
 }
 
-Point Robot::estimatePositionAtFutureTime(double time_delta) const
+Point Robot::estimatePositionAtFutureTime(
+    const std::chrono::milliseconds &milliseconds_in_future) const
 {
+    if (milliseconds_in_future < std::chrono::milliseconds(0))
+    {
+        // TODO: Error. We should never be updating with times from the past
+        // TODO: Throw a proper exception here
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+    }
+
     // TODO: This is a simple linear implementation that does not necessarily reflect
     // real-world behavior. Position prediction should be improved as outlined in
     // https://github.com/UBC-Thunderbots/Software/issues/50
-    return position_ + velocity_.norm(velocity_.len() * time_delta);
+    typedef std::chrono::duration<double> double_seconds;
+    double seconds_in_future =
+        std::chrono::duration_cast<double_seconds>(milliseconds_in_future).count();
+    return position_ + velocity_.norm(velocity_.len() * seconds_in_future);
 }
 
 Vector Robot::velocity() const
@@ -68,8 +120,16 @@ Vector Robot::velocity() const
     return velocity_;
 }
 
-Vector Robot::estimateVelocityAtFutureTime(double time_delta) const
+Vector Robot::estimateVelocityAtFutureTime(
+    const std::chrono::milliseconds &milliseconds_in_future) const
 {
+    if (milliseconds_in_future < std::chrono::milliseconds(0))
+    {
+        // TODO: Error. We should never be updating with times from the past
+        // TODO: Throw a proper exception here
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+    }
+
     // TODO: This simple implementation that assumes the robot maintains the same velocity
     // and does not necessarily reflect real-world behavior. Velocity prediction should be
     // improved as outlined in https://github.com/UBC-Thunderbots/Software/issues/50
@@ -81,12 +141,23 @@ Angle Robot::orientation() const
     return orientation_;
 }
 
-Angle Robot::estimateOrientationAtFutureTime(double time_delta) const
+Angle Robot::estimateOrientationAtFutureTime(
+    const std::chrono::milliseconds &milliseconds_in_future) const
 {
+    if (milliseconds_in_future < std::chrono::milliseconds(0))
+    {
+        // TODO: Error. We should never be updating with times from the past
+        // TODO: Throw a proper exception here
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+    }
+
     // TODO: This is a simple linear implementation that does not necessarily reflect
     // real-world behavior. Orientation prediction should be improved as outlined in
     // https://github.com/UBC-Thunderbots/Software/issues/50
-    return orientation_ + angularVelocity_ * time_delta;
+    typedef std::chrono::duration<double> double_seconds;
+    double seconds_in_future =
+        std::chrono::duration_cast<double_seconds>(milliseconds_in_future).count();
+    return orientation_ + angularVelocity_ * seconds_in_future;
 }
 
 AngularVelocity Robot::angularVelocity() const
@@ -94,8 +165,16 @@ AngularVelocity Robot::angularVelocity() const
     return angularVelocity_;
 }
 
-AngularVelocity Robot::estimateAngularVelocityAtFutureTime(double time_delta) const
+AngularVelocity Robot::estimateAngularVelocityAtFutureTime(
+    const std::chrono::milliseconds &milliseconds_in_future) const
 {
+    if (milliseconds_in_future < std::chrono::milliseconds(0))
+    {
+        // TODO: Error. We should never be updating with times from the past
+        // TODO: Throw a proper exception here
+        // https://github.com/UBC-Thunderbots/Software/issues/16
+    }
+
     // TODO: This simple implementation that assumes the robot maintains the same
     // angular velocity and does not necessarily reflect real-world behavior. Angular
     // velocity prediction should be improved as outlined in

--- a/src/thunderbots/software/ai/world/robot.h
+++ b/src/thunderbots/software/ai/world/robot.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include "geom/angle.h"
 #include "geom/point.h"
 
@@ -13,8 +14,13 @@ class Robot
      * Creates a new robot given a pattern id
      *
      * @param id The id of the robot to create
+     * @param timestamp The timestamp at which the robot was observed to be in the given
+     * state. The timestamp must be >= the robot's latest update timestamp. Default
+     * is the current time
      */
-    explicit Robot(unsigned int id);
+    explicit Robot(unsigned int id,
+                   std::chrono::steady_clock::time_point timestamp =
+                       std::chrono::steady_clock::now());
 
     /**
      * Creates a new robot given robot data
@@ -25,9 +31,12 @@ class Robot
      * @param orientation the new orientation of the robot, in Radians.
      * @param angular_velocity the new angular velocity of the robot, in Radians
      * per second
+     * @param timestamp The timestamp at which the robot was observed to be in the given
+     * state. The timestamp must be >= the robot's latest update timestamp
      */
     explicit Robot(unsigned int id, const Point& position, const Vector& velocity,
-                   const Angle& orientation, const AngularVelocity& angular_velocity);
+                   const Angle& orientation, const AngularVelocity& angular_velocity,
+                   std::chrono::steady_clock::time_point timestamp);
 
     /**
      * Updates the state of the robot.
@@ -37,10 +46,13 @@ class Robot
      * @param new_orientation the new orientation of the robot, in Radians.
      * @param new_angular_velocity the new angular velocity of the robot, in Radians
      * per second
+     * @param timestamp The timestamp at which the robot was observed to be in the given
+     * state. The timestamp must be >= the robot's latest update timestamp
      */
-    void update(const Point& new_position, const Vector& new_velocity,
-                const Angle& new_orientation,
-                const AngularVelocity& new_angular_velocity);
+    void updateState(const Point& new_position, const Vector& new_velocity,
+                     const Angle& new_orientation,
+                     const AngularVelocity& new_angular_velocity,
+                     std::chrono::steady_clock::time_point timestamp);
 
     /**
      * Updates the robot with new data, updating the current state as well as the
@@ -48,7 +60,23 @@ class Robot
      *
      * @param new_robot_data A robot containing new robot data
      */
-    void update(const Robot& new_robot_data);
+    void updateState(const Robot& new_robot_data);
+
+    /**
+     * Updates the robot's state to be its predicted state at the given timestamp.
+     * The timestamp must be >= the robot's last update timestamp
+     *
+     * @param timestamp The timestamp at which to update the robot's state to. Must
+     * be >= the robot's last update timestamp
+     */
+    void updateStateToPredictedState(std::chrono::steady_clock::time_point timestamp);
+
+    /**
+     * Returns the timestamp for when this robot's data was last updated
+     *
+     * @return the timestamp for when this robot's data was last updated
+     */
+    std::chrono::steady_clock::time_point lastUpdateTimestamp() const;
 
     /**
      * Returns the id of the robot
@@ -65,17 +93,19 @@ class Robot
     Point position() const;
 
     /**
-     * Returns the estimated position of the robot at a future time, relative to the
-     * current time
+     * Returns the estimated position of the robot at a future time, relative to when
+     * the robot was last updated
      *
-     * @param time_delta The relative amount of time in the future (in seconds) at which
-     * to predict the robot's position. For example, a value of 1.5 would return the
-     * estimated position of the robot 1.5s in the future.
+     * @param milliseconds_in_future The relative amount of time in the future
+     * (in milliseconds) at which to predict the robot's position. Value must be >= 0.
+     * For example, a value of 1500 would return the estimated position of the robot
+     * 1.5 seconds in the future.
      *
-     * @return the estimated position of the robot at a future time.
-     * Coordinates are in metres.
+     * @return the estimated position of the robot at the given number of milliseconds
+     * in the future. Coordinates are in metres.
      */
-    Point estimatePositionAtFutureTime(double time_delta = 0.0) const;
+    Point estimatePositionAtFutureTime(
+        const std::chrono::milliseconds& milliseconds_in_future) const;
 
     /**
      * Returns the current velocity of the robot
@@ -85,17 +115,19 @@ class Robot
     Vector velocity() const;
 
     /**
-     * Returns the estimated velocity of the robot at a future time, relative to the
-     * current time
+     * Returns the estimated velocity of the robot at a future time, relative to when
+     * the robot was last updated
      *
-     * @param time_delta The relative amount of time in the future (in seconds) at which
-     * to predict the robot's velocity. For example, a value of 1.5 would return the
-     * estimated velocity of the robot 1.5s in the future.
+     * @param milliseconds_in_future The relative amount of time in the future
+     * (in milliseconds) at which to predict the robot's velocity. Value must be >= 0.
+     * For example, a value of 1500 would return the estimated velocity of the robot
+     * 1.5 seconds in the future.
      *
-     * @return the estimated velocity of the robot at a future time.
-     * Coordinates are in metres.
+     * @return the estimated velocity of the robot at the given number of milliseconds
+     * in the future, in metres per second
      */
-    Vector estimateVelocityAtFutureTime(double time_delta = 0.0) const;
+    Vector estimateVelocityAtFutureTime(
+        const std::chrono::milliseconds& milliseconds_in_future) const;
 
     /**
      * Returns the current orientation of the robot
@@ -105,17 +137,19 @@ class Robot
     Angle orientation() const;
 
     /**
-     * Returns the estimated orientation of the robot at a future time, relative to the
-     * current time
+     * Returns the estimated orientation of the robot at a future time, relative to when
+     * the robot was last updated
      *
-     * @param time_delta The relative amount of time in the future (in seconds) at which
-     * to predict the robot's orientation. For example, a value of 1.5 would return the
-     * estimated orientation of the robot 1.5s in the future.
+     * @param milliseconds_in_future The relative amount of time in the future
+     * (in milliseconds) at which to predict the robot's orientation. Value must be >= 0.
+     * For example, a value of 1500 would return the estimated orientation of the robot
+     * 1.5 seconds in the future.
      *
-     * @return the estimated orientation of the robot at a future time.
-     * Coordinates are in metres.
+     * @return the estimated orientation of the robot at the given number of milliseconds
+     * in the future. Coordinates are in metres.
      */
-    Angle estimateOrientationAtFutureTime(double time_delta = 0.0) const;
+    Angle estimateOrientationAtFutureTime(
+        const std::chrono::milliseconds& milliseconds_in_future) const;
 
     /**
      * Returns the current angular velocity of the robot
@@ -126,20 +160,24 @@ class Robot
 
     /**
      * Returns the estimated angular velocity of the robot at a future time, relative to
-     * the current time
+     * when
+     * the robot was last updated
      *
-     * @param time_delta The relative amount of time in the future (in seconds) at which
-     * to predict the robot's angular velocity. For example, a value of 1.5 would return
-     * the estimated angular velocity of the robot 1.5s in the future.
+     * @param milliseconds_in_future The relative amount of time in the future
+     * (in milliseconds) at which to predict the robot's angular velocity. Value must be
+     * >= 0. For example, a value of 1500 would return the estimated angular velocity of
+     * the robot 1.5 seconds in the future.
      *
-     * @return the estimated angular velocity of the robot at a future time.
-     * Coordinates are in metres.
+     * @return the estimated angular velocity of the robot at the given number of
+     * milliseconds in the future. Coordinates are in metres. Coordinates are in metres.
      */
-    AngularVelocity estimateAngularVelocityAtFutureTime(double time_delta = 0.0) const;
+    AngularVelocity estimateAngularVelocityAtFutureTime(
+        const std::chrono::milliseconds& milliseconds_in_future) const;
 
     /**
      * Defines the equality operator for a Robot. Robots are equal if their IDs and
-     * all other parameters (position, orientation, etc) are equal
+     * all other parameters (position, orientation, etc) are equal. The last update
+     * timestamp is not part of the equality.
      *
      * @param other The robot to compare against for equality
      * @return True if the other robot is equal to this robot, and false otherwise
@@ -165,4 +203,6 @@ class Robot
     Angle orientation_;
     // The current angular velocity of the robot, in radians per second
     AngularVelocity angularVelocity_;
+    // The timestamp for when this Robot was last updated
+    std::chrono::steady_clock::time_point last_update_timestamp;
 };

--- a/src/thunderbots/software/test/util/ros_messages.cpp
+++ b/src/thunderbots/software/test/util/ros_messages.cpp
@@ -1,7 +1,24 @@
 #include "util/ros_messages.h"
 #include <gtest/gtest.h>
 
-TEST(ROSMessageUtilTest, create_ball_from_ros_message)
+using namespace std::chrono;
+
+class ROSMessageUtilTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        auto epoch = time_point<std::chrono::steady_clock>();
+        // An arbitrary fixed point in time. 10000 seconds after the epoch
+        auto since_epoch = std::chrono::seconds(10000);
+
+        current_time       = epoch + since_epoch;
+    }
+
+    steady_clock::time_point current_time;
+};
+
+TEST_F(ROSMessageUtilTest, create_ball_from_ros_message)
 {
     thunderbots_msgs::Ball ball_msg;
 
@@ -15,7 +32,7 @@ TEST(ROSMessageUtilTest, create_ball_from_ros_message)
     EXPECT_EQ(Ball(Point(1.2, -8.07), Vector(0, 3)), ball);
 }
 
-TEST(ROSMessageUtilTest, create_robot_from_ros_message)
+TEST_F(ROSMessageUtilTest, create_robot_from_ros_message)
 {
     unsigned int id                  = 2;
     Point position                   = Point(1.2, -8.07);
@@ -35,10 +52,10 @@ TEST(ROSMessageUtilTest, create_robot_from_ros_message)
 
     Robot robot = Util::ROSMessages::createRobotFromROSMessage(robot_msg);
 
-    EXPECT_EQ(Robot(id, position, velocity, orientation, angular_velocity), robot);
+    EXPECT_EQ(Robot(id, position, velocity, orientation, angular_velocity, current_time), robot);
 }
 
-TEST(ROSMessageUtilTest, create_field_from_ros_message)
+TEST_F(ROSMessageUtilTest, create_field_from_ros_message)
 {
     double length               = 9.0;
     double width                = 6.0;

--- a/src/thunderbots/software/test/util/ros_messages.cpp
+++ b/src/thunderbots/software/test/util/ros_messages.cpp
@@ -5,14 +5,14 @@ using namespace std::chrono;
 
 class ROSMessageUtilTest : public ::testing::Test
 {
-protected:
+   protected:
     void SetUp() override
     {
         auto epoch = time_point<std::chrono::steady_clock>();
         // An arbitrary fixed point in time. 10000 seconds after the epoch
         auto since_epoch = std::chrono::seconds(10000);
 
-        current_time       = epoch + since_epoch;
+        current_time = epoch + since_epoch;
     }
 
     steady_clock::time_point current_time;
@@ -52,7 +52,8 @@ TEST_F(ROSMessageUtilTest, create_robot_from_ros_message)
 
     Robot robot = Util::ROSMessages::createRobotFromROSMessage(robot_msg);
 
-    EXPECT_EQ(Robot(id, position, velocity, orientation, angular_velocity, current_time), robot);
+    EXPECT_EQ(Robot(id, position, velocity, orientation, angular_velocity, current_time),
+              robot);
 }
 
 TEST_F(ROSMessageUtilTest, create_field_from_ros_message)

--- a/src/thunderbots/software/test/world/ball.cpp
+++ b/src/thunderbots/software/test/world/ball.cpp
@@ -8,10 +8,11 @@ class BallTest : public ::testing::Test
    protected:
     void SetUp() override
     {
-        auto epoch = time_point<std::chrono::steady_clock>();
-        // An arbitrary fixed point in time. 10000 seconds after the epoch
+        auto epoch       = time_point<std::chrono::steady_clock>();
         auto since_epoch = std::chrono::seconds(10000);
 
+        // An arbitrary fixed point in time. 10000 seconds after the epoch.
+        // We use this fixed point in time to make the tests deterministic.
         current_time                          = epoch + since_epoch;
         one_hundred_fifty_milliseconds_future = current_time + milliseconds(150);
         half_second_future                    = current_time + milliseconds(500);
@@ -47,7 +48,7 @@ TEST_F(BallTest, construct_with_params)
     EXPECT_EQ(current_time, ball.lastUpdateTimestamp());
 }
 
-TEST_F(BallTest, update_state_with_all_values)
+TEST_F(BallTest, update_state_with_all_params)
 {
     Ball ball = Ball(Point(), Vector(), current_time);
 
@@ -105,19 +106,6 @@ TEST_F(BallTest, update_state_to_predicted_state_with_future_timestamp)
     EXPECT_EQ(one_second_future, ball.lastUpdateTimestamp());
 }
 
-TEST_F(BallTest, update_state_to_predicted_state_with_future_timestamp_2)
-{
-    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
-
-    ball.updateStateToPredictedState(one_hundred_fifty_milliseconds_future);
-
-    // A small distance to check that values are approximately equal
-    double EPSILON = 1e-4;
-
-    EXPECT_EQ(Point(2.325, 6.982), ball.position());
-    EXPECT_TRUE(Vector(-4.4330, -0.1182).isClose(ball.velocity(), EPSILON));
-    EXPECT_EQ(one_hundred_fifty_milliseconds_future, ball.lastUpdateTimestamp());
-}
 
 TEST_F(BallTest, update_state_to_predicted_state_with_past_timestamp)
 {
@@ -132,7 +120,7 @@ TEST_F(BallTest, get_position_at_current_time)
     EXPECT_EQ(Point(3, 7), ball.position());
 }
 
-TEST_F(BallTest, get_position_at_future_time)
+TEST_F(BallTest, get_position_at_future_time_with_positive_ball_velocity)
 {
     Ball ball = Ball(Point(), Vector(1, 2), current_time);
 
@@ -141,7 +129,7 @@ TEST_F(BallTest, get_position_at_future_time)
     EXPECT_EQ(Point(2, 4), ball.estimatePositionAtFutureTime(milliseconds(2000)));
 }
 
-TEST_F(BallTest, get_position_at_future_time_2)
+TEST_F(BallTest, get_position_at_future_time_with_negative_ball_velocity)
 {
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
@@ -163,7 +151,7 @@ TEST_F(BallTest, get_velocity_at_current_time)
     EXPECT_EQ(Vector(-4.5, -0.12), ball.velocity());
 }
 
-TEST_F(BallTest, get_velocity_at_future_time)
+TEST_F(BallTest, get_velocity_at_future_time_with_positive_ball_velocity)
 {
     Ball ball = Ball(Point(), Vector(1, 2), current_time);
 
@@ -181,7 +169,7 @@ TEST_F(BallTest, get_velocity_at_future_time)
             .isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
 }
 
-TEST_F(BallTest, get_velocity_at_future_time_2)
+TEST_F(BallTest, get_velocity_at_future_time_with_negative_ball_velocity)
 {
     // A small distance to check that values are approximately equal
     double EPSILON = 1e-4;
@@ -214,17 +202,6 @@ TEST_F(BallTest, get_last_update_timestamp)
     ball.updateStateToPredictedState(half_second_future);
 
     EXPECT_EQ(half_second_future, ball.lastUpdateTimestamp());
-}
-
-TEST_F(BallTest, get_last_update_timestamp_2)
-{
-    Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
-
-    EXPECT_EQ(current_time, ball.lastUpdateTimestamp());
-
-    ball.updateStateToPredictedState(nine_seconds_future);
-
-    EXPECT_EQ(nine_seconds_future, ball.lastUpdateTimestamp());
 }
 
 TEST_F(BallTest, equality_operators)

--- a/src/thunderbots/software/test/world/robot.cpp
+++ b/src/thunderbots/software/test/world/robot.cpp
@@ -1,214 +1,328 @@
 #include "ai/world/robot.h"
 #include <gtest/gtest.h>
 
-TEST(RobotTest, construct_with_id_only)
+using namespace std::chrono;
+
+class RobotTest : public ::testing::Test
 {
-    Robot robot = Robot(0);
+   protected:
+    void SetUp() override
+    {
+        auto epoch = time_point<std::chrono::steady_clock>();
+        // An arbitrary fixed point in time. 10000 seconds after the epoch
+        auto since_epoch = std::chrono::seconds(10000);
+
+        current_time       = epoch + since_epoch;
+        half_second_future = current_time + milliseconds(500);
+        one_second_future  = current_time + seconds(1);
+    }
+
+    steady_clock::time_point current_time;
+    steady_clock::time_point half_second_future;
+    steady_clock::time_point one_second_future;
+};
+
+TEST_F(RobotTest, construct_with_id)
+{
+    Robot robot = Robot(0, current_time);
 
     EXPECT_EQ(0, robot.id());
     EXPECT_EQ(Point(), robot.position());
     EXPECT_EQ(Vector(), robot.velocity());
     EXPECT_EQ(Angle::zero(), robot.orientation());
     EXPECT_EQ(AngularVelocity::zero(), robot.angularVelocity());
+    EXPECT_EQ(current_time, robot.lastUpdateTimestamp());
 }
 
-TEST(RobotTest, construct_with_all_params)
+TEST_F(RobotTest, construct_with_all_params)
 {
     Robot robot = Robot(3, Point(1, 1), Vector(-0.3, 0), Angle::ofRadians(2.2),
-                        AngularVelocity::ofRadians(-0.6));
+                        AngularVelocity::ofRadians(-0.6), current_time);
 
     EXPECT_EQ(3, robot.id());
     EXPECT_EQ(Point(1, 1), robot.position());
     EXPECT_EQ(Vector(-0.3, 0), robot.velocity());
     EXPECT_EQ(Angle::ofRadians(2.2), robot.orientation());
     EXPECT_EQ(AngularVelocity::ofRadians(-0.6), robot.angularVelocity());
+    EXPECT_EQ(current_time, robot.lastUpdateTimestamp());
 }
 
-TEST(RobotTest, update_with_all_params)
+TEST_F(RobotTest, update_state_with_all_params)
 {
-    Robot robot = Robot(0);
+    Robot robot = Robot(0, current_time);
 
-    robot.update(Point(-1.2, 3), Vector(2.2, -0.05), Angle::quarter(),
-                 AngularVelocity::ofRadians(1.1));
+    robot.updateState(Point(-1.2, 3), Vector(2.2, -0.05), Angle::quarter(),
+                      AngularVelocity::ofRadians(1.1), half_second_future);
 
     EXPECT_EQ(0, robot.id());
     EXPECT_EQ(Point(-1.2, 3), robot.position());
     EXPECT_EQ(Vector(2.2, -0.05), robot.velocity());
     EXPECT_EQ(Angle::quarter(), robot.orientation());
     EXPECT_EQ(AngularVelocity::ofRadians(1.1), robot.angularVelocity());
+    EXPECT_EQ(half_second_future, robot.lastUpdateTimestamp());
 }
 
-TEST(RobotTest, update_specific_params)
+TEST_F(RobotTest, update_state_with_specific_params)
 {
-    Robot robot = Robot(0);
+    Robot robot = Robot(0, current_time);
 
     // Only update certain parameters and leave the rest as their previous values
-    robot.update(robot.position(), Vector(2.2, -0.05), robot.orientation(),
-                 AngularVelocity::ofRadians(1.1));
+    robot.updateState(robot.position(), Vector(2.2, -0.05), robot.orientation(),
+                      AngularVelocity::ofRadians(1.1), current_time);
 
     EXPECT_EQ(0, robot.id());
     EXPECT_EQ(Point(), robot.position());
     EXPECT_EQ(Vector(2.2, -0.05), robot.velocity());
     EXPECT_EQ(Angle::zero(), robot.orientation());
     EXPECT_EQ(AngularVelocity::ofRadians(1.1), robot.angularVelocity());
+    EXPECT_EQ(current_time, robot.lastUpdateTimestamp());
+}
+
+TEST_F(RobotTest, update_state_with_specific_params_2)
+{
+    Robot robot = Robot(0, Point(), Vector(2.2, -0.05), Angle::zero(),
+                        AngularVelocity::ofRadians(1.1), current_time);
 
     // Repeat with a different combination of parameters
-    robot.update(Point(-1.2, 3), robot.velocity(), Angle::quarter(),
-                 robot.angularVelocity());
+    robot.updateState(Point(-1.2, 3), robot.velocity(), Angle::quarter(),
+                      robot.angularVelocity(), one_second_future);
 
     EXPECT_EQ(0, robot.id());
     EXPECT_EQ(Point(-1.2, 3), robot.position());
     EXPECT_EQ(Vector(2.2, -0.05), robot.velocity());
     EXPECT_EQ(Angle::quarter(), robot.orientation());
     EXPECT_EQ(AngularVelocity::ofRadians(1.1), robot.angularVelocity());
+    EXPECT_EQ(one_second_future, robot.lastUpdateTimestamp());
 }
 
-TEST(RobotTest, update_with_new_robot)
+TEST_F(RobotTest, update_state_with_new_robot_with_same_id)
 {
-    Robot robot = Robot(0);
+    Robot robot = Robot(0, current_time);
 
     Robot update_robot = Robot(0, Point(-1.2, 3), robot.velocity(), Angle::quarter(),
-                               robot.angularVelocity());
+                               robot.angularVelocity(), current_time);
 
-    robot.update(update_robot);
+    robot.updateState(update_robot);
 
     EXPECT_EQ(robot, update_robot);
-
-    // TODO: Update this test to also test for a thrown exception once
-    // https://github.com/UBC-Thunderbots/Software/issues/16
-    // is completed. If a robot is updated using a robot with a different id, an
-    // exception should be thrown
 }
 
-TEST(RobotTest, get_position_at_current_time)
+TEST_F(RobotTest, update_with_new_robot_with_different_id)
+{
+    // TODO: Add unit test to check for a thrown exception when a robot with a different
+    // id is used once https://github.com/UBC-Thunderbots/Software/issues/16i is done
+}
+
+TEST_F(RobotTest, update_state_to_predicted_state_with_future_timestamp)
+{
+    Robot robot = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                        AngularVelocity::ofRadians(2), current_time);
+
+    robot.updateStateToPredictedState(one_second_future);
+
+    EXPECT_EQ(Point(4.5, -1), robot.position());
+    EXPECT_EQ(Point(3.5, 1), robot.velocity());
+    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(2), robot.orientation());
+    EXPECT_EQ(AngularVelocity::ofRadians(2), robot.angularVelocity());
+    EXPECT_EQ(one_second_future, robot.lastUpdateTimestamp());
+}
+
+TEST_F(RobotTest, update_state_to_predicted_state_with_past_timestamp)
+{
+    // TODO: Add unit tests to check for thrown exceptions when past timestamps are used
+    // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
+}
+
+TEST_F(RobotTest, get_position_at_current_time)
 {
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
-                        AngularVelocity::ofRadians(0.7));
+                        AngularVelocity::ofRadians(0.7), current_time);
 
     EXPECT_EQ(Point(-1.2, 3), robot.position());
 }
 
-TEST(RobotTest, get_position_at_future_time)
+TEST_F(RobotTest, get_position_at_future_time)
 {
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
-                        AngularVelocity::ofRadians(0.7));
+                        AngularVelocity::ofRadians(0.7), current_time);
 
-    EXPECT_EQ(Point(-1.4, 4.04), robot.estimatePositionAtFutureTime(0.4));
-    EXPECT_EQ(Point(-1.7, 5.6), robot.estimatePositionAtFutureTime(1));
-    EXPECT_EQ(Point(-2.7, 10.8), robot.estimatePositionAtFutureTime(3));
-
-    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
-                              AngularVelocity::ofRadians(2));
-
-    EXPECT_EQ(Point(2.4, -1.6), robot_other.estimatePositionAtFutureTime(0.4));
-    EXPECT_EQ(Point(4.5, -1), robot_other.estimatePositionAtFutureTime(1));
-    EXPECT_EQ(Point(11.5, 1), robot_other.estimatePositionAtFutureTime(3));
+    EXPECT_EQ(Point(-1.4, 4.04), robot.estimatePositionAtFutureTime(milliseconds(400)));
+    EXPECT_EQ(Point(-1.7, 5.6), robot.estimatePositionAtFutureTime(milliseconds(1000)));
+    EXPECT_EQ(Point(-2.7, 10.8), robot.estimatePositionAtFutureTime(milliseconds(3000)));
 }
 
-TEST(RobotTest, get_velocity_at_current_time)
+TEST_F(RobotTest, get_position_at_future_time_2)
+{
+    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                              AngularVelocity::ofRadians(2), current_time);
+
+    EXPECT_EQ(Point(2.4, -1.6),
+              robot_other.estimatePositionAtFutureTime(milliseconds(400)));
+    EXPECT_EQ(Point(4.5, -1),
+              robot_other.estimatePositionAtFutureTime(milliseconds(1000)));
+    EXPECT_EQ(Point(11.5, 1),
+              robot_other.estimatePositionAtFutureTime(milliseconds(3000)));
+}
+
+TEST_F(RobotTest, get_position_at_past_time)
+{
+    // TODO: Add unit tests to check for thrown exceptions when a negative value is passed
+    // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
+}
+
+TEST_F(RobotTest, get_velocity_at_current_time)
 {
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
-                        AngularVelocity::ofRadians(0.7));
+                        AngularVelocity::ofRadians(0.7), current_time);
 
     EXPECT_EQ(Vector(-0.5, 2.6), robot.velocity());
 }
 
-TEST(RobotTest, get_velocity_at_future_time)
+TEST_F(RobotTest, get_velocity_at_future_time)
 {
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
-                        AngularVelocity::ofRadians(0.7));
+                        AngularVelocity::ofRadians(0.7), current_time);
 
-    EXPECT_EQ(Point(-0.5, 2.6), robot.estimateVelocityAtFutureTime(0.4));
-    EXPECT_EQ(Point(-0.5, 2.6), robot.estimateVelocityAtFutureTime(1));
-    EXPECT_EQ(Point(-0.5, 2.6), robot.estimateVelocityAtFutureTime(3));
-
-    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
-                              AngularVelocity::ofRadians(2));
-
-    EXPECT_EQ(Point(3.5, 1), robot_other.estimateVelocityAtFutureTime(0.4));
-    EXPECT_EQ(Point(3.5, 1), robot_other.estimateVelocityAtFutureTime(1));
-    EXPECT_EQ(Point(3.5, 1), robot_other.estimateVelocityAtFutureTime(3));
+    EXPECT_EQ(Point(-0.5, 2.6), robot.estimateVelocityAtFutureTime(milliseconds(400)));
+    EXPECT_EQ(Point(-0.5, 2.6), robot.estimateVelocityAtFutureTime(milliseconds(1000)));
+    EXPECT_EQ(Point(-0.5, 2.6), robot.estimateVelocityAtFutureTime(milliseconds(3000)));
 }
 
-TEST(RobotTest, get_orientation_at_current_time)
+TEST_F(RobotTest, get_velocity_at_future_time_2)
+{
+    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                              AngularVelocity::ofRadians(2), current_time);
+
+    EXPECT_EQ(Point(3.5, 1), robot_other.estimateVelocityAtFutureTime(milliseconds(400)));
+    EXPECT_EQ(Point(3.5, 1),
+              robot_other.estimateVelocityAtFutureTime(milliseconds(1000)));
+    EXPECT_EQ(Point(3.5, 1),
+              robot_other.estimateVelocityAtFutureTime(milliseconds(3000)));
+}
+
+TEST_F(RobotTest, get_velocity_at_past_time)
+{
+    // TODO: Add unit tests to check for thrown exceptions when a negative value is passed
+    // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
+}
+
+TEST_F(RobotTest, get_orientation_at_current_time)
 {
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
-                        AngularVelocity::ofRadians(0.7));
+                        AngularVelocity::ofRadians(0.7), current_time);
 
     EXPECT_EQ(Angle::quarter(), robot.orientation());
 }
 
-TEST(RobotTest, get_orientation_at_future_time)
+TEST_F(RobotTest, get_orientation_at_future_time)
 {
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
-                        AngularVelocity::ofRadians(0.7));
+                        AngularVelocity::ofRadians(0.7), current_time);
 
     EXPECT_EQ(Angle::quarter() + Angle::ofRadians(0.28),
-              robot.estimateOrientationAtFutureTime(0.4));
+              robot.estimateOrientationAtFutureTime(milliseconds(400)));
     EXPECT_EQ(Angle::quarter() + Angle::ofRadians(0.7),
-              robot.estimateOrientationAtFutureTime(1));
+              robot.estimateOrientationAtFutureTime(milliseconds(1000)));
     EXPECT_EQ(Angle::quarter() + Angle::ofRadians(2.1),
-              robot.estimateOrientationAtFutureTime(3));
-
-    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
-                              AngularVelocity::ofRadians(2));
-
-    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(0.8),
-              robot_other.estimateOrientationAtFutureTime(0.4));
-    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(2),
-              robot_other.estimateOrientationAtFutureTime(1));
-    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(6),
-              robot_other.estimateOrientationAtFutureTime(3));
+              robot.estimateOrientationAtFutureTime(milliseconds(3000)));
 }
 
-TEST(RobotTest, get_angular_velocity_at_current_time)
+TEST_F(RobotTest, get_orientation_at_future_time_2)
+{
+    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                              AngularVelocity::ofRadians(2), current_time);
+
+    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(0.8),
+              robot_other.estimateOrientationAtFutureTime(milliseconds(400)));
+    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(2),
+              robot_other.estimateOrientationAtFutureTime(milliseconds(1000)));
+    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(6),
+              robot_other.estimateOrientationAtFutureTime(milliseconds(3000)));
+}
+
+TEST_F(RobotTest, get_orientation_at_past_time)
+{
+    // TODO: Add unit tests to check for thrown exceptions when a negative value is passed
+    // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
+}
+
+TEST_F(RobotTest, get_angular_velocity_at_current_time)
 {
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
-                        AngularVelocity::ofRadians(0.7));
+                        AngularVelocity::ofRadians(0.7), current_time);
 
     EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.angularVelocity());
 }
 
-TEST(RobotTest, get_angularVelocity_at_future_time)
+TEST_F(RobotTest, get_angular_velocity_at_future_time)
 {
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, 2.6), Angle::quarter(),
-                        AngularVelocity::ofRadians(0.7));
+                        AngularVelocity::ofRadians(0.7), current_time);
 
     EXPECT_EQ(AngularVelocity::ofRadians(0.7),
-              robot.estimateAngularVelocityAtFutureTime(0.4));
+              robot.estimateAngularVelocityAtFutureTime(milliseconds(400)));
     EXPECT_EQ(AngularVelocity::ofRadians(0.7),
-              robot.estimateAngularVelocityAtFutureTime(1));
+              robot.estimateAngularVelocityAtFutureTime(milliseconds(1000)));
     EXPECT_EQ(AngularVelocity::ofRadians(0.7),
-              robot.estimateAngularVelocityAtFutureTime(3));
-
-    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
-                              AngularVelocity::ofRadians(2));
-
-    EXPECT_EQ(AngularVelocity::ofRadians(2),
-              robot_other.estimateAngularVelocityAtFutureTime(0.4));
-    EXPECT_EQ(AngularVelocity::ofRadians(2),
-              robot_other.estimateAngularVelocityAtFutureTime(1));
-    EXPECT_EQ(AngularVelocity::ofRadians(2),
-              robot_other.estimateAngularVelocityAtFutureTime(3));
+              robot.estimateAngularVelocityAtFutureTime(milliseconds(3000)));
 }
 
-TEST(RobotTest, equality_operators)
+TEST_F(RobotTest, get_angular_velocity_at_future_time_2)
 {
-    Robot robot_0_0 = Robot(0);
-    robot_0_0.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
-                     AngularVelocity::ofDegrees(30));
+    Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                              AngularVelocity::ofRadians(2), current_time);
 
-    Robot robot_0_1 = Robot(0);
-    robot_0_1.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
-                     AngularVelocity::ofDegrees(-30));
+    EXPECT_EQ(AngularVelocity::ofRadians(2),
+              robot_other.estimateAngularVelocityAtFutureTime(milliseconds(400)));
+    EXPECT_EQ(AngularVelocity::ofRadians(2),
+              robot_other.estimateAngularVelocityAtFutureTime(milliseconds(1000)));
+    EXPECT_EQ(AngularVelocity::ofRadians(2),
+              robot_other.estimateAngularVelocityAtFutureTime(milliseconds(3000)));
+}
 
-    Robot robot_1 = Robot(1);
-    robot_1.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
-                   AngularVelocity::ofDegrees(30));
+TEST_F(RobotTest, get_angular_velocity_at_past_time)
+{
+    // TODO: Add unit tests to check for thrown exceptions when a negative value is passed
+    // once https://github.com/UBC-Thunderbots/Software/issues/16 is done
+}
 
-    Robot robot_2 = Robot(2);
-    robot_2.update(Point(3, 1.2), Vector(3, 1), Angle::ofDegrees(0),
-                   AngularVelocity::ofDegrees(25));
+TEST_F(RobotTest, get_last_update_timestamp)
+{
+    Robot robot = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                        AngularVelocity::ofRadians(2), current_time);
+
+    EXPECT_EQ(current_time, robot.lastUpdateTimestamp());
+
+    robot.updateStateToPredictedState(half_second_future);
+
+    EXPECT_EQ(half_second_future, robot.lastUpdateTimestamp());
+}
+
+TEST_F(RobotTest, get_last_update_timestamp_2)
+{
+    Robot robot = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
+                        AngularVelocity::ofRadians(2), half_second_future);
+
+    EXPECT_EQ(half_second_future, robot.lastUpdateTimestamp());
+
+    robot.updateStateToPredictedState(one_second_future);
+
+    EXPECT_EQ(one_second_future, robot.lastUpdateTimestamp());
+}
+
+TEST_F(RobotTest, equality_operators)
+{
+    Robot robot_0_0 = Robot(0, Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
+                            AngularVelocity::ofDegrees(30), current_time);
+
+    Robot robot_0_1 = Robot(0, Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
+                            AngularVelocity::ofDegrees(-30), current_time);
+
+    Robot robot_1 = Robot(1, Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
+                          AngularVelocity::ofDegrees(30), half_second_future);
+
+    Robot robot_2 = Robot(2, Point(3, 1.2), Vector(3, 1), Angle::ofDegrees(0),
+                          AngularVelocity::ofDegrees(25), one_second_future);
 
     EXPECT_EQ(robot_0_0, robot_0_0);
     EXPECT_NE(robot_0_0, robot_0_1);
@@ -222,14 +336,14 @@ TEST(RobotTest, equality_operators)
     EXPECT_NE(robot_0_1, robot_2);
 
     // Update robot_2 to be the same as robot_1 (except for the robot id)
-    robot_2.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
-                   AngularVelocity::ofDegrees(30));
+    robot_2.updateState(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
+                        AngularVelocity::ofDegrees(30), one_second_future);
 
     EXPECT_NE(robot_1, robot_2);
 
     // Update robot_0_1 to be the same as robot_0
-    robot_0_1.update(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
-                     AngularVelocity::ofDegrees(30));
+    robot_0_1.updateState(Point(1, -1.5), Vector(-0.7, -0.55), Angle::ofDegrees(100),
+                          AngularVelocity::ofDegrees(30), one_second_future);
 
     EXPECT_EQ(robot_0_0, robot_0_1);
 }

--- a/src/thunderbots/software/util/ros_messages.cpp
+++ b/src/thunderbots/software/util/ros_messages.cpp
@@ -23,8 +23,9 @@ namespace Util
             AngularVelocity robot_angular_velocity =
                 Angle::ofRadians(robot_msg.angular_velocity);
 
-            Robot robot = Robot(robot_id, robot_position, robot_velocity,
-                                robot_orientation, robot_angular_velocity, std::chrono::steady_clock::now());
+            Robot robot =
+                Robot(robot_id, robot_position, robot_velocity, robot_orientation,
+                      robot_angular_velocity, std::chrono::steady_clock::now());
 
             return robot;
         }

--- a/src/thunderbots/software/util/ros_messages.cpp
+++ b/src/thunderbots/software/util/ros_messages.cpp
@@ -24,7 +24,7 @@ namespace Util
                 Angle::ofRadians(robot_msg.angular_velocity);
 
             Robot robot = Robot(robot_id, robot_position, robot_velocity,
-                                robot_orientation, robot_angular_velocity);
+                                robot_orientation, robot_angular_velocity, std::chrono::steady_clock::now());
 
             return robot;
         }


### PR DESCRIPTION
Similar to #54 

Timestamps are now `std::chrono`, new function to update the state to a predicted state, and added tests.

partially resolves #49 