### PR TITLE
fixed ballfilter segfault

### DIFF
--- a/src/thunderbots/software/network_input/filter/ball_filter.cpp
+++ b/src/thunderbots/software/network_input/filter/ball_filter.cpp
@@ -1,34 +1,30 @@
 #include "ball_filter.h"
 
-BallFilter::BallFilter() {}
+BallFilter::BallFilter()
+{
+    ball_data.position  = Point();
+    ball_data.velocity  = Vector();
+    ball_data.timestamp = 0;
+}
 
 FilteredBallData BallFilter::getFilteredData(std::vector<SSLBallData> new_ball_data)
 {
     // The input messages do not seem to be transmitting ball velocity correctly so
     // calculate it based on the balls current and previous position.
-    if (ball_data == nullptr)
-    {
-        ball_data =
-            new BallData(new_ball_data[0].position, Vector(), new_ball_data[0].timestamp);
-    }
-    else
-    {
-        double time_diff = std::fabs(new_ball_data[0].timestamp - ball_data->timestamp);
+    double time_diff = std::fabs(new_ball_data[0].timestamp - ball_data.timestamp);
 
-        if (time_diff != 0)
-        {
-            Vector ball_velocity =
-                (new_ball_data[0].position - ball_data->position) / time_diff;
-            ball_data->velocity = ball_velocity;
-        }
-
-        ball_data->position  = new_ball_data[0].position;
-        ball_data->timestamp = new_ball_data[0].timestamp;
+    if (time_diff != 0)
+    {
+        Vector ball_velocity =
+            (new_ball_data[0].position - ball_data.position) / time_diff;
+        ball_data.velocity  = ball_velocity;
+        ball_data.position  = new_ball_data[0].position;
+        ball_data.timestamp = new_ball_data[0].timestamp;
     }
 
     FilteredBallData filtered_data;
     filtered_data.position = new_ball_data[0].position;
-    filtered_data.velocity = ball_data->velocity;
+    filtered_data.velocity = ball_data.velocity;
     // This is a placeholder timestamp for now. Timestamps should be fixed in
     // https://github.com/UBC-Thunderbots/Software/issues/228
     filtered_data.timestamp = Timestamp::getTimestampNow();

--- a/src/thunderbots/software/network_input/filter/ball_filter.h
+++ b/src/thunderbots/software/network_input/filter/ball_filter.h
@@ -54,6 +54,8 @@ class BallFilter
    private:
     struct BallData
     {
+        BallData() = default;
+
         BallData(Point position, Vector velocity, double timestamp)
             : position(position), velocity(velocity), timestamp(timestamp)
         {
@@ -64,5 +66,5 @@ class BallFilter
         double timestamp;
     };
 
-    BallData *ball_data;
+    BallData ball_data;
 };


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Fixed segfault occuring in the Ball Filter

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Manually verified the segfault no longer happens

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
None

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
