### PR TITLE
Added ROS Message utils

### DIFF
--- a/src/thunderbots/software/ai/world/team.cpp
+++ b/src/thunderbots/software/ai/world/team.cpp
@@ -126,7 +126,8 @@ std::optional<Robot> Team::goalie() const
     return std::nullopt;
 }
 
-std::optional<unsigned int> Team::getGoalieID() const {
+std::optional<unsigned int> Team::getGoalieID() const
+{
     return goalie_id;
 }
 

--- a/src/thunderbots/software/ai/world/team.cpp
+++ b/src/thunderbots/software/ai/world/team.cpp
@@ -126,6 +126,10 @@ std::optional<Robot> Team::goalie() const
     return std::nullopt;
 }
 
+std::optional<unsigned int> Team::getGoalieID() const {
+    return goalie_id;
+}
+
 std::vector<Robot> Team::getAllRobots() const
 {
     std::vector<Robot> all_robots;

--- a/src/thunderbots/software/ai/world/team.cpp
+++ b/src/thunderbots/software/ai/world/team.cpp
@@ -95,7 +95,7 @@ std::size_t Team::numRobots() const
     return team_robots.size();
 }
 
-Duration Team::getRobotExpiryBufferDuration()
+Duration Team::getRobotExpiryBufferDuration() const
 {
     return robot_expiry_buffer_duration;
 }

--- a/src/thunderbots/software/ai/world/team.h
+++ b/src/thunderbots/software/ai/world/team.h
@@ -139,6 +139,15 @@ class Team
     std::optional<Robot> goalie() const;
 
     /**
+     * Returns the ID of the goalie for this team, if one has been specified. Otherwise
+     * returns std::nullopt
+     *
+     * @return The ID of the goalie robot for this team if one is specified, otherwise
+     * returns std::nullopt
+     */
+    std::optional<unsigned int> getGoalieID() const;
+
+    /**
      * Returns a vector of all the robots on this team.
      *
      * @return a vector of all the robots on this team.

--- a/src/thunderbots/software/ai/world/team.h
+++ b/src/thunderbots/software/ai/world/team.h
@@ -107,7 +107,7 @@ class Team
      * @return the Duration for which a Robot must not have been updated for before
      * being removed from this team.
      */
