### PR TITLE
Normalizing timestamps to use new Timestamp class

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -602,7 +602,7 @@ if (CATKIN_ENABLE_TESTING)
 
     target_link_libraries(stop_primitive_test ${catkin_LIBRARIES}
             ${G3LOG})
-
+        
     catkin_add_gtest(grsim_catch_primitive_test
             grsim_communication/visitor/grsim_command_primitive_visitor.cpp
             test/grsim_command_primitive_visitor/catch_primitive.cpp
@@ -633,6 +633,13 @@ if (CATKIN_ENABLE_TESTING)
 
     target_link_libraries(grsim_catch_primitive_test ${catkin_LIBRARIES}
             ${G3LOG})
+
+    catkin_add_gtest(timestamp_test
+            test/util/timestamp.cpp
+            util/timestamp.cpp
+            )
+
+    target_link_libraries(timestamp_test ${catkin_LIBRARIES})
 
 endif()
 

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -272,6 +272,7 @@ if (CATKIN_ENABLE_TESTING)
             grsim_communication/grsim_backend.h
             grsim_communication/grsim_backend.cpp
             grsim_communication/visitor/grsim_command_primitive_visitor.cpp
+            util/timestamp.cpp
             )
     target_link_libraries(grsim_backend_test ${catkin_LIBRARIES}
             ${PROTOBUF_LIBRARIES}
@@ -301,6 +302,7 @@ if (CATKIN_ENABLE_TESTING)
     catkin_add_gtest(ball_test
             test/world/ball.cpp
             ai/world/ball.cpp
+            util/timestamp.cpp
             geom/point.h
             geom/angle.h)
 
@@ -309,6 +311,7 @@ if (CATKIN_ENABLE_TESTING)
     catkin_add_gtest(robot_test
             test/world/robot.cpp
             ai/world/robot.cpp
+            util/timestamp.cpp
             geom/point.h
             geom/angle.h)
 
@@ -318,6 +321,7 @@ if (CATKIN_ENABLE_TESTING)
             test/world/team.cpp
             ai/world/team.cpp
             ai/world/robot.cpp
+            util/timestamp.cpp
             geom/point.h
             geom/angle.h)
 
@@ -330,6 +334,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/robot.cpp
             ai/world/field.cpp
             ai/world/team.cpp
+            util/timestamp.cpp
             geom/point.h
             geom/angle.h)
 
@@ -340,7 +345,8 @@ if (CATKIN_ENABLE_TESTING)
             grsim_communication/motion_controller/motion_controller.cpp
             ai/world/robot.cpp
             geom/point.h
-            geom/angle.h)
+            geom/angle.h
+            util/timestamp.cpp)
 
     target_link_libraries(motion_controller_test ${catkin_LIBRARIES})
 
@@ -352,7 +358,8 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/field.cpp
             ai/world/robot.cpp
             ai/world/team.cpp
-            ai/world/game_state.cpp)
+            ai/world/game_state.cpp
+            util/timestamp.cpp)
 
     target_link_libraries(world_test ${catkin_LIBRARIES})
 
@@ -365,6 +372,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/robot.cpp
             ai/world/team.cpp
             ai/world/game_state.cpp
+            util/timestamp.cpp
             )
 
     target_link_libraries(test_util_test ${catkin_LIBRARIES})
@@ -379,7 +387,8 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/robot.cpp
             ai/world/team.cpp
             ai/world/game_state.cpp
-            util/refbox_constants.cpp)
+            util/refbox_constants.cpp
+            util/timestamp.cpp)
 
     target_link_libraries(game_state_test ${catkin_LIBRARIES})
 

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -418,6 +418,7 @@ if (CATKIN_ENABLE_TESTING)
             geom/angle.h
             util/logger/custom_g3log_sinks.h
             util/logger/init.h
+            util/timestamp.cpp
             )
     target_link_libraries(move_spin_primitive_test ${catkin_LIBRARIES}
             ${G3LOG})
@@ -638,6 +639,7 @@ if (CATKIN_ENABLE_TESTING)
             geom/angle.h
             util/logger/custom_g3log_sinks.h
             util/logger/init.h
+            util/timestamp.cpp
     )
 
     target_link_libraries(grsim_catch_primitive_test ${catkin_LIBRARIES}
@@ -662,6 +664,7 @@ if (CATKIN_ENABLE_TESTING)
             util/logger/custom_g3log_sinks.h
             util/logger/init.h
             test/util/logger_test.cpp
+            util/timestamp.cpp
             )
     target_link_libraries(logger_test ${catkin_LIBRARIES}
             ${G3LOG})
@@ -669,6 +672,7 @@ if (CATKIN_ENABLE_TESTING)
     # The test node that verifies the rostest utils are working correctly
     add_rostest_gtest(rostest_util_test test/test_util/rostest_util_test.test
             test/test_util/rostest_util_test.cpp
+            util/timestamp.cpp
             )
     target_link_libraries(rostest_util_test ${catkin_LIBRARIES})
 

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -602,7 +602,7 @@ if (CATKIN_ENABLE_TESTING)
 
     target_link_libraries(stop_primitive_test ${catkin_LIBRARIES}
             ${G3LOG})
-        
+
     catkin_add_gtest(grsim_catch_primitive_test
             grsim_communication/visitor/grsim_command_primitive_visitor.cpp
             test/grsim_command_primitive_visitor/catch_primitive.cpp

--- a/src/thunderbots/software/ai/ai.cpp
+++ b/src/thunderbots/software/ai/ai.cpp
@@ -10,7 +10,7 @@ AI::AI(const World &world)
 }
 
 std::vector<std::unique_ptr<Primitive>> AI::getPrimitives(
-    const AITimestamp &timestamp) const
+    const Timestamp &timestamp) const
 {
     // NOTE: The only thing the AI really needs an updated timestamp for (updated relative
     // to the timestamp when the state/world was last updated) is to update the

--- a/src/thunderbots/software/ai/ai.h
+++ b/src/thunderbots/software/ai/ai.h
@@ -32,7 +32,7 @@ class AI final
      * of the world.
      */
     std::vector<std::unique_ptr<Primitive>> getPrimitives(
-        const AITimestamp& timestamp) const;
+        const Timestamp& timestamp) const;
 
     /**
      * Updates the state of the ball in the AI's world with the new ball data

--- a/src/thunderbots/software/ai/hl/stp/tactic/move.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/move.cpp
@@ -7,7 +7,7 @@ Robot MoveTactic::selectRobot(const World &world,
 {
     // Placeholder for now
     return Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
-                 std::chrono::steady_clock::now());
+                 Timestamp::fromSeconds(0));
 }
 
 std::unique_ptr<Intent> MoveTactic::getNextIntent(const World &world, const Robot &robot)

--- a/src/thunderbots/software/ai/main.cpp
+++ b/src/thunderbots/software/ai/main.cpp
@@ -20,12 +20,12 @@
 namespace
 {
     // Initialize our AI, which is the main object that maintains state
-    AI ai = AI(
-        World(Field(0, 0, 0, 0, 0, 0, 0), Ball(Point(), Vector()),
-              Team(std::chrono::milliseconds(
-                  Util::DynamicParameters::robot_expiry_buffer_milliseconds.value())),
-              Team(std::chrono::milliseconds(
-                  Util::DynamicParameters::robot_expiry_buffer_milliseconds.value()))));
+    AI ai = AI(World(
+        Field(0, 0, 0, 0, 0, 0, 0), Ball(Point(), Vector(), Timestamp::fromSeconds(0)),
+        Team(Duration::fromMilliseconds(
+            Util::DynamicParameters::robot_expiry_buffer_milliseconds.value())),
+        Team(Duration::fromMilliseconds(
+            Util::DynamicParameters::robot_expiry_buffer_milliseconds.value()))));
 }  // namespace
 
 // Callbacks to update the state of the world
@@ -117,7 +117,9 @@ int main(int argc, char **argv)
             // to let the AI update its predictors so that decisions are always made with
             // the most up to date predicted data (eg. future Robot or Ball position),
             // even if some time has passed since the AI's state was last updated.
-            AITimestamp timestamp = Timestamp::getTimestampNow();
+            // TODO: This is a placeholder timestamp. It should be removed as part of
+            // https://github.com/UBC-Thunderbots/Software/issues/227
+            Timestamp timestamp = Timestamp::fromSeconds(0);
             std::vector<std::unique_ptr<Primitive>> assignedPrimitives =
                 ai.getPrimitives(timestamp);
 

--- a/src/thunderbots/software/ai/world/ball.h
+++ b/src/thunderbots/software/ai/world/ball.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <chrono>
-
 #include "geom/point.h"
+#include "util/timestamp.h"
 
 class Ball final
 {
@@ -13,11 +12,9 @@ class Ball final
      * @param position The position of the ball, with coordinates in metres
      * @param velocity The velocity of the ball, in metres per second
      * @param timestamp The timestamp at which the ball was observed to be at the
-     * given position and velocity. Default is the current time.
+     * given position and velocity
      */
-    explicit Ball(Point position, Vector velocity,
-                  std::chrono::steady_clock::time_point timestamp =
-                      std::chrono::steady_clock::now());
+    explicit Ball(Point position, Vector velocity, const Timestamp& timestamp);
 
     /**
      * Updates the ball with new data, updating the current data as well as the predictive
@@ -29,7 +26,7 @@ class Ball final
      * position and velocity. The timestamp must be >= the ball's latest update timestamp
      */
     void updateState(const Point& new_position, const Vector& new_velocity,
-                     std::chrono::steady_clock::time_point timestamp);
+                     const Timestamp& timestamp);
 
     /**
      * Updates the ball with new data, updating the current data as well as the predictive
@@ -48,14 +45,14 @@ class Ball final
      * @param timestamp The timestamp at which to update the ball's state to. Must
      * be >= the ball's last update timestamp
      */
-    void updateStateToPredictedState(std::chrono::steady_clock::time_point timestamp);
+    void updateStateToPredictedState(const Timestamp& timestamp);
 
     /**
      * Returns the timestamp for when this ball's data was last updated
      *
      * @return the timestamp for when this ball's data was last updated
      */
-    std::chrono::steady_clock::time_point lastUpdateTimestamp() const;
+    Timestamp lastUpdateTimestamp() const;
 
     /**
      * Returns the current position of the ball
@@ -68,9 +65,9 @@ class Ball final
      * Returns the estimated position of the ball at a future time, relative to when the
      * ball was last updated.
      *
-     * @param milliseconds_in_future The relative amount of time in the future
-     * (in milliseconds) at which to predict the ball's position. Value must be >= 0.
-     * For example, a value of 1500 would return the estimated position of the ball
+     * @param duration_in_future The relative amount of time in the future
+     * at which to predict the ball's position. Value must be >= 0.
+     * For example, a value of 1.5 seconds would return the estimated position of the ball
      * 1.5 seconds in the future.
      *
      * @throws std::invalid_argument if the ball is estimating the position with a time
@@ -78,8 +75,7 @@ class Ball final
      * @return the estimated position of the ball at the given number of milliseconds
      * in the future. Coordinates are in metres.
      */
-    Point estimatePositionAtFutureTime(
-        const std::chrono::milliseconds& milliseconds_in_future) const;
+    Point estimatePositionAtFutureTime(const Duration& duration_in_future) const;
 
     /**
      * Returns the current velocity of the ball
@@ -92,9 +88,9 @@ class Ball final
      * Returns the estimated velocity of the ball at a future time, relative to when the
      * ball was last updated
      *
-     * @param milliseconds_in_future The relative amount of time in the future
-     * (in milliseconds) at which to predict the ball's velocity. Value must be >= 0.
-     * For example, a value of 1500 would return the estimated velocity of the ball
+     * @param duration_in_future The relative amount of time in the future
+     * at which to predict the ball's velocity. Value must be >= 0.
+     * For example, a value of 1.5 seconds would return the estimated velocity of the ball
      * 1.5 seconds in the future.
      *
      * @throws std::invalid_argument if the ball is estimating the velocity with a time
@@ -102,8 +98,7 @@ class Ball final
      * @return the estimated velocity of the ball at the given number of milliseconds
      * in the future. Coordinates are in metres.
      */
-    Vector estimateVelocityAtFutureTime(
-        const std::chrono::milliseconds& milliseconds_in_future) const;
+    Vector estimateVelocityAtFutureTime(const Duration& duration_in_future) const;
 
     /**
      * Defines the equality operator for a Ball. Balls are equal if their positions and
@@ -128,5 +123,5 @@ class Ball final
     // The current velocity of the ball, in metres per second
     Vector velocity_;
     // The timestamp for when this ball was last updated
-    std::chrono::steady_clock::time_point last_update_timestamp;
+    Timestamp last_update_timestamp;
 };

--- a/src/thunderbots/software/ai/world/robot.cpp
+++ b/src/thunderbots/software/ai/world/robot.cpp
@@ -2,7 +2,7 @@
 
 Robot::Robot(unsigned int id, const Point &position, const Vector &velocity,
              const Angle &orientation, const AngularVelocity &angular_velocity,
-             std::chrono::steady_clock::time_point timestamp)
+             const Timestamp &timestamp)
     : id_(id),
       position_(position),
       velocity_(velocity),
@@ -15,7 +15,7 @@ Robot::Robot(unsigned int id, const Point &position, const Vector &velocity,
 void Robot::updateState(const Point &new_position, const Vector &new_velocity,
                         const Angle &new_orientation,
                         const AngularVelocity &new_angular_velocity,
-                        std::chrono::steady_clock::time_point timestamp)
+                        const Timestamp &timestamp)
 {
     if (timestamp < last_update_timestamp)
     {
@@ -43,7 +43,7 @@ void Robot::updateState(const Robot &new_robot_data)
                 new_robot_data.lastUpdateTimestamp());
 }
 
-void Robot::updateStateToPredictedState(std::chrono::steady_clock::time_point timestamp)
+void Robot::updateStateToPredictedState(const Timestamp &timestamp)
 {
     if (timestamp < last_update_timestamp)
     {
@@ -51,19 +51,18 @@ void Robot::updateStateToPredictedState(std::chrono::steady_clock::time_point ti
             "Error: Predicted state is updating times from the past");
     }
 
-    auto milliseconds_in_future = std::chrono::duration_cast<std::chrono::milliseconds>(
-        timestamp - last_update_timestamp);
-    Point new_position    = estimatePositionAtFutureTime(milliseconds_in_future);
-    Vector new_velocity   = estimateVelocityAtFutureTime(milliseconds_in_future);
-    Angle new_orientation = estimateOrientationAtFutureTime(milliseconds_in_future);
+    Duration duration_in_future = timestamp - last_update_timestamp;
+    Point new_position          = estimatePositionAtFutureTime(duration_in_future);
+    Vector new_velocity         = estimateVelocityAtFutureTime(duration_in_future);
+    Angle new_orientation       = estimateOrientationAtFutureTime(duration_in_future);
     AngularVelocity new_angular_velocity =
-        estimateAngularVelocityAtFutureTime(milliseconds_in_future);
+        estimateAngularVelocityAtFutureTime(duration_in_future);
 
     updateState(new_position, new_velocity, new_orientation, new_angular_velocity,
                 timestamp);
 }
 
-std::chrono::steady_clock::time_point Robot::lastUpdateTimestamp() const
+Timestamp Robot::lastUpdateTimestamp() const
 {
     return last_update_timestamp;
 }
@@ -78,10 +77,9 @@ Point Robot::position() const
     return position_;
 }
 
-Point Robot::estimatePositionAtFutureTime(
-    const std::chrono::milliseconds &milliseconds_in_future) const
+Point Robot::estimatePositionAtFutureTime(const Duration &duration_in_future) const
 {
-    if (milliseconds_in_future < std::chrono::milliseconds(0))
+    if (duration_in_future < Duration::fromSeconds(0))
     {
         throw std::invalid_argument(
             "Error: Position estimate is updating times from the past");
@@ -90,9 +88,7 @@ Point Robot::estimatePositionAtFutureTime(
     // TODO: This is a simple linear implementation that does not necessarily reflect
     // real-world behavior. Position prediction should be improved as outlined in
     // https://github.com/UBC-Thunderbots/Software/issues/50
-    typedef std::chrono::duration<double> double_seconds;
-    double seconds_in_future =
-        std::chrono::duration_cast<double_seconds>(milliseconds_in_future).count();
+    double seconds_in_future = duration_in_future.getSeconds();
     return position_ + velocity_.norm(velocity_.len() * seconds_in_future);
 }
 
@@ -101,10 +97,9 @@ Vector Robot::velocity() const
     return velocity_;
 }
 
-Vector Robot::estimateVelocityAtFutureTime(
-    const std::chrono::milliseconds &milliseconds_in_future) const
+Vector Robot::estimateVelocityAtFutureTime(const Duration &duration_in_future) const
 {
-    if (milliseconds_in_future < std::chrono::milliseconds(0))
+    if (duration_in_future < Duration::fromSeconds(0))
     {
         throw std::invalid_argument(
             "Error: Velocity estimate is updating times from the past");
@@ -121,10 +116,9 @@ Angle Robot::orientation() const
     return orientation_;
 }
 
-Angle Robot::estimateOrientationAtFutureTime(
-    const std::chrono::milliseconds &milliseconds_in_future) const
+Angle Robot::estimateOrientationAtFutureTime(const Duration &duration_in_future) const
 {
-    if (milliseconds_in_future < std::chrono::milliseconds(0))
+    if (duration_in_future < Duration::fromSeconds(0))
     {
         throw std::invalid_argument(
             "Error: Orientation estimate is updating times from the past");
@@ -133,9 +127,7 @@ Angle Robot::estimateOrientationAtFutureTime(
     // TODO: This is a simple linear implementation that does not necessarily reflect
     // real-world behavior. Orientation prediction should be improved as outlined in
     // https://github.com/UBC-Thunderbots/Software/issues/50
-    typedef std::chrono::duration<double> double_seconds;
-    double seconds_in_future =
-        std::chrono::duration_cast<double_seconds>(milliseconds_in_future).count();
+    double seconds_in_future = duration_in_future.getSeconds();
     return orientation_ + angularVelocity_ * seconds_in_future;
 }
 
@@ -145,9 +137,9 @@ AngularVelocity Robot::angularVelocity() const
 }
 
 AngularVelocity Robot::estimateAngularVelocityAtFutureTime(
-    const std::chrono::milliseconds &milliseconds_in_future) const
+    const Duration &duration_in_future) const
 {
-    if (milliseconds_in_future < std::chrono::milliseconds(0))
+    if (duration_in_future < Duration::fromSeconds(0))
     {
         throw std::invalid_argument(
             "Error: Angular velocity estimate is updating times from the past");

--- a/src/thunderbots/software/ai/world/robot.h
+++ b/src/thunderbots/software/ai/world/robot.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <chrono>
-
 #include "geom/angle.h"
 #include "geom/point.h"
+#include "util/timestamp.h"
 
 /**
  * Defines an SSL robot
@@ -21,11 +20,11 @@ class Robot
      * @param angular_velocity the new angular velocity of the robot, in Radians
      * per second
      * @param timestamp The timestamp at which the robot was observed to be in the given
-     * state. The timestamp must be >= the robot's latest update timestamp
+     * state
      */
