### PR TITLE
Corrected javadoc comments to match argument names

### DIFF
--- a/src/thunderbots/software/grsim_communication/visitor/grsim_command_primitive_visitor.h
+++ b/src/thunderbots/software/grsim_communication/visitor/grsim_command_primitive_visitor.h
@@ -31,7 +31,7 @@ class GrsimCommandPrimitiveVisitor : public PrimitiveVisitor
      * Generates and stores the MotionControllerCommand the robot should perform at the
      * current moment in time in order to simulate the ChipPrimitive
      *
-     * @param catch_primitive The ChipPrimitive to simulate
+     * @param chip_primitive The ChipPrimitive to simulate
      */
     void visit(const ChipPrimitive &chip_primtiive) override;
 
@@ -39,7 +39,7 @@ class GrsimCommandPrimitiveVisitor : public PrimitiveVisitor
      * Generates and stores the MotionControllerCommand the robot should perform at the
      * current moment in time in order to simulate the DirectVelocityPrimitive
      *
-     * @param catch_primitive The DirectVelocityPrimitive to simulate
+     * @param direct_velocity_primitive The DirectVelocityPrimitive to simulate
      */
     void visit(const DirectVelocityPrimitive &direct_velocity_primtiive) override;
 
@@ -47,7 +47,7 @@ class GrsimCommandPrimitiveVisitor : public PrimitiveVisitor
      * Generates and stores the MotionControllerCommand the robot should perform at the
      * current moment in time in order to simulate the KickPrimitive
      *
-     * @param catch_primitive The KickPrimitive to simulate
+     * @param kick_primitive The KickPrimitive to simulate
      */
     void visit(const KickPrimitive &kick_primtiive) override;
 
@@ -55,7 +55,7 @@ class GrsimCommandPrimitiveVisitor : public PrimitiveVisitor
      * Generates and stores the MotionControllerCommand the robot should perform at the
      * current moment in time in order to simulate the MovePrimitive
      *
-     * @param catch_primitive The MovePrimitive to simulate
+     * @param move_primitive The MovePrimitive to simulate
      */
     void visit(const MovePrimitive &move_primitive) override;
 
@@ -63,7 +63,7 @@ class GrsimCommandPrimitiveVisitor : public PrimitiveVisitor
      * Generates and stores the MotionControllerCommand the robot should perform at the
      * current moment in time in order to simulate the PivotPrimitive
      *
-     * @param catch_primitive The PivotPrimitive to simulate
+     * @param pivot_primitive The PivotPrimitive to simulate
      */
     void visit(const PivotPrimitive &pivot_primtiive) override;
 


### PR DESCRIPTION
## Please fill out the following before requesting review on this PR

### Description
Copy-pasting without correction in between multiple functions left comments referencing arguments for a different function; this was corrected.

### Testing Done
No testing; only comments changed

### Resolved Issues
None

### Review Checklist
*(Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)*
***It is the reviewers responsibility to also make sure every item here has been covered***
- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom` 
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

***Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!***