-    Duration getRobotExpiryBufferDuration();
+    Duration getRobotExpiryBufferDuration() const;
 
     /**
      * Sets the Duration for which a Robot must not have been updated for before being

--- a/src/thunderbots/software/test/util/ros_messages.cpp
+++ b/src/thunderbots/software/test/util/ros_messages.cpp
@@ -57,8 +57,10 @@ TEST(ROSMessageUtilTest, create_robot_from_ros_message)
 
 TEST(ROSMessageUtilTest, convert_robot_to_ros_message)
 {
-    Robot robot = Robot(1, Point(0, -5.01), Vector(0, 0), Angle::quarter(), AngularVelocity::ofRadians(1), Timestamp::fromSeconds(4.4));
-    thunderbots_msgs::Robot robot_msg = Util::ROSMessages::convertRobotToROSMessage(robot);
+    Robot robot = Robot(1, Point(0, -5.01), Vector(0, 0), Angle::quarter(),
+                        AngularVelocity::ofRadians(1), Timestamp::fromSeconds(4.4));
+    thunderbots_msgs::Robot robot_msg =
+        Util::ROSMessages::convertRobotToROSMessage(robot);
 
     EXPECT_EQ(1, robot_msg.id);
     EXPECT_EQ(0, robot_msg.position.x);
@@ -109,9 +111,10 @@ TEST(ROSMessageUtilTest, convert_field_to_ros_message)
     double center_circle_radius = 0.5;
 
     Field field = Field(length, width, defense_length, defense_width, goal_width,
-                              boundary_width, center_circle_radius);
+                        boundary_width, center_circle_radius);
 
-    thunderbots_msgs::Field field_msg = Util::ROSMessages::convertFieldToROSMessage(field);
+    thunderbots_msgs::Field field_msg =
+        Util::ROSMessages::convertFieldToROSMessage(field);
 
     EXPECT_EQ(length, field_msg.field_length);
     EXPECT_EQ(width, field_msg.field_width);
@@ -204,7 +207,8 @@ TEST(ROSMessageUtilTest, create_team_from_ros_message_with_non_member)
 
 TEST(ROSMessageUtilTest, convert_team_with_goalie_to_ros_message)
 {
-    Robot robot = Robot(1, Point(0, -5.01), Vector(0, 0), Angle::quarter(), AngularVelocity::ofRadians(1), Timestamp::fromSeconds(4.4));
+    Robot robot = Robot(1, Point(0, -5.01), Vector(0, 0), Angle::quarter(),
+                        AngularVelocity::ofRadians(1), Timestamp::fromSeconds(4.4));
 
     Team team = Team(Duration::fromMilliseconds(500));
     team.updateRobots({robot});
@@ -228,7 +232,8 @@ TEST(ROSMessageUtilTest, convert_team_with_goalie_to_ros_message)
 
 TEST(ROSMessageUtilTest, convert_team_with_no_goalie_to_ros_message)
 {
-    Robot robot = Robot(1, Point(0, -5.01), Vector(0, 0), Angle::quarter(), AngularVelocity::ofRadians(1), Timestamp::fromSeconds(4.4));
+    Robot robot = Robot(1, Point(0, -5.01), Vector(0, 0), Angle::quarter(),
+                        AngularVelocity::ofRadians(1), Timestamp::fromSeconds(4.4));
 
     Team team = Team(Duration::fromMilliseconds(500));
     team.updateRobots({robot});

--- a/src/thunderbots/software/test/util/ros_messages.cpp
+++ b/src/thunderbots/software/test/util/ros_messages.cpp
@@ -17,6 +17,18 @@ TEST(ROSMessageUtilTest, create_ball_from_ros_message)
     EXPECT_EQ(Ball(Point(1.2, -8.07), Vector(0, 3), Timestamp::fromSeconds(1.4)), ball);
 }
 
+TEST(ROSMessageUtilTest, convert_ball_to_ros_message)
+{
+    Ball ball = Ball(Point(-1.3, 0.2), Vector(0, 5.4), Timestamp::fromSeconds(123.45));
+    thunderbots_msgs::Ball ball_msg = Util::ROSMessages::convertBallToROSMessage(ball);
+
+    EXPECT_EQ(-1.3, ball_msg.position.x);
+    EXPECT_EQ(0.2, ball_msg.position.y);
+    EXPECT_EQ(0, ball_msg.velocity.x);
+    EXPECT_EQ(5.4, ball_msg.velocity.y);
+    EXPECT_EQ(123.45, ball_msg.timestamp_seconds);
+}
+
 TEST(ROSMessageUtilTest, create_robot_from_ros_message)
 {
     unsigned int id                  = 2;
@@ -41,6 +53,21 @@ TEST(ROSMessageUtilTest, create_robot_from_ros_message)
     EXPECT_EQ(Robot(id, position, velocity, orientation, angular_velocity,
                     Timestamp::fromSeconds(5.5)),
               robot);
+}
+
+TEST(ROSMessageUtilTest, convert_robot_to_ros_message)
+{
+    Robot robot = Robot(1, Point(0, -5.01), Vector(0, 0), Angle::quarter(), AngularVelocity::ofRadians(1), Timestamp::fromSeconds(4.4));
+    thunderbots_msgs::Robot robot_msg = Util::ROSMessages::convertRobotToROSMessage(robot);
+
+    EXPECT_EQ(1, robot_msg.id);
+    EXPECT_EQ(0, robot_msg.position.x);
+    EXPECT_EQ(-5.01, robot_msg.position.y);
+    EXPECT_EQ(0, robot_msg.velocity.x);
+    EXPECT_EQ(0, robot_msg.velocity.y);
+    EXPECT_EQ(Angle::quarter().toRadians(), robot_msg.orientation);
+    EXPECT_EQ(1, robot_msg.angular_velocity);
+    EXPECT_EQ(4.4, robot_msg.timestamp_seconds);
 }
 
 TEST(ROSMessageUtilTest, create_field_from_ros_message)
@@ -69,6 +96,30 @@ TEST(ROSMessageUtilTest, create_field_from_ros_message)
                               boundary_width, center_circle_radius);
 
     EXPECT_EQ(field_other, field);
+}
+
+TEST(ROSMessageUtilTest, convert_field_to_ros_message)
+{
+    double length               = 9.0;
+    double width                = 6.0;
+    double goal_width           = 1.0;
+    double defense_width        = 2.0;
+    double defense_length       = 1.0;
+    double boundary_width       = 0.3;
+    double center_circle_radius = 0.5;
+
+    Field field = Field(length, width, defense_length, defense_width, goal_width,
+                              boundary_width, center_circle_radius);
+
+    thunderbots_msgs::Field field_msg = Util::ROSMessages::convertFieldToROSMessage(field);
+
+    EXPECT_EQ(length, field_msg.field_length);
+    EXPECT_EQ(width, field_msg.field_width);
+    EXPECT_EQ(defense_length, field_msg.defense_length);
+    EXPECT_EQ(defense_width, field_msg.defense_width);
+    EXPECT_EQ(goal_width, field_msg.goal_width);
+    EXPECT_EQ(boundary_width, field_msg.boundary_width);
+    EXPECT_EQ(center_circle_radius, field_msg.center_circle_radius);
 }
 
 TEST(ROSMessageUtilTest, create_team_from_ros_message)
@@ -149,6 +200,54 @@ TEST(ROSMessageUtilTest, create_team_from_ros_message_with_non_member)
 
                  team_other.updateRobots({robot}); team_other.assignGoalie(goalie_id);
                  , std::invalid_argument);
+}
+
+TEST(ROSMessageUtilTest, convert_team_with_goalie_to_ros_message)
+{
+    Robot robot = Robot(1, Point(0, -5.01), Vector(0, 0), Angle::quarter(), AngularVelocity::ofRadians(1), Timestamp::fromSeconds(4.4));
+
+    Team team = Team(Duration::fromMilliseconds(500));
+    team.updateRobots({robot});
+    team.assignGoalie(1);
+
+    thunderbots_msgs::Team team_msg = Util::ROSMessages::convertTeamToROSMessage(team);
+
+    EXPECT_EQ(500, team_msg.robot_expiry_buffer_milliseconds);
+    EXPECT_EQ(1, team_msg.goalie_id);
+    EXPECT_EQ(1, team_msg.robots.size());
+
+    EXPECT_EQ(1, team_msg.robots.at(0).id);
+    EXPECT_EQ(0, team_msg.robots.at(0).position.x);
+    EXPECT_EQ(-5.01, team_msg.robots.at(0).position.y);
+    EXPECT_EQ(0, team_msg.robots.at(0).velocity.x);
+    EXPECT_EQ(0, team_msg.robots.at(0).velocity.y);
+    EXPECT_EQ(Angle::quarter().toRadians(), team_msg.robots.at(0).orientation);
+    EXPECT_EQ(1, team_msg.robots.at(0).angular_velocity);
+    EXPECT_EQ(4.4, team_msg.robots.at(0).timestamp_seconds);
+}
+
+TEST(ROSMessageUtilTest, convert_team_with_no_goalie_to_ros_message)
+{
+    Robot robot = Robot(1, Point(0, -5.01), Vector(0, 0), Angle::quarter(), AngularVelocity::ofRadians(1), Timestamp::fromSeconds(4.4));
+
+    Team team = Team(Duration::fromMilliseconds(500));
+    team.updateRobots({robot});
+    team.clearGoalie();
+
+    thunderbots_msgs::Team team_msg = Util::ROSMessages::convertTeamToROSMessage(team);
+
+    EXPECT_EQ(500, team_msg.robot_expiry_buffer_milliseconds);
+    EXPECT_EQ(-1, team_msg.goalie_id);
+    EXPECT_EQ(1, team_msg.robots.size());
+
+    EXPECT_EQ(1, team_msg.robots.at(0).id);
+    EXPECT_EQ(0, team_msg.robots.at(0).position.x);
+    EXPECT_EQ(-5.01, team_msg.robots.at(0).position.y);
+    EXPECT_EQ(0, team_msg.robots.at(0).velocity.x);
+    EXPECT_EQ(0, team_msg.robots.at(0).velocity.y);
+    EXPECT_EQ(Angle::quarter().toRadians(), team_msg.robots.at(0).orientation);
+    EXPECT_EQ(1, team_msg.robots.at(0).angular_velocity);
+    EXPECT_EQ(4.4, team_msg.robots.at(0).timestamp_seconds);
 }
 
 int main(int argc, char **argv)

--- a/src/thunderbots/software/test/world/team.cpp
+++ b/src/thunderbots/software/test/world/team.cpp
@@ -345,6 +345,25 @@ TEST_F(TeamTest, clear_goalie)
     EXPECT_EQ(std::nullopt, team.goalie());
 }
 
+TEST_F(TeamTest, get_goalie_id_with_no_goalie)
+{
+    Team team = Team(Duration::fromMilliseconds(1000));
+
+    EXPECT_EQ(std::nullopt, team.getGoalieID());
+}
+
+TEST_F(TeamTest, get_goalie_id_with_goalie)
+{
+    Team team = Team(Duration::fromMilliseconds(1000));
+
+    Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
+                          AngularVelocity::threeQuarter(), current_time);
+    team.updateRobots({robot_0});
+    team.assignGoalie(0);
+
+    EXPECT_EQ(0, team.getGoalieID());
+}
+
 TEST_F(TeamTest, get_robot_expiry_buffer)
 {
     Team team = Team(Duration::fromMilliseconds(500));

--- a/src/thunderbots/software/util/ros_messages.cpp
+++ b/src/thunderbots/software/util/ros_messages.cpp
@@ -17,6 +17,20 @@ namespace Util
             return ball;
         }
 
+        thunderbots_msgs::Ball convertBallToROSMessage(const Ball& ball) {
+            thunderbots_msgs::Ball ball_msg;
+
+            ball_msg.position.x = ball.position().x();
+            ball_msg.position.y = ball.position().y();
+
+            ball_msg.velocity.x = ball.velocity().x();
+            ball_msg.velocity.y = ball.velocity().y();
+
+            ball_msg.timestamp_seconds = ball.lastUpdateTimestamp().getSeconds();
+
+            return ball_msg;
+        }
+
         Robot createRobotFromROSMessage(const thunderbots_msgs::Robot& robot_msg)
         {
             unsigned int robot_id   = robot_msg.id;
@@ -33,6 +47,24 @@ namespace Util
             return robot;
         }
 
+        thunderbots_msgs::Robot convertRobotToROSMessage(const Robot& robot) {
+            thunderbots_msgs::Robot robot_msg;
+
+            robot_msg.id = robot.id();
+
+            robot_msg.position.x = robot.position().x();
+            robot_msg.position.y = robot.position().y();
+
+            robot_msg.velocity.x = robot.velocity().x();
+            robot_msg.velocity.y = robot.velocity().y();
+
+            robot_msg.orientation = robot.orientation().toRadians();
+            robot_msg.angular_velocity = robot.angularVelocity().toRadians();
+            robot_msg.timestamp_seconds = robot.lastUpdateTimestamp().getSeconds();
+
+            return robot_msg;
+        }
+
         Field createFieldFromROSMessage(const thunderbots_msgs::Field& field_msg)
         {
             Field field = Field(field_msg.field_length, field_msg.field_width,
@@ -41,6 +73,20 @@ namespace Util
                                 field_msg.center_circle_radius);
 
             return field;
+        }
+
+        thunderbots_msgs::Field convertFieldToROSMessage(const Field& field) {
+            thunderbots_msgs::Field field_msg;
+
+            field_msg.field_length = field.length();
+            field_msg.field_width = field.width();
+            field_msg.defense_length = field.defenseAreaLength();
+            field_msg.defense_width = field.defenseAreaWidth();
+            field_msg.goal_width = field.goalWidth();
+            field_msg.boundary_width = field.boundaryWidth();
+            field_msg.center_circle_radius = field.centreCircleRadius();
+
+            return field_msg;
         }
 
         Team createTeamFromROSMessage(const thunderbots_msgs::Team& team_msg)
@@ -80,6 +126,12 @@ namespace Util
             }
 
             return team;
+        }
+
+        thunderbots_msgs::Team convertTeamToROSMessage(const Team& team) {
+            thunderbots_msgs::Team team_msg;
+
+            team_msg.robot_expiry_buffer_milliseconds = team.getRobotExpiryBufferDuration().getMilliseconds();
         }
 
         RefboxGameState createGameStateFromROSMessage(

--- a/src/thunderbots/software/util/ros_messages.cpp
+++ b/src/thunderbots/software/util/ros_messages.cpp
@@ -132,6 +132,21 @@ namespace Util
             thunderbots_msgs::Team team_msg;
 
             team_msg.robot_expiry_buffer_milliseconds = team.getRobotExpiryBufferDuration().getMilliseconds();
+
+            if(team.getGoalieID()) {
+                team_msg.goalie_id = *team.getGoalieID();
+            } else {
+                team_msg.goalie_id = -1;
+            }
+
+            auto robots = team.getAllRobots();
+            auto robot_msgs = std::vector<thunderbots_msgs::Robot>();
+            for(auto robot : robots) {
+                robot_msgs.emplace_back(convertRobotToROSMessage(robot));
+            }
+            team_msg.robots = robot_msgs;
+
+            return team_msg;
         }
 
         RefboxGameState createGameStateFromROSMessage(

--- a/src/thunderbots/software/util/ros_messages.cpp
+++ b/src/thunderbots/software/util/ros_messages.cpp
@@ -17,7 +17,8 @@ namespace Util
             return ball;
         }
 
-        thunderbots_msgs::Ball convertBallToROSMessage(const Ball& ball) {
+        thunderbots_msgs::Ball convertBallToROSMessage(const Ball& ball)
+        {
             thunderbots_msgs::Ball ball_msg;
 
             ball_msg.position.x = ball.position().x();
@@ -47,7 +48,8 @@ namespace Util
             return robot;
         }
 
-        thunderbots_msgs::Robot convertRobotToROSMessage(const Robot& robot) {
+        thunderbots_msgs::Robot convertRobotToROSMessage(const Robot& robot)
+        {
             thunderbots_msgs::Robot robot_msg;
 
             robot_msg.id = robot.id();
@@ -58,8 +60,8 @@ namespace Util
             robot_msg.velocity.x = robot.velocity().x();
             robot_msg.velocity.y = robot.velocity().y();
 
-            robot_msg.orientation = robot.orientation().toRadians();
-            robot_msg.angular_velocity = robot.angularVelocity().toRadians();
+            robot_msg.orientation       = robot.orientation().toRadians();
+            robot_msg.angular_velocity  = robot.angularVelocity().toRadians();
             robot_msg.timestamp_seconds = robot.lastUpdateTimestamp().getSeconds();
 
             return robot_msg;
@@ -75,15 +77,16 @@ namespace Util
             return field;
         }
 
-        thunderbots_msgs::Field convertFieldToROSMessage(const Field& field) {
+        thunderbots_msgs::Field convertFieldToROSMessage(const Field& field)
+        {
             thunderbots_msgs::Field field_msg;
 
-            field_msg.field_length = field.length();
-            field_msg.field_width = field.width();
-            field_msg.defense_length = field.defenseAreaLength();
-            field_msg.defense_width = field.defenseAreaWidth();
-            field_msg.goal_width = field.goalWidth();
-            field_msg.boundary_width = field.boundaryWidth();
+            field_msg.field_length         = field.length();
+            field_msg.field_width          = field.width();
+            field_msg.defense_length       = field.defenseAreaLength();
+            field_msg.defense_width        = field.defenseAreaWidth();
+            field_msg.goal_width           = field.goalWidth();
+            field_msg.boundary_width       = field.boundaryWidth();
             field_msg.center_circle_radius = field.centreCircleRadius();
 
             return field_msg;
@@ -128,20 +131,26 @@ namespace Util
             return team;
         }
 
-        thunderbots_msgs::Team convertTeamToROSMessage(const Team& team) {
+        thunderbots_msgs::Team convertTeamToROSMessage(const Team& team)
+        {
             thunderbots_msgs::Team team_msg;
 
-            team_msg.robot_expiry_buffer_milliseconds = team.getRobotExpiryBufferDuration().getMilliseconds();
+            team_msg.robot_expiry_buffer_milliseconds =
+                team.getRobotExpiryBufferDuration().getMilliseconds();
 
-            if(team.getGoalieID()) {
+            if (team.getGoalieID())
+            {
                 team_msg.goalie_id = *team.getGoalieID();
-            } else {
+            }
+            else
+            {
                 team_msg.goalie_id = -1;
             }
 
-            auto robots = team.getAllRobots();
+            auto robots     = team.getAllRobots();
             auto robot_msgs = std::vector<thunderbots_msgs::Robot>();
-            for(auto robot : robots) {
+            for (auto robot : robots)
+            {
                 robot_msgs.emplace_back(convertRobotToROSMessage(robot));
             }
             team_msg.robots = robot_msgs;

--- a/src/thunderbots/software/util/ros_messages.h
+++ b/src/thunderbots/software/util/ros_messages.h
@@ -28,12 +28,28 @@ namespace Util
         Ball createBallFromROSMessage(const thunderbots_msgs::Ball& ball_msg);
 
         /**
+         * Creates and returns the ROS Message representation of the given Ball object
+         *
+         * @param ball The Ball to convert to a ROS Message
+         * @return The ROS Message representation of the given ball
+         */
+        thunderbots_msgs::Ball convertBallToROSMessage(const Ball& ball);
+
+        /**
          * Given a Robot message, constructs and returns a Robot object
          *
          * @param robot_msg The message containing the robot message data
          * @return A Robot object created with the given robot message data
          */
         Robot createRobotFromROSMessage(const thunderbots_msgs::Robot& robot_msg);