-    explicit Robot(unsigned int id, const Point& position, const Vector& velocity,
-                   const Angle& orientation, const AngularVelocity& angular_velocity,
-                   std::chrono::steady_clock::time_point timestamp);
+    explicit Robot(unsigned int id, const Point &position, const Vector &velocity,
+                   const Angle &orientation, const AngularVelocity &angular_velocity,
+                   const Timestamp &timestamp);
 
     /**
      * Updates the state of the robot.
@@ -39,10 +38,10 @@ class Robot
      * @param timestamp The timestamp at which the robot was observed to be in the given
      * state. The timestamp must be >= the robot's latest update timestamp
      */
-    void updateState(const Point& new_position, const Vector& new_velocity,
-                     const Angle& new_orientation,
-                     const AngularVelocity& new_angular_velocity,
-                     std::chrono::steady_clock::time_point timestamp);
+    void updateState(const Point &new_position, const Vector &new_velocity,
+                     const Angle &new_orientation,
+                     const AngularVelocity &new_angular_velocity,
+                     const Timestamp &timestamp);
 
     /**
      * Updates the robot with new data, updating the current state as well as the
@@ -50,7 +49,7 @@ class Robot
      *
      * @param new_robot_data A robot containing new robot data
      */
-    void updateState(const Robot& new_robot_data);
+    void updateState(const Robot &new_robot_data);
 
     /**
      * Updates the robot's state to be its predicted state at the given timestamp.
@@ -60,14 +59,14 @@ class Robot
      * @param timestamp The timestamp at which to update the robot's state to. Must
      * be >= the robot's last update timestamp
      */
-    void updateStateToPredictedState(std::chrono::steady_clock::time_point timestamp);
+    void updateStateToPredictedState(const Timestamp &timestamp);
 
     /**
      * Returns the timestamp for when this robot's data was last updated
      *
      * @return the timestamp for when this robot's data was last updated
      */
-    std::chrono::steady_clock::time_point lastUpdateTimestamp() const;
+    Timestamp lastUpdateTimestamp() const;
 
     /**
      * Returns the id of the robot
@@ -87,18 +86,17 @@ class Robot
      * Returns the estimated position of the robot at a future time, relative to when
      * the robot was last updated
      *
-     * @param milliseconds_in_future The relative amount of time in the future
-     * (in milliseconds) at which to predict the robot's position. Value must be >= 0.
-     * For example, a value of 1500 would return the estimated position of the robot
-     * 1.5 seconds in the future.
+     * @param duration_in_future The relative amount of time in the future
+     * at which to predict the robot's position. Value must be >= 0.
+     * For example, a value of 1.5 seconds would return the estimated position of the
+     * robot 1.5 seconds in the future.
      *
      * @throws std::invalid_argument if the robot is estimating the position with a time
      * from the past
      * @return the estimated position of the robot at the given number of milliseconds
      * in the future. Coordinates are in metres.
      */
-    Point estimatePositionAtFutureTime(
-        const std::chrono::milliseconds& milliseconds_in_future) const;
+    Point estimatePositionAtFutureTime(const Duration &duration_in_future) const;
 
     /**
      * Returns the current velocity of the robot
@@ -111,18 +109,17 @@ class Robot
      * Returns the estimated velocity of the robot at a future time, relative to when
      * the robot was last updated
      *
-     * @param milliseconds_in_future The relative amount of time in the future
-     * (in milliseconds) at which to predict the robot's velocity. Value must be >= 0.
-     * For example, a value of 1500 would return the estimated velocity of the robot
-     * 1.5 seconds in the future.
+     * @param duration_in_future The relative amount of time in the future
+     * at which to predict the robot's velocity. Value must be >= 0.
+     * For example, a value of 1.5 seconds would return the estimated velocity of the
+     * robot 1.5 seconds in the future.
      *
      * @throws std::invalid_argument if the robot is estimating the velocity with a time
      * from the past
      * @return the estimated velocity of the robot at the given number of milliseconds
      * in the future, in metres per second
      */
-    Vector estimateVelocityAtFutureTime(
-        const std::chrono::milliseconds& milliseconds_in_future) const;
+    Vector estimateVelocityAtFutureTime(const Duration &duration_in_future) const;
 
     /**
      * Returns the current orientation of the robot
@@ -135,18 +132,17 @@ class Robot
      * Returns the estimated orientation of the robot at a future time, relative to when
      * the robot was last updated
      *
-     * @param milliseconds_in_future The relative amount of time in the future
-     * (in milliseconds) at which to predict the robot's orientation. Value must be >= 0.
-     * For example, a value of 1500 would return the estimated orientation of the robot
-     * 1.5 seconds in the future.
+     * @param duration_in_future The relative amount of time in the future
+     * at which to predict the robot's orientation. Value must be >= 0.
+     * For example, a value of 1.5 seconds would return the estimated orientation of the
+     * robot 1.5 seconds in the future.
      *
      * @throws std::invalid_argument if the robot is estimating the orientation with a
      * time from the past
      * @return the estimated orientation of the robot at the given number of milliseconds
      * in the future. Coordinates are in metres.
      */
-    Angle estimateOrientationAtFutureTime(
-        const std::chrono::milliseconds& milliseconds_in_future) const;
+    Angle estimateOrientationAtFutureTime(const Duration &duration_in_future) const;
 
     /**
      * Returns the current angular velocity of the robot
@@ -157,13 +153,12 @@ class Robot
 
     /**
      * Returns the estimated angular velocity of the robot at a future time, relative to
-     * when
-     * the robot was last updated
+     * when the robot was last updated
      *
-     * @param milliseconds_in_future The relative amount of time in the future
-     * (in milliseconds) at which to predict the robot's angular velocity. Value must be
-     * >= 0. For example, a value of 1500 would return the estimated angular velocity of
-     * the robot 1.5 seconds in the future.
+     * @param duration_in_future The relative amount of time in the future
+     * at which to predict the robot's angular velocity. Value must be
+     * >= 0. For example, a value of 1.5 seconds would return the estimated angular
+     * velocity of the robot 1.5 seconds in the future.
      *
      * @throws std::invalid_argument if the robot is estimating the angular velocity with
      * a time from the past
@@ -171,7 +166,7 @@ class Robot
      * milliseconds in the future. Coordinates are in metres. Coordinates are in metres.
      */
     AngularVelocity estimateAngularVelocityAtFutureTime(
-        const std::chrono::milliseconds& milliseconds_in_future) const;
+        const Duration &duration_in_future) const;
 
     /**
      * Defines the equality operator for a Robot. Robots are equal if their IDs and
@@ -181,7 +176,7 @@ class Robot
      * @param other The robot to compare against for equality
      * @return True if the other robot is equal to this robot, and false otherwise
      */
-    bool operator==(const Robot& other) const;
+    bool operator==(const Robot &other) const;
 
     /**
      * Defines the inequality operator for a Robot.
@@ -189,7 +184,7 @@ class Robot
      * @param other The robot to compare against for inequality
      * @return True if the other robot is not equal to this robots, and false otherwise
      */
-    bool operator!=(const Robot& other) const;
+    bool operator!=(const Robot &other) const;
 
    private:
     // The id of this robot
@@ -203,5 +198,5 @@ class Robot
     // The current angular velocity of the robot, in radians per second
     AngularVelocity angularVelocity_;
     // The timestamp for when this Robot was last updated
-    std::chrono::steady_clock::time_point last_update_timestamp;
+    Timestamp last_update_timestamp;
 };

--- a/src/thunderbots/software/ai/world/team.cpp
+++ b/src/thunderbots/software/ai/world/team.cpp
@@ -4,10 +4,10 @@
 
 #include "shared/constants.h"
 
-Team::Team(const std::chrono::milliseconds robot_expiry_buffer_milliseconds)
+Team::Team(const Duration& robot_expiry_buffer_duration)
     : team_robots(),
       goalie_id(),
-      robot_expiry_buffer_milliseconds(robot_expiry_buffer_milliseconds)
+      robot_expiry_buffer_duration(robot_expiry_buffer_duration)
 {
 }
 
@@ -46,8 +46,7 @@ void Team::updateState(const Team& new_team_data)
     this->goalie_id = new_team_data.goalie_id;
 }
 
-void Team::updateStateToPredictedState(
-    const std::chrono::steady_clock::time_point timestamp)
+void Team::updateStateToPredictedState(const Timestamp& timestamp)
 {
     // Update the state of all robots to their predicted state
     for (auto it = team_robots.begin(); it != team_robots.end(); it++)
@@ -56,14 +55,13 @@ void Team::updateStateToPredictedState(
     }
 }
 
