### PR TITLE
Fix to ensure yarn.lock is not modified when running catkin_make

### DIFF
--- a/src/corner_kick/CMakeLists.txt
+++ b/src/corner_kick/CMakeLists.txt
@@ -19,6 +19,9 @@ add_custom_target(
   COMMENT Packaging up ${PROJECT_NAME}
 
   # Get dependencies
+  # We enforce `yarn.lock` with flag --frozen-lockfile 
+  # at this step to ensure our dependencies remain
+  # consistent outside of development
   COMMAND yarn --silent --frozen-lockfile
 
   # Only build if src has changed

--- a/src/corner_kick/CMakeLists.txt
+++ b/src/corner_kick/CMakeLists.txt
@@ -19,7 +19,7 @@ add_custom_target(
   COMMENT Packaging up ${PROJECT_NAME}
 
   # Get dependencies
-  COMMAND yarn
+  COMMAND yarn --silent --frozen-lockfile
 
   # Only build if src has changed
   COMMAND ./scripts/compare_src.sh || yarn build


### PR DESCRIPTION
### Description
When running `catkin_make` or the CI, we currently let `yarn.lock` in the visualizer to be modified. This is not correct behaviour. This PR ensures the dependencies specified in `yarn.lock` are enforced, which in turns ensures our project behaves predictably outside of development (avoids only work my machine errors).

Used official [yarn documentation](https://yarnpkg.com/lang/en/docs/cli/install/) for reference.

### Testing Done
Manual testing

### Resolved Issues
Closes #238 

### Review Checklist
*(Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)*
***It is the reviewers responsibility to also make sure every item here has been covered***
- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom` 
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.


