### PR TITLE
Polygon support for visualizer messenger

### DIFF
--- a/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.cpp
+++ b/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.cpp
@@ -30,6 +30,7 @@ namespace Util
     void VisualizerMessenger::publishAndClearLayers()
     {
         // Check if publisher is initialized before publishing messages
+        // TODO: #312: refresh rate limit by comparing time delta
         if (!this->publisher)
         {
             LOG(WARNING)
@@ -88,6 +89,26 @@ namespace Util
         new_shape.data.push_back(y);
         new_shape.data.push_back(w);
         new_shape.data.push_back(h);
+
+        applyDrawStyleToMsg(new_shape, draw_style);
+        applyDrawTransformToMsg(new_shape, draw_transform);
+        addShapeToLayer(layer, new_shape);
+    }
+
+    void VisualizerMessenger::drawPoly(const std::string& layer,
+                                       std::vector<std::pair<double, double>>& vertices,
+                                       DrawStyle draw_style, DrawTransform draw_transform)
+    {
+        ShapeMsg new_shape;
+        new_shape.type = "poly";
+        new_shape.data.clear();
+
+        for (auto vertexIter = vertices.begin(); vertexIter != vertices.end();
+             vertexIter++)
+        {
+            new_shape.data.push_back((*vertexIter).first);
+            new_shape.data.push_back((*vertexIter).second);
+        }
 
         applyDrawStyleToMsg(new_shape, draw_style);
         applyDrawTransformToMsg(new_shape, draw_transform);

--- a/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.cpp
+++ b/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.cpp
@@ -96,7 +96,7 @@ namespace Util
     }
 
     void VisualizerMessenger::drawPoly(const std::string& layer,
-                                       std::vector<std::pair<double, double>>& vertices,
+                                       std::vector<Point2D>& vertices,
                                        DrawStyle draw_style, DrawTransform draw_transform)
     {
         ShapeMsg new_shape;
@@ -106,8 +106,8 @@ namespace Util
         for (auto vertexIter = vertices.begin(); vertexIter != vertices.end();
              vertexIter++)
         {
-            new_shape.data.push_back((*vertexIter).first);
-            new_shape.data.push_back((*vertexIter).second);
+            new_shape.data.push_back((*vertexIter).x);
+            new_shape.data.push_back((*vertexIter).y);
         }
 
         applyDrawStyleToMsg(new_shape, draw_style);

--- a/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.h
+++ b/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.h
@@ -132,8 +132,19 @@ namespace Util
                       DrawStyle draw_style         = DrawStyle(),
                       DrawTransform draw_transform = DrawTransform());
 
-        // TODO: #258 polygon support
-        void drawPoly();
+        /**
+         * Reuqest a message to draw a polygon shape. The origin is the
+         * first vertex passed in.
+         *
+         * @param layer: The layer name this shape is being drawn to
+         * @param vertices: A vector of pairs of vertex positions
+         * @param draw_style: the drawing style of the shape
+         * @param draw_transform: the transformation of the shape
+         */
+        void drawPoly(const std::string& layer,
+                      std::vector<std::pair<double, double>>& vertices,
+                      DrawStyle draw_style         = DrawStyle(),
+                      DrawTransform draw_transform = DrawTransform());
 
         /**
          * Request a message to draw an arc. The origin is the center point

--- a/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.h
+++ b/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.h
@@ -18,6 +18,7 @@
 
 #include "thunderbots_msgs/DrawLayer.h"
 #include "thunderbots_msgs/DrawShape.h"
+#include "thunderbots_msgs/Point2D.h"
 
 
 // Forward declaration
@@ -32,6 +33,7 @@ namespace Util
     using LayerMsg    = thunderbots_msgs::DrawLayer;
     using LayerMsgMap = std::map<std::string, LayerMsg>;
     using ShapeMsg    = thunderbots_msgs::DrawShape;
+    using Point2D     = thunderbots_msgs::Point2D;
 
     class VisualizerMessenger
     {
@@ -137,12 +139,11 @@ namespace Util
          * first vertex passed in.
          *
          * @param layer: The layer name this shape is being drawn to
-         * @param vertices: A vector of pairs of vertex positions
+         * @param vertices: A vector of Point2Ds that specifies x and y of vertices
          * @param draw_style: the drawing style of the shape
          * @param draw_transform: the transformation of the shape
          */
-        void drawPoly(const std::string& layer,
-                      std::vector<std::pair<double, double>>& vertices,
+        void drawPoly(const std::string& layer, std::vector<Point2D>& vertices,
                       DrawStyle draw_style         = DrawStyle(),
                       DrawTransform draw_transform = DrawTransform());
 

--- a/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.h
+++ b/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.h
@@ -133,7 +133,7 @@ namespace Util
                       DrawTransform draw_transform = DrawTransform());
 
         /**
-         * Reuqest a message to draw a polygon shape. The origin is the
+         * Request a message to draw a polygon shape. The origin is the
          * first vertex passed in.
          *
          * @param layer: The layer name this shape is being drawn to


### PR DESCRIPTION
### Description

Added ability to use VisualizerMessenger to send polygon shape messages

### Testing Done

Compiled; low risk

### Resolved Issues

Resolves #258 

### Length Justification

N/A

### Review Checklist


**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.
