### PR TITLE
Fixed typo in visualizer messenger layer name strings

### DIFF
--- a/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.cpp
+++ b/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.cpp
@@ -133,7 +133,7 @@ namespace Util
     {
         // TODO: #268 list these existing layer names elsewhere where it's more obvious
         std::vector<std::string> layer_names = std::vector<std::string>(
-            {"field", "ball", "ball_vel", "fiendly_robot", "fiendly_robot_vel",
+            {"field", "ball", "ball_vel", "friendly_robot", "friendly_robot_vel",
              "enemy_robot", "enemy_robot_vel", "nav", "rule", "passing", "test", "misc"});
 
         for (std::string layer_name : layer_names)


### PR DESCRIPTION
### Description

Fixed typo from PR #251

### Testing Done

Compiled; low risk

### Resolved Issues

N/A

### Length Justification

N/A

### Review Checklist

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.