-void Team::removeExpiredRobots(const std::chrono::steady_clock::time_point timestamp)
+void Team::removeExpiredRobots(const Timestamp& timestamp)
 {
     // Check to see if any Robots have "expired". If it more time than the expiry_buffer
     // has passed, then remove the robot from the team
     for (auto it = team_robots.begin(); it != team_robots.end();)
     {
-        if (std::chrono::duration(timestamp - it->second.lastUpdateTimestamp()) >
-            robot_expiry_buffer_milliseconds)
+        if ((timestamp - it->second.lastUpdateTimestamp()) > robot_expiry_buffer_duration)
         {
             it = team_robots.erase(it);
         }
@@ -97,15 +95,14 @@ std::size_t Team::numRobots() const
     return team_robots.size();
 }
 
-std::chrono::milliseconds Team::getRobotExpiryBufferMilliseconds()
+Duration Team::getRobotExpiryBufferDuration()
 {
-    return robot_expiry_buffer_milliseconds;
+    return robot_expiry_buffer_duration;
 }
 
-void Team::setRobotExpiryBuffer(
-    std::chrono::milliseconds new_robot_expiry_buffer_milliseconds)
+void Team::setRobotExpiryBuffer(const Duration& new_robot_expiry_buffer_duration)
 {
-    robot_expiry_buffer_milliseconds = new_robot_expiry_buffer_milliseconds;
+    robot_expiry_buffer_duration = new_robot_expiry_buffer_duration;
 }
 
 std::optional<Robot> Team::getRobotById(const unsigned int id) const
@@ -149,8 +146,7 @@ bool Team::operator==(const Team& other) const
 {
     return this->getAllRobots() == other.getAllRobots() &&
            this->goalie_id == other.goalie_id &&
-           this->robot_expiry_buffer_milliseconds ==
-               other.robot_expiry_buffer_milliseconds;
+           this->robot_expiry_buffer_duration == other.robot_expiry_buffer_duration;
 }
 
 bool Team::operator!=(const Team& other) const

--- a/src/thunderbots/software/ai/world/team.h
+++ b/src/thunderbots/software/ai/world/team.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <chrono>
 #include <cstdlib>
 #include <map>
 #include <optional>
 #include <vector>
 
 #include "ai/world/robot.h"
+#include "util/timestamp.h"
 
 
 /**
@@ -27,10 +27,10 @@ class Team
     /**
      * Create a new team
      *
-     * @param robot_expiry_buffer_milliseconds The number of milliseconds a robot must not
+     * @param robot_expiry_buffer_duration The Duration for which a robot must not
      * have been updated for before it is removed from the team
      */
-    explicit Team(const std::chrono::milliseconds robot_expiry_buffer_milliseconds);
+    explicit Team(const Duration& robot_expiry_buffer_duration);
 
     /**
      * Updates this team with new robots.
@@ -61,8 +61,7 @@ class Team
      * @param timestamp The timestamp at which to update the team's state to. Must
      * be >= the last update timestamp of the robots on the team
      */
-    void updateStateToPredictedState(
-        const std::chrono::steady_clock::time_point timestamp);
+    void updateStateToPredictedState(const Timestamp& timestamp);
 
     /**
      * Removes expired robots from the team. Robots are expired if it has been more than
@@ -74,7 +73,7 @@ class Team
      *
      * @param timestamp The timestamp for when this removal is taking place
      */
-    void removeExpiredRobots(const std::chrono::steady_clock::time_point timestamp);
+    void removeExpiredRobots(const Timestamp& timestamp);
 
     /**
      * Assigns the goalie for this team, making it the robot with the newly given id.
@@ -102,23 +101,22 @@ class Team
     std::size_t numRobots() const;
 
     /**
-     * Returns the number of milliseconds a Robot must not have been updated for before
+     * Returns the Duration for which a Robot must not have been updated for before
      * being removed from this team.
      *
-     * @return the number of milliseconds a Robot must not have been updated for before
+     * @return the Duration for which a Robot must not have been updated for before
      * being removed from this team.
      */
-    std::chrono::milliseconds getRobotExpiryBufferMilliseconds();
+    Duration getRobotExpiryBufferDuration();
 
     /**
-     * Sets the number of milliseconds a Robot must not have been updated for before being
+     * Sets the Duration for which a Robot must not have been updated for before being
      * removed from this team.
      *
-     * @param new_robot_expiry_buffer_milliseconds the number of milliseconds a Robot must
+     * @param new_robot_expiry_buffer_duration the Duration for which a Robot must
      * not have been updated for before being removed from this team.
      */
-    void setRobotExpiryBuffer(
-        std::chrono::milliseconds new_robot_expiry_buffer_milliseconds);
+    void setRobotExpiryBuffer(const Duration& new_robot_expiry_buffer_duration);
 
     /**
      * Returns the robot with the given id. If this team does not have that robot,
@@ -177,7 +175,7 @@ class Team
     // The robot id of the goalie for this team
     std::optional<unsigned int> goalie_id;
 
-    // The number of milliseconds a Robot must not have been updated for before
+    // The duration for which a Robot must not have been updated for before
     // being removed from this team.
-    std::chrono::milliseconds robot_expiry_buffer_milliseconds;
+    Duration robot_expiry_buffer_duration;
 };

--- a/src/thunderbots/software/grsim_communication/grsim_backend.cpp
+++ b/src/thunderbots/software/grsim_communication/grsim_backend.cpp
@@ -29,9 +29,10 @@ void GrSimBackend::sendPrimitives(
     const Ball& ball)
 {
     // TODO: Can't replace this timestamp as part of issue #228 because the Timestamp
-    // class doesn't support absolute "wall time". The MotionController will need to be
+    // class doesn't support absolute "wall time". This function will need to be
     // changed to make use of the timestamps stored with the robots
-    // TODO: Make ticket
+    // https://github.com/UBC-Thunderbots/Software/issues/279
+    //
     // initial timestamp for bang-bang set as current time
     static auto bangbang_timestamp = std::chrono::steady_clock::now();
 

--- a/src/thunderbots/software/grsim_communication/grsim_backend.cpp
+++ b/src/thunderbots/software/grsim_communication/grsim_backend.cpp
@@ -28,6 +28,10 @@ void GrSimBackend::sendPrimitives(
     const std::vector<std::unique_ptr<Primitive>>& primitives, const Team& friendly_team,
     const Ball& ball)
 {
+    // TODO: Can't replace this timestamp as part of issue #228 because the Timestamp
+    // class doesn't support absolute "wall time". The MotionController will need to be
+    // changed to make use of the timestamps stored with the robots
+    // TODO: Make ticket
     // initial timestamp for bang-bang set as current time
     static auto bangbang_timestamp = std::chrono::steady_clock::now();
 

--- a/src/thunderbots/software/grsim_communication/main.cpp
+++ b/src/thunderbots/software/grsim_communication/main.cpp
@@ -28,8 +28,8 @@ namespace
     // the Primitives in grSim
     std::vector<std::unique_ptr<Primitive>> primitives;
 
-    Team friendly_team = Team(std::chrono::milliseconds(1000));
-    Ball ball          = Ball(Point(0, 0), Vector());
+    Team friendly_team = Team(Duration::fromMilliseconds(1000));
+    Ball ball          = Ball(Point(0, 0), Vector(), Timestamp::fromSeconds(0));
 }  // namespace
 
 // Callbacks

--- a/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
+++ b/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
@@ -14,7 +14,6 @@
 #include "grsim_communication/motion_controller/motion_controller.h"
 
 #include <algorithm>
-#include <chrono>
 
 #include "shared/constants.h"
 

--- a/src/thunderbots/software/grsim_communication/visitor/grsim_command_primitive_visitor.cpp
+++ b/src/thunderbots/software/grsim_communication/visitor/grsim_command_primitive_visitor.cpp
@@ -29,15 +29,15 @@ void GrsimCommandPrimitiveVisitor::visit(const CatchPrimitive &catch_primitive)
     Point finalDest;
     if (robot.velocity().len() != 0)
     {
-        finalDest = ball.estimatePositionAtFutureTime(std::chrono::milliseconds(
-            (int)fabs(distanceToBall / robot.velocity().len()) * 1000));
+        finalDest = ball.estimatePositionAtFutureTime(
+            Duration::fromSeconds((int)fabs(distanceToBall / robot.velocity().len())));
         finalDest = Point(finalDest.x(), finalDest.y());
     }
     else
     {
         // If Robot is not moving, estimate position based on a standard velocity of 1
         finalDest = ball.estimatePositionAtFutureTime(
-            std::chrono::milliseconds((int)fabs(distanceToBall / 1) * 1000));
+            Duration::fromSeconds((int)fabs(distanceToBall / 1)));
         finalDest = Point(finalDest.x(), finalDest.y());
     }
 

--- a/src/thunderbots/software/network_input/backend.cpp
+++ b/src/thunderbots/software/network_input/backend.cpp
@@ -73,13 +73,16 @@ std::optional<thunderbots_msgs::Team> Backend::getFilteredFriendlyTeamMsg(
         {
             for (const SSL_DetectionRobot &friendly_robot : ssl_robots)
             {
-                SSLRobotData new_robot_data{
-                    friendly_robot.robot_id(),
+                SSLRobotData new_robot_data;
+
+                new_robot_data.id = friendly_robot.robot_id();
+                new_robot_data.position =
                     Point(friendly_robot.x() * METERS_PER_MILLIMETER,
-                          friendly_robot.y() * METERS_PER_MILLIMETER),
-                    Angle::ofRadians(friendly_robot.orientation()),
-                    friendly_robot.confidence(),
-                    Timestamp::fromSeconds(detection.t_capture())};
+                          friendly_robot.y() * METERS_PER_MILLIMETER);
+                new_robot_data.orientation =
+                    Angle::ofRadians(friendly_robot.orientation());
+                new_robot_data.confidence = friendly_robot.confidence();
+                new_robot_data.timestamp  = Timestamp::fromSeconds(detection.t_capture());
 
                 friendly_team_robot_data.emplace_back(new_robot_data);
             }
@@ -118,12 +121,14 @@ std::optional<thunderbots_msgs::Team> Backend::getFilteredEnemyTeamMsg(
         {
             for (const SSL_DetectionRobot &enemy_robot : ssl_robots)
             {
-                SSLRobotData new_robot_data{
-                    enemy_robot.robot_id(),
-                    Point(enemy_robot.x() * METERS_PER_MILLIMETER,
-                          enemy_robot.y() * METERS_PER_MILLIMETER),
-                    Angle::ofRadians(enemy_robot.orientation()), enemy_robot.confidence(),
-                    Timestamp::fromSeconds(detection.t_capture())};
+                SSLRobotData new_robot_data;
+
+                new_robot_data.id       = enemy_robot.robot_id();
+                new_robot_data.position = Point(enemy_robot.x() * METERS_PER_MILLIMETER,
+                                                enemy_robot.y() * METERS_PER_MILLIMETER);
+                new_robot_data.orientation = Angle::ofRadians(enemy_robot.orientation());
+                new_robot_data.confidence  = enemy_robot.confidence();
+                new_robot_data.timestamp = Timestamp::fromSeconds(detection.t_capture());
 
                 enemy_team_robot_data.emplace_back(new_robot_data);
             }

--- a/src/thunderbots/software/network_input/backend.cpp
+++ b/src/thunderbots/software/network_input/backend.cpp
@@ -73,17 +73,13 @@ std::optional<thunderbots_msgs::Team> Backend::getFilteredFriendlyTeamMsg(
         {
             for (const SSL_DetectionRobot &friendly_robot : ssl_robots)
             {
-                SSLRobotData new_robot_data;
-
-                new_robot_data.id = friendly_robot.robot_id();
-                new_robot_data.position =
+                SSLRobotData new_robot_data{
+                    friendly_robot.robot_id(),
                     Point(friendly_robot.x() * METERS_PER_MILLIMETER,
-                          friendly_robot.y() * METERS_PER_MILLIMETER);
-                new_robot_data.orientation =
-                    Angle::ofRadians(friendly_robot.orientation());
-                new_robot_data.confidence = friendly_robot.confidence();
-                new_robot_data.timestamp =
-                    detection.t_capture();  // Units of t_capture is seconds
+                          friendly_robot.y() * METERS_PER_MILLIMETER),
+                    Angle::ofRadians(friendly_robot.orientation()),
+                    friendly_robot.confidence(),
+                    Timestamp::fromSeconds(detection.t_capture())};
 
                 friendly_team_robot_data.emplace_back(new_robot_data);
             }
@@ -122,14 +118,12 @@ std::optional<thunderbots_msgs::Team> Backend::getFilteredEnemyTeamMsg(
         {
             for (const SSL_DetectionRobot &enemy_robot : ssl_robots)
             {
-                SSLRobotData new_robot_data;
-
-                new_robot_data.id       = enemy_robot.robot_id();
-                new_robot_data.position = Point(enemy_robot.x() * METERS_PER_MILLIMETER,
-                                                enemy_robot.y() * METERS_PER_MILLIMETER);
-                new_robot_data.orientation = Angle::ofRadians(enemy_robot.orientation());
-                new_robot_data.confidence  = enemy_robot.confidence();
-                new_robot_data.timestamp   = detection.t_capture();
+                SSLRobotData new_robot_data{
+                    enemy_robot.robot_id(),
+                    Point(enemy_robot.x() * METERS_PER_MILLIMETER,
+                          enemy_robot.y() * METERS_PER_MILLIMETER),
+                    Angle::ofRadians(enemy_robot.orientation()), enemy_robot.confidence(),
+                    Timestamp::fromSeconds(detection.t_capture())};
 
                 enemy_team_robot_data.emplace_back(new_robot_data);
             }

--- a/src/thunderbots/software/network_input/filter/ball_filter.cpp
+++ b/src/thunderbots/software/network_input/filter/ball_filter.cpp
@@ -27,7 +27,7 @@ FilteredBallData BallFilter::getFilteredData(std::vector<SSLBallData> new_ball_d
     filtered_data.velocity = ball_data.velocity;
     // This is a placeholder timestamp for now. Timestamps should be fixed in
     // https://github.com/UBC-Thunderbots/Software/issues/228
-    filtered_data.timestamp = Timestamp::getTimestampNow();
+    filtered_data.timestamp = Timestamp::fromSeconds(new_ball_data[0].timestamp);
 
     return filtered_data;
 }

--- a/src/thunderbots/software/network_input/filter/ball_filter.cpp
+++ b/src/thunderbots/software/network_input/filter/ball_filter.cpp
@@ -25,6 +25,7 @@ FilteredBallData BallFilter::getFilteredData(std::vector<SSLBallData> new_ball_d
     FilteredBallData filtered_data;
     filtered_data.position = new_ball_data[0].position;
     filtered_data.velocity = ball_data.velocity;
+    // TODO: This is a placeholder timestamp. It should be
     // This is a placeholder timestamp for now. Timestamps should be fixed in
     // https://github.com/UBC-Thunderbots/Software/issues/228
     filtered_data.timestamp = Timestamp::fromSeconds(new_ball_data[0].timestamp);

--- a/src/thunderbots/software/network_input/filter/ball_filter.h
+++ b/src/thunderbots/software/network_input/filter/ball_filter.h
@@ -25,18 +25,6 @@ typedef struct
  */
 typedef struct FilteredBallData
 {
-    /**
-     * Creates a new FilteredBallData struct
-     *
-     * @param position The position of the ball
-     * @param velocity The velocity of the ball
-     * @param timestamp The timestamp of the data
-     */
-    FilteredBallData(Point position, Vector velocity, Timestamp timestamp)
-        : position(position), velocity(velocity), timestamp(timestamp)
-    {
-    }
-
     Point position;
     Vector velocity;
     Timestamp timestamp;

--- a/src/thunderbots/software/network_input/filter/ball_filter.h
+++ b/src/thunderbots/software/network_input/filter/ball_filter.h
@@ -23,11 +23,23 @@ typedef struct
  * something like std::pair so it's very explicit what data is being accessed, since
  * it's accessed by name rather than by index (first/second)
  */
-typedef struct
+typedef struct FilteredBallData
 {
+    /**
+     * Creates a new FilteredBallData struct
+     *
+     * @param position The position of the ball
+     * @param velocity The velocity of the ball
+     * @param timestamp The timestamp of the data
+     */
+    FilteredBallData(Point position, Vector velocity, Timestamp timestamp)
+        : position(position), velocity(velocity), timestamp(timestamp)
+    {
+    }
+
     Point position;
     Vector velocity;
-    AITimestamp timestamp;
+    Timestamp timestamp;
 } FilteredBallData;
 
 /**

--- a/src/thunderbots/software/network_input/filter/ball_filter.h
+++ b/src/thunderbots/software/network_input/filter/ball_filter.h
@@ -23,7 +23,7 @@ typedef struct
  * something like std::pair so it's very explicit what data is being accessed, since
  * it's accessed by name rather than by index (first/second)
  */
-typedef struct FilteredBallData
+typedef struct FilteredBallData_t
 {
     Point position;
     Vector velocity;

--- a/src/thunderbots/software/network_input/filter/particle_filter.cpp
+++ b/src/thunderbots/software/network_input/filter/particle_filter.cpp
@@ -1,7 +1,5 @@
 #include "particle_filter.h"
 
-#include <chrono>
-
 #include "geom/util.h"
 
 /* Notes on the weights and evaluation:
@@ -30,8 +28,7 @@ ParticleFilter::ParticleFilter(double length, double width)
     particles = std::vector<Particle>(PARTICLE_FILTER_NUM_PARTICLES, Particle());
 
     // Set the seed for the random number generator
-    seed = static_cast<unsigned int>(
-        std::chrono::system_clock::now().time_since_epoch().count());
+    seed = static_cast<unsigned int>(time(NULL));
 
     // These will be used to generate Points with a gaussian distribution
     generator = std::default_random_engine(seed);

--- a/src/thunderbots/software/network_input/filter/robot_filter.cpp
+++ b/src/thunderbots/software/network_input/filter/robot_filter.cpp
@@ -7,7 +7,8 @@ RobotFilter::RobotFilter(unsigned int id) : robot_id(id) {}
 FilteredRobotData RobotFilter::getFilteredData(
     const std::vector<SSLRobotData> &new_robot_data)
 {
-    return FilteredRobotData();
+    return FilteredRobotData(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                             Timestamp::fromSeconds(0));
 }
 
 unsigned int RobotFilter::getRobotId() const

--- a/src/thunderbots/software/network_input/filter/robot_filter.cpp
+++ b/src/thunderbots/software/network_input/filter/robot_filter.cpp
@@ -7,8 +7,15 @@ RobotFilter::RobotFilter(unsigned int id) : robot_id(id) {}
 FilteredRobotData RobotFilter::getFilteredData(
     const std::vector<SSLRobotData> &new_robot_data)
 {
-    return FilteredRobotData(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
-                             Timestamp::fromSeconds(0));
+    FilteredRobotData filtered_data;
+    filtered_data.id               = 0;
+    filtered_data.position         = Point();
+    filtered_data.velocity         = Vector();
+    filtered_data.orientation      = Angle::zero();
+    filtered_data.angular_velocity = AngularVelocity::zero();
+    filtered_data.timestamp        = Timestamp::fromSeconds(0);
+
+    return filtered_data;
 }
 
 unsigned int RobotFilter::getRobotId() const

--- a/src/thunderbots/software/network_input/filter/robot_filter.h
+++ b/src/thunderbots/software/network_input/filter/robot_filter.h
@@ -12,7 +12,7 @@
  * so we can make this module more generic and abstract away
  * the protobuf for testing
  */
-typedef struct SSLRobotData
+typedef struct SSLRobotData_t
 {
     unsigned int id;
     Point position;
@@ -24,7 +24,7 @@ typedef struct SSLRobotData
 /**
  * A lightweight datatype used to pass filtered robot data
  */
-typedef struct FilteredRobotData
+typedef struct FilteredRobotData_t
 {
     unsigned int id;
     Point position;

--- a/src/thunderbots/software/network_input/filter/robot_filter.h
+++ b/src/thunderbots/software/network_input/filter/robot_filter.h
@@ -12,26 +12,65 @@
  * so we can make this module more generic and abstract away
  * the protobuf for testing
  */
-typedef struct
+typedef struct SSLRobotData
 {
+    /**
+     * Creates a new SSLRobotData struct
+     *
+     * @param id The id of the robot
+     * @param position The position of the robot
+     * @param orientation The orientation of the robot
+     * @param confidence The confidence (0.0 <= confidence <= 1.0) of this robot data
+     * @param timestamp The timestamp of this data
+     */
+    SSLRobotData(unsigned int id, Point position, Angle orientation, double confidence,
+                 Timestamp timestamp)
+        : id(id),
+          position(position),
+          orientation(orientation),
+          confidence(confidence),
+          timestamp(timestamp)
+    {
+    }
+
     unsigned int id;
     Point position;
     Angle orientation;
     double confidence;
-    double timestamp;
+    Timestamp timestamp;
 } SSLRobotData;
 
 /**
  * A lightweight datatype used to pass filtered robot data
  */
-typedef struct
+typedef struct FilteredRobotData
 {
+    /**
+     * Creates a new FilteredRobotData struct
+     *
+     * @param id The id of the robot
+     * @param position The position of the robot
+     * @param velocity The velocity of the robot
+     * @param orientation The orientation of the robot
+     * @param angular_velocity The angular velocity of the robot
+     * @param timestamp The timestamp of the robot
+     */
+    FilteredRobotData(unsigned int id, Point position, Vector velocity, Angle orientation,
+                      AngularVelocity angular_velocity, Timestamp timestamp)
+        : id(id),
+          position(position),
+          velocity(velocity),
+          angular_velocity(angular_velocity),
+          timestamp(timestamp)
+    {
+    }
+
     unsigned int id;
     Point position;
     Vector velocity;
     Angle orientation;
     AngularVelocity angular_velocity;
-    AITimestamp timestamp;
+    Timestamp timestamp;
 } FilteredRobotData;
 
 class RobotFilter

--- a/src/thunderbots/software/network_input/filter/robot_filter.h
+++ b/src/thunderbots/software/network_input/filter/robot_filter.h
@@ -14,25 +14,6 @@
  */
 typedef struct SSLRobotData
 {
-    /**
-     * Creates a new SSLRobotData struct
-     *
-     * @param id The id of the robot
-     * @param position The position of the robot
-     * @param orientation The orientation of the robot
-     * @param confidence The confidence (0.0 <= confidence <= 1.0) of this robot data
-     * @param timestamp The timestamp of this data
-     */
-    SSLRobotData(unsigned int id, Point position, Angle orientation, double confidence,
-                 Timestamp timestamp)
-        : id(id),
-          position(position),
-          orientation(orientation),
-          confidence(confidence),
-          timestamp(timestamp)
-    {
-    }
-
     unsigned int id;
     Point position;
     Angle orientation;
@@ -45,26 +26,6 @@ typedef struct SSLRobotData
  */
 typedef struct FilteredRobotData
 {
-    /**
-     * Creates a new FilteredRobotData struct
-     *
-     * @param id The id of the robot
-     * @param position The position of the robot
-     * @param velocity The velocity of the robot
-     * @param orientation The orientation of the robot
-     * @param angular_velocity The angular velocity of the robot
-     * @param timestamp The timestamp of the robot
-     */
-    FilteredRobotData(unsigned int id, Point position, Vector velocity, Angle orientation,
-                      AngularVelocity angular_velocity, Timestamp timestamp)
-        : id(id),
-          position(position),
-          velocity(velocity),
-          angular_velocity(angular_velocity),
-          timestamp(timestamp)
-    {
-    }
-
     unsigned int id;
     Point position;
     Vector velocity;

--- a/src/thunderbots/software/network_input/filter/robot_team_filter.cpp
+++ b/src/thunderbots/software/network_input/filter/robot_team_filter.cpp
@@ -49,13 +49,16 @@ std::vector<FilteredRobotData> RobotTeamFilter::getFilteredData(
                 RobotData(new_robot_data.position, new_robot_data.orientation,
                           new_robot_data.timestamp);
 
-            FilteredRobotData filtered_data{
-                new_robot_data.id, new_robot_data.position, robot_velocity,
-                new_robot_data.orientation, robot_angular_velocity,
-                // TODO: This timestamp is a placeholder and should be fixed once the
-                // robot filter PR is merged
-                // https://github.com/UBC-Thunderbots/Software/issues/199
-                Timestamp::fromSeconds(0)};
+            FilteredRobotData filtered_data;
+            filtered_data.id               = new_robot_data.id;
+            filtered_data.position         = new_robot_data.position;
+            filtered_data.velocity         = robot_velocity;
+            filtered_data.orientation      = new_robot_data.orientation;
+            filtered_data.angular_velocity = robot_angular_velocity;
+            // TODO: This timestamp is a placeholder and should be fixed once the
+            // robot filter PR is merged
+            // https://github.com/UBC-Thunderbots/Software/issues/199
+            filtered_data.timestamp = Timestamp::fromSeconds(0);
 
             result.push_back(filtered_data);
         }

--- a/src/thunderbots/software/network_input/filter/robot_team_filter.cpp
+++ b/src/thunderbots/software/network_input/filter/robot_team_filter.cpp
@@ -54,6 +54,7 @@ std::vector<FilteredRobotData> RobotTeamFilter::getFilteredData(
                 new_robot_data.orientation, robot_angular_velocity,
                 // TODO: This timestamp is a placeholder and should be fixed once the
                 // robot filter PR is merged
+                // https://github.com/UBC-Thunderbots/Software/issues/199
                 Timestamp::fromSeconds(0)};
 
             result.push_back(filtered_data);

--- a/src/thunderbots/software/network_input/filter/robot_team_filter.cpp
+++ b/src/thunderbots/software/network_input/filter/robot_team_filter.cpp
@@ -1,6 +1,7 @@
 #include "robot_team_filter.h"
 
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <vector>
 
@@ -24,8 +25,9 @@ std::vector<FilteredRobotData> RobotTeamFilter::getFilteredData(
         }
         else
         {
-            double time_difference = std::fabs(new_robot_data.timestamp -
-                                               robot_map.at(new_robot_data.id).timestamp);
+            double time_difference =
+                std::fabs(new_robot_data.timestamp.getSeconds() -
+                          robot_map.at(new_robot_data.id).timestamp.getSeconds());
             // If the time difference is 0, we have already received and processed this
             // data. Do nothing so we do not calculate false values
             if (time_difference == 0)
@@ -47,13 +49,12 @@ std::vector<FilteredRobotData> RobotTeamFilter::getFilteredData(
                 RobotData(new_robot_data.position, new_robot_data.orientation,
                           new_robot_data.timestamp);
 
-            FilteredRobotData filtered_data;
-            filtered_data.position         = new_robot_data.position;
-            filtered_data.velocity         = robot_velocity;
-            filtered_data.orientation      = new_robot_data.orientation;
-            filtered_data.angular_velocity = robot_angular_velocity;
-            filtered_data.timestamp        = Timestamp::getTimestampNow();
-            filtered_data.id               = new_robot_data.id;
+            FilteredRobotData filtered_data{
+                new_robot_data.id, new_robot_data.position, robot_velocity,
+                new_robot_data.orientation, robot_angular_velocity,
+                // TODO: This timestamp is a placeholder and should be fixed once the
+                // robot filter PR is merged
+                Timestamp::fromSeconds(0)};
 
             result.push_back(filtered_data);
         }

--- a/src/thunderbots/software/network_input/filter/robot_team_filter.h
+++ b/src/thunderbots/software/network_input/filter/robot_team_filter.h
@@ -32,14 +32,14 @@ class RobotTeamFilter
     // https://github.com/UBC-Thunderbots/Software/issues/200
     struct RobotData
     {
-        RobotData(Point position, Angle orientation, double timestamp)
+        RobotData(Point position, Angle orientation, Timestamp timestamp)
             : position(position), orientation(orientation), timestamp(timestamp)
         {
         }
 
         Point position;
         Angle orientation;
-        double timestamp;
+        Timestamp timestamp;
     };
 
     std::map<unsigned int, RobotData> robot_map;

--- a/src/thunderbots/software/network_input/util/ros_messages.cpp
+++ b/src/thunderbots/software/network_input/util/ros_messages.cpp
@@ -88,8 +88,7 @@ thunderbots_msgs::Ball MessageUtil::createBallMsgFromFilteredBallData(
     ball_msg.velocity.x = filtered_ball_data.velocity.x();
     ball_msg.velocity.y = filtered_ball_data.velocity.y();
 
-    ball_msg.timestamp_microseconds =
-        Timestamp::getMicroseconds(filtered_ball_data.timestamp);
+    ball_msg.timestamp_seconds = filtered_ball_data.timestamp.getSeconds();
 
     return ball_msg;
 }
@@ -111,11 +110,7 @@ thunderbots_msgs::Robot MessageUtil::createRobotMsgFromFilteredRobotData(
 
     robot_msg.angular_velocity = filtered_robot_data.angular_velocity.toRadians();
 
-    robot_msg.timestamp_nanoseconds_since_epoch = static_cast<unsigned long>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
-            std::chrono::microseconds(
-                Timestamp::getMicroseconds(filtered_robot_data.timestamp)))
-            .count());
+    robot_msg.timestamp_seconds = filtered_robot_data.timestamp.getSeconds();
 
     return robot_msg;
 }

--- a/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
+++ b/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
@@ -1,5 +1,7 @@
 #include "grsim_communication/motion_controller/motion_controller.h"
 
+#include <chrono>
+
 #include "geom/angle.h"
 #include "gtest/gtest.h"
 #include "shared/constants.h"
@@ -23,17 +25,16 @@ using namespace std::chrono;
 class MotionControllerTest : public ::testing::Test
 {
    protected:
+    MotionControllerTest() : current_time(Timestamp::fromSeconds(0)) {}
+
     void SetUp() override
     {
-        auto epoch       = time_point<std::chrono::steady_clock>();
-        auto since_epoch = std::chrono::seconds(10000);
-
-        // An arbitrary fixed point in time. 10000 seconds after the epoch.
+        // An arbitrary fixed point in time
         // We use this fixed point in time to make the tests deterministic.
-        current_time = epoch + since_epoch;
+        current_time = Timestamp::fromSeconds(300);
     }
 
-    steady_clock::time_point current_time;
+    Timestamp current_time;
 
     double calculateVelocityTolerance(double velocity)
     {

--- a/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
+++ b/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
@@ -25,8 +25,6 @@ using namespace std::chrono;
 class MotionControllerTest : public ::testing::Test
 {
    protected:
-    MotionControllerTest() : current_time(Timestamp::fromSeconds(0)) {}
-
     void SetUp() override
     {
         // An arbitrary fixed point in time

--- a/src/thunderbots/software/test/grsim_command_primitive_visitor/catch_primitive.cpp
+++ b/src/thunderbots/software/test/grsim_command_primitive_visitor/catch_primitive.cpp
@@ -8,42 +8,23 @@
 #include "shared/constants.h"
 #include "software/ai/world/robot.h"
 
-using namespace std::chrono;
-
 #define POSITION_TOLERANCE 0.01
 #define VELOCITY_BASE_TOLERANCE 0.015
 #define VELOCITY_TOLERANCE_SCALE_FACTOR 0.01
 
-// set up test class to keep deterministic time
-class CatchPrimitiveTest : public ::testing::Test
+double calculateVelocityTolerance(double velocity)
 {
-   protected:
-    void SetUp() override
-    {
-        auto epoch       = time_point<std::chrono::steady_clock>();
-        auto since_epoch = std::chrono::seconds(10000);
+    return VELOCITY_BASE_TOLERANCE + VELOCITY_TOLERANCE_SCALE_FACTOR * velocity;
+}
 
-        // An arbitrary fixed point in time. 10000 seconds after the epoch.
-        // We use this fixed point in time to make the tests deterministic.
-        current_time = epoch + since_epoch;
-    }
-
-    steady_clock::time_point current_time;
-
-    double calculateVelocityTolerance(double velocity)
-    {
-        return VELOCITY_BASE_TOLERANCE + VELOCITY_TOLERANCE_SCALE_FACTOR * velocity;
-    }
-};
-
-TEST_F(CatchPrimitiveTest, robot_stationary_meets_ball_on_x_axis)
+TEST(CatchPrimitiveTest, robot_stationary_meets_ball_on_x_axis)
 {
     Robot robot = Robot(1, Point(2, 2), Vector(0, 0), Angle::ofRadians(0.0),
-                        AngularVelocity::ofRadians(0.0), current_time);
+                        AngularVelocity::ofRadians(0.0), Timestamp::fromSeconds(0));
 
     CatchPrimitive primitive = CatchPrimitive(1, 0, 10, 0.3);
 
-    Ball ball = Ball(Point(0, 0), Vector(1, 0), current_time);
+    Ball ball = Ball(Point(0, 0), Vector(1, 0), Timestamp::fromSeconds(0));
 
     GrsimCommandPrimitiveVisitor grsim_command_primitive_visitor =
         GrsimCommandPrimitiveVisitor(robot, ball);
@@ -56,14 +37,14 @@ TEST_F(CatchPrimitiveTest, robot_stationary_meets_ball_on_x_axis)
     EXPECT_NEAR(0, motionCommand.global_destination.y(), 0.1);
 }
 
-TEST_F(CatchPrimitiveTest, robot_moving_away_from_final_dest)
+TEST(CatchPrimitiveTest, robot_moving_away_from_final_dest)
 {
     Robot robot = Robot(1, Point(2, 2), Vector(-1, 1), Angle::ofRadians(0.0),
-                        AngularVelocity::ofRadians(0.0), current_time);
+                        AngularVelocity::ofRadians(0.0), Timestamp::fromSeconds(0));
 
     CatchPrimitive primitive = CatchPrimitive(1, 0, 10, 0.3);
 
-    Ball ball = Ball(Point(0, 0), Vector(1, 0), current_time);
+    Ball ball = Ball(Point(0, 0), Vector(1, 0), Timestamp::fromSeconds(0));
 
     GrsimCommandPrimitiveVisitor grsim_command_primitive_visitor =
         GrsimCommandPrimitiveVisitor(robot, ball);
@@ -76,14 +57,14 @@ TEST_F(CatchPrimitiveTest, robot_moving_away_from_final_dest)
     EXPECT_NEAR(0, motionCommand.global_destination.y(), POSITION_TOLERANCE);
 }
 
-TEST_F(CatchPrimitiveTest, robot_moving_towards_final_dest)
+TEST(CatchPrimitiveTest, robot_moving_towards_final_dest)
 {
     Robot robot = Robot(1, Point(2, 2), Vector(0, -1), Angle::ofRadians(0.0),
-                        AngularVelocity::ofRadians(0.0), current_time);
+                        AngularVelocity::ofRadians(0.0), Timestamp::fromSeconds(0));
 
     CatchPrimitive primitive = CatchPrimitive(1, 0, 10, 0.3);
 
-    Ball ball = Ball(Point(0, 0), Vector(1, 0), current_time);
+    Ball ball = Ball(Point(0, 0), Vector(1, 0), Timestamp::fromSeconds(0));
 
     GrsimCommandPrimitiveVisitor grsim_command_primitive_visitor =
         GrsimCommandPrimitiveVisitor(robot, ball);
@@ -96,14 +77,14 @@ TEST_F(CatchPrimitiveTest, robot_moving_towards_final_dest)
     EXPECT_NEAR(0, motionCommand.global_destination.y(), POSITION_TOLERANCE);
 }
 
-TEST_F(CatchPrimitiveTest, robot_already_in_final_dest_not_moving)
+TEST(CatchPrimitiveTest, robot_already_in_final_dest_not_moving)
 {
     Robot robot = Robot(1, Point(2.3, 0), Vector(0, 0), Angle::ofRadians(0.0),
-                        AngularVelocity::ofRadians(0.0), current_time);
+                        AngularVelocity::ofRadians(0.0), Timestamp::fromSeconds(0));
 
     CatchPrimitive primitive = CatchPrimitive(1, 0, 10, 0.3);
 
-    Ball ball = Ball(Point(0, 0), Vector(1, 0), current_time);
+    Ball ball = Ball(Point(0, 0), Vector(1, 0), Timestamp::fromSeconds(0));
 
     GrsimCommandPrimitiveVisitor grsim_command_primitive_visitor =
         GrsimCommandPrimitiveVisitor(robot, ball);
@@ -116,14 +97,14 @@ TEST_F(CatchPrimitiveTest, robot_already_in_final_dest_not_moving)
     EXPECT_NEAR(0, motionCommand.global_destination.y(), POSITION_TOLERANCE);
 }
 
-TEST_F(CatchPrimitiveTest, robot_close_to_ball)
+TEST(CatchPrimitiveTest, robot_close_to_ball)
 {
     Robot robot = Robot(1, Point(0.2, 0), Vector(1, 0), Angle::ofRadians(0.0),
-                        AngularVelocity::ofRadians(0.0), current_time);
+                        AngularVelocity::ofRadians(0.0), Timestamp::fromSeconds(0));
 
     CatchPrimitive primitive = CatchPrimitive(1, 0.2, 10, 0.3);
 
-    Ball ball = Ball(Point(0, 0), Vector(1, 0), current_time);
+    Ball ball = Ball(Point(0, 0), Vector(1, 0), Timestamp::fromSeconds(0));
 
     GrsimCommandPrimitiveVisitor grsim_command_primitive_visitor =
         GrsimCommandPrimitiveVisitor(robot, ball);
@@ -131,8 +112,6 @@ TEST_F(CatchPrimitiveTest, robot_close_to_ball)
 
     MotionController::MotionControllerCommand motionCommand =
         grsim_command_primitive_visitor.getMotionControllerCommand();
-
-
 
     EXPECT_NEAR(0, motionCommand.global_destination.x(), POSITION_TOLERANCE);
     EXPECT_NEAR(0, motionCommand.global_destination.y(), POSITION_TOLERANCE);

--- a/src/thunderbots/software/test/grsim_command_primitive_visitor/move_spin_primitive.cpp
+++ b/src/thunderbots/software/test/grsim_command_primitive_visitor/move_spin_primitive.cpp
@@ -14,12 +14,9 @@ TEST(MoveSpinPrimitiveTest, move_spin_primitive_test)
 {
     MoveSpinPrimitive* move_spin_primitive =
         new MoveSpinPrimitive(1, Point(3, -1), AngularVelocity::ofDegrees(50));
-    Robot* test_robot =
-        new Robot(1, Point(0, 0), Vector(1, 2), Angle::zero(), AngularVelocity::zero(),
-                  std::chrono::steady_clock::time_point(std::chrono::seconds(4)));
-    Ball* test_ball =
-        new Ball(Point(1, 0), Vector(-1, -1),
-                 std::chrono::steady_clock::time_point(std::chrono::seconds(4)));
+    Robot* test_robot = new Robot(1, Point(0, 0), Vector(1, 2), Angle::zero(),
+                                  AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball* test_ball   = new Ball(Point(1, 0), Vector(-1, -1), Timestamp::fromSeconds(0));
     auto* grsimCommandPrimitiveVisitor =
         new GrsimCommandPrimitiveVisitor(*test_robot, *test_ball);
     move_spin_primitive->accept(*grsimCommandPrimitiveVisitor);

--- a/src/thunderbots/software/test/test_util/rostest_util.h
+++ b/src/thunderbots/software/test/test_util/rostest_util.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <thread>
 
+#include "util/timestamp.h"
+
 namespace RosTestUtil
 {
     /**
@@ -26,7 +28,7 @@ namespace RosTestUtil
      * @param node_handle A reference to the NodeHandle object that will be subscribing to
      * the topic
      * @param topic_name A string containing the name of the topic to subscribe to
-     * @param timeout The number of seconds the function will wait for a message to be
+     * @param timeout The duration the function will wait for a message to be
      * received on the topic before an exception is thrown
      * @throw std::runtime_error If no messages are received on the topic before the
      * timout expires
@@ -34,7 +36,7 @@ namespace RosTestUtil
      */
     template <typename T>
     T waitForMessageOnTopic(ros::NodeHandle &node_handle, std::string topic_name,
-                            std::chrono::seconds timeout = std::chrono::seconds(10))
+                            Duration timeout = Duration::fromSeconds(10))
     {
         std::optional<T> msg_ptr;
 
@@ -47,7 +49,9 @@ namespace RosTestUtil
         auto sub = node_handle.subscribe<T>(topic_name, 1, callback);
 
         std::chrono::time_point start = std::chrono::steady_clock::now();
-        while (!msg_ptr && (std::chrono::steady_clock::now() - start) < timeout)
+        while (!msg_ptr && std::chrono::duration_cast<std::chrono::seconds>(
+                               std::chrono::steady_clock::now() - start)
+                                   .count() < timeout.getSeconds())
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
             ros::spinOnce();

--- a/src/thunderbots/software/test/test_util/rostest_util_test.cpp
+++ b/src/thunderbots/software/test/test_util/rostest_util_test.cpp
@@ -19,15 +19,15 @@ class RosTestUtilsTest : public testing::Test
         // the tests will fail
         test_publisher = node_handle.advertise<std_msgs::String>(topic_name, 1, true);
 
-        one_second  = std::chrono::seconds(1);
-        ten_seconds = std::chrono::seconds(10);
+        one_second  = Duration::fromSeconds(1);
+        ten_seconds = Duration::fromSeconds(10);
     }
 
     ros::NodeHandle node_handle;
     ros::Publisher test_publisher;
 
-    std::chrono::seconds one_second;
-    std::chrono::seconds ten_seconds;
+    Duration one_second;
+    Duration ten_seconds;
 
     const std::string topic_name = "/rostest_utils_test";
 };

--- a/src/thunderbots/software/test/test_util/test_util.cpp
+++ b/src/thunderbots/software/test/test_util/test_util.cpp
@@ -15,9 +15,9 @@ namespace Test
     World TestUtil::createBlankTestingWorld()
     {
         Field field        = createSSLDivBField();
-        Team friendly_team = Team(std::chrono::milliseconds(1000));
-        Team enemy_team    = Team(std::chrono::milliseconds(1000));
-        Ball ball          = Ball(Point(), Vector());
+        Team friendly_team = Team(Duration::fromMilliseconds(1000));
+        Team enemy_team    = Team(Duration::fromMilliseconds(1000));
+        Ball ball          = Ball(Point(), Vector(), Timestamp::fromSeconds(0));
 
         World world = World(field, ball, friendly_team, enemy_team);
 
@@ -25,15 +25,15 @@ namespace Test
     }
 
     Team TestUtil::setRobotPositionsHelper(Team team,
-                                           const std::vector<Point> &robot_positions)
+                                           const std::vector<Point> &robot_positions,
+                                           const Timestamp &timestamp)
     {
         std::vector<Robot> robots;
         unsigned int robot_id_index = 0;
         for (const Point &robot_position : robot_positions)
         {
-            Robot robot =
-                Robot(robot_id_index, robot_position, Vector(), Angle::zero(),
-                      AngularVelocity::zero(), std::chrono::steady_clock::now());
+            Robot robot = Robot(robot_id_index, robot_position, Vector(), Angle::zero(),
+                                AngularVelocity::zero(), timestamp);
             robots.emplace_back(robot);
 
             robot_id_index++;
@@ -46,10 +46,11 @@ namespace Test
     }
 
     World TestUtil::setFriendlyRobotPositions(World world,
-                                              std::vector<Point> robot_positions)
+                                              std::vector<Point> robot_positions,
+                                              const Timestamp &timestamp)
     {
         Team new_friendly_team =
-            setRobotPositionsHelper(world.friendlyTeam(), robot_positions);
+            setRobotPositionsHelper(world.friendlyTeam(), robot_positions, timestamp);
         world.mutableFriendlyTeam().clearAllRobots();
         world.updateFriendlyTeamState(new_friendly_team);
 
@@ -57,28 +58,29 @@ namespace Test
     }
 
     World TestUtil::setEnemyRobotPositions(World world,
-                                           std::vector<Point> robot_positions)
+                                           std::vector<Point> robot_positions,
+                                           const Timestamp &timestamp)
     {
-        Team new_enemy_team = setRobotPositionsHelper(world.enemyTeam(), robot_positions);
+        Team new_enemy_team =
+            setRobotPositionsHelper(world.enemyTeam(), robot_positions, timestamp);
         world.mutableEnemyTeam().clearAllRobots();
         world.updateEnemyTeamState(new_enemy_team);
 
         return world;
     }
 
-    World TestUtil::setBallPosition(World world, Point ball_position)
+    World TestUtil::setBallPosition(World world, Point ball_position, Timestamp timestamp)
     {
-        Ball ball = Ball(ball_position, world.ball().velocity(),
-                         std::chrono::steady_clock::now());
+        Ball ball = Ball(ball_position, world.ball().velocity(), timestamp);
         world.updateBallState(ball);
 
         return world;
     }
 
-    World TestUtil::setBallVelocity(World world, Vector ball_velocity)
+    World TestUtil::setBallVelocity(World world, Vector ball_velocity,
+                                    Timestamp timestamp)
     {
-        Ball ball = Ball(world.ball().position(), ball_velocity,
-                         std::chrono::steady_clock::now());
+        Ball ball = Ball(world.ball().position(), ball_velocity, timestamp);
         world.updateBallState(ball);
 
         return world;

--- a/src/thunderbots/software/test/test_util/test_util.h
+++ b/src/thunderbots/software/test/test_util/test_util.h
@@ -42,7 +42,8 @@ namespace Test
          * @return A new world object with friendly robots in the given positions
          */
         static World setFriendlyRobotPositions(World world,
-                                               std::vector<Point> robot_positions);
+                                               std::vector<Point> robot_positions,
+                                               const Timestamp &timestamp);
 
         /**
          * Returns a new World object with enemy robots in the positions specified
@@ -55,7 +56,8 @@ namespace Test
          * @return A new world object with enemy robots in the given positions
          */
         static World setEnemyRobotPositions(World world,
-                                            std::vector<Point> robot_positions);
+                                            std::vector<Point> robot_positions,
+                                            const Timestamp &timestamp);
 
         /**
          * Returns a new World object with the Ball placed in the new position
@@ -65,7 +67,8 @@ namespace Test
          * @param ball_position The new position for the ball
          * @return A new World object with the ball placed in the given position
          */
-        static World setBallPosition(World world, Point ball_position);
+        static World setBallPosition(World world, Point ball_position,
+                                     Timestamp timestamp);
 
         /**
          * Returns a new World object with the Ball's velocity set to the new velocity
@@ -74,7 +77,8 @@ namespace Test
          * @param ball_velocity The new velocity for the ball
          * @return A new World object with the ball's velocity set to the new velocity
          */
-        static World setBallVelocity(World world, Vector ball_velocity);
+        static World setBallVelocity(World world, Vector ball_velocity,
+                                     Timestamp timestamp);
 
         /**
          * Returns a vector containing all Refbox game states except for
@@ -96,6 +100,7 @@ namespace Test
          * @return A new team with robots placed at the given positions
          */
         static Team setRobotPositionsHelper(Team team,
-                                            const std::vector<Point> &robot_positions);
+                                            const std::vector<Point> &robot_positions,
+                                            const Timestamp &timestamp);
     };
 }  // namespace Test