+
+        /**
+         * Creates and returns the ROS Message representation of the given Robot object
+         *
+         * @param robot The Robot to convert to a ROS Message
+         * @return The ROS Message representation of the given robot
+         */
+        thunderbots_msgs::Robot convertRobotToROSMessage(const Robot& robot);
 
         /**
          * Given a Field message, constructs and returns a Field object
@@ -44,12 +60,28 @@ namespace Util
         Field createFieldFromROSMessage(const thunderbots_msgs::Field& field_msg);
 
         /**
+         * Creates and returns the ROS Message representation of the given Field object
+         *
+         * @param field The Field to convert to a ROS Message
+         * @return The ROS Message representation of the given robot
+         */
+        thunderbots_msgs::Field convertFieldToROSMessage(const Field& field);
+
+        /**
          * Given a Team message, constructs and returns a Team object
          *
          * @param team_msg The message containing the team message data
          * @return A Team object created with the given team message data
          */
         Team createTeamFromROSMessage(const thunderbots_msgs::Team& team_msg);
+
+        /**
+         * Creates and returns the ROS Message representation of the given Team object
+         *
+         * @param team The Team to convert to a ROS Message
+         * @return The ROS Message representation of the given Team
+         */
+        thunderbots_msgs::Team convertTeamToROSMessage(const Team& team);
 
         /**
          * Given a Team message, constructs and returns a Team object

--- a/src/thunderbots_msgs/msg/Team.msg
+++ b/src/thunderbots_msgs/msg/Team.msg
@@ -9,4 +9,4 @@ int32 goalie_id
 
 # The number of milliseconds a robot must not have
 # been updated for before it is removed from the team
-uint32 robot_expiry_buffer_milliseconds
+float64 robot_expiry_buffer_milliseconds


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Added more ROS message utils to convert `Balls`, `Teams`, `Robots`, and `Fields` to their ROS message equivalents.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Added unit tests for each new function.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
part of #230 but separated to reduce the diff size.

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
NA

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
