### PR TITLE
Correct Pivot Primitive to include pivot_radius instead of robot_orientation

### DIFF
--- a/src/thunderbots/software/ai/primitive/pivot_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/pivot_primitive.cpp
@@ -17,12 +17,12 @@ PivotPrimitive::PivotPrimitive(const thunderbots_msgs::Primitive &primitive_msg)
 {
     validatePrimitiveMessage(primitive_msg, getPrimitiveName());
 
-    robot_id         = primitive_msg.robot_id;
-    double center_x  = primitive_msg.parameters.at(0);
-    double center_y  = primitive_msg.parameters.at(1);
-    pivot_point      = Point(center_x, center_y);
-    final_angle      = Angle::ofRadians(primitive_msg.parameters.at(2));
-    pivot_radius     = primitive_msg.parameters.at(3);
+    robot_id        = primitive_msg.robot_id;
+    double center_x = primitive_msg.parameters.at(0);
+    double center_y = primitive_msg.parameters.at(1);
+    pivot_point     = Point(center_x, center_y);
+    final_angle     = Angle::ofRadians(primitive_msg.parameters.at(2));
+    pivot_radius    = primitive_msg.parameters.at(3);
 }
 
 std::string PivotPrimitive::getPrimitiveName() const
@@ -45,15 +45,15 @@ Angle PivotPrimitive::getFinalAngle() const
     return final_angle;
 }
 
-double PivotPrimitive::getPivotRadius() const {
+double PivotPrimitive::getPivotRadius() const
+{
     return pivot_radius;
 }
 
 std::vector<double> PivotPrimitive::getParameters() const
 {
     std::vector<double> parameters = {pivot_point.x(), pivot_point.y(),
-                                      final_angle.toRadians(),
-                                      pivot_radius};
+                                      final_angle.toRadians(), pivot_radius};
     return parameters;
 }
 

--- a/src/thunderbots/software/ai/primitive/pivot_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/pivot_primitive.cpp
@@ -5,11 +5,11 @@
 const std::string PivotPrimitive::PRIMITIVE_NAME = "Pivot Primitive";
 
 PivotPrimitive::PivotPrimitive(unsigned int robot_id, const Point &pivot_point,
-                               const Angle &final_angle, const Angle &robot_orientation)
+                               const Angle &final_angle, const double pivot_radius)
     : robot_id(robot_id),
       pivot_point(pivot_point),
       final_angle(final_angle),
-      robot_orientation(robot_orientation)
+      pivot_radius(pivot_radius)
 {
 }
 
@@ -17,12 +17,12 @@ PivotPrimitive::PivotPrimitive(const thunderbots_msgs::Primitive &primitive_msg)
 {
     validatePrimitiveMessage(primitive_msg, getPrimitiveName());
 
-    robot_id          = primitive_msg.robot_id;
-    double center_x   = primitive_msg.parameters.at(0);
-    double center_y   = primitive_msg.parameters.at(1);
-    pivot_point       = Point(center_x, center_y);
-    final_angle       = Angle::ofRadians(primitive_msg.parameters.at(2));
-    robot_orientation = Angle::ofRadians(primitive_msg.parameters.at(3));
+    robot_id         = primitive_msg.robot_id;
+    double center_x  = primitive_msg.parameters.at(0);
+    double center_y  = primitive_msg.parameters.at(1);
+    pivot_point      = Point(center_x, center_y);
+    final_angle      = Angle::ofRadians(primitive_msg.parameters.at(2));
+    pivot_radius     = primitive_msg.parameters.at(3);
 }
 
 std::string PivotPrimitive::getPrimitiveName() const
@@ -45,16 +45,15 @@ Angle PivotPrimitive::getFinalAngle() const
     return final_angle;
 }
 
-Angle PivotPrimitive::getRobotOrientation() const
-{
-    return robot_orientation;
+double PivotPrimitive::getPivotRadius() const {
+    return pivot_radius;
 }
 
 std::vector<double> PivotPrimitive::getParameters() const
 {
     std::vector<double> parameters = {pivot_point.x(), pivot_point.y(),
                                       final_angle.toRadians(),
-                                      robot_orientation.toRadians()};
+                                      pivot_radius};
     return parameters;
 }
 

--- a/src/thunderbots/software/ai/primitive/pivot_primitive.h
+++ b/src/thunderbots/software/ai/primitive/pivot_primitive.h
@@ -14,17 +14,16 @@ class PivotPrimitive : public Primitive
      * Pivots the robot around the specified point, maintaining a constant
      * distance from this point.
      * 	   The robot will pivot in the direction of the shortest path