--- a/src/thunderbots/software/test/test_util/test_util_test.cpp
+++ b/src/thunderbots/software/test/test_util/test_util_test.cpp
@@ -7,9 +7,6 @@
 /*
  * Unit tests for the unit test utilities
  */
-
-using namespace std::chrono;
-
 TEST(TestUtilsTest, create_testing_field)
 {
     Field field = ::Test::TestUtil::createSSLDivBField();
@@ -46,9 +43,9 @@ TEST(TestUtilsTest, create_testing_world)
     World world = ::Test::TestUtil::createBlankTestingWorld();
 
     EXPECT_EQ(::Test::TestUtil::createSSLDivBField(), world.field());
-    EXPECT_EQ(Team(milliseconds(1000)), world.friendlyTeam());
-    EXPECT_EQ(Team(milliseconds(1000)), world.enemyTeam());
-    EXPECT_EQ(Ball(Point(), Vector()), world.ball());
+    EXPECT_EQ(Team(Duration::fromMilliseconds(1000)), world.friendlyTeam());
+    EXPECT_EQ(Team(Duration::fromMilliseconds(1000)), world.enemyTeam());
+    EXPECT_EQ(Ball(Point(), Vector(), Timestamp::fromSeconds(0)), world.ball());
 }
 
 TEST(TestUtilsTest, set_friendly_robot_positions_in_world_with_positive_number_of_robots)
