### PR TITLE
Fix erroneous massive acceleration in the wrong direction in grsim motion controller

### DIFF
--- a/src/thunderbots/software/grsim_communication/main.cpp
+++ b/src/thunderbots/software/grsim_communication/main.cpp
@@ -3,7 +3,6 @@
 #include <ros/time.h>
 #include <thunderbots_msgs/Primitive.h>
 #include <thunderbots_msgs/PrimitiveArray.h>
-#include <grsim_communication/motion_controller/motion_controller.h>
 
 #include "ai/primitive/direct_velocity_primitive.h"
 #include "ai/primitive/directwheels_primitive.h"
@@ -11,6 +10,7 @@
 #include "ai/primitive/primitive.h"
 #include "geom/point.h"
 #include "grsim_communication/grsim_backend.h"
+#include "grsim_communication/motion_controller/motion_controller.h"
 #include "util/constants.h"
 #include "util/logger/init.h"
 #include "util/ros_messages.h"
@@ -87,31 +87,14 @@ int main(int argc, char** argv)
     // We loop at a set rate so that we don't overload the network with too many packets
     ros::Rate tick_rate(TICK_RATE);
 
-    std::stringstream csv_filename;
-    csv_filename << "motion_controller_log-" << std::time(nullptr) << ".csv";
-
-    MotionController::csv_output_path = boost::filesystem::current_path()
-            /= boost::filesystem::path(csv_filename.str());
-
-    LOG(WARNING) << MotionController::csv_output_path.string();
-
-    boost::filesystem::ofstream csv_ostream(MotionController::csv_output_path);
-
-    // write the columns to the CSV file
-    // timestamp, absolute position, absolute ball position,
-    // angle to ball (deg), delta v, angle between delta v and ball
-    csv_ostream << "time,pos_x,pos_y,ball_pos_x,ball_pos_y,angle_to_ball,v_x,v_y,v_to_dest_angle,dv_x,dv_y,dv_to_dest_angle"
-            << MotionController::CRLF;
-
-    csv_ostream.close();
-
     // Main loop
     while (ros::ok())
     {
         // Clear all primitives each tick
         primitives.clear();
 
-        primitives.emplace_back(new MovePrimitive(0, ball.position(), Angle(), 0.5));
+        primitives.emplace_back(
+            new MovePrimitive(0, ball.position(), Angle::full(), 0.5));
 
         // Spin once to let all necessary callbacks run
         // The callbacks will populate the primitives vector

--- a/src/thunderbots/software/grsim_communication/main.cpp
+++ b/src/thunderbots/software/grsim_communication/main.cpp
@@ -93,9 +93,6 @@ int main(int argc, char** argv)
         // Clear all primitives each tick
         primitives.clear();
 
-        primitives.emplace_back(
-            new MovePrimitive(0, ball.position(), Angle::full(), 0.5));
-
         // Spin once to let all necessary callbacks run
         // The callbacks will populate the primitives vector
         ros::spinOnce();

--- a/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
+++ b/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
@@ -118,12 +118,12 @@ Vector MotionController::determineLinearVelocity(const Robot robot, const Point 
     // velocity is greater in magnitude than the current velocity, as the above
     // function will increase in magnitude as the distance to the destination increases
 
-    bool moving_in_opposite_direction =
+    bool moving_away_from_dest =
         (robot.velocity().orientation() - unit_vector_to_dest.orientation())
             .angleMod()
             .abs() > Angle::quarter();
 
-    if (moving_in_opposite_direction &&
+    if (moving_away_from_dest &&
         additional_velocity.len() < robot.velocity().len())
     {
         new_robot_velocity_magnitude *= -1;

--- a/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
+++ b/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
@@ -14,7 +14,6 @@
 #include "grsim_communication/motion_controller/motion_controller.h"
 
 #include <algorithm>
-#include <chrono>
 
 #include "shared/constants.h"
 #include "util/logger/init.h"
@@ -118,9 +117,13 @@ Vector MotionController::determineLinearVelocity(const Robot robot, const Point 
     // Check for the case where we are moving away from the target AND the additional
     // velocity is greater in magnitude than the current velocity, as the above
     // function will increase in magnitude as the distance to the destination increases
-    if ((robot.velocity().orientation() - unit_vector_to_dest.orientation())
-                .angleMod()
-                .abs() > Angle::quarter() &&
+
+    bool moving_in_opposite_direction =
+        (robot.velocity().orientation() - unit_vector_to_dest.orientation())
+            .angleMod()
+            .abs() > Angle::quarter();
+
+    if (moving_in_opposite_direction &&
         additional_velocity.len() < robot.velocity().len())
     {
         new_robot_velocity_magnitude *= -1;

--- a/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
+++ b/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
@@ -123,8 +123,7 @@ Vector MotionController::determineLinearVelocity(const Robot robot, const Point 
             .angleMod()
             .abs() > Angle::quarter();
 
-    if (moving_away_from_dest &&
-        additional_velocity.len() < robot.velocity().len())
+    if (moving_away_from_dest && additional_velocity.len() < robot.velocity().len())
     {
         new_robot_velocity_magnitude *= -1;
     }

--- a/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
+++ b/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
@@ -118,8 +118,10 @@ Vector MotionController::determineLinearVelocity(const Robot robot, const Point 
     // Check for the case where we are moving away from the target AND the additional
     // velocity is greater in magnitude than the current velocity, as the above
     // function will increase in magnitude as the distance to the destination increases
-    if ((robot.velocity().orientation() - unit_vector_to_dest.orientation()).angleMod().abs() >
-        Angle::quarter() && additional_velocity.len() < robot.velocity().len())
+    if ((robot.velocity().orientation() - unit_vector_to_dest.orientation())
+                .angleMod()
+                .abs() > Angle::quarter() &&
+        additional_velocity.len() < robot.velocity().len())
     {
         new_robot_velocity_magnitude *= -1;
     }

--- a/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
+++ b/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
@@ -111,8 +111,8 @@ Vector MotionController::determineLinearVelocity(const Robot robot, const Point 
     // a square root-esque function of the distance to the destination. This allows us to
     // bring the robot velocity to zero as we approach the destination
     double new_robot_velocity_magnitude =
-            std::sqrt(std::max<double>((dest - robot.position()).len() - 0.01, 0)) * 2 +
-            desired_final_speed;
+        std::sqrt(std::max<double>((dest - robot.position()).len() - 0.01, 0)) * 2 +
+        desired_final_speed;
 
     // https://github.com/UBC-Thunderbots/Software/issues/270
     // Check for the case where we are moving away from the target AND the additional

--- a/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
+++ b/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.cpp
@@ -111,8 +111,8 @@ Vector MotionController::determineLinearVelocity(const Robot robot, const Point 
     // a square root-esque function of the distance to the destination. This allows us to
     // bring the robot velocity to zero as we approach the destination
     double new_robot_velocity_magnitude =
-        std::sqrt(std::fabs((dest - robot.position()).len() - 0.01)) * 2 +
-        desired_final_speed;
+            std::sqrt(std::max<double>((dest - robot.position()).len() - 0.01, 0)) * 2 +
+            desired_final_speed;
 
     // https://github.com/UBC-Thunderbots/Software/issues/270
     // Check for the case where we are moving away from the target AND the additional

--- a/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.h
+++ b/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.h
@@ -4,20 +4,12 @@
 
 #pragma once
 
-#include <boost/filesystem.hpp>
-
 #include "ai/world/robot.h"
 #include "geom/angle.h"
 #include "geom/point.h"
 
 namespace MotionController
 {
-    // this might have to be some of the stupidest spaghetti code
-    // i've ever written
-    // one day, i'll make smth cleaner for writing to a csv
-    extern boost::filesystem::path csv_output_path;
-    extern std::string CRLF;
-
     struct Velocity
     {
         Vector linear_velocity;

--- a/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.h
+++ b/src/thunderbots/software/grsim_communication/motion_controller/motion_controller.h
@@ -4,12 +4,20 @@
 
 #pragma once
 
+#include <boost/filesystem.hpp>
+
 #include "ai/world/robot.h"
 #include "geom/angle.h"
 #include "geom/point.h"
 
 namespace MotionController
 {
+    // this might have to be some of the stupidest spaghetti code
+    // i've ever written
+    // one day, i'll make smth cleaner for writing to a csv
+    extern boost::filesystem::path csv_output_path;
+    extern std::string CRLF;
+
     struct Velocity
     {
         Vector linear_velocity;

--- a/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
+++ b/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
@@ -717,7 +717,7 @@ TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_
     EXPECT_GT(robot_velocities.linear_velocity.x(), initial_velocity.x());
 }
 
-TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_2_test)
+TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_large_initial_velocity_test)
 {
     // same as above, test with a large initial velocity this time
     Vector initial_velocity(-2, 0);

--- a/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
+++ b/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
@@ -717,6 +717,24 @@ TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_
     EXPECT_GT(robot_velocities.linear_velocity.x(), initial_velocity.x());
 }
 
+TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_2_test)
+{
+    // same as above, test with a large initial velocity this time
+    Vector initial_velocity(-2, 0);
+    Robot robot             = Robot(0, Point(0, 0), initial_velocity, Angle::ofRadians(0),
+                        AngularVelocity::ofRadians(0), current_time);
+    const double delta_time = TIME_STEP;
+    Point destination       = Point(0.1, 0);
+    Angle destination_angle = Angle::ofRadians(0);
+
+    MotionController::Velocity robot_velocities =
+        MotionController::bangBangVelocityController(robot, destination, 2,
+                                                     destination_angle, delta_time);
+    // if the destination is on the +x side of the robot, the velocity should always have
+    // x > 0
+    EXPECT_GT(robot_velocities.linear_velocity.x(), initial_velocity.x());
+}
+
 int main(int argc, char **argv)
 {
     std::cout << argv[0] << std::endl;

--- a/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
+++ b/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
@@ -694,7 +694,8 @@ TEST_F(MotionControllerTest, negative_rotation_position_test)
                 POSITION_TOLERANCE);
 }
 
-TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_small_initial_velocity_test)
+TEST_F(MotionControllerTest,
+       wrong_direction_impulse_while_close_to_destination_small_initial_velocity_test)
 {
     // basic sanity test to make sure we don't continue accelerating in the wrong
     // direction when we accelerate slightly in the opposite direction of the destination
@@ -717,7 +718,8 @@ TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_
     EXPECT_GT(robot_velocities.linear_velocity.x(), initial_velocity.x());
 }
 
-TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_large_initial_velocity_test)
+TEST_F(MotionControllerTest,
+       wrong_direction_impulse_while_close_to_destination_large_initial_velocity_test)
 {
     // same as above, test with a large initial velocity this time
     Vector initial_velocity(-2, 0);

--- a/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
+++ b/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
@@ -694,7 +694,7 @@ TEST_F(MotionControllerTest, negative_rotation_position_test)
                 POSITION_TOLERANCE);
 }
 
-TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_test)
+TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_small_initial_velocity_test)
 {
     // basic sanity test to make sure we don't continue accelerating in the wrong
     // direction when we accelerate slightly in the opposite direction of the destination

--- a/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
+++ b/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
@@ -696,24 +696,25 @@ TEST_F(MotionControllerTest, negative_rotation_position_test)
 
 TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_test)
 {
-    // basic sanity test to make sure we don't continue accelerating in the wrong direction
-    // when we accelerate slightly in the opposite direction of the destination
+    // basic sanity test to make sure we don't continue accelerating in the wrong
+    // direction when we accelerate slightly in the opposite direction of the destination
     // https://github.com/UBC-Thunderbots/Software/issues/270
 
     // we need to test the case that we have a small velocity away from the destination
     // while we are trying to accelerate toward the destination
     Vector initial_velocity(-0.1, 0);
-    Robot robot = Robot(0, Point(0, 0), initial_velocity,
-            Angle::ofRadians(0), AngularVelocity::ofRadians(0), current_time);
+    Robot robot             = Robot(0, Point(0, 0), initial_velocity, Angle::ofRadians(0),
+                        AngularVelocity::ofRadians(0), current_time);
     const double delta_time = TIME_STEP;
-    Point destination = Point(0.1, 0);
+    Point destination       = Point(0.1, 0);
     Angle destination_angle = Angle::ofRadians(0);
 
-    MotionController::Velocity robot_velocities = MotionController::bangBangVelocityController(
-            robot, destination, 2, destination_angle, delta_time);
-    // if the destination is on the +x side of the robot, the velocity should always have x > 0
+    MotionController::Velocity robot_velocities =
+        MotionController::bangBangVelocityController(robot, destination, 2,
+                                                     destination_angle, delta_time);
+    // if the destination is on the +x side of the robot, the velocity should always have
+    // x > 0
     EXPECT_GT(robot_velocities.linear_velocity.x(), initial_velocity.x());
-
 }
 
 int main(int argc, char **argv)

--- a/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
+++ b/src/thunderbots/software/test/grsim_backend/motion_controller.cpp
@@ -694,6 +694,28 @@ TEST_F(MotionControllerTest, negative_rotation_position_test)
                 POSITION_TOLERANCE);
 }
 
+TEST_F(MotionControllerTest, wrong_direction_impulse_while_close_to_destination_test)
+{
+    // basic sanity test to make sure we don't continue accelerating in the wrong direction
+    // when we accelerate slightly in the opposite direction of the destination
+    // https://github.com/UBC-Thunderbots/Software/issues/270
+
+    // we need to test the case that we have a small velocity away from the destination
+    // while we are trying to accelerate toward the destination
+    Vector initial_velocity(-0.1, 0);
+    Robot robot = Robot(0, Point(0, 0), initial_velocity,
+            Angle::ofRadians(0), AngularVelocity::ofRadians(0), current_time);
+    const double delta_time = TIME_STEP;
+    Point destination = Point(0.1, 0);
+    Angle destination_angle = Angle::ofRadians(0);
+
+    MotionController::Velocity robot_velocities = MotionController::bangBangVelocityController(
+            robot, destination, 2, destination_angle, delta_time);
+    // if the destination is on the +x side of the robot, the velocity should always have x > 0
+    EXPECT_GT(robot_velocities.linear_velocity.x(), initial_velocity.x());
+
+}
+
 int main(int argc, char **argv)
 {
     std::cout << argv[0] << std::endl;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
This fixes the case in the grsim motion controller where the robot would massively accelerate in the wrong direction when the robot receives a small acceleration in the opposite direction that exceeds the additional velocity in the correct direction applied during that tick. 

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Robot no longer accelerates in the opposite direction when hitting the wall in grsim. Unit test added for this particular case. 5 test cases still fail - working on it right now. 

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

Resolves #270 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