-     * 	   The robot will always face the point around which it pivots
+     * 	   Assume robot always faces the point around which it pivots
      *
      *
-     * @param robot_id          The id of the robot to run this primitive
-     * @param pivot_point       The point around which the robot will pivot
-     * @param final_angle       Global angle from rotation point to robot (in radians)
-     * @param robot_orientation The orientation of robot (facing direction)
-     *                          during pivot (radians; Not used)
+     * @param robot_id      The id of the robot to run this primitive
+     * @param pivot_point   The point around which the robot will pivot
+     * @param final_angle   Global angle from rotation point to robot (in radians)
+     * @param pivot_radius  The distance from robot to pivot_point during movement
      */
     explicit PivotPrimitive(unsigned int robot_id, const Point &pivot_point,
-                            const Angle &final_angle, const Angle &robot_orientation);
+                            const Angle &final_angle, const double pivot_radius);
 
     /**
      * Create a new Pivot Primitive from a Primitive message
@@ -54,16 +53,16 @@ class PivotPrimitive : public Primitive
     /**
      * Get the robot's final orientation
      *
-     * @return the robot's orientation after a pivot as an Angle
+     * @return the radius the robot maintains during pivot (as double)
      */
-    Angle getRobotOrientation() const;
+    double getPivotRadius() const;
 
     /**
      * Returns the generic vector of parameters for this Primitive
      *
      * @return A vector of the form {pivot_point.x(), pivot_point.y(),
      *                               final_angle.toRadians(),
-     *                               robot_orientation.toRadians()}
+     *                               pivot_radius}
      */
     std::vector<double> getParameters() const override;
 
@@ -80,5 +79,5 @@ class PivotPrimitive : public Primitive
     unsigned int robot_id;
     Point pivot_point;
     Angle final_angle;
-    Angle robot_orientation;
+    double pivot_radius;
 };

--- a/src/thunderbots/software/test/primitive/pivot_primitive.cpp
+++ b/src/thunderbots/software/test/primitive/pivot_primitive.cpp
@@ -12,7 +12,7 @@ TEST(PivotPrimTest, construct_with_no_params_test)
 {
     const std::string pivot_prim_name = "Pivot Primitive";
 
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle());
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), 0);
 
     EXPECT_EQ(0, pivot_prim.getRobotId());
     EXPECT_EQ(pivot_prim_name, pivot_prim.getPrimitiveName());
@@ -22,7 +22,7 @@ TEST(PivotPrimTest, get_robot_id_test)
 {
     unsigned int robot_id = 4U;
 
-    PivotPrimitive pivot_prim = PivotPrimitive(robot_id, Point(), Angle(), Angle());
+    PivotPrimitive pivot_prim = PivotPrimitive(robot_id, Point(), Angle(), 0);
 
     EXPECT_EQ(robot_id, pivot_prim.getRobotId());
 }
@@ -32,24 +32,24 @@ TEST(PivotPrimTest, parameter_array_test)
     const unsigned int robot_id = 6U;
     const Point pivot_point     = Point(-1, 2);
     const Angle final_angle     = Angle::ofRadians(1.5);
-    const Angle orientation     = Angle::ofRadians(0.0);
+    const double pivot_radius   = 2.5;
 
     PivotPrimitive pivot_prim =
-        PivotPrimitive(robot_id, pivot_point, final_angle, orientation);
+        PivotPrimitive(robot_id, pivot_point, final_angle, pivot_radius);
 
     std::vector<double> param_array = pivot_prim.getParameters();
 
     EXPECT_DOUBLE_EQ(pivot_point.x(), param_array[0]);
     EXPECT_DOUBLE_EQ(pivot_point.y(), param_array[1]);
     EXPECT_DOUBLE_EQ(final_angle.toRadians(), param_array[2]);
-    EXPECT_DOUBLE_EQ(orientation.toRadians(), param_array[3]);
+    EXPECT_DOUBLE_EQ(pivot_radius, param_array[3]);
 }
 
 TEST(PivotPrimTest, get_pivot_point_test)
 {
     Point pivot_point = Point(-4, 3);
 
-    PivotPrimitive pivot_prim = PivotPrimitive(0, pivot_point, Angle(), Angle());
+    PivotPrimitive pivot_prim = PivotPrimitive(0, pivot_point, Angle(), 0);
 
     EXPECT_EQ(pivot_point, pivot_prim.getPivotPoint());
 }