@@ -56,7 +53,7 @@ TEST(TestUtilsTest, set_friendly_robot_positions_in_world_with_positive_number_o
     World world = ::Test::TestUtil::createBlankTestingWorld();
 
     world = ::Test::TestUtil::setFriendlyRobotPositions(
-        world, {Point(), Point(-4, 1.2), Point(2.2, -0.1)});
+        world, {Point(), Point(-4, 1.2), Point(2.2, -0.1)}, Timestamp::fromSeconds(0));
 
     EXPECT_EQ(3, world.friendlyTeam().numRobots());
     EXPECT_EQ(0, world.enemyTeam().numRobots());
@@ -71,7 +68,8 @@ TEST(TestUtilsTest, set_enemy_robot_positions_in_world_with_positive_number_of_r
     World world = ::Test::TestUtil::createBlankTestingWorld();
 
     world = ::Test::TestUtil::setEnemyRobotPositions(
-        world, {world.field().enemyGoal(), world.field().friendlyCornerPos()});
+        world, {world.field().enemyGoal(), world.field().friendlyCornerPos()},
+        Timestamp::fromSeconds(0));
 
     EXPECT_EQ(2, world.enemyTeam().numRobots());
     EXPECT_EQ(world.field().enemyGoal(), (*world.enemyTeam().getRobotById(0)).position());
@@ -85,7 +83,8 @@ TEST(TestUtilsTest, set_friendly_robot_positions_in_world_with_zero_robots)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
 
-    world = ::Test::TestUtil::setFriendlyRobotPositions(world, {});
+    world =
+        ::Test::TestUtil::setFriendlyRobotPositions(world, {}, Timestamp::fromSeconds(0));
 
     EXPECT_EQ(0, world.friendlyTeam().numRobots());
 }
@@ -94,7 +93,8 @@ TEST(TestUtilsTest, set_enemy_robot_positions_in_world_with_zero_robots)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
 
-    world = ::Test::TestUtil::setEnemyRobotPositions(world, {});
+    world =
+        ::Test::TestUtil::setEnemyRobotPositions(world, {}, Timestamp::fromSeconds(0));
 
     EXPECT_EQ(0, world.enemyTeam().numRobots());
 }
@@ -103,7 +103,8 @@ TEST(TestUtilsTest, set_ball_position_in_world)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
 
-    world = ::Test::TestUtil::setBallPosition(world, Point(-0.2, 3.11));
+    world = ::Test::TestUtil::setBallPosition(world, Point(-0.2, 3.11),
+                                              Timestamp::fromSeconds(0));
     EXPECT_EQ(Point(-0.2, 3.11), world.ball().position());
     EXPECT_EQ(Vector(), world.ball().velocity());
 }
@@ -112,7 +113,8 @@ TEST(TestUtilsTest, set_ball_velocity_in_world)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
 
-    world = ::Test::TestUtil::setBallVelocity(world, Vector(0, -2));
+    world = ::Test::TestUtil::setBallVelocity(world, Vector(0, -2),
+                                              Timestamp::fromSeconds(0));
     EXPECT_EQ(Point(), world.ball().position());
     EXPECT_EQ(Vector(0, -2), world.ball().velocity());
 }

--- a/src/thunderbots/software/test/util/ros_messages.cpp
+++ b/src/thunderbots/software/test/util/ros_messages.cpp
@@ -2,38 +2,22 @@
 
 #include <gtest/gtest.h>
 
-using namespace std::chrono;
-
-class ROSMessageUtilTest : public ::testing::Test
-{
-   protected:
-    void SetUp() override
-    {
-        auto epoch = time_point<std::chrono::steady_clock>();
-        // An arbitrary fixed point in time. 10000 seconds after the epoch
-        auto since_epoch = std::chrono::seconds(10000);
-
-        current_time = epoch + since_epoch;
-    }
-
-    steady_clock::time_point current_time;
-};
-
-TEST_F(ROSMessageUtilTest, create_ball_from_ros_message)
+TEST(ROSMessageUtilTest, create_ball_from_ros_message)
 {
     thunderbots_msgs::Ball ball_msg;
 
-    ball_msg.position.x = 1.2;
-    ball_msg.position.y = -8.07;
-    ball_msg.velocity.x = 0;
-    ball_msg.velocity.y = 3;
+    ball_msg.position.x        = 1.2;
+    ball_msg.position.y        = -8.07;
+    ball_msg.velocity.x        = 0;
+    ball_msg.velocity.y        = 3;
+    ball_msg.timestamp_seconds = 1.4;
 
     Ball ball = Util::ROSMessages::createBallFromROSMessage(ball_msg);
 
-    EXPECT_EQ(Ball(Point(1.2, -8.07), Vector(0, 3)), ball);
+    EXPECT_EQ(Ball(Point(1.2, -8.07), Vector(0, 3), Timestamp::fromSeconds(1.4)), ball);
 }
 
-TEST_F(ROSMessageUtilTest, create_robot_from_ros_message)
+TEST(ROSMessageUtilTest, create_robot_from_ros_message)
 {
     unsigned int id                  = 2;
     Point position                   = Point(1.2, -8.07);
@@ -43,23 +27,23 @@ TEST_F(ROSMessageUtilTest, create_robot_from_ros_message)
 
     thunderbots_msgs::Robot robot_msg;
 
-    robot_msg.id                                = id;
-    robot_msg.position.x                        = position.x();
-    robot_msg.position.y                        = position.y();
-    robot_msg.velocity.x                        = velocity.x();
-    robot_msg.velocity.y                        = velocity.y();
-    robot_msg.orientation                       = orientation.toRadians();
-    robot_msg.angular_velocity                  = angular_velocity.toRadians();
-    robot_msg.timestamp_nanoseconds_since_epoch = static_cast<uint64_t>(
-        std::chrono::nanoseconds(current_time.time_since_epoch()).count());
+    robot_msg.id                = id;
+    robot_msg.position.x        = position.x();
+    robot_msg.position.y        = position.y();
+    robot_msg.velocity.x        = velocity.x();
+    robot_msg.velocity.y        = velocity.y();
+    robot_msg.orientation       = orientation.toRadians();
+    robot_msg.angular_velocity  = angular_velocity.toRadians();
+    robot_msg.timestamp_seconds = 5.5;
 
     Robot robot = Util::ROSMessages::createRobotFromROSMessage(robot_msg);
 
-    EXPECT_EQ(Robot(id, position, velocity, orientation, angular_velocity, current_time),
+    EXPECT_EQ(Robot(id, position, velocity, orientation, angular_velocity,
+                    Timestamp::fromSeconds(5.5)),
               robot);
 }
 
-TEST_F(ROSMessageUtilTest, create_field_from_ros_message)
+TEST(ROSMessageUtilTest, create_field_from_ros_message)
 {
     double length               = 9.0;
     double width                = 6.0;
@@ -87,43 +71,40 @@ TEST_F(ROSMessageUtilTest, create_field_from_ros_message)
     EXPECT_EQ(field_other, field);
 }
 
-TEST_F(ROSMessageUtilTest, create_team_from_ros_message)
+TEST(ROSMessageUtilTest, create_team_from_ros_message)
 {
-    auto robot_expiry_buffer_milliseconds = milliseconds(1000);
-    unsigned int goalie_id                = 5;
+    auto robot_expiry_buffer_duration = Duration::fromMilliseconds(1000);
+    unsigned int goalie_id            = 5;
 
     unsigned int robot_id            = 5;
     Point position                   = Point(1.2, -8.07);
     Vector velocity                  = Vector(0, 3);
     Angle orientation                = Angle::ofRadians(1.16);
     AngularVelocity angular_velocity = AngularVelocity::ofRadians(-0.85);
-    auto timestamp_nanoseconds_since_epoch =
-        std::chrono::duration_cast<nanoseconds>(current_time.time_since_epoch());
 
     thunderbots_msgs::Robot robot_msg;
 
-    robot_msg.id               = robot_id;
-    robot_msg.position.x       = position.x();
-    robot_msg.position.y       = position.y();
-    robot_msg.velocity.x       = velocity.x();
-    robot_msg.velocity.y       = velocity.y();
-    robot_msg.orientation      = orientation.toRadians();
-    robot_msg.angular_velocity = angular_velocity.toRadians();
-    robot_msg.timestamp_nanoseconds_since_epoch =
-        static_cast<uint64_t>(timestamp_nanoseconds_since_epoch.count());
+    robot_msg.id                = robot_id;
+    robot_msg.position.x        = position.x();
+    robot_msg.position.y        = position.y();
+    robot_msg.velocity.x        = velocity.x();
+    robot_msg.velocity.y        = velocity.y();
+    robot_msg.orientation       = orientation.toRadians();
+    robot_msg.angular_velocity  = angular_velocity.toRadians();
+    robot_msg.timestamp_seconds = 123.45;
 
     thunderbots_msgs::Team team_msg;
 
     team_msg.robots.emplace_back(robot_msg);
     team_msg.goalie_id = goalie_id;
     team_msg.robot_expiry_buffer_milliseconds =
-        static_cast<unsigned int>(robot_expiry_buffer_milliseconds.count());
+        robot_expiry_buffer_duration.getMilliseconds();
 
     Team team = Util::ROSMessages::createTeamFromROSMessage(team_msg);
 
-    Team team_other = Team(robot_expiry_buffer_milliseconds);
-    Robot robot =
-        Robot(robot_id, position, velocity, orientation, angular_velocity, current_time);
+    Team team_other = Team(robot_expiry_buffer_duration);
+    Robot robot     = Robot(robot_id, position, velocity, orientation, angular_velocity,
+                        Timestamp::fromSeconds(123.45));
 
     team_other.updateRobots({robot});
     team_other.assignGoalie(goalie_id);
@@ -131,43 +112,40 @@ TEST_F(ROSMessageUtilTest, create_team_from_ros_message)
     EXPECT_EQ(team_other, team);
 }
 
-TEST_F(ROSMessageUtilTest, create_team_from_ros_message_with_non_member)
+TEST(ROSMessageUtilTest, create_team_from_ros_message_with_non_member)
 {
-    auto robot_expiry_buffer_milliseconds = milliseconds(1000);
-    unsigned int goalie_id                = 5;
+    auto robot_expiry_buffer_duration = Duration::fromMilliseconds(1000);
+    unsigned int goalie_id            = 5;
 
     unsigned int robot_id            = 9;
     Point position                   = Point(1.2, -8.07);
     Vector velocity                  = Vector(0, 3);
     Angle orientation                = Angle::ofRadians(1.16);
     AngularVelocity angular_velocity = AngularVelocity::ofRadians(-0.85);
-    auto timestamp_nanoseconds_since_epoch =
-        std::chrono::duration_cast<nanoseconds>(current_time.time_since_epoch());
 
     thunderbots_msgs::Robot robot_msg;
 
-    robot_msg.id               = robot_id;
-    robot_msg.position.x       = position.x();
-    robot_msg.position.y       = position.y();
-    robot_msg.velocity.x       = velocity.x();
-    robot_msg.velocity.y       = velocity.y();
-    robot_msg.orientation      = orientation.toRadians();
-    robot_msg.angular_velocity = angular_velocity.toRadians();
-    robot_msg.timestamp_nanoseconds_since_epoch =
-        static_cast<uint64_t>(timestamp_nanoseconds_since_epoch.count());
+    robot_msg.id                = robot_id;
+    robot_msg.position.x        = position.x();
+    robot_msg.position.y        = position.y();
+    robot_msg.velocity.x        = velocity.x();
+    robot_msg.velocity.y        = velocity.y();
+    robot_msg.orientation       = orientation.toRadians();
+    robot_msg.angular_velocity  = angular_velocity.toRadians();
+    robot_msg.timestamp_seconds = 33;
 
     thunderbots_msgs::Team team_msg;
 
     team_msg.robots.emplace_back(robot_msg);
     team_msg.goalie_id = goalie_id;
     team_msg.robot_expiry_buffer_milliseconds =
-        static_cast<unsigned int>(robot_expiry_buffer_milliseconds.count());
+        robot_expiry_buffer_duration.getMilliseconds();
 
     ASSERT_THROW(Team team = Util::ROSMessages::createTeamFromROSMessage(team_msg);
 
-                 Team team_other = Team(robot_expiry_buffer_milliseconds);
+                 Team team_other = Team(robot_expiry_buffer_duration);
                  Robot robot     = Robot(robot_id, position, velocity, orientation,
-                                     angular_velocity, current_time);
+                                     angular_velocity, Timestamp::fromSeconds(33));
 
                  team_other.updateRobots({robot}); team_other.assignGoalie(goalie_id);
                  , std::invalid_argument);

--- a/src/thunderbots/software/test/util/test_parameter_exists.cpp
+++ b/src/thunderbots/software/test/util/test_parameter_exists.cpp
@@ -16,7 +16,7 @@ namespace
     std::vector<Parameter<std::string>> string_parameters;
 
     // how long to wait for before running the tests, allowing time for the node to spawn
-    const int WAIT_FOR_PARAMS_S = 5;
+    const int WAIT_FOR_PARAMS_SECONDS = 5;
     // msg to display before the name of the paramter that is not found
     const std::string MISMATCH_MSG = "Parameter mismatch with: ";
 }  // namespace
@@ -102,6 +102,6 @@ int main(int argc, char** argv)
     // run tests
     ros::init(argc, argv, "parameter_existance_test");
     testing::InitGoogleTest(&argc, argv);
-    std::this_thread::sleep_for(std::chrono::seconds(WAIT_FOR_PARAMS_S));
+    std::this_thread::sleep_for(std::chrono::seconds(WAIT_FOR_PARAMS_SECONDS));
     return RUN_ALL_TESTS();
 }

