### PR TITLE
temporarily suppressed exceptions thrown when assigning a goalie

### DIFF
--- a/src/thunderbots/software/util/ros_messages.cpp
+++ b/src/thunderbots/software/util/ros_messages.cpp
@@ -61,7 +61,18 @@ namespace Util
 
             if (team_msg.goalie_id >= 0)
             {
-                team.assignGoalie(static_cast<unsigned int>(team_msg.goalie_id));
+                // TODO: Remove this exception handling. It is a temporary fix for
+                // https://github.com/UBC-Thunderbots/Software/issues/287
+                // and should be fixed and removed as part of
+                // https://github.com/UBC-Thunderbots/Software/issues/230
+                try
+                {
+                    team.assignGoalie(static_cast<unsigned int>(team_msg.goalie_id));
+                }
+                catch (std::invalid_argument)
+                {
+                    // Do nothing
+                }
             }
             else
             {


### PR DESCRIPTION


<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Handled the exception thrown when assigning a goalie to a team.


### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
All unit tests pass. No tests added.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
Part of #287, but I won't mark it resolved until it's properly resolved by #230 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