@@ -58,23 +58,23 @@ TEST(PivotPrimTest, get_final_angle_test)
 {
     Angle final_angle = Angle::ofRadians(1.51);
 
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), final_angle, Angle());
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), final_angle, 0);
 
     EXPECT_EQ(final_angle, pivot_prim.getFinalAngle());
 }
 
-TEST(PivotPrimTest, get_robot_orientation_test)
+TEST(PivotPrimTest, get_pivot_radius_test)
 {
-    Angle robot_orient = Angle::ofRadians(3.16);
+    double pivot_radius = 1.85;
 
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), robot_orient);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), pivot_radius);
 
-    EXPECT_EQ(robot_orient, pivot_prim.getRobotOrientation());
+    EXPECT_DOUBLE_EQ(pivot_radius, pivot_prim.getPivotRadius());
 }
 
 TEST(PivotPrimTest, get_extra_bit_array_test)
 {
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle());
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), 0);
 
     std::vector<bool> extra_bit_array = pivot_prim.getExtraBits();
 

--- a/src/thunderbots/software/test/primitive/primitive.cpp
+++ b/src/thunderbots/software/test/primitive/primitive.cpp
@@ -184,10 +184,10 @@ TEST(PrimitiveTest, convert_CatchPrimitive_to_message_and_back_to_CatchPrimitive
 // started with
 TEST(PivotPrimTest, convert_PivotPrimitive_to_message_and_back_to_PivotPrimitive)
 {
-    const unsigned int robot_id  = 2U;
-    const Point pivot_point      = Point(2, -1);
-    const Angle final_angle      = Angle::ofRadians(2.56);
-    const double pivot_radius    = .78;
+    const unsigned int robot_id = 2U;
+    const Point pivot_point     = Point(2, -1);
+    const Angle final_angle     = Angle::ofRadians(2.56);
+    const double pivot_radius   = .78;
 
     PivotPrimitive pivot_prim =
         PivotPrimitive(robot_id, pivot_point, final_angle, pivot_radius);

--- a/src/thunderbots/software/test/primitive/primitive.cpp
+++ b/src/thunderbots/software/test/primitive/primitive.cpp
@@ -184,13 +184,13 @@ TEST(PrimitiveTest, convert_CatchPrimitive_to_message_and_back_to_CatchPrimitive
 // started with
 TEST(PivotPrimTest, convert_PivotPrimitive_to_message_and_back_to_PivotPrimitive)
 {
-    const unsigned int robot_id   = 2U;
-    const Point pivot_point       = Point(2, -1);
-    const Angle final_angle       = Angle::ofRadians(2.56);
-    const Angle robot_orientation = Angle::ofRadians(0.78);
+    const unsigned int robot_id  = 2U;
+    const Point pivot_point      = Point(2, -1);
+    const Angle final_angle      = Angle::ofRadians(2.56);
+    const double pivot_radius    = .78;
 
     PivotPrimitive pivot_prim =
-        PivotPrimitive(robot_id, pivot_point, final_angle, robot_orientation);
+        PivotPrimitive(robot_id, pivot_point, final_angle, pivot_radius);
 
     thunderbots_msgs::Primitive prim_msg = pivot_prim.createMsg();
     std::unique_ptr<Primitive> new_prim  = PivotPrimitive::createPrimitive(prim_msg);
@@ -201,7 +201,7 @@ TEST(PivotPrimTest, convert_PivotPrimitive_to_message_and_back_to_PivotPrimitive
     EXPECT_DOUBLE_EQ(pivot_point.x(), parameters[0]);
     EXPECT_DOUBLE_EQ(pivot_point.y(), parameters[1]);
     EXPECT_DOUBLE_EQ(final_angle.toRadians(), parameters[2]);
-    EXPECT_DOUBLE_EQ(robot_orientation.toRadians(), parameters[3]);
+    EXPECT_DOUBLE_EQ(pivot_radius, parameters[3]);
     EXPECT_EQ(std::vector<bool>(), new_prim->getExtraBits());
 }
 


### PR DESCRIPTION
### Description
Pivot primitive was specified to include a robot_orientation parameter (not used). To match firmware, should instead have a pivot radius. The primitive and tests were updated to reflect this update.

### Testing Done
Unit tests for the primitive updated and are now passing.

### Resolved Issues
Does not resolve any open issues.

### Review Checklist
*(Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)*
***It is the reviewers responsibility to also make sure every item here has been covered***
- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom` 
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.
