### PR TITLE
Added primitive visitor to serialize radio packets

### DIFF
--- a/src/thunderbots/software/radio_communication/visitor/radio_packet_serializer_primitive_visitor.cpp
+++ b/src/thunderbots/software/radio_communication/visitor/radio_packet_serializer_primitive_visitor.cpp
@@ -1,0 +1,32 @@
+#include "radio_communication/visitor/radio_packet_serializer_primitive_visitor.h"
+
+void RadioPacketSerializerPrimitiveVisitor::visit(const CatchPrimitive &catch_primitive)
+{
+    // TODO: https://github.com/UBC-Thunderbots/Software/issues/63
+}
+
+void RadioPacketSerializerPrimitiveVisitor::visit(const ChipPrimitive &chip_primitive)
+{
+    // TODO: https://github.com/UBC-Thunderbots/Software/issues/63
+}
+
+void RadioPacketSerializerPrimitiveVisitor::visit(
+    const DirectVelocityPrimitive &direct_velocity_primitive)
+{
+    // TODO: https://github.com/UBC-Thunderbots/Software/issues/63
+}
+
+void RadioPacketSerializerPrimitiveVisitor::visit(const KickPrimitive &kick_primitive)
+{
+    // TODO: https://github.com/UBC-Thunderbots/Software/issues/63
+}
+
+void RadioPacketSerializerPrimitiveVisitor::visit(const MovePrimitive &move_primitive)
+{
+    // TODO: https://github.com/UBC-Thunderbots/Software/issues/63
+}
+
+void RadioPacketSerializerPrimitiveVisitor::visit(const PivotPrimitive &pivot_primitive)
+{
+    // TODO: https://github.com/UBC-Thunderbots/Software/issues/63
+}

--- a/src/thunderbots/software/radio_communication/visitor/radio_packet_serializer_primitive_visitor.h
+++ b/src/thunderbots/software/radio_communication/visitor/radio_packet_serializer_primitive_visitor.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "ai/primitive/visitor/primitive_visitor.h"
+
+/**
+ * This class implements a Visitor that serializes the Primitive classes into packets
+ * that can be send over the radio to the physical robots
+ */
+class RadioPacketSerializerPrimitiveVisitor : public PrimitiveVisitor
+{
+   public:
+    /**
+     * Creates a new RadioSerializerPrimitiveVisitor
+     */
+    RadioPacketSerializerPrimitiveVisitor() = default;
+
+    /**
+     * Serializes the given CatchPrimitive into a radio packet
+     *
+     * @param catch_primitive The CatchPrimitive to serialize
+     */
+    void visit(const CatchPrimitive &catch_primtiive) override;
+
+    /**
+     * Serializes the given ChipPrimitive into a radio packet
+     *
+     * @param chip_primitive The ChipPrimitive to simulate
+     */
+    void visit(const ChipPrimitive &chip_primtiive) override;
+
+    /**
+     * Serializes the given DirectVelocityPrimitive into a radio packet
+     *
+     * @param direct_velocity_primitive The DirectVelocityPrimitive to simulate
+     */
+    void visit(const DirectVelocityPrimitive &direct_velocity_primtiive) override;
+
+    /**
+     * Serializes the given KickPrimitive into a radio packet
+     *
+     * @param kick_primitive The KickPrimitive to simulate
+     */
+    void visit(const KickPrimitive &kick_primtiive) override;
+
+    /**
+     * Serializes the given MovePrimitive into a radio packet
+     *
+     * @param move_primitive The MovePrimitive to simulate
+     */
+    void visit(const MovePrimitive &move_primitive) override;
+
+    /**
+     * Serializes the given PivotPrimitive into a radio packet
+     *
+     * @param pivot_primitive The PivotPrimitive to simulate
+     */
+    void visit(const PivotPrimitive &pivot_primtiive) override;
+
+    /**
+     * Returns the most recent serialized packet created by this
+     * RadioPacketSerializerPrimitiveVisitor. This is the radio packet created by
+     * one of the 'visit' functions
+     *
+     * Calling this function before this Visitor has been called at least once has
+     * undefined behavior
+     *
+     * @return The most recent serialized packet created by this
+     * RadioPacketSerializerPrimitiveVisitor
+     */
+    uint64_t getSerializedRadioPacket();
+
+   private:
+    // The serialzed data encoded to tbe sent to the robots over radio
+    // TODO: This may not be the type actually required for the radio
+    // See: https://github.com/UBC-Thunderbots/Software/issues/63
+    uint64_t radio_packet;
+};


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
*Give a high-level description of the changes in this PR*
Added a new `PrimitiveVisitor` that will be responsible for serializing `Primitive` classes into radio packets.

Note: I've linked issue #63 for all the `TODOs`, as there's not a specific issue for radio serialization yet. I'll leave this up to @henrymliu as he has a better idea of the scope of radio changes and how they're being broken up. Similarly, the `uint64_t` return type for the radio packet is mostly a placeholder as I'm not sure exactly what time will be returned. I'll also leave this up to @henrymliu to correct when the implementation is being implemented.

I'm also hoping #126 and #151 get merged first so they don't need to be updated. That means this PR will need to be updated, but it will simply be adding new `visit` functions.

### Testing Done
*Outline any testing that was done for these changes. This could be unit tests, integration tests, etc.*
None, as there is no implementation.

### Resolved Issues
*Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)*
resolves #235 

### Length Justification
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
N/A

### Review Checklist
*(Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)*
***It is the reviewers responsibility to also make sure every item here has been covered***
- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom` 
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

***Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!***


