### PR TITLE
Implemented Default Constructor For World

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -247,6 +247,7 @@ if (CATKIN_ENABLE_TESTING)
     catkin_add_gtest(field_test
             test/world/field.cpp
             ai/world/field.cpp
+            util/parameter/dynamic_parameters.cpp
             )
     target_link_libraries(field_test ${catkin_LIBRARIES})
 
@@ -359,7 +360,9 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/robot.cpp
             ai/world/team.cpp
             ai/world/game_state.cpp
-            util/timestamp.cpp)
+            util/timestamp.cpp
+            util/parameter/dynamic_parameters.cpp
+            )
 
     target_link_libraries(world_test ${catkin_LIBRARIES})
 
@@ -373,6 +376,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/team.cpp
             ai/world/game_state.cpp
             util/timestamp.cpp
+            util/parameter/dynamic_parameters.cpp
             )
 
     target_link_libraries(test_util_test ${catkin_LIBRARIES})
@@ -388,7 +392,9 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/team.cpp
             ai/world/game_state.cpp
             util/refbox_constants.cpp
-            util/timestamp.cpp)
+            util/timestamp.cpp
+            util/parameter/dynamic_parameters.cpp
+            )
 
     target_link_libraries(game_state_test ${catkin_LIBRARIES})
 
@@ -419,6 +425,7 @@ if (CATKIN_ENABLE_TESTING)
             util/logger/custom_g3log_sinks.h
             util/logger/init.h
             util/timestamp.cpp
+            util/parameter/dynamic_parameters.cpp
             )
     target_link_libraries(move_spin_primitive_test ${catkin_LIBRARIES}
             ${G3LOG})
@@ -640,6 +647,7 @@ if (CATKIN_ENABLE_TESTING)
             util/logger/custom_g3log_sinks.h
             util/logger/init.h
             util/timestamp.cpp
+            util/parameter/dynamic_parameters.cpp
     )
 
     target_link_libraries(grsim_catch_primitive_test ${catkin_LIBRARIES}
@@ -665,6 +673,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/team.cpp
             ai/world/world.cpp
             test/test_util/test_util.cpp
+            util/parameter/dynamic_parameters.cpp
             )
 
     target_link_libraries(deflect_off_enemy_target_test ${catkin_LIBRARIES})
@@ -672,6 +681,7 @@ if (CATKIN_ENABLE_TESTING)
     catkin_add_gtest(evaluation_robot_orientation_within_angle_threshold_of_target_test
             test/evaluation/robot.cpp
             ai/hl/stp/evaluation/robot.cpp
+            util/parameter/dynamic_parameters.cpp
             )
 
     target_link_libraries(evaluation_robot_orientation_within_angle_threshold_of_target_test ${catkin_LIBRARIES})

--- a/src/thunderbots/software/ai/world/world.cpp
+++ b/src/thunderbots/software/ai/world/world.cpp
@@ -1,5 +1,17 @@
 #include "world.h"
 
+#include <util/parameter/dynamic_parameters.h>
+
+World::World()
+    : World(Field(0, 0, 0, 0, 0, 0, 0),
+            Ball(Point(), Vector(), Timestamp::fromSeconds(0)),
+            Team(Duration::fromMilliseconds(
+                Util::DynamicParameters::robot_expiry_buffer_milliseconds.value())),
+            Team(Duration::fromMilliseconds(
+                Util::DynamicParameters::robot_expiry_buffer_milliseconds.value())))
+{
+}
+
 World::World(const Field &field, const Ball &ball, const Team &friendly_team,
              const Team &enemy_team)
     : field_(field),

--- a/src/thunderbots/software/ai/world/world.h
+++ b/src/thunderbots/software/ai/world/world.h
@@ -15,6 +15,11 @@ class World final
 {
    public:
     /**
+     * Creates an Empty World
+     */
+    explicit World();
+
+    /**
      * Creates a new world.
      *
      * @param field the field for the world

--- a/src/thunderbots/software/test/world/world.cpp
+++ b/src/thunderbots/software/test/world/world.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "test/test_util/test_util.h"
+#include "util/parameter/dynamic_parameters.h"
 
 class WorldTest : public ::testing::Test
 {
@@ -52,6 +53,20 @@ class WorldTest : public ::testing::Test
     Team friendly_team;
     World world;
 };
+
+TEST_F(WorldTest, default_constructor)
+{
+    World world;
+    // Check that objects used for construction are returned by the accessors
+    EXPECT_EQ(Field(0, 0, 0, 0, 0, 0, 0), world.field());
+    EXPECT_EQ(Ball(Point(), Vector(), Timestamp::fromSeconds(0)), world.ball());
+    EXPECT_EQ(Team(Duration::fromMilliseconds(
+                  Util::DynamicParameters::robot_expiry_buffer_milliseconds.value())),
+              world.friendlyTeam());
+    EXPECT_EQ(Team(Duration::fromMilliseconds(
+                  Util::DynamicParameters::robot_expiry_buffer_milliseconds.value())),
+              world.enemyTeam());
+}
 
 TEST_F(WorldTest, construction_with_parameters)
 {


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Default Constructor for World

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Added a unit test for the default constructor.

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