--- a/src/thunderbots/software/test/util/timestamp.cpp
+++ b/src/thunderbots/software/test/util/timestamp.cpp
@@ -1,0 +1,120 @@
+#include "util/timestamp.h"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+TEST(TimestampTest, create_timestamp_from_positive_seconds)
+{
+    Timestamp timestamp = Timestamp::fromSeconds(1.0);
+    EXPECT_DOUBLE_EQ(timestamp.getSeconds(), 1.0);
+}
+
+TEST(TimestampTest, create_timestamp_from_negative_seconds)
+{
+    EXPECT_THROW(Timestamp::fromSeconds(-0.2), std::invalid_argument);
+}
+
+TEST(TimestampTest, create_timestamp_from_zero_milliseconds)
+{
+    Timestamp timestamp = Timestamp::fromMilliseconds(0);
+    EXPECT_DOUBLE_EQ(timestamp.getMilliseconds(), 0);
+}
+
+TEST(TimestampTest, create_timestamp_from_negative_milliseconds)
+{
+    EXPECT_THROW(Timestamp::fromMilliseconds(-125), std::invalid_argument);
+}
+
+TEST(TimestampTest, get_seconds_timestamp_in_milliseconds)
+{
+    Timestamp timestamp = Timestamp::fromSeconds(5);
+    EXPECT_DOUBLE_EQ(timestamp.getMilliseconds(), 5000);
+}
+
+TEST(TimestampTest, create_millisecond_timestamp_in_seconds)
+{
+    Timestamp timestamp = Timestamp::fromMilliseconds(300);
+    EXPECT_DOUBLE_EQ(timestamp.getSeconds(), 0.3);
+}
+
+TEST(TimestampTest, test_equality_operator)
+{
+    Timestamp t1 = Timestamp::fromSeconds(6.2);
+    Timestamp t2 = Timestamp::fromMilliseconds(6200);
+    EXPECT_TRUE(t1 == t2);
+}
+
+TEST(TimestampTest, test_inequality_operator)
+{
+    Timestamp t1 = Timestamp::fromSeconds(0);
+    Timestamp t2 = Timestamp::fromMilliseconds(6.2);
+    EXPECT_TRUE(t1 != t2);
+    EXPECT_FALSE(t2 != t2);
+}
+
+TEST(TimestampTest, test_less_than_operator)
+{
+    Timestamp t1 = Timestamp::fromSeconds(6.15);
+    Timestamp t2 = Timestamp::fromSeconds(6.2);
+    EXPECT_TRUE(t1 < t2);
+    EXPECT_FALSE(t2 < t1);
+}
+
+TEST(TimestampTest, test_less_than_or_equal_to_operator)
+{
+    Timestamp t1 = Timestamp::fromSeconds(6.2);
+    Timestamp t2 = Timestamp::fromSeconds(6.2);
+    Timestamp t3 = Timestamp::fromSeconds(0.88);
+    EXPECT_TRUE(t3 <= t2);
+    EXPECT_TRUE(t2 <= t1);
+    EXPECT_FALSE(t1 <= t3);
+}
+
+TEST(TimestampTest, test_greater_than_operator)
+{
+    Timestamp t1 = Timestamp::fromSeconds(0.4);
+    Timestamp t2 = Timestamp::fromSeconds(3.01);
+    EXPECT_TRUE(t2 > t1);
+    EXPECT_FALSE(t1 > t2);
+}
+
+TEST(TimestampTest, test_greater_than_or_equal_to_operator)
+{
+    Timestamp t1 = Timestamp::fromSeconds(0.4);
+    Timestamp t2 = Timestamp::fromSeconds(3.01);
+    EXPECT_TRUE(t2 >= t1);
+    EXPECT_TRUE(t2 >= t2);
+    EXPECT_FALSE(t1 >= t2);
+}
+
+TEST(TimestampTest, test_addition_operator)
+{
+    Timestamp t1              = Timestamp::fromSeconds(0.12);
+    Duration d1               = Duration::fromMilliseconds(350);
+    Timestamp result          = t1 + d1;
+    Timestamp expected_result = Timestamp::fromMilliseconds(470);
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(TimestampTest, test_subtraction_operator_with_positive_result)
+{
+    Timestamp t1              = Timestamp::fromMilliseconds(1234);
+    Duration d1               = Duration::fromMilliseconds(600);
+    Timestamp result          = t1 - d1;
+    Timestamp expected_result = Timestamp::fromMilliseconds(634);
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(TimestampTest, test_subtraction_operator_with_negative_result)
+{
+    Timestamp t1 = Timestamp::fromMilliseconds(1234);
+    Duration d1  = Duration::fromMilliseconds(1235);
+    EXPECT_THROW(t1 - d1, std::invalid_argument);
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/world/ball.cpp
+++ b/src/thunderbots/software/test/world/ball.cpp
@@ -2,42 +2,47 @@
 
 #include <gtest/gtest.h>
 
-using namespace std::chrono;
-
 class BallTest : public ::testing::Test
 {
    protected:
-    void SetUp() override
+    // We need to provide a constructor that initializes the Timestamp variables
+    // since the Timestamp class has no default constructor
+    BallTest()
+        : ::testing::Test(),
+          current_time(Timestamp::fromSeconds(0)),
+          half_second_future(Timestamp::fromSeconds(0)),
+          one_second_future(Timestamp::fromSeconds(0)),
+          one_hundred_fifty_milliseconds_future(Timestamp::fromSeconds(0)),
+          one_second_past(Timestamp::fromSeconds(0))
     {
-        auto epoch       = time_point<std::chrono::steady_clock>();
-        auto since_epoch = std::chrono::seconds(10000);
-
-        // An arbitrary fixed point in time. 10000 seconds after the epoch.
-        // We use this fixed point in time to make the tests deterministic.
-        current_time                          = epoch + since_epoch;
-        one_hundred_fifty_milliseconds_future = current_time + milliseconds(150);
-        half_second_future                    = current_time + milliseconds(500);
-        one_second_future                     = current_time + seconds(1);
-        one_second_past                       = current_time - seconds(1);
     }
 
-    steady_clock::time_point current_time;
-    steady_clock::time_point half_second_future;
-    steady_clock::time_point one_second_future;
-    steady_clock::time_point one_hundred_fifty_milliseconds_future;
-    steady_clock::time_point one_second_past;
+    void SetUp() override
+    {
+        // An arbitrary fixed point in time.
+        // We use this fixed point in time to make the tests deterministic.
+        current_time = Timestamp::fromSeconds(123);
+        one_hundred_fifty_milliseconds_future =
+            current_time + Duration::fromMilliseconds(150);
+        half_second_future = current_time + Duration::fromMilliseconds(500);
+        one_second_future  = current_time + Duration::fromSeconds(1);
+        one_second_past    = current_time - Duration::fromSeconds(1);
+    }
+
+    Timestamp current_time;
+    Timestamp half_second_future;
+    Timestamp one_second_future;
+    Timestamp one_hundred_fifty_milliseconds_future;
+    Timestamp one_second_past;
 };
 
 TEST_F(BallTest, construct_with_no_params)
 {
-    Ball ball = Ball(Point(), Vector());
+    Ball ball = Ball(Point(), Vector(), current_time);
 
     EXPECT_EQ(Point(), ball.position());
     EXPECT_EQ(Vector(), ball.velocity());
-    // Can't compare timestamp values here because the ball and the expected timestamp
-    // would not be createdx at the same time, and would not be equal. We could check
-    // that the timestamps are within a certain threshold, but that is not robust and
-    // makes the test dependant on the speed of the system executing it
+    EXPECT_EQ(current_time, ball.lastUpdateTimestamp());
 }
 
 TEST_F(BallTest, construct_with_params)
@@ -129,27 +134,33 @@ TEST_F(BallTest, get_position_at_future_time_with_positive_ball_velocity)
 {
     Ball ball = Ball(Point(), Vector(1, 2), current_time);
 
-    EXPECT_EQ(Point(0.15, 0.3), ball.estimatePositionAtFutureTime(milliseconds(150)));
-    EXPECT_EQ(Point(1, 2), ball.estimatePositionAtFutureTime(milliseconds(1000)));
-    EXPECT_EQ(Point(2, 4), ball.estimatePositionAtFutureTime(milliseconds(2000)));
+    EXPECT_EQ(Point(0.15, 0.3),
+              ball.estimatePositionAtFutureTime(Duration::fromMilliseconds(150)));
+    EXPECT_EQ(Point(1, 2),
+              ball.estimatePositionAtFutureTime(Duration::fromMilliseconds(1000)));
+    EXPECT_EQ(Point(2, 4),
+              ball.estimatePositionAtFutureTime(Duration::fromMilliseconds(2000)));
 }
 
 TEST_F(BallTest, get_position_at_future_time_with_negative_ball_velocity)
 {
     Ball ball = Ball(Point(3, 7), Vector(-4.5, -0.12), current_time);
 
-    EXPECT_EQ(Point(2.325, 6.982), ball.estimatePositionAtFutureTime(milliseconds(150)));
-    EXPECT_EQ(Point(-1.5, 6.88), ball.estimatePositionAtFutureTime(milliseconds(1000)));
-    EXPECT_EQ(Point(-6, 6.76), ball.estimatePositionAtFutureTime(milliseconds(2000)));
+    EXPECT_EQ(Point(2.325, 6.982),
+              ball.estimatePositionAtFutureTime(Duration::fromMilliseconds(150)));
+    EXPECT_EQ(Point(-1.5, 6.88),
+              ball.estimatePositionAtFutureTime(Duration::fromMilliseconds(1000)));
+    EXPECT_EQ(Point(-6, 6.76),
+              ball.estimatePositionAtFutureTime(Duration::fromMilliseconds(2000)));
 }
 
 TEST_F(BallTest, get_position_at_past_time)
 {
     Ball ball = Ball(Point(3, 7), Vector(1, 0.12), current_time);
 
-    ASSERT_THROW(ball.estimatePositionAtFutureTime(milliseconds(-200)),
+    ASSERT_THROW(ball.estimatePositionAtFutureTime(Duration::fromMilliseconds(-200)),
                  std::invalid_argument);
-    ASSERT_THROW(ball.estimatePositionAtFutureTime(milliseconds(-2000)),
+    ASSERT_THROW(ball.estimatePositionAtFutureTime(Duration::fromMilliseconds(-2000)),
                  std::invalid_argument);
 }
 
@@ -169,13 +180,16 @@ TEST_F(BallTest, get_velocity_at_future_time_with_positive_ball_velocity)
 
     EXPECT_TRUE(
         Vector(0.9851, 1.9702)
-            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(150)), EPSILON));
+            .isClose(ball.estimateVelocityAtFutureTime(Duration::fromMilliseconds(150)),
+                     EPSILON));
     EXPECT_TRUE(
         Vector(0.9048, 1.8097)
-            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(1000)), EPSILON));
+            .isClose(ball.estimateVelocityAtFutureTime(Duration::fromMilliseconds(1000)),
+                     EPSILON));
     EXPECT_TRUE(
         Vector(0.8187, 1.6375)
-            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
+            .isClose(ball.estimateVelocityAtFutureTime(Duration::fromMilliseconds(2000)),
+                     EPSILON));
 }
 
 TEST_F(BallTest, get_velocity_at_future_time_with_negative_ball_velocity)
@@ -187,22 +201,25 @@ TEST_F(BallTest, get_velocity_at_future_time_with_negative_ball_velocity)
 
     EXPECT_TRUE(
         Vector(-4.4330, -0.1182)
-            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(150)), EPSILON));
+            .isClose(ball.estimateVelocityAtFutureTime(Duration::fromMilliseconds(150)),
+                     EPSILON));
     EXPECT_TRUE(
         Vector(-4.0717, -0.1086)
-            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(1000)), EPSILON));
+            .isClose(ball.estimateVelocityAtFutureTime(Duration::fromMilliseconds(1000)),
+                     EPSILON));
     EXPECT_TRUE(
         Vector(-3.6843, -0.0982)
-            .isClose(ball.estimateVelocityAtFutureTime(milliseconds(2000)), EPSILON));
+            .isClose(ball.estimateVelocityAtFutureTime(Duration::fromMilliseconds(2000)),
+                     EPSILON));
 }
 
 TEST_F(BallTest, get_velocity_at_past_time)
 {
     Ball ball = Ball(Point(), Vector(1, 2), current_time);
 
-    ASSERT_THROW(ball.estimateVelocityAtFutureTime(milliseconds(-150)),
+    ASSERT_THROW(ball.estimateVelocityAtFutureTime(Duration::fromMilliseconds(-150)),
                  std::invalid_argument);
-    ASSERT_THROW(ball.estimateVelocityAtFutureTime(milliseconds(-1000)),
+    ASSERT_THROW(ball.estimateVelocityAtFutureTime(Duration::fromMilliseconds(-1000)),
                  std::invalid_argument);
 }
 
@@ -219,7 +236,7 @@ TEST_F(BallTest, get_last_update_timestamp)
 
 TEST_F(BallTest, equality_operator_compare_ball_with_itself)
 {
-    Ball ball_0 = Ball(Point(), Vector());
+    Ball ball_0 = Ball(Point(), Vector(), current_time);
 
     Ball ball_1 = Ball(Point(2, -3), Vector(0, 1), one_hundred_fifty_milliseconds_future);
 

--- a/src/thunderbots/software/test/world/ball.cpp
+++ b/src/thunderbots/software/test/world/ball.cpp
@@ -5,18 +5,6 @@
 class BallTest : public ::testing::Test
 {
    protected:
-    // We need to provide a constructor that initializes the Timestamp variables
-    // since the Timestamp class has no default constructor
-    BallTest()
-        : ::testing::Test(),
-          current_time(Timestamp::fromSeconds(0)),
-          half_second_future(Timestamp::fromSeconds(0)),
-          one_second_future(Timestamp::fromSeconds(0)),
-          one_hundred_fifty_milliseconds_future(Timestamp::fromSeconds(0)),
-          one_second_past(Timestamp::fromSeconds(0))
-    {
-    }
-
     void SetUp() override
     {
         // An arbitrary fixed point in time.

--- a/src/thunderbots/software/test/world/robot.cpp
+++ b/src/thunderbots/software/test/world/robot.cpp
@@ -2,28 +2,34 @@
 
 #include <gtest/gtest.h>
 
-using namespace std::chrono;
-
 class RobotTest : public ::testing::Test
 {
    protected:
-    void SetUp() override
+    // We need to provide a constructor that initializes the Timestamp variables
+    // since the Timestamp class has no default constructor
+    RobotTest()
+        : ::testing::Test(),
+          current_time(Timestamp::fromSeconds(0)),
+          half_second_future(Timestamp::fromSeconds(0)),
+          one_second_future(Timestamp::fromSeconds(0)),
+          one_second_past(Timestamp::fromSeconds(0))
     {
-        auto epoch       = time_point<std::chrono::steady_clock>();
-        auto since_epoch = std::chrono::seconds(10000);
-
-        // An arbitrary fixed point in time. 10000 seconds after the epoch.
-        // We use this fixed point in time to make the tests deterministic.
-        current_time       = epoch + since_epoch;
-        half_second_future = current_time + milliseconds(500);
-        one_second_future  = current_time + seconds(1);
-        one_second_past    = current_time - seconds(1);
     }
 
-    steady_clock::time_point current_time;
-    steady_clock::time_point half_second_future;
-    steady_clock::time_point one_second_future;
-    steady_clock::time_point one_second_past;
+    void SetUp() override
+    {
+        // An arbitrary fixed point in time
+        // We use this fixed point in time to make the tests deterministic.
+        current_time       = Timestamp::fromSeconds(123);
+        half_second_future = current_time + Duration::fromMilliseconds(500);
+        one_second_future  = current_time + Duration::fromSeconds(1);
+        one_second_past    = current_time - Duration::fromSeconds(1);
+    }
+
+    Timestamp current_time;
+    Timestamp half_second_future;
+    Timestamp one_second_future;
+    Timestamp one_second_past;
 };
 
 TEST_F(RobotTest, construct_with_all_params)
@@ -115,9 +121,12 @@ TEST_F(RobotTest, get_position_at_future_time_with_negative_robot_velocity)
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, -2.6), Angle::quarter(),
                         AngularVelocity::ofRadians(0.7), current_time);
 
-    EXPECT_EQ(Point(-1.4, 1.96), robot.estimatePositionAtFutureTime(milliseconds(400)));
-    EXPECT_EQ(Point(-1.7, 0.4), robot.estimatePositionAtFutureTime(milliseconds(1000)));
-    EXPECT_EQ(Point(-2.7, -4.8), robot.estimatePositionAtFutureTime(milliseconds(3000)));
+    EXPECT_EQ(Point(-1.4, 1.96),
+              robot.estimatePositionAtFutureTime(Duration::fromMilliseconds(400)));
+    EXPECT_EQ(Point(-1.7, 0.4),
+              robot.estimatePositionAtFutureTime(Duration::fromMilliseconds(1000)));
+    EXPECT_EQ(Point(-2.7, -4.8),
+              robot.estimatePositionAtFutureTime(Duration::fromMilliseconds(3000)));
 }
 
 TEST_F(RobotTest, get_position_at_future_time_with_positive_robot_velocity)
@@ -126,11 +135,11 @@ TEST_F(RobotTest, get_position_at_future_time_with_positive_robot_velocity)
                               AngularVelocity::ofRadians(2), current_time);
 
     EXPECT_EQ(Point(2.4, -1.6),
-              robot_other.estimatePositionAtFutureTime(milliseconds(400)));
+              robot_other.estimatePositionAtFutureTime(Duration::fromMilliseconds(400)));
     EXPECT_EQ(Point(4.5, -1),
-              robot_other.estimatePositionAtFutureTime(milliseconds(1000)));
+              robot_other.estimatePositionAtFutureTime(Duration::fromMilliseconds(1000)));
     EXPECT_EQ(Point(11.5, 1),
-              robot_other.estimatePositionAtFutureTime(milliseconds(3000)));
+              robot_other.estimatePositionAtFutureTime(Duration::fromMilliseconds(3000)));
 }
 
 TEST_F(RobotTest, get_position_at_past_time)
@@ -138,10 +147,12 @@ TEST_F(RobotTest, get_position_at_past_time)
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2), current_time);
 
-    ASSERT_THROW((robot_other.estimatePositionAtFutureTime(milliseconds(-100))),
-                 std::invalid_argument);
-    ASSERT_THROW((robot_other.estimatePositionAtFutureTime(milliseconds(-1000))),
-                 std::invalid_argument);
+    ASSERT_THROW(
+        (robot_other.estimatePositionAtFutureTime(Duration::fromMilliseconds(-100))),
+        std::invalid_argument);
+    ASSERT_THROW(
+        (robot_other.estimatePositionAtFutureTime(Duration::fromMilliseconds(-1000))),
+        std::invalid_argument);
 }
 
 TEST_F(RobotTest, get_velocity_at_current_time)
@@ -157,9 +168,12 @@ TEST_F(RobotTest, get_velocity_at_future_time_with_negative_robot_velocity)
     Robot robot = Robot(0, Point(-1.2, 3), Vector(-0.5, -2.6), Angle::quarter(),
                         AngularVelocity::ofRadians(0.7), current_time);
 
-    EXPECT_EQ(Point(-0.5, -2.6), robot.estimateVelocityAtFutureTime(milliseconds(400)));
-    EXPECT_EQ(Point(-0.5, -2.6), robot.estimateVelocityAtFutureTime(milliseconds(1000)));
-    EXPECT_EQ(Point(-0.5, -2.6), robot.estimateVelocityAtFutureTime(milliseconds(3000)));
+    EXPECT_EQ(Point(-0.5, -2.6),
+              robot.estimateVelocityAtFutureTime(Duration::fromMilliseconds(400)));
+    EXPECT_EQ(Point(-0.5, -2.6),
+              robot.estimateVelocityAtFutureTime(Duration::fromMilliseconds(1000)));
+    EXPECT_EQ(Point(-0.5, -2.6),
+              robot.estimateVelocityAtFutureTime(Duration::fromMilliseconds(3000)));
 }
 
 TEST_F(RobotTest, get_velocity_at_future_time_with_positive_robot_velocity)
@@ -167,11 +181,12 @@ TEST_F(RobotTest, get_velocity_at_future_time_with_positive_robot_velocity)
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2), current_time);
 
