### PR TITLE
Removed `clang-format` as a dependency in setup_software.sh

### DIFF
--- a/environment_setup/setup_software.sh
+++ b/environment_setup/setup_software.sh
@@ -197,7 +197,6 @@ sudo apt-get update
 host_software_packages=(
     g++-7 # We need g++ 7 or greater to support the C++17 standard
     python-rosinstall
-    clang-format
     protobuf-compiler
     libprotobuf-dev
 )


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
We actually commit in the clang format executable (in `clang_format`)
for the sake of consistency, so we don't need to install it on the host
system.


### Testing Done
Just need to check that CI passes.

### Resolved Issues
Nope

### Review Checklist
*(Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)*
***It is the reviewers responsibility to also make sure every item here has been covered***
- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom` 
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

***Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!***


