### PR TITLE
Moved glob recurse for cmake SHARED_UTIL_SRC to top level CMakeLists.txt

### DIFF
--- a/src/thunderbots/CMakeLists.txt
+++ b/src/thunderbots/CMakeLists.txt
@@ -9,4 +9,26 @@
 cmake_minimum_required(VERSION 3.8.2)
 project(thunderbots_all)
 
+# All the test files in the shared code directory
+# This is put at top level since shared files may be used across software and firmware,
+# and globbing the files from here removes the need for relative paths
+# (i.e. paths with .. in them)
+file(GLOB_RECURSE SHARED_UTIL_TEST LIST_DIRECTORIES false CONFIGURE_DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/shared/test/*.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/shared/test/*.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/shared/test/*.h
+        )
+
+# All the source files in the shared code directory. Initially this includes the test
+# files because of the globbing
+file(GLOB_RECURSE SHARED_UTIL_SRC LIST_DIRECTORIES false CONFIGURE_DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/shared/*.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/shared/*.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/shared/*.h
+        )
+
+# Remove the test files from the SHARED_UTIL_SRC so that we are only left with source
+# files, and no test files
+list(REMOVE_ITEM SHARED_UTIL_SRC ${SHARED_UTIL_TEST})
+
 add_subdirectory(software)

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -34,14 +34,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor")
 # Call our CMake file to include and build protobuf
 include("${CMAKE_CURRENT_SOURCE_DIR}/proto/build_proto.cmake")
 
-# Create a list of files from the shared folder
-file(GLOB SHARED_UTIL_SRC LIST_DIRECTORIES false CONFIGURE_DEPENDS
-        ${CMAKE_CURRENT_SOURCE_DIR}/../shared/*.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../shared/*.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/../shared/*.h
-        )
-
-
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
         roscpp


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
*Give a high-level description of the changes in this PR*
Proposal to move the GLOB_RECURSE for SHARED_UTIL_SRC to the top level CMakeLists.txt under thunderbots/ since these files will be used in firmware and software. This removes the need for hard-coding paths with ".." in them, since they are not full proof if we move stuff around.

This is a new version of #42 since I can't push to Daniel's branch.

### Testing Done
*Outline any testing that was done for these changes. This could be unit tests, integration tests, etc.*
Verified the code builds when opened from either the `src/CMakeLists.txt` file or the `src/thunderbots/CMakeLists.txt` file.

### Resolved Issues
*Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)*

NA

### Review Checklist
*(Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)*
***It is the reviewers responsibility to also make sure every item here has been covered***
- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom` 
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

***Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!***


