### PR TITLE
WIP: Persist key:value data using local storage

### DIFF
--- a/src/corner_kick/package.json
+++ b/src/corner_kick/package.json
@@ -40,6 +40,7 @@
         "http-server": "0.11.1",
         "jest": "23.6.0",
         "redux-mock-store": "1.5.3",
+        "redux-saga-test-plan": "^3.7.0",
         "style-loader": "0.23.1",
         "ts-jest": "23.10.5",
         "ts-loader": "5.3.1",

--- a/src/corner_kick/src/store/actions/__tests__/settings.test.ts
+++ b/src/corner_kick/src/store/actions/__tests__/settings.test.ts
@@ -1,0 +1,49 @@
+/**
+ * This file is for testing the Settings actions
+ * Each test case has a description of what it tests
+ */
+
+import configureMockStore from 'redux-mock-store';
+import * as settingsActions from '../settings';
+
+const mockStore = configureMockStore();
+const store = mockStore();
+
+describe('settingsActions', () => {
+    beforeEach(() => {
+        store.clearActions();
+    });
+
+    describe('when we hydrate data to state', () => {
+        test('Dispatches the correct hydrateSettings action and payload', () => {
+            const expectedActions = [
+                {
+                    payload: {
+                        settings: { color: 'blue' },
+                    },
+                    type: 'HYDRATE_SETTINGS',
+                },
+            ];
+
+            store.dispatch(settingsActions.hydrateSettings({ color: 'blue' }));
+            expect(store.getActions()).toEqual(expectedActions);
+        });
+    });
+
+    describe('when we send settings to update state', () => {
+        test('Dispatches the correct send settings action and payload', () => {
+            const expectedActions = [
+                {
+                    payload: {
+                        key: 'dog',
+                        value: 'bark',
+                    },
+                    type: 'UPDATE_SETTINGS',
+                },
+            ];
+
+            store.dispatch(settingsActions.updateSettings('dog', 'bark'));
+            expect(store.getActions()).toEqual(expectedActions);
+        });
+    });
+});

--- a/src/corner_kick/src/store/actions/settings.ts
+++ b/src/corner_kick/src/store/actions/settings.ts
@@ -1,0 +1,23 @@
+/*
+ * This file specifies the Settings specific action
+ *
+ * We are using the format specified here
+ * @see https://github.com/piotrwitek/typesafe-actions#createaction
+ */
+
+import { IPersistDataState } from 'SRC/types';
+import { createAction } from 'typesafe-actions';
+
+/**
+ * Hydrate data to state
+ */
+export const hydrateSettings = createAction('HYDRATE_SETTINGS', (resolve) => {
+    return (settings: IPersistDataState) => resolve({ settings });
+});
+
+/**
+ * Send data to persist (currently only for strings key-value pairs)
+ */
+export const updateSettings = createAction('UPDATE_SETTINGS', (resolve) => {
+    return (key: string, value: string) => resolve({ key, value });
+});

--- a/src/corner_kick/src/store/reducers/__tests__/settings.test.ts
+++ b/src/corner_kick/src/store/reducers/__tests__/settings.test.ts
@@ -3,8 +3,6 @@
  * Each test case has a description of what it tests
  */
 
-// import { IPersistDataState } from 'SRC/types';
-
 import * as settings from '../../actions/settings';
 import settingsReducer from '../settings';
 

--- a/src/corner_kick/src/store/reducers/__tests__/settings.test.ts
+++ b/src/corner_kick/src/store/reducers/__tests__/settings.test.ts
@@ -1,0 +1,30 @@
+/**
+ * This file is for testing settings reducers
+ * Each test case has a description of what it tests
+ */
+
+// import { IPersistDataState } from 'SRC/types';
+
+import * as settings from '../../actions/settings';
+import settingsReducer from '../settings';
+
+describe('settings reducer', () => {
+    describe('when we receive action HYDRATE_SETTINGS', () => {
+        it('should hydrate data to state', () => {
+            const mockAction = settings.hydrateSettings({ color: 'blue' });
+
+            const state = settingsReducer(undefined, mockAction);
+
+            expect(state['color']).toEqual('blue');
+        });
+    });
+    describe('when we receive action SEND_SETTINGS', () => {
+        it('should push data to the state', () => {
+            const mockAction = settings.updateSettings('testKey', 'testValue');
+
+            const state = settingsReducer(undefined, mockAction);
+
+            expect(state['testKey']).toEqual('testValue');
+        });
+    });
+});