-    EXPECT_EQ(Point(3.5, 1), robot_other.estimateVelocityAtFutureTime(milliseconds(400)));
     EXPECT_EQ(Point(3.5, 1),
-              robot_other.estimateVelocityAtFutureTime(milliseconds(1000)));
+              robot_other.estimateVelocityAtFutureTime(Duration::fromMilliseconds(400)));
     EXPECT_EQ(Point(3.5, 1),
-              robot_other.estimateVelocityAtFutureTime(milliseconds(3000)));
+              robot_other.estimateVelocityAtFutureTime(Duration::fromMilliseconds(1000)));
+    EXPECT_EQ(Point(3.5, 1),
+              robot_other.estimateVelocityAtFutureTime(Duration::fromMilliseconds(3000)));
 }
 
 TEST_F(RobotTest, get_velocity_at_past_time)
@@ -179,10 +194,12 @@ TEST_F(RobotTest, get_velocity_at_past_time)
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2), current_time);
 
-    ASSERT_THROW((robot_other.estimateVelocityAtFutureTime(milliseconds(-100))),
-                 std::invalid_argument);
-    ASSERT_THROW((robot_other.estimateVelocityAtFutureTime(milliseconds(-1000))),
-                 std::invalid_argument);
+    ASSERT_THROW(
+        (robot_other.estimateVelocityAtFutureTime(Duration::fromMilliseconds(-100))),
+        std::invalid_argument);
+    ASSERT_THROW(
+        (robot_other.estimateVelocityAtFutureTime(Duration::fromMilliseconds(-1000))),
+        std::invalid_argument);
 }
 
 TEST_F(RobotTest, get_orientation_at_current_time)
@@ -199,11 +216,11 @@ TEST_F(RobotTest, get_orientation_at_future_time_with_positive_robot_angular_vel
                         AngularVelocity::ofRadians(0.7), current_time);
 
     EXPECT_EQ(Angle::quarter() + Angle::ofRadians(0.28),
-              robot.estimateOrientationAtFutureTime(milliseconds(400)));
+              robot.estimateOrientationAtFutureTime(Duration::fromMilliseconds(400)));
     EXPECT_EQ(Angle::quarter() + Angle::ofRadians(0.7),
-              robot.estimateOrientationAtFutureTime(milliseconds(1000)));
+              robot.estimateOrientationAtFutureTime(Duration::fromMilliseconds(1000)));
     EXPECT_EQ(Angle::quarter() + Angle::ofRadians(2.1),
-              robot.estimateOrientationAtFutureTime(milliseconds(3000)));
+              robot.estimateOrientationAtFutureTime(Duration::fromMilliseconds(3000)));
 }
 
 TEST_F(RobotTest, get_orientation_at_future_time_with_negative_robot_angular_velocity)
@@ -211,12 +228,15 @@ TEST_F(RobotTest, get_orientation_at_future_time_with_negative_robot_angular_vel
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2), current_time);
 
-    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(0.8),
-              robot_other.estimateOrientationAtFutureTime(milliseconds(400)));
-    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(2),
-              robot_other.estimateOrientationAtFutureTime(milliseconds(1000)));
-    EXPECT_EQ(Angle::ofRadians(-0.3) + Angle::ofRadians(6),
-              robot_other.estimateOrientationAtFutureTime(milliseconds(3000)));
+    EXPECT_EQ(
+        Angle::ofRadians(-0.3) + Angle::ofRadians(0.8),
+        robot_other.estimateOrientationAtFutureTime(Duration::fromMilliseconds(400)));
+    EXPECT_EQ(
+        Angle::ofRadians(-0.3) + Angle::ofRadians(2),
+        robot_other.estimateOrientationAtFutureTime(Duration::fromMilliseconds(1000)));
+    EXPECT_EQ(
+        Angle::ofRadians(-0.3) + Angle::ofRadians(6),
+        robot_other.estimateOrientationAtFutureTime(Duration::fromMilliseconds(3000)));
 }
 
 TEST_F(RobotTest, get_orientation_at_past_time)
@@ -224,10 +244,12 @@ TEST_F(RobotTest, get_orientation_at_past_time)
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2), current_time);
 
-    ASSERT_THROW(robot_other.estimateOrientationAtFutureTime(milliseconds(-100)),
-                 std::invalid_argument);
-    ASSERT_THROW(robot_other.estimateOrientationAtFutureTime(milliseconds(-1000)),
-                 std::invalid_argument);
+    ASSERT_THROW(
+        robot_other.estimateOrientationAtFutureTime(Duration::fromMilliseconds(-100)),
+        std::invalid_argument);
+    ASSERT_THROW(
+        robot_other.estimateOrientationAtFutureTime(Duration::fromMilliseconds(-1000)),
+        std::invalid_argument);
 }
 
 TEST_F(RobotTest, get_angular_velocity_at_current_time)
@@ -245,11 +267,11 @@ TEST_F(RobotTest,
                         AngularVelocity::ofRadians(0.7), current_time);
 
     EXPECT_EQ(AngularVelocity::ofRadians(0.7),
-              robot.estimateAngularVelocityAtFutureTime(milliseconds(400)));
-    EXPECT_EQ(AngularVelocity::ofRadians(0.7),
-              robot.estimateAngularVelocityAtFutureTime(milliseconds(1000)));
-    EXPECT_EQ(AngularVelocity::ofRadians(0.7),
-              robot.estimateAngularVelocityAtFutureTime(milliseconds(3000)));
+              robot.estimateAngularVelocityAtFutureTime(Duration::fromMilliseconds(400)));
+    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.estimateAngularVelocityAtFutureTime(
+                                                   Duration::fromMilliseconds(1000)));
+    EXPECT_EQ(AngularVelocity::ofRadians(0.7), robot.estimateAngularVelocityAtFutureTime(
+                                                   Duration::fromMilliseconds(3000)));
 }
 
 TEST_F(RobotTest,
@@ -258,12 +280,15 @@ TEST_F(RobotTest,
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2), current_time);
 
+    EXPECT_EQ(
+        AngularVelocity::ofRadians(2),
+        robot_other.estimateAngularVelocityAtFutureTime(Duration::fromMilliseconds(400)));
     EXPECT_EQ(AngularVelocity::ofRadians(2),
-              robot_other.estimateAngularVelocityAtFutureTime(milliseconds(400)));
+              robot_other.estimateAngularVelocityAtFutureTime(
+                  Duration::fromMilliseconds(1000)));
     EXPECT_EQ(AngularVelocity::ofRadians(2),
-              robot_other.estimateAngularVelocityAtFutureTime(milliseconds(1000)));
-    EXPECT_EQ(AngularVelocity::ofRadians(2),
-              robot_other.estimateAngularVelocityAtFutureTime(milliseconds(3000)));
+              robot_other.estimateAngularVelocityAtFutureTime(
+                  Duration::fromMilliseconds(3000)));
 }
 
 TEST_F(RobotTest, get_angular_velocity_at_past_time)
@@ -271,9 +296,11 @@ TEST_F(RobotTest, get_angular_velocity_at_past_time)
     Robot robot_other = Robot(1, Point(1, -2), Vector(3.5, 1), Angle::ofRadians(-0.3),
                               AngularVelocity::ofRadians(2), current_time);
 
-    ASSERT_THROW(robot_other.estimateAngularVelocityAtFutureTime(milliseconds(-100)),
-                 std::invalid_argument);
-    ASSERT_THROW(robot_other.estimateAngularVelocityAtFutureTime(milliseconds(-1000)),
+    ASSERT_THROW(
+        robot_other.estimateAngularVelocityAtFutureTime(Duration::fromMilliseconds(-100)),
+        std::invalid_argument);
+    ASSERT_THROW(robot_other.estimateAngularVelocityAtFutureTime(
+                     Duration::fromMilliseconds(-1000)),
                  std::invalid_argument);
 }
 

