### PR TITLE
Added Javascript Formatting Checking via Clang Format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 ﻿---
+Language: Cpp
 BasedOnStyle: Google
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: 'true'
@@ -17,7 +18,6 @@ Cpp11BracedListStyle: 'true'
 IncludeBlocks: Regroup
 IndentCaseLabels: 'true'
 IndentWidth: '4'
-Language: Cpp
 MaxEmptyLinesToKeep: '3'
 NamespaceIndentation: All
 ReflowComments: 'true'
@@ -25,6 +25,12 @@ SortIncludes: 'true'
 Standard: Cpp11
 TabWidth: '4'
 UseTab: Never
+---
+Language: JavaScript
+BasedOnStyle: Google
+ColumnLimit: '90'
+JavaScriptWrapImports: 'true'
+SpacesInContainerLiterals: 'false'
 ---
 Language: Proto
 # Don't format proto files.

--- a/clang_format/fix_formatting.sh
+++ b/clang_format/fix_formatting.sh
@@ -37,8 +37,17 @@ while test $# -gt 0; do
             
             # Find all the files that we want to format, and pass them to
             # clang-format as arguments
-            find $CURR_DIR/../src/ -iname *.h -o -iname *.cpp -o -iname *.c \
-                -o -iname *.hpp -o -iname *.tpp \
+            find $CURR_DIR/../src/ \
+                -path "*node_modules*" -prune \
+                -o -iname *.h \
+                -o -iname *.cpp \
+                -o -iname *.c \
+                -o -iname *.hpp \
+                -o -iname *.tpp \
+                -o -iname *.tpp \
+                -o -iname *.ts \
+                -o -iname *.js \
+                -o -iname *.tsx \
                 | xargs $CURR_DIR/clang-format-$CLANG_VERSION -i -style=file
 
             shift


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Adds formatting checking for javascript and typescript files via clang-format. This should be merged before #77, so that the first time we have a major influx of typescript/javascript files they're formatted properly and we don't need to pollute git history with a major cleanup.

### Testing Done
Ran over the repo with some typescript files and it formatted them as expected

### Resolved Issues
None

### Review Checklist
*(Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)*
***It is the reviewers responsibility to also make sure every item here has been covered***
- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom` 
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

***Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!***