--- a/src/corner_kick/src/store/reducers/index.ts
+++ b/src/corner_kick/src/store/reducers/index.ts
@@ -6,6 +6,7 @@ import { combineReducers } from 'redux';
 
 import consoleReducer from './console';
 import rosReducer from './ros';
+import settingsReducer from './settings';
 
 /**
  * Combines all reducers. This is what the Redux accepts when being
@@ -14,4 +15,5 @@ import rosReducer from './ros';
 export default combineReducers({
     console: consoleReducer,
     ros: rosReducer,
+    settings: settingsReducer,
 });

--- a/src/corner_kick/src/store/reducers/settings.ts
+++ b/src/corner_kick/src/store/reducers/settings.ts
@@ -1,0 +1,38 @@
+/*
+ * This file specifies the Settings reducer
+ */
+
+import { ActionType, getType } from 'typesafe-actions';
+
+import { IPersistDataState } from 'SRC/types';
+
+import * as settings from '../actions/settings';
+export type SettingsAction = ActionType<typeof settings>;
+
+const defaultState: IPersistDataState = {
+    testKey: 'testValue',
+};
+
+/**
+ * Reducer function for Settings
+ */
+export default (state: IPersistDataState = defaultState, action: SettingsAction) => {
+    switch (action.type) {
+        // Read key-value pair into state
+        case getType(settings.hydrateSettings):
+            return {
+                ...state,
+                ...action.payload.settings,
+            };
+
+        // Push key-value pair to state
+        case getType(settings.updateSettings):
+            return {
+                ...state,
+                [action.payload.key]: action.payload.value,
+            };
+
+        default:
+            return state;
+    }
+};