--- a/src/thunderbots/software/test/world/robot.cpp
+++ b/src/thunderbots/software/test/world/robot.cpp
@@ -5,17 +5,6 @@
 class RobotTest : public ::testing::Test
 {
    protected:
-    // We need to provide a constructor that initializes the Timestamp variables
-    // since the Timestamp class has no default constructor
-    RobotTest()
-        : ::testing::Test(),
-          current_time(Timestamp::fromSeconds(0)),
-          half_second_future(Timestamp::fromSeconds(0)),
-          one_second_future(Timestamp::fromSeconds(0)),
-          one_second_past(Timestamp::fromSeconds(0))
-    {
-    }
-
     void SetUp() override
     {
         // An arbitrary fixed point in time

--- a/src/thunderbots/software/test/world/team.cpp
+++ b/src/thunderbots/software/test/world/team.cpp
@@ -7,18 +7,6 @@
 class TeamTest : public ::testing::Test
 {
    protected:
-    // We need to provide a constructor that initializes the Timestamp variables
-    // since the Timestamp class has no default constructor
-    TeamTest()
-        : ::testing::Test(),
-          current_time(Timestamp::fromSeconds(0)),
-          one_second_future(Timestamp::fromSeconds(0)),
-          two_seconds_future(Timestamp::fromSeconds(0)),
-          two_seconds_100ms_future(Timestamp::fromSeconds(0)),
-          one_second_past(Timestamp::fromSeconds(0))
-    {
-    }
-
     void SetUp() override
     {
         current_time = Timestamp::fromSeconds(123);

--- a/src/thunderbots/software/test/world/team.cpp
+++ b/src/thunderbots/software/test/world/team.cpp
@@ -41,7 +41,7 @@ TEST_F(TeamTest, construction)
     EXPECT_EQ(std::nullopt, team.getRobotById(2));
     EXPECT_EQ(std::nullopt, team.goalie());
     EXPECT_EQ(std::vector<Robot>(), team.getAllRobots());
-    EXPECT_EQ(milliseconds(1000), team.getRobotExpiryBufferMilliseconds());
+    EXPECT_EQ(milliseconds(1000), team.getRobotExpiryBufferDuration());
 }
 
 TEST_F(TeamTest, update_with_3_robots)
@@ -354,7 +354,7 @@ TEST_F(TeamTest, get_robot_expiry_buffer)
 {
     Team team = Team(milliseconds(500));
 
-    EXPECT_EQ(milliseconds(500), team.getRobotExpiryBufferMilliseconds());
+    EXPECT_EQ(milliseconds(500), team.getRobotExpiryBufferDuration());
 }
 
 TEST_F(TeamTest, set_robot_expiry_buffer)
@@ -363,7 +363,7 @@ TEST_F(TeamTest, set_robot_expiry_buffer)
 
     team.setRobotExpiryBuffer(milliseconds(831));
 
-    EXPECT_EQ(milliseconds(831), team.getRobotExpiryBufferMilliseconds());
+    EXPECT_EQ(milliseconds(831), team.getRobotExpiryBufferDuration());
 }
 
 TEST_F(TeamTest, equality_operator_compare_team_with_itself)

--- a/src/thunderbots/software/test/world/team.cpp
+++ b/src/thunderbots/software/test/world/team.cpp
@@ -2,51 +2,58 @@
 
 #include <gtest/gtest.h>
 
-using namespace std::chrono;
+#include <stdexcept>
 
 class TeamTest : public ::testing::Test
 {
    protected:
-    void SetUp() override
+    // We need to provide a constructor that initializes the Timestamp variables
+    // since the Timestamp class has no default constructor
+    TeamTest()
+        : ::testing::Test(),
+          current_time(Timestamp::fromSeconds(0)),
+          one_second_future(Timestamp::fromSeconds(0)),
+          two_seconds_future(Timestamp::fromSeconds(0)),
+          two_seconds_100ms_future(Timestamp::fromSeconds(0)),
+          one_second_past(Timestamp::fromSeconds(0))
     {
-        auto epoch       = time_point<std::chrono::steady_clock>();
-        auto since_epoch = std::chrono::seconds(10000);
-
-        // An arbitrary fixed point in time. 10000 seconds after the epoch.
-        // We use this fixed point in time to make the tests deterministic.
-        current_time = epoch + since_epoch;
-
-        one_second_future        = current_time + seconds(1);
-        two_seconds_future       = current_time + seconds(2);
-        two_seconds_100ms_future = current_time + milliseconds(2100);
-
-        one_second_past = current_time - seconds(1);
     }
 
-    steady_clock::time_point current_time;
+    void SetUp() override
+    {
+        current_time = Timestamp::fromSeconds(123);
 
-    steady_clock::time_point one_second_future;
-    steady_clock::time_point two_seconds_future;
-    steady_clock::time_point two_seconds_100ms_future;
+        one_second_future        = current_time + Duration::fromSeconds(1);
+        two_seconds_future       = current_time + Duration::fromSeconds(2);
+        two_seconds_100ms_future = current_time + Duration::fromMilliseconds(2100);
 
-    steady_clock::time_point one_second_past;
+        one_second_past = current_time - Duration::fromSeconds(1);
+    }
+
+    Timestamp current_time;
+
+    Timestamp one_second_future;
+    Timestamp two_seconds_future;
+    Timestamp two_seconds_100ms_future;
+
+    Timestamp one_second_past;
 };
 
 TEST_F(TeamTest, construction)
 {
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
 
     EXPECT_EQ(0, team.numRobots());
     EXPECT_EQ(std::nullopt, team.getRobotById(0));
     EXPECT_EQ(std::nullopt, team.getRobotById(2));
     EXPECT_EQ(std::nullopt, team.goalie());
     EXPECT_EQ(std::vector<Robot>(), team.getAllRobots());
-    EXPECT_EQ(milliseconds(1000), team.getRobotExpiryBufferDuration());
+    EXPECT_EQ(Duration::fromMilliseconds(1000), team.getRobotExpiryBufferDuration());
 }
 
 TEST_F(TeamTest, update_with_3_robots)
 {
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -72,7 +79,7 @@ TEST_F(TeamTest, update_with_3_robots)
 
 TEST_F(TeamTest, update_with_new_team)
 {
-    Team team_update = Team(milliseconds(1000));
+    Team team_update = Team(Duration::fromMilliseconds(1000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -87,7 +94,7 @@ TEST_F(TeamTest, update_with_new_team)
 
     team_update.updateRobots(robot_list);
 
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
 
     team.updateState(team_update);
 
@@ -104,7 +111,7 @@ TEST_F(TeamTest, update_with_new_team)
 
 TEST_F(TeamTest, update_state_to_predicted_state_with_future_timestamp)
 {
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -134,7 +141,7 @@ TEST_F(TeamTest, update_state_to_predicted_state_with_future_timestamp)
 
 TEST_F(TeamTest, update_state_to_predicted_state_with_past_timestamp)
 {
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -161,7 +168,7 @@ TEST_F(TeamTest, update_state_to_predicted_state_with_past_timestamp)
 
 TEST_F(TeamTest, remove_expired_robots_at_current_time_so_no_robots_expire)
 {
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -180,7 +187,7 @@ TEST_F(TeamTest, remove_expired_robots_at_current_time_so_no_robots_expire)
 
 TEST_F(TeamTest, remove_expired_robots_in_future_before_expiry_time_so_no_robots_expire)
 {
-    Team team = Team(milliseconds(2100));
+    Team team = Team(Duration::fromMilliseconds(2100));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -199,7 +206,7 @@ TEST_F(TeamTest, remove_expired_robots_in_future_before_expiry_time_so_no_robots
 
 TEST_F(TeamTest, remove_expired_robots_in_past_so_no_robots_expire)
 {
-    Team team = Team(milliseconds(2000));
+    Team team = Team(Duration::fromMilliseconds(2000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -209,7 +216,7 @@ TEST_F(TeamTest, remove_expired_robots_in_past_so_no_robots_expire)
 
     team.updateRobots({robot_0, robot_1});
 
-    team.removeExpiredRobots(one_second_past);
+    EXPECT_THROW(team.removeExpiredRobots(one_second_past), std::invalid_argument);
 
     EXPECT_EQ(2, team.numRobots());
     EXPECT_EQ(robot_0, team.getRobotById(0));
@@ -218,7 +225,7 @@ TEST_F(TeamTest, remove_expired_robots_in_past_so_no_robots_expire)
 
 TEST_F(TeamTest, remove_expired_robots_in_future_so_all_robots_expire)
 {
-    Team team = Team(milliseconds(2000));
+    Team team = Team(Duration::fromMilliseconds(2000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -237,7 +244,7 @@ TEST_F(TeamTest, remove_expired_robots_in_future_so_all_robots_expire)
 
 TEST_F(TeamTest, remove_expired_robots_in_future_so_1_robot_expires_1_robot_does_not)
 {
-    Team team = Team(milliseconds(2000));
+    Team team = Team(Duration::fromMilliseconds(2000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -256,7 +263,7 @@ TEST_F(TeamTest, remove_expired_robots_in_future_so_1_robot_expires_1_robot_does
 
 TEST_F(TeamTest, clear_all_robots)
 {
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -287,7 +294,7 @@ TEST_F(TeamTest, clear_all_robots)
 
 TEST_F(TeamTest, assign_goalie_starting_with_no_goalie)
 {
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -308,7 +315,7 @@ TEST_F(TeamTest, assign_goalie_starting_with_no_goalie)
 
 TEST_F(TeamTest, assign_goalie_starting_with_different_robot_as_goalie)
 {
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -330,7 +337,7 @@ TEST_F(TeamTest, assign_goalie_starting_with_different_robot_as_goalie)
 
 TEST_F(TeamTest, clear_goalie)
 {
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
 
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
@@ -352,18 +359,18 @@ TEST_F(TeamTest, clear_goalie)
 
 TEST_F(TeamTest, get_robot_expiry_buffer)
 {
-    Team team = Team(milliseconds(500));
+    Team team = Team(Duration::fromMilliseconds(500));
 
-    EXPECT_EQ(milliseconds(500), team.getRobotExpiryBufferDuration());
+    EXPECT_EQ(Duration::fromMilliseconds(500), team.getRobotExpiryBufferDuration());
 }
 
 TEST_F(TeamTest, set_robot_expiry_buffer)
 {
-    Team team = Team(milliseconds(0));
+    Team team = Team(Duration::fromMilliseconds(0));
 
-    team.setRobotExpiryBuffer(milliseconds(831));
+    team.setRobotExpiryBuffer(Duration::fromMilliseconds(831));
 
-    EXPECT_EQ(milliseconds(831), team.getRobotExpiryBufferDuration());
+    EXPECT_EQ(Duration::fromMilliseconds(831), team.getRobotExpiryBufferDuration());
 }
 
 TEST_F(TeamTest, equality_operator_compare_team_with_itself)
@@ -371,17 +378,19 @@ TEST_F(TeamTest, equality_operator_compare_team_with_itself)
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
 
-    Team team = Team(milliseconds(1000));
+    Team team = Team(Duration::fromMilliseconds(1000));
     team.updateRobots({robot_0});
     team.assignGoalie(0);
 
-    EXPECT_EQ(Team(milliseconds(500)), Team(milliseconds(500)));
+    EXPECT_EQ(Team(Duration::fromMilliseconds(500)),
+              Team(Duration::fromMilliseconds(500)));
     EXPECT_EQ(team, team);
 }
 
 TEST_F(TeamTest, equality_operator_teams_with_different_expiry_buffers)
 {
-    EXPECT_NE(Team(milliseconds(50)), Team(milliseconds(1000)));
+    EXPECT_NE(Team(Duration::fromMilliseconds(50)),
+              Team(Duration::fromMilliseconds(1000)));
 }
 
 TEST_F(TeamTest, equality_operator_teams_with_different_number_of_robots)
@@ -395,10 +404,10 @@ TEST_F(TeamTest, equality_operator_teams_with_different_number_of_robots)
     Robot robot_2 = Robot(2, Point(), Vector(-0.5, 4), Angle::quarter(),
                           AngularVelocity::half(), current_time);
 
-    Team team_0 = Team(milliseconds(1000));
+    Team team_0 = Team(Duration::fromMilliseconds(1000));
     team_0.updateRobots({robot_0, robot_1, robot_2});
 
-    Team team_1 = Team(milliseconds(1000));
+    Team team_1 = Team(Duration::fromMilliseconds(1000));
     team_1.updateRobots({robot_0, robot_2});
 
     EXPECT_NE(team_0, team_1);
@@ -415,10 +424,10 @@ TEST_F(TeamTest, equality_operator_teams_with_same_number_of_robots_but_differen
     Robot robot_2 = Robot(2, Point(), Vector(-0.5, 4), Angle::quarter(),
                           AngularVelocity::half(), current_time);
 
-    Team team_0 = Team(milliseconds(1000));
+    Team team_0 = Team(Duration::fromMilliseconds(1000));
     team_0.updateRobots({robot_0, robot_1});
 
-    Team team_1 = Team(milliseconds(1000));
+    Team team_1 = Team(Duration::fromMilliseconds(1000));
     team_1.updateRobots({robot_0, robot_2});
 
     EXPECT_NE(team_0, team_1);
@@ -435,11 +444,11 @@ TEST_F(TeamTest, equality_operator_teams_with_different_goalie)
     Robot robot_2 = Robot(2, Point(), Vector(-0.5, 4), Angle::quarter(),
                           AngularVelocity::half(), current_time);
 
-    Team team_0 = Team(milliseconds(1000));
+    Team team_0 = Team(Duration::fromMilliseconds(1000));
     team_0.updateRobots({robot_0, robot_1});
     team_0.assignGoalie(0);
 
-    Team team_1 = Team(milliseconds(1000));
+    Team team_1 = Team(Duration::fromMilliseconds(1000));
     team_1.updateRobots({robot_0, robot_1});
     team_1.assignGoalie(1);
 

--- a/src/thunderbots/software/test/world/world.cpp
+++ b/src/thunderbots/software/test/world/world.cpp
@@ -4,22 +4,19 @@
 
 #include "test/test_util/test_util.h"
 
-using namespace std::chrono;
-
 class WorldTest : public ::testing::Test
 {
    protected:
+    WorldTest() : ::testing::Test(), current_time(Timestamp::fromSeconds(0)) {}
+
     void SetUp() override
     {
-        auto epoch       = time_point<std::chrono::steady_clock>();
-        auto since_epoch = std::chrono::seconds(10000);
-
-        // An arbitrary fixed point in time. 10000 seconds after the epoch.
+        // An arbitrary fixed point in time
         // We use this fixed point in time to make the tests deterministic.
-        current_time = epoch + since_epoch;
+        current_time = Timestamp::fromSeconds(123);
     }
 
-    steady_clock::time_point current_time;
+    Timestamp current_time;
 };
 
 TEST_F(WorldTest, construction_with_parameters)
@@ -34,7 +31,7 @@ TEST_F(WorldTest, construction_with_parameters)
     Robot friendly_robot_1 = Robot(1, Point(3, -1), Vector(), Angle::zero(),
                                    AngularVelocity::zero(), current_time);
 
-    Team friendly_team = Team(milliseconds(1000));
+    Team friendly_team = Team(Duration::fromMilliseconds(1000));
     friendly_team.updateRobots({friendly_robot_0, friendly_robot_1});
     friendly_team.assignGoalie(1);
 
@@ -44,7 +41,7 @@ TEST_F(WorldTest, construction_with_parameters)
     Robot enemy_robot_1 = Robot(1, Point(), Vector(-0.5, 4), Angle::quarter(),
                                 AngularVelocity::half(), current_time);
 
-    Team enemy_team = Team(milliseconds(1000));
+    Team enemy_team = Team(Duration::fromMilliseconds(1000));
     enemy_team.updateRobots({enemy_robot_0, enemy_robot_1});
     enemy_team.assignGoalie(0);
 

--- a/src/thunderbots/software/test/world/world.cpp
+++ b/src/thunderbots/software/test/world/world.cpp
@@ -7,8 +7,6 @@
 class WorldTest : public ::testing::Test
 {
    protected:
-    WorldTest() : ::testing::Test(), current_time(Timestamp::fromSeconds(0)) {}
-
     void SetUp() override
     {
         // An arbitrary fixed point in time

--- a/src/thunderbots/software/util/ros_messages.cpp
+++ b/src/thunderbots/software/util/ros_messages.cpp
@@ -1,5 +1,7 @@
 #include "util/ros_messages.h"
 
+#include "util/timestamp.h"
+
 namespace Util
 {
     namespace ROSMessages
@@ -8,8 +10,9 @@ namespace Util
         {
             Point ball_position  = Point(ball_msg.position.x, ball_msg.position.y);
             Vector ball_velocity = Vector(ball_msg.velocity.x, ball_msg.velocity.y);
+            Timestamp timestamp  = Timestamp::fromSeconds(ball_msg.timestamp_seconds);
 
-            Ball ball = Ball(ball_position, ball_velocity);
+            Ball ball = Ball(ball_position, ball_velocity, timestamp);
 
             return ball;
         }
@@ -22,10 +25,7 @@ namespace Util
             Angle robot_orientation = Angle::ofRadians(robot_msg.orientation);
             AngularVelocity robot_angular_velocity =
                 Angle::ofRadians(robot_msg.angular_velocity);
-            auto epoch = std::chrono::steady_clock::time_point();
-            auto since_epoch =
-                std::chrono::nanoseconds(robot_msg.timestamp_nanoseconds_since_epoch);
-            auto timestamp = epoch + since_epoch;
+            Timestamp timestamp = Timestamp::fromSeconds(robot_msg.timestamp_seconds);
 
             Robot robot = Robot(robot_id, robot_position, robot_velocity,
                                 robot_orientation, robot_angular_velocity, timestamp);
@@ -53,7 +53,7 @@ namespace Util
             }
 
             auto expiry_buffer =
-                std::chrono::milliseconds(team_msg.robot_expiry_buffer_milliseconds);
+                Duration::fromMilliseconds(team_msg.robot_expiry_buffer_milliseconds);
 
             Team team = Team(expiry_buffer);
 

--- a/src/thunderbots/software/util/timestamp.cpp
+++ b/src/thunderbots/software/util/timestamp.cpp
@@ -1,0 +1,77 @@
+#include "util/timestamp.h"
+
+#include <cmath>
+#include <stdexcept>
+
+#include "shared/constants.h"
+
+Timestamp::Timestamp(double timestamp_seconds)
+{
+    if (timestamp_seconds < 0.0)
+    {
+        throw std::invalid_argument(
+            "Error: Timestamps cannot be created from negative values");
+    }
+
+    timestamp_in_seconds = timestamp_seconds;
+}
+
+const Timestamp Timestamp::fromSeconds(double seconds)
+{
+    return Timestamp(seconds);
+}
+
+const Timestamp Timestamp::fromMilliseconds(double milliseconds)
+{
+    return Timestamp(milliseconds * SECONDS_PER_MILLISECOND);
+}
+
+double Timestamp::getSeconds() const
+{
+    return timestamp_in_seconds;
+}
+
+double Timestamp::getMilliseconds() const
+{
+    return timestamp_in_seconds * MILLISECONDS_PER_SECOND;
+}
+
+bool Timestamp::operator==(const Timestamp &other) const
+{
+    return std::fabs(other.getSeconds() - getSeconds()) < EPSILON;
+}
+
+bool Timestamp::operator!=(const Timestamp &other) const
+{
+    return !(*this == other);
+}
+
+bool Timestamp::operator<(const Timestamp &other) const
+{
+    return (*this != other) && (getSeconds() < other.getSeconds());
+}
+
+bool Timestamp::operator>=(const Timestamp &other) const
+{
+    return !(*this < other);
+}
+
+bool Timestamp::operator>(const Timestamp &other) const
+{
+    return (*this != other) && (getSeconds() > other.getSeconds());
+}
+
+bool Timestamp::operator<=(const Timestamp &other) const
+{
+    return !(*this > other);
+}
+
+Timestamp Timestamp::operator+(const Duration &duration) const
+{
+    return Timestamp::fromSeconds(getSeconds() + duration.getSeconds());
+}
+
+Timestamp Timestamp::operator-(const Duration &duration) const
+{
+    return Timestamp::fromSeconds(getSeconds() - duration.getSeconds());
+}

--- a/src/thunderbots/software/util/timestamp.cpp
+++ b/src/thunderbots/software/util/timestamp.cpp
@@ -5,6 +5,8 @@
 
 #include "shared/constants.h"
 
+Timestamp::Timestamp() : timestamp_in_seconds(0) {}
+
 Timestamp::Timestamp(double timestamp_seconds)
 {
     if (timestamp_seconds < 0.0)

--- a/src/thunderbots/software/util/timestamp.h
+++ b/src/thunderbots/software/util/timestamp.h
@@ -36,6 +36,11 @@ class Timestamp
     static constexpr double EPSILON = 1e-15;
 
     /**
+     * The default constructor for a Timestamp. Creates a Timestamp at time 0
+     */
+    Timestamp();
+
+    /**
      * Creates a new Timestamp value from a value in seconds.
      * @param seconds A value >= 0.0, in seconds, from which to create the Timestamp
      * @throws std::invalid_argument if the given value is < 0.0

--- a/src/thunderbots/software/util/timestamp.h
+++ b/src/thunderbots/software/util/timestamp.h
@@ -1,30 +1,154 @@
 #pragma once
 
-#include <chrono>
+// The forward declaration is required for the typedef to appear before the class
+class Timestamp;
 
-typedef std::chrono::steady_clock::duration AITimestamp;
+/**
+ * This Timestamp class can also represent a duration in time, so we create a typedef
+ * for Durations to make that distinction explicit
+ * This typedef appears before the Timestamp class so that the class can return Duration
+ * values
+ */
+typedef Timestamp Duration;
 
-namespace Timestamp
+/**
+ * A simple Timestamp class built around doubles. This Timestamp is intended to represent
+ * the t_capture timestamps we receive from the SSL Vision system. These t_capture values
+ * are monotonic (meaning they are always positive and always increase), and are relative
+ * to the "epoch time" defined by SSL Vision. This "epoch" is when SSL Vision starts up
+ * and begins streaming data. Therefore, these timestamps are not absolute "wall clock"
+ * time, but points in time relative to when the SSL Vision program started. They can and
+ * should be used to timestamp all data received from SSL Vision and propagated throughout
+ * the system in order to calculate time differences (durations), velocities, and other
+ * time-dependent values.
+ */
+class Timestamp
 {
-    /**
-     * Returns an AITimestamp of the current time
-     *
-     * @return an AITimestamp of the current time
-     */
-    static inline AITimestamp getTimestampNow()
-    {
-        return std::chrono::steady_clock::now().time_since_epoch();
-    }
+   public:
+    // Due to internal representation of doubles being slightly less accurate/consistent
+    // with some numbers and operations, we consider timestamps that are very close
+    // together to be equal (since they likely are, just possibly slightly misrepresented
+    // by the system/compiler). We use this EPSILON as a threshold for comparison. 1e-15
+    // was chosen as a value because doubles have about 16 consistent significant figures.
+    // Comparing numbers with 15 significant figures gives us a
+    // small buffer while remaining as accurate as possible.
+    // http://www.cplusplus.com/forum/beginner/95128/
+    static constexpr double EPSILON = 1e-15;
 
     /**
-     * Returns the given timestamp in microseconds
-     *
-     * @param timestamp the timestamp to convert to microseconds
-     *
-     * @return the given timestamp in microseconds
+     * Creates a new Timestamp value from a value in seconds.
+     * @param seconds A value >= 0.0, in seconds, from which to create the Timestamp
+     * @throws std::invalid_argument if the given value is < 0.0
+     * @return A Timestamp created from the given value
      */
-    static inline int64_t getMicroseconds(const AITimestamp& timestamp)
-    {
-        return std::chrono::duration_cast<std::chrono::microseconds>(timestamp).count();
-    }
-}  // namespace Timestamp
+    static const Timestamp fromSeconds(double seconds);
+
+    /**
+     * Creates a new Timestamp value from a value in milliseconds
+     * @param milliseconds A value >= 0.0, in milliseconds, from which to create the
+     * Timestamp
+     * @throws std::invalid_argument if the given value is < 0.0
+     * @return A Timestamp created from the given value
+     */
+    static const Timestamp fromMilliseconds(double milliseconds);
+
+    /**
+     * Returns the value of the Timestamp in seconds
+     * @return the value of the Timestamp in seconds
+     */
+    double getSeconds() const;
+
+    /**
+     * Returns the value of the Timestamp in milliseconds
+     * @return the value of the Timestamp in milliseconds
+     */
+    double getMilliseconds() const;
+
+    /**
+     * Compares Timestamps for equality. Timestamps are considered equal if their values
+     * in seconds are within EPSILON from one another.
+     *
+     * @param other the Timestamp to compare with for equality
+     * @return true if the timestamps are equal and false otherwise
+     */
+    bool operator==(const Timestamp& other) const;
+
+    /**
+     * Compares Timestamps for inequality
+     *
+     * @param other the Timestamp to compare with for inequality
+     * @return true if the timestamps are not equal, and false otherwise
+     */
+    bool operator!=(const Timestamp& other) const;
+
+    /**
+     * Defines the "less than" operator. Returns true if this Timestamp is strictly less
+     * than (and not equal to) the other timestamp
+     *
+     * @param other the Timestamp to compare with
+     * @return true if this Timestamp is strictly less than (and not equal to) the other
+     * timestamp, and false otherwise
+     */
+    bool operator<(const Timestamp& other) const;
+
+    /**
+     * Defines the "less than or equal to" operator. Returns true if this Timestamp is
+     * less than or equal to the other timestamp
+     *
+     * @param other the Timestamp to compare with
+     * @return true if this Timestamp is less than or equal to the other timestamp, and
+     * false otherwise
+     */
+    bool operator<=(const Timestamp& other) const;
+
+    /**
+     * Defines the "greater than" operator. Returns true if this Timestamp is strictly
+     * greater than (and not equal to) the other timestamp
+     *
+     * @param other the Timestamp to compare with
+     * @return true if this Timestamp is strictly greater than (and not equal to) the
+     * other timestamp, and false otherwise
+     */
+    bool operator>(const Timestamp& other) const;
+
+    /**
+     * Defines the "greater than or equal to" operator. Returns true if this Timestamp
+     * is greater than or equal to the other timestamp
+     *
+     * @param other the Timestamp to compare with
+     * @return true if this Timestamp is greater than or equal to the other timestamp, and
+     * false otherwise
+     */
+    bool operator>=(const Timestamp& other) const;
+
+    /**
+     * Defines the addition operator for Timestamps. Allows Durations to be added to
+     * Timestamps
+     *
+     * @param duration the Duration to add to this Timestamp
+     * @return A new Timestamp with the given Duration added to this Timestamp
+     */
+    Timestamp operator+(const Duration& duration) const;
+
+    /**
+     * Defines the subtraction operator for Timestamps. Allows Durations to be subtracted
+     * from Timestamps
+     *
+     * @param duration the Duration to subtract from this Timestamp
+     * @return A new Timestamp with the given Duration subtracted from this current
+     * Timestamp
+     */
+    Timestamp operator-(const Duration& duration) const;
+
+   private:
+    /**
+     * Constructs a Timestamp value from a value in seconds.
+     * @param timestamp_seconds A value >= 0.0, in seconds, from which to create the
+     * timestamp
+     * @throws std::invalid_argument if the provided value is < 0.0
+     */
+    explicit Timestamp(double timestamp_seconds);
+
+    // The stored internal value of the timestamp, in seconds
+    double timestamp_in_seconds;
+};

--- a/src/thunderbots_msgs/msg/Ball.msg
+++ b/src/thunderbots_msgs/msg/Ball.msg
@@ -1,7 +1,7 @@
 # Describes the current state of the ball
 
-# The timestamp when this data was received, in microseconds
-int64 timestamp_microseconds
+# The timestamp of this data in seconds
+float64 timestamp_seconds
 
 # The position of the ball. Coordinates are in metres
 Point2D position

--- a/src/thunderbots_msgs/msg/Robot.msg
+++ b/src/thunderbots_msgs/msg/Robot.msg
@@ -1,7 +1,7 @@
 # Describes the current state of a robot
 
-# The timestamp for this data, represented by the number of nanoseconds since the epoch
-uint64 timestamp_nanoseconds_since_epoch
+# The timestamp of this data in seconds
+float64 timestamp_seconds
 
 # The id of the robot
 uint32 id


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Replaces the previous timestamping system(s) with a single, unified `Timestamp` class. This new class is built with the `t_capture` timestamp we receive from protobuf packets in mind, and should be simpler to work with than `std::chrono`

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
* Unit tests for the new Timestamp class
* All other unit tests have been updated to use the new Timestamp class

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #228 

### Length Justification
Once I modified the old `AITimestamp` class everything had to change at once, and I didn't want to leave the old and new systems in together between PRs.

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