--- a/src/corner_kick/src/store/sagas/__tests__/settings.test.ts
+++ b/src/corner_kick/src/store/sagas/__tests__/settings.test.ts
@@ -5,9 +5,7 @@ import * as settings from '../../actions/settings';
 
 describe('updateSettings', () => {
     it('update the settings in local storage', () => {
-        const mockAction = {
-            payload: settings.updateSettings('testKey', 'testVal'),
-        };
+        const mockAction = settings.updateSettings('testKey', 'testVal');
 
         return (
             expectSaga(settingsSaga.updateSettings, mockAction)

--- a/src/corner_kick/src/store/sagas/__tests__/settings.test.ts
+++ b/src/corner_kick/src/store/sagas/__tests__/settings.test.ts
@@ -1,0 +1,16 @@
+import { expectSaga } from 'redux-saga-test-plan';
+
+import { updateSettings } from '../../actions/settings';
+
+describe('updateSettings', () => {
+    it('should update settings', () => {
+        const callback = jest.fn();
+
+        return (
+            expectSaga(updateSettings as any, 'testKey', 'testValue', callback)
+                .call.like({ args: [callback] })
+                // Start the test. Returns a Promise.
+                .run()
+        );
+    });
+});

--- a/src/corner_kick/src/store/sagas/__tests__/settings.test.ts
+++ b/src/corner_kick/src/store/sagas/__tests__/settings.test.ts
@@ -1,14 +1,21 @@
 import { expectSaga } from 'redux-saga-test-plan';
+import * as settingsSaga from '../settings';
 
-import { updateSettings } from '../../actions/settings';
+import * as settings from '../../actions/settings';
 
 describe('updateSettings', () => {
-    it('should update settings', () => {
-        const callback = jest.fn();
+    it('update the settings in local storage', () => {
+        const mockAction = {
+            payload: settings.updateSettings('testKey', 'testVal'),
+        };
 
         return (
-            expectSaga(updateSettings as any, 'testKey', 'testValue', callback)
-                .call.like({ args: [callback] })
+            expectSaga(settingsSaga.updateSettings, mockAction)
+                .call(
+                    localStorage.setItem,
+                    'settings',
+                    JSON.stringify({ testKey: 'testVal' }),
+                )
                 // Start the test. Returns a Promise.
                 .run()
         );

--- a/src/corner_kick/src/store/sagas/settings.ts
+++ b/src/corner_kick/src/store/sagas/settings.ts
@@ -1,8 +1,7 @@
 /*
  * This file specifies the saga for Settings
  */
-import { put, spawn, takeLatest } from 'redux-saga/effects';
-import { getType } from 'typesafe-actions';
+import { put, spawn, takeEvery } from 'redux-saga/effects';
 
 import * as settings from '../actions/settings';
 
@@ -11,12 +10,24 @@ export default function* init() {
 }
 
 /**
- * We hydrate settings upon starting
+ * Hydrate settings upon starting
  */
-function startSettings() {
-    // Use localStorage.getItem
+function* startSettings() {
+    // Retrieve settings from local storage
+    const initializedSettingsBuffer = localStorage.getItem('settings');
+    if (initializedSettingsBuffer != null) {
+        const initializedSettings = JSON.parse(initializedSettingsBuffer);
+        // Put hydrateSettings action from item
+        yield put(settings.hydrateSettings(initializedSettings));
+    }
+    // Listen for updateSettings
+    yield takeEvery('UPDATE_SETTINGS', updateSettings);
 }
 
+/**
+ * Update settings by putting into local storage
+ */
 function updateSettings() {
     // Use localStorage.setItem
+    // localStorage.setItem('settings', JSON.stringify(RETRIEVED_SETTINGS))
 }

--- a/src/corner_kick/src/store/sagas/settings.ts
+++ b/src/corner_kick/src/store/sagas/settings.ts
@@ -1,13 +1,15 @@
 /*
  * This file specifies the saga for Settings
  */
-import { put, spawn, takeEvery } from 'redux-saga/effects';
+import { call, put, spawn, takeEvery } from 'redux-saga/effects';
 import { getType } from 'typesafe-actions';
 
 import * as settings from '../actions/settings';
 
 export default function* init() {
     yield spawn(startSettings);
+    // Listen for updateSettings
+    yield takeEvery(getType(settings.updateSettings), updateSettings);
 }
 
 let settingsStored = {};
@@ -23,18 +25,16 @@ function* startSettings() {
         // Put hydrateSettings action from item
         yield put(settings.hydrateSettings(settingsStored));
     }
-    // Listen for updateSettings
-    yield takeEvery(getType(settings.updateSettings), updateSettings);
 }
 
 /**
  * Update settings by putting into local storage
  */
-function updateSettings(action: ReturnType<typeof settings.updateSettings>) {
+function* updateSettings(action: ReturnType<typeof settings.updateSettings>) {
     // Use localStorage.setItem
     settingsStored = {
         ...settingsStored,
         [action.payload.key]: action.payload.value,
     };
-    localStorage.setItem('settings', JSON.stringify(settingsStored));
+    yield call(localStorage.setItem, 'settings', JSON.stringify(settingsStored));
 }

--- a/src/corner_kick/src/store/sagas/settings.ts
+++ b/src/corner_kick/src/store/sagas/settings.ts
@@ -30,7 +30,7 @@ function* startSettings() {
 /**
  * Update settings by putting into local storage
  */
-function* updateSettings(action: ReturnType<typeof settings.updateSettings>) {
+export function* updateSettings(action: ReturnType<typeof settings.updateSettings>) {
     // Use localStorage.setItem
     settingsStored = {
         ...settingsStored,

--- a/src/corner_kick/src/store/sagas/settings.ts
+++ b/src/corner_kick/src/store/sagas/settings.ts
@@ -1,0 +1,22 @@
+/*
+ * This file specifies the saga for Settings
+ */
+import { put, spawn, takeLatest } from 'redux-saga/effects';
+import { getType } from 'typesafe-actions';
+
+import * as settings from '../actions/settings';
+
+export default function* init() {
+    yield spawn(startSettings);
+}
+
+/**
+ * We hydrate settings upon starting
+ */
+function startSettings() {
+    // Use localStorage.getItem
+}
+
+function updateSettings() {
+    // Use localStorage.setItem
+}

--- a/src/corner_kick/src/types/index.ts
+++ b/src/corner_kick/src/types/index.ts
@@ -5,5 +5,5 @@
 export { Color } from './primitives';
 export { IThemeProvider } from './theme';
 export { IRosoutMessage } from './standardROSMessages';
-export { IRootState, IROSState, IMessagesState } from './state';
+export { IRootState, IROSState, IMessagesState, IPersistDataState } from './state';
 export { ILayer, ILayerMessage, IShape } from './visualizer';

--- a/src/corner_kick/src/types/state.ts
+++ b/src/corner_kick/src/types/state.ts
@@ -29,3 +29,10 @@ export interface IROSState {
 export interface IMessagesState {
     messages: IRosoutMessage[];
 }
+
+/**
+ * The data to persist state
+ */
+export interface IPersistDataState {
+    [key: string]: string;
+}

--- a/src/corner_kick/yarn.lock
+++ b/src/corner_kick/yarn.lock
@@ -1893,12 +1893,12 @@ array-includes@^3.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
 
-array-map@~0.0.0:
+array-map@0.0.0, array-map@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
   integrity sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=
 
-array-reduce@~0.0.0:
+array-reduce@0.0.0, array-reduce@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
   integrity sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=
@@ -3243,6 +3243,11 @@ core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.3.tgz#4b70938bdffdaf64931e66e2db158f0892289c49"
   integrity sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==
 
+core-js@^2.4.1:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
+  integrity sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -4525,6 +4530,11 @@ for-own@^0.1.3, for-own@^0.1.4:
   dependencies:
     for-in "^1.0.1"
 
+foreach@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.4.tgz#cc5d0d8ae1d46cc9a555c2682f910977859935df"
+  integrity sha1-zF0NiuHUbMmlVcJoL5EJd4WZNd8=
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -4622,6 +4632,11 @@ fsevents@^1.2.3:
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
+
+fsm-iterator@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fsm-iterator/-/fsm-iterator-1.1.0.tgz#337de45de19eb205788cf02e3a955ec206760dec"
+  integrity sha1-M33kXeGesgV4jPAuOpVewgZ2Dew=
 
 function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
@@ -6074,6 +6089,11 @@ json3@3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.2.6.tgz#f6efc93c06a04de9aec53053df2559bb19e2038b"
 
+json3@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.0.tgz#0e9e7f6c5d270b758929af4d6fefdc84bd66e259"
+  integrity sha1-Dp5/bF0nC3WJKa9Nb+/chL1m4lk=
+
 json3@3.3.2, json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -6260,6 +6280,16 @@ locate-path@^3.0.0:
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lodash.ismatch@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
+  integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
@@ -6875,6 +6905,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-keys@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.5.0.tgz#09e211f3e00318afc4f592e36e7cdc10d9ad7293"
+  integrity sha1-CeIR8+ADGK/E9ZLjbnzcENmtcpM=
 
 object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.0.12"
@@ -8025,6 +8060,18 @@ redux-mock-store@1.5.3:
   integrity sha512-ryhkkb/4D4CUGpAV2ln1GOY/uh51aczjcRz9k2L2bPx/Xja3c5pSGJJPyR25GNVRXtKIExScdAgFdiXp68GmJA==
   dependencies:
     lodash.isplainobject "^4.0.6"
+
+redux-saga-test-plan@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/redux-saga-test-plan/-/redux-saga-test-plan-3.7.0.tgz#c8f513b1c6e13eef526a6b8a2e9076b6f26f5698"
+  integrity sha512-et9kCnME01kjoKXFfSk4FkozgOPPvllt9TlpL6A7ZYIS/WgoEFMLXk/UYww8KWXbmk5Qo2IF6xCc/IS1KmvP6A==
+  dependencies:
+    core-js "^2.4.1"
+    fsm-iterator "^1.1.0"
+    lodash.isequal "^4.5.0"
+    lodash.ismatch "^4.4.0"
+    object-assign "^4.1.0"
+    util-inspect "^0.1.8"
 
 redux-saga@0.16.2:
   version "0.16.2"
@@ -9597,6 +9644,19 @@ utf8@2.1.0:
 util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+util-inspect@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/util-inspect/-/util-inspect-0.1.8.tgz#2b39dbcd2d921f2d8430923caff40f4b5cea5db1"
+  integrity sha1-KznbzS2SHy2EMJI8r/QPS1zqXbE=
+  dependencies:
+    array-map "0.0.0"
+    array-reduce "0.0.0"
+    foreach "2.0.4"
+    indexof "0.0.1"
+    isarray "0.0.1"
+    json3 "3.3.0"
+    object-keys "0.5.0"
 
 util.promisify@1.0.0, util.promisify@^1.0.0, util.promisify@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description
The Visualizer would greatly benefit from having data be persisted across application runs to circumvent users from having to input their settings after every run. As such, it is possible to achieve this using local storage in the browser to retrieve data and push it to the state so that we can use it.

### Testing Done
Wrote preliminary unit tests for the reducer and action. 

### Resolved Issues

Resolves #311 

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
