### PR TITLE
Add intent equality and inequality operators

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -734,6 +734,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             )
     target_link_libraries(catch_intent_test
+            ${G3LOG}
             ${catkin_LIBRARIES})
 
     catkin_add_gtest(chip_intent_test
@@ -744,6 +745,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             )
     target_link_libraries(chip_intent_test
+            ${G3LOG}
             ${catkin_LIBRARIES})
 
     catkin_add_gtest(direct_velocity_intent_test
@@ -754,6 +756,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             )
     target_link_libraries(direct_velocity_intent_test
+            ${G3LOG}
             ${catkin_LIBRARIES})
 
     catkin_add_gtest(direct_wheels_intent_test
@@ -776,6 +779,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             )
     target_link_libraries(dribble_intent_test
+            ${G3LOG}
             ${catkin_LIBRARIES})
 
     catkin_add_gtest(kick_intent_test
@@ -786,6 +790,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             )
     target_link_libraries(kick_intent_test
+            ${G3LOG}
             ${catkin_LIBRARIES})
 
     catkin_add_gtest(move_intent_test
@@ -796,6 +801,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             )
     target_link_libraries(move_intent_test
+            ${G3LOG}
             ${catkin_LIBRARIES})
 
     catkin_add_gtest(movespin_intent_test
@@ -806,6 +812,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             )
     target_link_libraries(movespin_intent_test
+            ${G3LOG}
             ${catkin_LIBRARIES})
 
     catkin_add_gtest(pivot_intent_test
@@ -816,6 +823,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             )
     target_link_libraries(pivot_intent_test
+            ${G3LOG}
             ${catkin_LIBRARIES})
 
     catkin_add_gtest(stop_intent_test
@@ -826,6 +834,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             )
     target_link_libraries(stop_intent_test
+            ${G3LOG}
             ${catkin_LIBRARIES})
 
     catkin_add_gtest(intent_test
@@ -836,6 +845,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             )
     target_link_libraries(intent_test
+            ${G3LOG}
             ${catkin_LIBRARIES})
 endif()
 

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -424,6 +424,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/dribble_primitive.cpp
             ai/primitive/movespin_primitive.cpp
             ai/primitive/stop_primitive.cpp
+            ai/primitive/direct_wheels_primitive.cpp
             ai/primitive/primitive.cpp
             geom/point.h
             ai/world/world.cpp
@@ -600,6 +601,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/dribble_primitive.cpp
             ai/primitive/movespin_primitive.cpp
             ai/primitive/stop_primitive.cpp
+            ai/primitive/direct_wheels_primitive.cpp
             ai/primitive/primitive.cpp
             geom/point.h
             ai/world/world.cpp

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -725,6 +725,118 @@ if (CATKIN_ENABLE_TESTING)
             ${catkin_LIBRARIES}
             ${G3LOG}
             ${Boost_LIBRARIES})
+
+    catkin_add_gtest(catch_intent_test
+            test/intent/catch_intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/catch_intent.cpp
+            ai/primitive/catch_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(catch_intent_test
+            ${catkin_LIBRARIES})
+
+    catkin_add_gtest(chip_intent_test
+            test/intent/chip_intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/chip_intent.cpp
+            ai/primitive/chip_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(chip_intent_test
+            ${catkin_LIBRARIES})
+
+    catkin_add_gtest(direct_velocity_intent_test
+            test/intent/direct_velocity_intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/direct_velocity_intent.cpp
+            ai/primitive/direct_velocity_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(direct_velocity_intent_test
+            ${catkin_LIBRARIES})
+
+    catkin_add_gtest(direct_wheels_intent_test
+            test/intent/direct_wheels_intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/direct_wheels_intent.cpp
+            ai/primitive/direct_wheels_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(direct_wheels_intent_test
+            ${catkin_LIBRARIES}
+            ${G3LOG}
+            )
+
+    catkin_add_gtest(dribble_intent_test
+            test/intent/dribble_intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/dribble_intent.cpp
+            ai/primitive/dribble_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(dribble_intent_test
+            ${catkin_LIBRARIES})
+
+    catkin_add_gtest(kick_intent_test
+            test/intent/kick_intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/kick_intent.cpp
+            ai/primitive/kick_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(kick_intent_test
+            ${catkin_LIBRARIES})
+
+    catkin_add_gtest(move_intent_test
+            test/intent/move_intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/move_intent.cpp
+            ai/primitive/move_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(move_intent_test
+            ${catkin_LIBRARIES})
+
+    catkin_add_gtest(movespin_intent_test
+            test/intent/movespin_intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/movespin_intent.cpp
+            ai/primitive/movespin_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(movespin_intent_test
+            ${catkin_LIBRARIES})
+
+    catkin_add_gtest(pivot_intent_test
+            test/intent/pivot_intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/pivot_intent.cpp
+            ai/primitive/pivot_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(pivot_intent_test
+            ${catkin_LIBRARIES})
+
+    catkin_add_gtest(stop_intent_test
+            test/intent/stop_intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/stop_intent.cpp
+            ai/primitive/stop_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(stop_intent_test
+            ${catkin_LIBRARIES})
+
+    catkin_add_gtest(intent_test
+            test/intent/intent.cpp
+            ai/intent/intent.cpp
+            ai/intent/move_intent.cpp
+            ai/primitive/move_primitive.cpp
+            ai/primitive/primitive.cpp
+            )
+    target_link_libraries(intent_test
+            ${catkin_LIBRARIES})
 endif()
 
 ##### ROSTests / Integration Tests #####

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
@@ -32,6 +32,6 @@ std::unique_ptr<Intent> MoveAction::calculateNextIntent(
     do
     {
         yield(std::make_unique<MoveIntent>(robot.id(), destination, final_orientation,
-                                           final_speed));
+                                           final_speed, 0));
     } while ((robot.position() - destination).len() > close_to_dest_threshold);
 }

--- a/src/thunderbots/software/ai/intent/catch_intent.cpp
+++ b/src/thunderbots/software/ai/intent/catch_intent.cpp
@@ -3,8 +3,9 @@
 const std::string CatchIntent::INTENT_NAME = "Catch Intent";
 
 CatchIntent::CatchIntent(unsigned int robot_id, double velocity, double dribbler_rpm,
-                         double ball_intercept_margin)
-    : CatchPrimitive(robot_id, velocity, dribbler_rpm, ball_intercept_margin)
+                         double ball_intercept_margin, unsigned int priority)
+    : CatchPrimitive(robot_id, velocity, dribbler_rpm, ball_intercept_margin),
+      Intent(priority)
 {
 }
 
@@ -13,10 +14,12 @@ std::string CatchIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
-bool CatchIntent::operator==(const CatchIntent &other) const {
+bool CatchIntent::operator==(const CatchIntent &other) const
+{
     return CatchPrimitive::operator==(other) && Intent::operator==(other);
 }
 
-bool CatchIntent::operator!=(const CatchIntent &other) const {
+bool CatchIntent::operator!=(const CatchIntent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/catch_intent.cpp
+++ b/src/thunderbots/software/ai/intent/catch_intent.cpp
@@ -12,3 +12,11 @@ std::string CatchIntent::getIntentName(void) const
 {
     return INTENT_NAME;
 }
+
+bool CatchIntent::operator==(const CatchIntent &other) const {
+    return CatchPrimitive::operator==(other) && Intent::operator==(other);
+}
+
+bool CatchIntent::operator!=(const CatchIntent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/catch_intent.h
+++ b/src/thunderbots/software/ai/intent/catch_intent.h
@@ -24,4 +24,21 @@ class CatchIntent : public Intent, public CatchPrimitive
                          double ball_intercept_margin);
 
     std::string getIntentName(void) const override;
+
+    /**
+     * Compares CatchIntents for equality. CatchIntents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the CatchIntents to compare with for equality
+     * @return true if the CatchIntents are equal and false otherwise
+     */
+    bool operator==(const CatchIntent& other) const;
+
+    /**
+     * Compares CatchIntents for inequality.
+     *
+     * @param other the CatchIntent to compare with for inequality
+     * @return true if the CatchIntents are not equal and false otherwise
+     */
+    bool operator!=(const CatchIntent& other) const;
 };

--- a/src/thunderbots/software/ai/intent/catch_intent.h
+++ b/src/thunderbots/software/ai/intent/catch_intent.h
@@ -19,9 +19,11 @@ class CatchIntent : public Intent, public CatchPrimitive
      * @param ball_intercept_margin A scaling factor for how far in front of the ball to
      * make the point of intercept. It scales based on the difference in velocity between
      * the robot and the ball.
+     * @param priority The priority of this Intent. A larger number indicates a higher
+     * priority
      */
     explicit CatchIntent(unsigned int robot_id, double velocity, double dribbler_rpm,
-                         double ball_intercept_margin);
+                         double ball_intercept_margin, unsigned int priority);
 
     std::string getIntentName(void) const override;
 

--- a/src/thunderbots/software/ai/intent/chip_intent.cpp
+++ b/src/thunderbots/software/ai/intent/chip_intent.cpp
@@ -3,8 +3,8 @@
 const std::string ChipIntent::INTENT_NAME = "Chip Intent";
 
 ChipIntent::ChipIntent(unsigned int robot_id, const Point &dest, const Angle &final_angle,
-                       double final_speed)
-    : ChipPrimitive(robot_id, dest, final_angle, final_speed)
+                       double final_speed, unsigned int priority)
+    : ChipPrimitive(robot_id, dest, final_angle, final_speed), Intent(priority)
 {
 }
 
@@ -13,10 +13,12 @@ std::string ChipIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
-bool ChipIntent::operator==(const ChipIntent &other) const {
+bool ChipIntent::operator==(const ChipIntent &other) const
+{
     return ChipPrimitive::operator==(other) && Intent::operator==(other);
 }
 
-bool ChipIntent::operator!=(const ChipIntent &other) const {
+bool ChipIntent::operator!=(const ChipIntent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/chip_intent.cpp
+++ b/src/thunderbots/software/ai/intent/chip_intent.cpp
@@ -12,3 +12,11 @@ std::string ChipIntent::getIntentName(void) const
 {
     return INTENT_NAME;
 }
+
+bool ChipIntent::operator==(const ChipIntent &other) const {
+    return ChipPrimitive::operator==(other) && Intent::operator==(other);
+}
+
+bool ChipIntent::operator!=(const ChipIntent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/chip_intent.h
+++ b/src/thunderbots/software/ai/intent/chip_intent.h
@@ -17,9 +17,12 @@ class ChipIntent : public Intent, public ChipPrimitive
      * @param final_angle The final angle the robot should have at the end of the movement
      * @param final_speed The final speed the robot should have when it arrives at its
      * destination
+     * @param priority The priority of this Intent. A larger number indicates a higher
+     * priority
      */
-    explicit ChipIntent(unsigned int robot_id, const Point &dest,
-                        const Angle &final_angle, double final_speed);
+    explicit ChipIntent(unsigned int robot_id, const Point& dest,
+                        const Angle& final_angle, double final_speed,
+                        unsigned int priority);
 
     std::string getIntentName(void) const override;
 

--- a/src/thunderbots/software/ai/intent/chip_intent.h
+++ b/src/thunderbots/software/ai/intent/chip_intent.h
@@ -22,4 +22,21 @@ class ChipIntent : public Intent, public ChipPrimitive
                         const Angle &final_angle, double final_speed);
 
     std::string getIntentName(void) const override;
+
+    /**
+     * Compares ChipIntents for equality. ChipIntents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the ChipIntents to compare with for equality
+     * @return true if the ChipIntents are equal and false otherwise
+     */
+    bool operator==(const ChipIntent& other) const;
+
+    /**
+     * Compares ChipIntents for inequality.
+     *
+     * @param other the ChipIntent to compare with for inequality
+     * @return true if the ChipIntents are not equal and false otherwise
+     */
+    bool operator!=(const ChipIntent& other) const;
 };

--- a/src/thunderbots/software/ai/intent/direct_velocity_intent.cpp
+++ b/src/thunderbots/software/ai/intent/direct_velocity_intent.cpp
@@ -14,3 +14,11 @@ std::string DirectVelocityIntent::getIntentName(void) const
 {
     return INTENT_NAME;
 }
+
+bool DirectVelocityIntent::operator==(const DirectVelocityIntent &other) const {
+    return DirectVelocityPrimitive::operator==(other) && Intent::operator==(other);
+}
+
+bool DirectVelocityIntent::operator!=(const DirectVelocityIntent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/direct_velocity_intent.cpp
+++ b/src/thunderbots/software/ai/intent/direct_velocity_intent.cpp
@@ -4,9 +4,10 @@ const std::string DirectVelocityIntent::INTENT_NAME = "Direct Velocity Intent";
 
 DirectVelocityIntent::DirectVelocityIntent(unsigned int robot_id, double x_velocity,
                                            double y_velocity, double angular_velocity,
-                                           double dribbler_rpm)
+                                           double dribbler_rpm, unsigned int priority)
     : DirectVelocityPrimitive(robot_id, x_velocity, y_velocity, angular_velocity,
-                              dribbler_rpm)
+                              dribbler_rpm),
+      Intent(priority)
 {
 }
 
@@ -15,10 +16,12 @@ std::string DirectVelocityIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
-bool DirectVelocityIntent::operator==(const DirectVelocityIntent &other) const {
+bool DirectVelocityIntent::operator==(const DirectVelocityIntent &other) const
+{
     return DirectVelocityPrimitive::operator==(other) && Intent::operator==(other);
 }
 
-bool DirectVelocityIntent::operator!=(const DirectVelocityIntent &other) const {
+bool DirectVelocityIntent::operator!=(const DirectVelocityIntent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/direct_velocity_intent.h
+++ b/src/thunderbots/software/ai/intent/direct_velocity_intent.h
@@ -23,4 +23,21 @@ class DirectVelocityIntent : public Intent, public DirectVelocityPrimitive
                                   double dribbler_rpm);
 
     std::string getIntentName(void) const override;
+
+    /**
+     * Compares DirectVelocityIntents for equality. DirectVelocityIntents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the DirectVelocityIntents to compare with for equality
+     * @return true if the DirectVelocityIntents are equal and false otherwise
+     */
+    bool operator==(const DirectVelocityIntent& other) const;
+
+    /**
+     * Compares DirectVelocityIntents for inequality.
+     *
+     * @param other the DirectVelocityIntent to compare with for inequality
+     * @return true if the DirectVelocityIntents are not equal and false otherwise
+     */
+    bool operator!=(const DirectVelocityIntent& other) const;
 };

--- a/src/thunderbots/software/ai/intent/direct_velocity_intent.h
+++ b/src/thunderbots/software/ai/intent/direct_velocity_intent.h
@@ -17,16 +17,18 @@ class DirectVelocityIntent : public Intent, public DirectVelocityPrimitive
      * @param y_velocity positive forward
      * @param angular_velocity positive clockwise
      * @param dribbler_rpm The dribbler speed in rpm
+     * @param priority The priority of this Intent. A larger number indicates a higher
+     * priority
      */
     explicit DirectVelocityIntent(unsigned int robot_id, double x_velocity,
                                   double y_velocity, double angular_velocity,
-                                  double dribbler_rpm);
+                                  double dribbler_rpm, unsigned int priority);
 
     std::string getIntentName(void) const override;
 
     /**
-     * Compares DirectVelocityIntents for equality. DirectVelocityIntents are considered equal if all
-     * their member variables are equal.
+     * Compares DirectVelocityIntents for equality. DirectVelocityIntents are considered
+     * equal if all their member variables are equal.
      *
      * @param other the DirectVelocityIntents to compare with for equality
      * @return true if the DirectVelocityIntents are equal and false otherwise

--- a/src/thunderbots/software/ai/intent/direct_wheels_intent.cpp
+++ b/src/thunderbots/software/ai/intent/direct_wheels_intent.cpp
@@ -2,14 +2,16 @@
 
 const std::string DirectWheelsIntent::INTENT_NAME = "Direct Wheels Intent";
 
-DirectWheelsIntent::DirectWheelsIntent(
-    unsigned int robot_id, int16_t front_left_wheel_power, int16_t back_left_wheel_power,
-    int16_t front_right_wheel_power, int16_t back_right_wheel_power, double dribbler_rpm)
-    : DirectWheelsPrimitive(robot_id,front_left_wheel_power,
-      back_left_wheel_power,
-      front_right_wheel_power,
-      back_right_wheel_power,
-      dribbler_rpm)
+DirectWheelsIntent::DirectWheelsIntent(unsigned int robot_id,
+                                       int16_t front_left_wheel_power,
+                                       int16_t back_left_wheel_power,
+                                       int16_t front_right_wheel_power,
+                                       int16_t back_right_wheel_power,
+                                       double dribbler_rpm, unsigned int priority)
+    : DirectWheelsPrimitive(robot_id, front_left_wheel_power, back_left_wheel_power,
+                            front_right_wheel_power, back_right_wheel_power,
+                            dribbler_rpm),
+      Intent(priority)
 {
 }
 
@@ -18,10 +20,12 @@ std::string DirectWheelsIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
-bool DirectWheelsIntent::operator==(const DirectWheelsIntent &other) const {
+bool DirectWheelsIntent::operator==(const DirectWheelsIntent &other) const
+{
     return DirectWheelsPrimitive::operator==(other) && Intent::operator==(other);
 }
 
-bool DirectWheelsIntent::operator!=(const DirectWheelsIntent &other) const {
+bool DirectWheelsIntent::operator!=(const DirectWheelsIntent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/direct_wheels_intent.cpp
+++ b/src/thunderbots/software/ai/intent/direct_wheels_intent.cpp
@@ -17,3 +17,11 @@ std::string DirectWheelsIntent::getIntentName(void) const
 {
     return INTENT_NAME;
 }
+
+bool DirectWheelsIntent::operator==(const DirectWheelsIntent &other) const {
+    return DirectWheelsPrimitive::operator==(other) && Intent::operator==(other);
+}
+
+bool DirectWheelsIntent::operator!=(const DirectWheelsIntent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/direct_wheels_intent.cpp
+++ b/src/thunderbots/software/ai/intent/direct_wheels_intent.cpp
@@ -1,0 +1,19 @@
+#include "ai/intent/direct_wheels_intent.h"
+
+const std::string DirectWheelsIntent::INTENT_NAME = "Direct Wheels Intent";
+
+DirectWheelsIntent::DirectWheelsIntent(
+    unsigned int robot_id, int16_t front_left_wheel_power, int16_t back_left_wheel_power,
+    int16_t front_right_wheel_power, int16_t back_right_wheel_power, double dribbler_rpm)
+    : DirectWheelsPrimitive(robot_id,front_left_wheel_power,
+      back_left_wheel_power,
+      front_right_wheel_power,
+      back_right_wheel_power,
+      dribbler_rpm)
+{
+}
+
+std::string DirectWheelsIntent::getIntentName(void) const
+{
+    return INTENT_NAME;
+}

--- a/src/thunderbots/software/ai/intent/direct_wheels_intent.h
+++ b/src/thunderbots/software/ai/intent/direct_wheels_intent.h
@@ -5,7 +5,7 @@
 
 class DirectWheelsIntent : public Intent, public DirectWheelsPrimitive
 {
-public:
+   public:
     static const std::string INTENT_NAME;
     // Power is a fraction of the total power we can apply to the robots,
     // with +-255 being the max/min, and 0 being no power.
@@ -22,17 +22,20 @@ public:
      * @param back_right_wheel_power a value between -255 and 255, where positive is
      * clockwise
      * @param dribbler_rpm the dribbler rpm
+     * @param priority The priority of this Intent. A larger number indicates a higher
+     * priority
      */
     explicit DirectWheelsIntent(unsigned int robot_id, int16_t front_left_wheel_power,
-                                   int16_t back_left_wheel_power,
-                                   int16_t front_right_wheel_power,
-                                   int16_t back_right_wheel_power, double dribbler_rpm);
+                                int16_t back_left_wheel_power,
+                                int16_t front_right_wheel_power,
+                                int16_t back_right_wheel_power, double dribbler_rpm,
+                                unsigned int priority);
 
     std::string getIntentName(void) const override;
 
     /**
-     * Compares DirectWheelsIntents for equality. DirectWheelsIntents are considered equal if all
-     * their member variables are equal.
+     * Compares DirectWheelsIntents for equality. DirectWheelsIntents are considered equal
+     * if all their member variables are equal.
      *
      * @param other the DirectWheelsIntents to compare with for equality
      * @return true if the DirectWheelsIntents are equal and false otherwise

--- a/src/thunderbots/software/ai/intent/direct_wheels_intent.h
+++ b/src/thunderbots/software/ai/intent/direct_wheels_intent.h
@@ -29,4 +29,21 @@ public:
                                    int16_t back_right_wheel_power, double dribbler_rpm);
 
     std::string getIntentName(void) const override;
+
+    /**
+     * Compares DirectWheelsIntents for equality. DirectWheelsIntents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the DirectWheelsIntents to compare with for equality
+     * @return true if the DirectWheelsIntents are equal and false otherwise
+     */
+    bool operator==(const DirectWheelsIntent& other) const;
+
+    /**
+     * Compares DirectWheelsIntents for inequality.
+     *
+     * @param other the DirectWheelsIntent to compare with for inequality
+     * @return true if the DirectWheelsIntents are not equal and false otherwise
+     */
+    bool operator!=(const DirectWheelsIntent& other) const;
 };

--- a/src/thunderbots/software/ai/intent/direct_wheels_intent.h
+++ b/src/thunderbots/software/ai/intent/direct_wheels_intent.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "ai/intent/intent.h"
+#include "ai/primitive/direct_wheels_primitive.h"
+
+class DirectWheelsIntent : public Intent, public DirectWheelsPrimitive
+{
+public:
+    static const std::string INTENT_NAME;
+    // Power is a fraction of the total power we can apply to the robots,
+    // with +-255 being the max/min, and 0 being no power.
+    /**
+     * Creates a new DirectWheels Intent
+     *
+     * @param robot_id the id of the robot
+     * @param front_left_wheel_power a value between -255 and 255, where positive is
+     * clockwise
+     * @param back_left_wheel_power a value between -255 and 255, where positive is
+     * clockwise
+     * @param front_right_wheel_power a value between -255 and 255, where positive is
+     * clockwise
+     * @param back_right_wheel_power a value between -255 and 255, where positive is
+     * clockwise
+     * @param dribbler_rpm the dribbler rpm
+     */
+    explicit DirectWheelsIntent(unsigned int robot_id, int16_t front_left_wheel_power,
+                                   int16_t back_left_wheel_power,
+                                   int16_t front_right_wheel_power,
+                                   int16_t back_right_wheel_power, double dribbler_rpm);
+
+    std::string getIntentName(void) const override;
+};

--- a/src/thunderbots/software/ai/intent/direct_wheels_intent.h
+++ b/src/thunderbots/software/ai/intent/direct_wheels_intent.h
@@ -7,10 +7,11 @@ class DirectWheelsIntent : public Intent, public DirectWheelsPrimitive
 {
    public:
     static const std::string INTENT_NAME;
-    // Power is a fraction of the total power we can apply to the robots,
-    // with +-255 being the max/min, and 0 being no power.
     /**
      * Creates a new DirectWheels Intent
+     *
+     * Power is a fraction of the total power we can apply to the robots,
+     * with +-255 being the max/min, and 0 being no power.
      *
      * @param robot_id the id of the robot
      * @param front_left_wheel_power a value between -255 and 255, where positive is

--- a/src/thunderbots/software/ai/intent/dribble_intent.cpp
+++ b/src/thunderbots/software/ai/intent/dribble_intent.cpp
@@ -1,12 +1,12 @@
 #include "ai/intent/dribble_intent.h"
-#include "ai/intent/visitor/intent_visitor.h"
 
 const std::string DribbleIntent::INTENT_NAME = "Dribble Intent";
 
 DribbleIntent::DribbleIntent(unsigned int robot_id, const Point &dest,
                              const Angle &final_angle, double final_speed, double rpm,
-                             bool small_kick_allowed) :
-                             DribblePrimitive(robot_id, dest, final_angle, final_speed, rpm, small_kick_allowed)
+                             bool small_kick_allowed, unsigned int priority)
+    : DribblePrimitive(robot_id, dest, final_angle, final_speed, rpm, small_kick_allowed),
+      Intent(priority)
 {
 }
 
@@ -15,10 +15,12 @@ std::string DribbleIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
-bool DribbleIntent::operator==(const DribbleIntent &other) const {
+bool DribbleIntent::operator==(const DribbleIntent &other) const
+{
     return DribblePrimitive::operator==(other) && Intent::operator==(other);
 }
 
-bool DribbleIntent::operator!=(const DribbleIntent &other) const {
+bool DribbleIntent::operator!=(const DribbleIntent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/dribble_intent.cpp
+++ b/src/thunderbots/software/ai/intent/dribble_intent.cpp
@@ -14,3 +14,11 @@ std::string DribbleIntent::getIntentName(void) const
 {
     return INTENT_NAME;
 }
+
+bool DribbleIntent::operator==(const DribbleIntent &other) const {
+    return DribblePrimitive::operator==(other) && Intent::operator==(other);
+}
+
+bool DribbleIntent::operator!=(const DribbleIntent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/dribble_intent.cpp
+++ b/src/thunderbots/software/ai/intent/dribble_intent.cpp
@@ -1,0 +1,16 @@
+#include "ai/intent/dribble_intent.h"
+#include "ai/intent/visitor/intent_visitor.h"
+
+const std::string DribbleIntent::INTENT_NAME = "Dribble Intent";
+
+DribbleIntent::DribbleIntent(unsigned int robot_id, const Point &dest,
+                             const Angle &final_angle, double final_speed, double rpm,
+                             bool small_kick_allowed) :
+                             DribblePrimitive(robot_id, dest, final_angle, final_speed, rpm, small_kick_allowed)
+{
+}
+
+std::string DribbleIntent::getIntentName(void) const
+{
+    return INTENT_NAME;
+}

--- a/src/thunderbots/software/ai/intent/dribble_intent.h
+++ b/src/thunderbots/software/ai/intent/dribble_intent.h
@@ -7,7 +7,7 @@
 
 class DribbleIntent : public Intent, public DribblePrimitive
 {
-public:
+   public:
     static const std::string INTENT_NAME;
     /**
      * Creates a new Dribble Intent
@@ -25,11 +25,13 @@ public:
      * kick while dribbling in order to release the ball. This is due to the rule that
      * a robot may not dribble more than 1 meter without releasing the ball. This is not
      * obeyed in firmware
+     * @param priority The priority of this Intent. A larger number indicates a higher
+     * priority
      *
      */
-    explicit DribbleIntent(unsigned int robot_id, const Point &dest,
-                              const Angle &final_angle, double final_speed, double rpm,
-                              bool small_kick_allowed);
+    explicit DribbleIntent(unsigned int robot_id, const Point& dest,
+                           const Angle& final_angle, double final_speed, double rpm,
+                           bool small_kick_allowed, unsigned int priority);
 
     std::string getIntentName(void) const override;
 
@@ -50,4 +52,3 @@ public:
      */
     bool operator!=(const DribbleIntent& other) const;
 };
-

--- a/src/thunderbots/software/ai/intent/dribble_intent.h
+++ b/src/thunderbots/software/ai/intent/dribble_intent.h
@@ -32,5 +32,22 @@ public:
                               bool small_kick_allowed);
 
     std::string getIntentName(void) const override;
+
+    /**
+     * Compares DribbleIntents for equality. DribbleIntents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the DribbleIntents to compare with for equality
+     * @return true if the DribbleIntents are equal and false otherwise
+     */
+    bool operator==(const DribbleIntent& other) const;
+
+    /**
+     * Compares DribbleIntents for inequality.
+     *
+     * @param other the DribbleIntent to compare with for inequality
+     * @return true if the DribbleIntents are not equal and false otherwise
+     */
+    bool operator!=(const DribbleIntent& other) const;
 };
 

--- a/src/thunderbots/software/ai/intent/dribble_intent.h
+++ b/src/thunderbots/software/ai/intent/dribble_intent.h
@@ -11,6 +11,7 @@ class DribbleIntent : public Intent, public DribblePrimitive
     static const std::string INTENT_NAME;
     /**
      * Creates a new Dribble Intent
+     *
      * Moves the robot in a straight line between its current position and the given
      * destination with the dribbler on
      *

--- a/src/thunderbots/software/ai/intent/dribble_intent.h
+++ b/src/thunderbots/software/ai/intent/dribble_intent.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "ai/intent/intent.h"
+#include "ai/primitive/dribble_primitive.h"
+#include "geom/angle.h"
+#include "geom/point.h"
+
+class DribbleIntent : public Intent, public DribblePrimitive
+{
+public:
+    static const std::string INTENT_NAME;
+    /**
+     * Creates a new Dribble Intent
+     * Moves the robot in a straight line between its current position and the given
+     * destination with the dribbler on
+     *
+     * @param robot_id The id of the Robot to run this Intent
+     * @param dest The final destination of the movement
+     * @param final_angle The final orientation the robot should have at the end
+     * of the movement
+     * @param final_speed The final speed the Robot should have when it reaches
+     * its destination at the end of the movement
+     * @param rpm The rotation speed of the dribbler in RPMs
+     * @param small_kick_allowed Boolean of whether the robot is allowed o do a small
+     * kick while dribbling in order to release the ball. This is due to the rule that
+     * a robot may not dribble more than 1 meter without releasing the ball. This is not
+     * obeyed in firmware
+     *
+     */
+    explicit DribbleIntent(unsigned int robot_id, const Point &dest,
+                              const Angle &final_angle, double final_speed, double rpm,
+                              bool small_kick_allowed);
+
+    std::string getIntentName(void) const override;
+};
+

--- a/src/thunderbots/software/ai/intent/intent.cpp
+++ b/src/thunderbots/software/ai/intent/intent.cpp
@@ -11,3 +11,11 @@ void Intent::setPriority(int new_priority)
 {
     priority = new_priority;
 }
+
+bool Intent::operator==(const Intent &other) const {
+    return this->priority == other.priority;
+}
+
+bool Intent::operator!=(const Intent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/intent.cpp
+++ b/src/thunderbots/software/ai/intent/intent.cpp
@@ -2,20 +2,24 @@
 
 // Implement concrete functions shared by all intents
 
-int Intent::getPriority(void) const
+Intent::Intent(unsigned int priority) : priority(priority) {}
+
+unsigned int Intent::getPriority(void) const
 {
     return priority;
 }
 
-void Intent::setPriority(int new_priority)
+void Intent::setPriority(unsigned int new_priority)
 {
     priority = new_priority;
 }
 
-bool Intent::operator==(const Intent &other) const {
+bool Intent::operator==(const Intent &other) const
+{
     return this->priority == other.priority;
 }
 
-bool Intent::operator!=(const Intent &other) const {
+bool Intent::operator!=(const Intent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/intent.cpp
+++ b/src/thunderbots/software/ai/intent/intent.cpp
@@ -1,8 +1,12 @@
 #include "intent.h"
+#include <algorithm>
+#include "util/logger/init.h"
 
 // Implement concrete functions shared by all intents
 
-Intent::Intent(unsigned int priority) : priority(priority) {}
+Intent::Intent(unsigned int priority) : {
+    setPriority(priority);
+}
 
 unsigned int Intent::getPriority(void) const
 {
@@ -11,6 +15,10 @@ unsigned int Intent::getPriority(void) const
 
 void Intent::setPriority(unsigned int new_priority)
 {
+    if(new_priority < 0 || new_priority > 100) {
+        LOG(WARNING) << "Intent set with out of range priority value: " << new_priority << ". Clamping to range [0, 100]" << std::endl;
+        new_priority = std::clamp<unsigned int>(new_priority, 0, 100);
+    }
     priority = new_priority;
 }
 

--- a/src/thunderbots/software/ai/intent/intent.cpp
+++ b/src/thunderbots/software/ai/intent/intent.cpp
@@ -1,10 +1,13 @@
 #include "intent.h"
+
 #include <algorithm>
+
 #include "util/logger/init.h"
 
 // Implement concrete functions shared by all intents
 
-Intent::Intent(unsigned int priority) : {
+Intent::Intent(unsigned int priority)
+{
     setPriority(priority);
 }
 
@@ -15,8 +18,10 @@ unsigned int Intent::getPriority(void) const
 
 void Intent::setPriority(unsigned int new_priority)
 {
-    if(new_priority < 0 || new_priority > 100) {
-        LOG(WARNING) << "Intent set with out of range priority value: " << new_priority << ". Clamping to range [0, 100]" << std::endl;
+    if (new_priority < 0 || new_priority > 100)
+    {
+        LOG(WARNING) << "Intent set with out of range priority value: " << new_priority
+                     << ". Clamping to range [0, 100]" << std::endl;
         new_priority = std::clamp<unsigned int>(new_priority, 0, 100);
     }
     priority = new_priority;

--- a/src/thunderbots/software/ai/intent/intent.h
+++ b/src/thunderbots/software/ai/intent/intent.h
@@ -20,6 +20,14 @@ class Intent
 {
    public:
     /**
+     * Creates a new Intent with the given priority. A larger number indicates a higher
+     * priority
+     *
+     * @param priority The priority of this Intent
+     */
+    explicit Intent(unsigned int priority);
+
+    /**
      * Returns the name of this Intent
      *
      * @return the name of this Intent
@@ -30,12 +38,12 @@ class Intent
      * Returns the priority of this Intent
      * @return the priority of this Intent
      */
-    int getPriority(void) const;
+    unsigned int getPriority(void) const;
 
     /**
      * Sets the priority of this Intent
      */
-    void setPriority(int);
+    void setPriority(unsigned int new_priority);
 
     /**
      * Compares Intents for equality. Intents are considered equal if all
@@ -61,5 +69,5 @@ class Intent
      * priority of this intent
      * higher value => higher priority
      */
-    int priority;
+    unsigned int priority;
 };

--- a/src/thunderbots/software/ai/intent/intent.h
+++ b/src/thunderbots/software/ai/intent/intent.h
@@ -21,7 +21,7 @@ class Intent
    public:
     /**
      * Creates a new Intent with the given priority. A larger number indicates a higher
-     * priority
+     * priority. The priority value must be in the range [0, 100]
      *
      * @param priority The priority of this Intent
      */
@@ -35,13 +35,16 @@ class Intent
     virtual std::string getIntentName(void) const = 0;
 
     /**
-     * Returns the priority of this Intent
+     * Returns the priority of this Intent. The priority value is an integer in the range
+     * [0, 100] that indicates the priority of this Intent.
+     *
      * @return the priority of this Intent
      */
     unsigned int getPriority(void) const;
 
     /**
-     * Sets the priority of this Intent
+     * Sets the priority of this Intent. The priority value must be an integer in the
+     * range [0, 100]
      */
     void setPriority(unsigned int new_priority);
 
@@ -66,7 +69,7 @@ class Intent
 
    private:
     /**
-     * priority of this intent
+     * The priority of this intent. Must be in the range [0, 100]
      * higher value => higher priority
      */
     unsigned int priority;

--- a/src/thunderbots/software/ai/intent/intent.h
+++ b/src/thunderbots/software/ai/intent/intent.h
@@ -37,6 +37,23 @@ class Intent
      */
     void setPriority(int);
 
+    /**
+     * Compares Intents for equality. Intents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the Intents to compare with for equality
+     * @return true if the Intents are equal and false otherwise
+     */
+    bool operator==(const Intent& other) const;
+
+    /**
+     * Compares Intents for inequality.
+     *
+     * @param other the Intent to compare with for inequality
+     * @return true if the Intents are not equal and false otherwise
+     */
+    bool operator!=(const Intent& other) const;
+
     virtual ~Intent() = default;
 
    private:

--- a/src/thunderbots/software/ai/intent/kick_intent.cpp
+++ b/src/thunderbots/software/ai/intent/kick_intent.cpp
@@ -12,3 +12,11 @@ std::string KickIntent::getIntentName(void) const
 {
     return INTENT_NAME;
 }
+
+bool KickIntent::operator==(const KickIntent &other) const {
+    return KickPrimitive::operator==(other) && Intent::operator==(other);
+}
+
+bool KickIntent::operator!=(const KickIntent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/kick_intent.cpp
+++ b/src/thunderbots/software/ai/intent/kick_intent.cpp
@@ -3,8 +3,10 @@
 const std::string KickIntent::INTENT_NAME = "Kick Intent";
 
 KickIntent::KickIntent(unsigned int robot_id, const Point &kick_origin,
-                       const Angle &kick_direction, double kick_speed_meters_per_second)
-    : KickPrimitive(robot_id, kick_origin, kick_direction, kick_speed_meters_per_second)
+                       const Angle &kick_direction, double kick_speed_meters_per_second,
+                       unsigned int priority)
+    : KickPrimitive(robot_id, kick_origin, kick_direction, kick_speed_meters_per_second),
+      Intent(priority)
 {
 }
 
@@ -13,10 +15,12 @@ std::string KickIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
-bool KickIntent::operator==(const KickIntent &other) const {
+bool KickIntent::operator==(const KickIntent &other) const
+{
     return KickPrimitive::operator==(other) && Intent::operator==(other);
 }
 
-bool KickIntent::operator!=(const KickIntent &other) const {
+bool KickIntent::operator!=(const KickIntent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/kick_intent.h
+++ b/src/thunderbots/software/ai/intent/kick_intent.h
@@ -22,4 +22,21 @@ class KickIntent : public Intent, public KickPrimitive
                         const Angle &final_angle, double final_speed);
 
     std::string getIntentName(void) const override;
+
+    /**
+     * Compares KickIntents for equality. KickIntents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the KickIntents to compare with for equality
+     * @return true if the KickIntents are equal and false otherwise
+     */
+    bool operator==(const KickIntent& other) const;
+
+    /**
+     * Compares KickIntents for inequality.
+     *
+     * @param other the KickIntent to compare with for inequality
+     * @return true if the KickIntents are not equal and false otherwise
+     */
+    bool operator!=(const KickIntent& other) const;
 };

--- a/src/thunderbots/software/ai/intent/kick_intent.h
+++ b/src/thunderbots/software/ai/intent/kick_intent.h
@@ -17,9 +17,12 @@ class KickIntent : public Intent, public KickPrimitive
      * @param final_angle The final angle the robot should have at the end of the movement
      * @param final_speed The final speed the robot should have when it arrives at its
      * destination
+     * @param priority The priority of this Intent. A larger number indicates a higher
+     * priority
      */
-    explicit KickIntent(unsigned int robot_id, const Point &dest,
-                        const Angle &final_angle, double final_speed);
+    explicit KickIntent(unsigned int robot_id, const Point& dest,
+                        const Angle& final_angle, double final_speed,
+                        unsigned int priority);
 
     std::string getIntentName(void) const override;
 

--- a/src/thunderbots/software/ai/intent/move_intent.cpp
+++ b/src/thunderbots/software/ai/intent/move_intent.cpp
@@ -3,8 +3,8 @@
 const std::string MoveIntent::INTENT_NAME = "Move Intent";
 
 MoveIntent::MoveIntent(unsigned int robot_id, const Point &dest, const Angle &final_angle,
-                       double final_speed)
-    : MovePrimitive(robot_id, dest, final_angle, final_speed)
+                       double final_speed, unsigned int priority)
+    : MovePrimitive(robot_id, dest, final_angle, final_speed), Intent(priority)
 {
 }
 
@@ -13,10 +13,12 @@ std::string MoveIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
-bool MoveIntent::operator==(const MoveIntent &other) const {
+bool MoveIntent::operator==(const MoveIntent &other) const
+{
     return MovePrimitive::operator==(other) && Intent::operator==(other);
 }
 
-bool MoveIntent::operator!=(const MoveIntent &other) const {
+bool MoveIntent::operator!=(const MoveIntent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/move_intent.cpp
+++ b/src/thunderbots/software/ai/intent/move_intent.cpp
@@ -12,3 +12,11 @@ std::string MoveIntent::getIntentName(void) const
 {
     return INTENT_NAME;
 }
+
+bool MoveIntent::operator==(const MoveIntent &other) const {
+    return MovePrimitive::operator==(other) && Intent::operator==(other);
+}
+
+bool MoveIntent::operator!=(const MoveIntent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/move_intent.h
+++ b/src/thunderbots/software/ai/intent/move_intent.h
@@ -17,9 +17,12 @@ class MoveIntent : public Intent, public MovePrimitive
      * @param final_angle The final angle the robot should have at the end of the movement
      * @param final_speed The final speed the robot should have when it arrives at its
      * destination
+     * @param priority The priority of this Intent. A larger number indicates a higher
+     * priority
      */
-    explicit MoveIntent(unsigned int robot_id, const Point &dest,
-                        const Angle &final_angle, double final_speed);
+    explicit MoveIntent(unsigned int robot_id, const Point& dest,
+                        const Angle& final_angle, double final_speed,
+                        unsigned int priority);
 
     std::string getIntentName(void) const override;
 

--- a/src/thunderbots/software/ai/intent/move_intent.h
+++ b/src/thunderbots/software/ai/intent/move_intent.h
@@ -22,4 +22,21 @@ class MoveIntent : public Intent, public MovePrimitive
                         const Angle &final_angle, double final_speed);
 
     std::string getIntentName(void) const override;
+
+    /**
+     * Compares MoveIntents for equality. MoveIntents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the MoveIntents to compare with for equality
+     * @return true if the MoveIntents are equal and false otherwise
+     */
+    bool operator==(const MoveIntent& other) const;
+
+    /**
+     * Compares MoveIntents for inequality.
+     *
+     * @param other the MoveIntent to compare with for inequality
+     * @return true if the MoveIntents are not equal and false otherwise
+     */
+    bool operator!=(const MoveIntent& other) const;
 };

--- a/src/thunderbots/software/ai/intent/movespin_intent.cpp
+++ b/src/thunderbots/software/ai/intent/movespin_intent.cpp
@@ -12,3 +12,10 @@ std::string MoveSpinIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
+bool MoveSpinIntent::operator==(const MoveSpinIntent &other) const {
+    return MoveSpinPrimitive::operator==(other) && Intent::operator==(other);
+}
+
+bool MoveSpinIntent::operator!=(const MoveSpinIntent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/movespin_intent.cpp
+++ b/src/thunderbots/software/ai/intent/movespin_intent.cpp
@@ -2,8 +2,9 @@
 
 const std::string MoveSpinIntent::INTENT_NAME = "MoveSpin Intent";
 
-MoveSpinIntent::MoveSpinIntent(unsigned int robot_id, const Point &dest, const AngularVelocity &angular_vel)
-        : MoveSpinPrimitive(robot_id, dest, angular_vel)
+MoveSpinIntent::MoveSpinIntent(unsigned int robot_id, const Point &dest,
+                               const AngularVelocity &angular_vel, unsigned int priority)
+    : MoveSpinPrimitive(robot_id, dest, angular_vel), Intent(priority)
 {
 }
 
@@ -12,10 +13,12 @@ std::string MoveSpinIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
-bool MoveSpinIntent::operator==(const MoveSpinIntent &other) const {
+bool MoveSpinIntent::operator==(const MoveSpinIntent &other) const
+{
     return MoveSpinPrimitive::operator==(other) && Intent::operator==(other);
 }
 
-bool MoveSpinIntent::operator!=(const MoveSpinIntent &other) const {
+bool MoveSpinIntent::operator!=(const MoveSpinIntent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/movespin_intent.cpp
+++ b/src/thunderbots/software/ai/intent/movespin_intent.cpp
@@ -1,0 +1,14 @@
+#include "ai/intent/movespin_intent.h"
+
+const std::string MoveSpinIntent::INTENT_NAME = "MoveSpin Intent";
+
+MoveSpinIntent::MoveSpinIntent(unsigned int robot_id, const Point &dest, const AngularVelocity &angular_vel)
+        : MoveSpinPrimitive(robot_id, dest, angular_vel)
+{
+}
+
+std::string MoveSpinIntent::getIntentName(void) const
+{
+    return INTENT_NAME;
+}
+

--- a/src/thunderbots/software/ai/intent/movespin_intent.h
+++ b/src/thunderbots/software/ai/intent/movespin_intent.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "ai/intent/intent.h"
+#include "ai/primitive/movespin_primitive.h"
+
+class MoveSpinIntent : public Intent, public MoveSpinPrimitive
+{
+public:
+    static const std::string INTENT_NAME;
+    /**
+     * Creates a new MoveSpin Intent
+     *
+     * @param robot_id The id of the Robot to run this Intent
+     * @param dest The final destination of the movement
+     * @param angular_vel The angular velocity of the robot
+     * of the movement
+     */
+    explicit MoveSpinIntent(unsigned int robot_id, const Point &dest,
+                               const AngularVelocity &angular_vel);
+
+    std::string getIntentName(void) const override;
+};
+

--- a/src/thunderbots/software/ai/intent/movespin_intent.h
+++ b/src/thunderbots/software/ai/intent/movespin_intent.h
@@ -5,7 +5,7 @@
 
 class MoveSpinIntent : public Intent, public MoveSpinPrimitive
 {
-public:
+   public:
     static const std::string INTENT_NAME;
     /**
      * Creates a new MoveSpin Intent
@@ -14,9 +14,11 @@ public:
      * @param dest The final destination of the movement
      * @param angular_vel The angular velocity of the robot
      * of the movement
+     * @param priority The priority of this Intent. A larger number indicates a higher
+     * priority
      */
-    explicit MoveSpinIntent(unsigned int robot_id, const Point &dest,
-                               const AngularVelocity &angular_vel);
+    explicit MoveSpinIntent(unsigned int robot_id, const Point& dest,
+                            const AngularVelocity& angular_vel, unsigned int priority);
 
     std::string getIntentName(void) const override;
 
@@ -37,4 +39,3 @@ public:
      */
     bool operator!=(const MoveSpinIntent& other) const;
 };
-

--- a/src/thunderbots/software/ai/intent/movespin_intent.h
+++ b/src/thunderbots/software/ai/intent/movespin_intent.h
@@ -19,5 +19,22 @@ public:
                                const AngularVelocity &angular_vel);
 
     std::string getIntentName(void) const override;
+
+    /**
+     * Compares MoveSpinIntents for equality. MoveSpinIntents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the MoveSpinIntents to compare with for equality
+     * @return true if the MoveSpinIntents are equal and false otherwise
+     */
+    bool operator==(const MoveSpinIntent& other) const;
+
+    /**
+     * Compares MoveSpinIntents for inequality.
+     *
+     * @param other the MoveSpinIntent to compare with for inequality
+     * @return true if the MoveSpinIntents are not equal and false otherwise
+     */
+    bool operator!=(const MoveSpinIntent& other) const;
 };
 

--- a/src/thunderbots/software/ai/intent/pivot_intent.cpp
+++ b/src/thunderbots/software/ai/intent/pivot_intent.cpp
@@ -12,3 +12,11 @@ std::string PivotIntent::getIntentName(void) const
 {
     return INTENT_NAME;
 }
+
+bool PivotIntent::operator==(const PivotIntent &other) const {
+    return PivotPrimitive::operator==(other) && Intent::operator==(other);
+}
+
+bool PivotIntent::operator!=(const PivotIntent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/pivot_intent.cpp
+++ b/src/thunderbots/software/ai/intent/pivot_intent.cpp
@@ -3,8 +3,9 @@
 const std::string PivotIntent::INTENT_NAME = "Pivot Intent";
 
 PivotIntent::PivotIntent(unsigned int robot_id, const Point &pivot_point,
-                         const Angle &final_angle, const double pivot_radius)
-    : PivotPrimitive(robot_id, pivot_point, final_angle, pivot_radius)
+                         const Angle &final_angle, const double pivot_radius,
+                         unsigned int priority)
+    : PivotPrimitive(robot_id, pivot_point, final_angle, pivot_radius), Intent(priority)
 {
 }
 
@@ -13,10 +14,12 @@ std::string PivotIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
-bool PivotIntent::operator==(const PivotIntent &other) const {
+bool PivotIntent::operator==(const PivotIntent &other) const
+{
     return PivotPrimitive::operator==(other) && Intent::operator==(other);
 }
 
-bool PivotIntent::operator!=(const PivotIntent &other) const {
+bool PivotIntent::operator!=(const PivotIntent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/pivot_intent.h
+++ b/src/thunderbots/software/ai/intent/pivot_intent.h
@@ -17,9 +17,12 @@ class PivotIntent : public Intent, public PivotPrimitive
      * @param final_angle The final angle the robot should have at the end of the movement
      * @param final_speed The final speed the robot should have when it arrives at its
      * destination
+     * @param priority The priority of this Intent. A larger number indicates a higher
+     * priority
      */
-    explicit PivotIntent(unsigned int robot_id, const Point &pivot_point,
-                         const Angle &final_angle, const double pivot_radius);
+    explicit PivotIntent(unsigned int robot_id, const Point& pivot_point,
+                         const Angle& final_angle, const double pivot_radius,
+                         unsigned int priority);
 
     std::string getIntentName(void) const override;
 

--- a/src/thunderbots/software/ai/intent/pivot_intent.h
+++ b/src/thunderbots/software/ai/intent/pivot_intent.h
@@ -22,4 +22,21 @@ class PivotIntent : public Intent, public PivotPrimitive
                          const Angle &final_angle, const double pivot_radius);
 
     std::string getIntentName(void) const override;
+
+    /**
+     * Compares PivotIntents for equality. PivotIntents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the PivotIntents to compare with for equality
+     * @return true if the PivotIntents are equal and false otherwise
+     */
+    bool operator==(const PivotIntent& other) const;
+
+    /**
+     * Compares PivotIntents for inequality.
+     *
+     * @param other the PivotIntent to compare with for inequality
+     * @return true if the PivotIntents are not equal and false otherwise
+     */
+    bool operator!=(const PivotIntent& other) const;
 };

--- a/src/thunderbots/software/ai/intent/stop_intent.cpp
+++ b/src/thunderbots/software/ai/intent/stop_intent.cpp
@@ -2,8 +2,8 @@
 
 const std::string StopIntent::INTENT_NAME = "Stop Intent";
 
-StopIntent::StopIntent(unsigned int robot_id, bool coast)
-        : StopPrimitive(robot_id, coast)
+StopIntent::StopIntent(unsigned int robot_id, bool coast, unsigned int priority)
+    : StopPrimitive(robot_id, coast), Intent(priority)
 {
 }
 
@@ -12,10 +12,12 @@ std::string StopIntent::getIntentName(void) const
     return INTENT_NAME;
 }
 
-bool StopIntent::operator==(const StopIntent &other) const {
+bool StopIntent::operator==(const StopIntent &other) const
+{
     return StopPrimitive::operator==(other) && Intent::operator==(other);
 }
 
-bool StopIntent::operator!=(const StopIntent &other) const {
+bool StopIntent::operator!=(const StopIntent &other) const
+{
     return !((*this) == other);
 }

--- a/src/thunderbots/software/ai/intent/stop_intent.cpp
+++ b/src/thunderbots/software/ai/intent/stop_intent.cpp
@@ -11,3 +11,11 @@ std::string StopIntent::getIntentName(void) const
 {
     return INTENT_NAME;
 }
+
+bool StopIntent::operator==(const StopIntent &other) const {
+    return StopPrimitive::operator==(other) && Intent::operator==(other);
+}
+
+bool StopIntent::operator!=(const StopIntent &other) const {
+    return !((*this) == other);
+}

--- a/src/thunderbots/software/ai/intent/stop_intent.cpp
+++ b/src/thunderbots/software/ai/intent/stop_intent.cpp
@@ -1,0 +1,13 @@
+#include "ai/intent/stop_intent.h"
+
+const std::string StopIntent::INTENT_NAME = "Stop Intent";
+
+StopIntent::StopIntent(unsigned int robot_id, bool coast)
+        : StopPrimitive(robot_id, coast)
+{
+}
+
+std::string StopIntent::getIntentName(void) const
+{
+    return INTENT_NAME;
+}

--- a/src/thunderbots/software/ai/intent/stop_intent.h
+++ b/src/thunderbots/software/ai/intent/stop_intent.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ai/intent/intent.h"
+#include "ai/primitive/stop_primitive.h"
+
+class StopIntent : public Intent, public StopPrimitive
+{
+public:
+    static const std::string INTENT_NAME;
+    /**
+     * Creates a new Stop Intent
+     *
+     * Stops the robot with the option to coast to a stop rather than stop immediately
+     *
+     * @param robot_id The id of the Robot to run this Primitive
+     * @param coast to coast to a stop or not
+     */
+    explicit StopIntent(unsigned int robot_id, bool coast);
+
+    std::string getIntentName(void) const override;
+};
+

--- a/src/thunderbots/software/ai/intent/stop_intent.h
+++ b/src/thunderbots/software/ai/intent/stop_intent.h
@@ -18,5 +18,22 @@ public:
     explicit StopIntent(unsigned int robot_id, bool coast);
 
     std::string getIntentName(void) const override;
+
+    /**
+     * Compares StopIntents for equality. StopIntents are considered equal if all
+     * their member variables are equal.
+     *
+     * @param other the StopIntents to compare with for equality
+     * @return true if the StopIntents are equal and false otherwise
+     */
+    bool operator==(const StopIntent& other) const;
+
+    /**
+     * Compares StopIntents for inequality.
+     *
+     * @param other the StopIntent to compare with for inequality
+     * @return true if the StopIntents are not equal and false otherwise
+     */
+    bool operator!=(const StopIntent& other) const;
 };
 

--- a/src/thunderbots/software/ai/intent/stop_intent.h
+++ b/src/thunderbots/software/ai/intent/stop_intent.h
@@ -5,7 +5,7 @@
 
 class StopIntent : public Intent, public StopPrimitive
 {
-public:
+   public:
     static const std::string INTENT_NAME;
     /**
      * Creates a new Stop Intent
@@ -14,8 +14,10 @@ public:
      *
      * @param robot_id The id of the Robot to run this Primitive
      * @param coast to coast to a stop or not
+     * @param priority The priority of this Intent. A larger number indicates a higher
+     * priority
      */
-    explicit StopIntent(unsigned int robot_id, bool coast);
+    explicit StopIntent(unsigned int robot_id, bool coast, unsigned int priority);
 
     std::string getIntentName(void) const override;
 
@@ -36,4 +38,3 @@ public:
      */
     bool operator!=(const StopIntent& other) const;
 };
-

--- a/src/thunderbots/software/ai/primitive/direct_wheels_primitive.h
+++ b/src/thunderbots/software/ai/primitive/direct_wheels_primitive.h
@@ -13,7 +13,7 @@ class DirectWheelsPrimitive : public Primitive
     // Power is a fraction of the total power we can apply to the robots,
     // with +-255 being the max/min, and 0 being no power.
     /**
-     * Creates a new Move Primitive
+     * Creates a new DirectWheels Primitive
      *
      * @param robot_id the id of the robot
      * @param front_left_wheel_power a value between -255 and 255, where positive is

--- a/src/thunderbots/software/grsim_communication/main.cpp
+++ b/src/thunderbots/software/grsim_communication/main.cpp
@@ -7,7 +7,6 @@
 #include "ai/primitive/primitive_factory.h"
 #include "geom/point.h"
 #include "grsim_communication/grsim_backend.h"
-#include "grsim_communication/motion_controller/motion_controller.h"
 #include "util/constants.h"
 #include "util/logger/init.h"
 #include "util/ros_messages.h"

--- a/src/thunderbots/software/test/intent/catch_intent.cpp
+++ b/src/thunderbots/software/test/intent/catch_intent.cpp
@@ -1,0 +1,40 @@
+/**
+ * This file contains unit tests for the Catch Intent class
+ */
+
+#include "ai/intent/catch_intent.h"
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(CatchIntentTest, intent_name_test)
+{
+    CatchIntent catch_intent = CatchIntent(0, 0, 0, 0, 0);
+
+    EXPECT_EQ("Catch Intent", catch_intent.getIntentName());
+}
+
+// For equality operators, we only check for cases not covered in the Primitive tests,
+// since Intents inherit from Primitives
+TEST(CatchIntentTest, test_equality_operator_intents_equal)
+{
+    CatchIntent catch_intent       = CatchIntent(0, 0, 0, 0, 0);
+    CatchIntent catch_intent_other = CatchIntent(0, 0, 0, 0, 0);
+
+    EXPECT_EQ(catch_intent, catch_intent_other);
+}
+
+TEST(CatchIntentTest, test_inequality_operator_with_mismatched_priorities)
+{
+    CatchIntent catch_intent       = CatchIntent(0, 0, 0, 0, 0);
+    CatchIntent catch_intent_other = CatchIntent(0, 0, 0, 0, 1);
+
+    EXPECT_NE(catch_intent, catch_intent_other);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/intent/chip_intent.cpp
+++ b/src/thunderbots/software/test/intent/chip_intent.cpp
@@ -1,0 +1,40 @@
+/**
+ * This file contains unit tests for the Chip Intent class
+ */
+
+#include "ai/intent/chip_intent.h"
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(ChipIntentTest, intent_name_test)
+{
+    ChipIntent chip_intent = ChipIntent(0, Point(), Angle::zero(), 0, 0);
+
+    EXPECT_EQ("Chip Intent", chip_intent.getIntentName());
+}
+
+// For equality operators, we only check for cases not covered in the Primitive tests,
+// since Intents inherit from Primitives
+TEST(ChipIntentTest, test_equality_operator_intents_equal)
+{
+    ChipIntent chip_intent       = ChipIntent(0, Point(), Angle::zero(), 0, 0);
+    ChipIntent chip_intent_other = ChipIntent(0, Point(), Angle::zero(), 0, 0);
+
+    EXPECT_EQ(chip_intent, chip_intent_other);
+}
+
+TEST(ChipIntentTest, test_inequality_operator_with_mismatched_priorities)
+{
+    ChipIntent chip_intent       = ChipIntent(0, Point(), Angle::zero(), 0, 1);
+    ChipIntent chip_intent_other = ChipIntent(0, Point(), Angle::zero(), 0, 3);
+
+    EXPECT_NE(chip_intent, chip_intent_other);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/intent/direct_velocity_intent.cpp
+++ b/src/thunderbots/software/test/intent/direct_velocity_intent.cpp
@@ -1,0 +1,42 @@
+/**
+ * This file contains unit tests for the DirectVelocity Intent class
+ */
+
+#include "ai/intent/direct_velocity_intent.h"
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(DirectVelocityIntentTest, intent_name_test)
+{
+    DirectVelocityIntent direct_velocity_intent = DirectVelocityIntent(0, 0, 0, 0, 0, 0);
+
+    EXPECT_EQ("Direct Velocity Intent", direct_velocity_intent.getIntentName());
+}
+
+// For equality operators, we only check for cases not covered in the Primitive tests,
+// since Intents inherit from Primitives
+TEST(DirectVelocityIntentTest, test_equality_operator_intents_equal)
+{
+    DirectVelocityIntent direct_velocity_intent = DirectVelocityIntent(0, 0, 0, 0, 0, 0);
+    DirectVelocityIntent direct_velocity_intent_other =
+        DirectVelocityIntent(0, 0, 0, 0, 0, 0);
+
+    EXPECT_EQ(direct_velocity_intent, direct_velocity_intent_other);
+}
+
+TEST(DirectVelocityIntentTest, test_inequality_operator_with_mismatched_priorities)
+{
+    DirectVelocityIntent direct_velocity_intent = DirectVelocityIntent(0, 0, 0, 0, 0, 0);
+    DirectVelocityIntent direct_velocity_intent_other =
+        DirectVelocityIntent(0, 0, 0, 0, 0, 2);
+
+    EXPECT_NE(direct_velocity_intent, direct_velocity_intent_other);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/intent/direct_wheels_intent.cpp
+++ b/src/thunderbots/software/test/intent/direct_wheels_intent.cpp
@@ -1,0 +1,42 @@
+/**
+ * This file contains unit tests for the DirectWheels Intent class
+ */
+
+#include "ai/intent/direct_wheels_intent.h"
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(DirectWheelsIntentTest, intent_name_test)
+{
+    DirectWheelsIntent direct_wheels_intent = DirectWheelsIntent(0, 0, 0, 0, 0, 0, 0);
+
+    EXPECT_EQ("Direct Wheels Intent", direct_wheels_intent.getIntentName());
+}
+
+// For equality operators, we only check for cases not covered in the Primitive tests,
+// since Intents inherit from Primitives
+TEST(DirectWheelsIntentTest, test_equality_operator_intents_equal)
+{
+    DirectWheelsIntent direct_wheels_intent = DirectWheelsIntent(0, 0, 0, 0, 0, 0, 0);
+    DirectWheelsIntent direct_wheels_intent_other =
+        DirectWheelsIntent(0, 0, 0, 0, 0, 0, 0);
+
+    EXPECT_EQ(direct_wheels_intent, direct_wheels_intent_other);
+}
+
+TEST(DirectWheelsIntentTest, test_inequality_operator_with_mismatched_priorities)
+{
+    DirectWheelsIntent direct_wheels_intent = DirectWheelsIntent(0, 0, 0, 0, 0, 0, 1);
+    DirectWheelsIntent direct_wheels_intent_other =
+        DirectWheelsIntent(0, 0, 0, 0, 0, 0, 3);
+
+    EXPECT_NE(direct_wheels_intent, direct_wheels_intent_other);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/intent/dribble_intent.cpp
+++ b/src/thunderbots/software/test/intent/dribble_intent.cpp
@@ -1,0 +1,45 @@
+/**
+ * This file contains unit tests for the Dribble Intent class
+ */
+
+#include "ai/intent/dribble_intent.h"
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(DribbleIntentTest, intent_name_test)
+{
+    DribbleIntent dribble_intent =
+        DribbleIntent(0, Point(), Angle::zero(), 0, 0, false, 0);
+
+    EXPECT_EQ("Dribble Intent", dribble_intent.getIntentName());
+}
+
+// For equality operators, we only check for cases not covered in the Primitive tests,
+// since Intents inherit from Primitives
+TEST(DribbleIntentTest, test_equality_operator_intents_equal)
+{
+    DribbleIntent dribble_intent =
+        DribbleIntent(0, Point(), Angle::zero(), 0, 0, false, 0);
+    DribbleIntent dribble_intent_other =
+        DribbleIntent(0, Point(), Angle::zero(), 0, 0, false, 0);
+
+    EXPECT_EQ(dribble_intent, dribble_intent_other);
+}
+
+TEST(DribbleIntentTest, test_inequality_operator_with_mismatched_priorities)
+{
+    DribbleIntent dribble_intent =
+        DribbleIntent(0, Point(), Angle::zero(), 0, 1, false, 0);
+    DribbleIntent dribble_intent_other =
+        DribbleIntent(0, Point(), Angle::zero(), 0, 1, false, 4);
+
+    EXPECT_NE(dribble_intent, dribble_intent_other);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/intent/intent.cpp
+++ b/src/thunderbots/software/test/intent/intent.cpp
@@ -1,0 +1,31 @@
+/**
+ * This file contains the unit tests for the Intent class
+ */
+
+#include "ai/intent/intent.h"
+
+#include <gtest/gtest.h>
+
+#include "ai/intent/move_intent.h"
+
+TEST(IntentTest, test_get_priority)
+{
+    MoveIntent move_intent = MoveIntent(0, Point(), Angle(), 0.0, 2);
+
+    EXPECT_EQ(2, move_intent.getPriority());
+}
+
+TEST(IntentTest, test_set_priority)
+{
+    MoveIntent move_intent = MoveIntent(0, Point(), Angle(), 0.0, 0);
+    move_intent.setPriority(7);
+
+    EXPECT_EQ(7, move_intent.getPriority());
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/intent/intent.cpp
+++ b/src/thunderbots/software/test/intent/intent.cpp
@@ -1,5 +1,7 @@
 /**
- * This file contains the unit tests for the Intent class (NOTE: `Intent` is virtual, so we use `MoveIntent` instead, but we're only testing functionality of the `Intent` class)
+ * This file contains the unit tests for the Intent class (NOTE: `Intent` is virtual, so
+ * we use `MoveIntent` instead, but we're only testing functionality of the `Intent`
+ * class)
  */
 
 #include "ai/intent/intent.h"

--- a/src/thunderbots/software/test/intent/intent.cpp
+++ b/src/thunderbots/software/test/intent/intent.cpp
@@ -1,5 +1,5 @@
 /**
- * This file contains the unit tests for the Intent class
+ * This file contains the unit tests for the Intent class (NOTE: `Intent` is virtual, so we use `MoveIntent` instead, but we're only testing functionality of the `Intent` class)
  */
 
 #include "ai/intent/intent.h"

--- a/src/thunderbots/software/test/intent/kick_intent.cpp
+++ b/src/thunderbots/software/test/intent/kick_intent.cpp
@@ -1,0 +1,40 @@
+/**
+ * This file contains unit tests for the Kick Intent class
+ */
+
+#include "ai/intent/kick_intent.h"
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(KickIntentTest, intent_name_test)
+{
+    KickIntent kick_intent = KickIntent(0, Point(), Angle::zero(), 0, 0);
+
+    EXPECT_EQ("Kick Intent", kick_intent.getIntentName());
+}
+
+// For equality operators, we only check for cases not covered in the Primitive tests,
+// since Intents inherit from Primitives
+TEST(KickIntentTest, test_equality_operator_intents_equal)
+{
+    KickIntent kick_intent       = KickIntent(0, Point(), Angle::zero(), 0, 0);
+    KickIntent kick_intent_other = KickIntent(0, Point(), Angle::zero(), 0, 0);
+
+    EXPECT_EQ(kick_intent, kick_intent_other);
+}
+
+TEST(KickIntentTest, test_inequality_operator_with_mismatched_priorities)
+{
+    KickIntent kick_intent       = KickIntent(0, Point(), Angle::zero(), 0, 9);
+    KickIntent kick_intent_other = KickIntent(0, Point(), Angle::zero(), 0, 7);
+
+    EXPECT_NE(kick_intent, kick_intent_other);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/intent/move_intent.cpp
+++ b/src/thunderbots/software/test/intent/move_intent.cpp
@@ -1,0 +1,40 @@
+/**
+ * This file contains unit tests for the Move Intent class
+ */
+
+#include "ai/intent/move_intent.h"
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(MoveIntentTest, intent_name_test)
+{
+    MoveIntent move_intent = MoveIntent(0, Point(), Angle::zero(), 0, 0);
+
+    EXPECT_EQ("Move Intent", move_intent.getIntentName());
+}
+
+// For equality operators, we only check for cases not covered in the Primitive tests,
+// since Intents inherit from Primitives
+TEST(MoveIntentTest, test_equality_operator_intents_equal)
+{
+    MoveIntent move_intent       = MoveIntent(0, Point(), Angle::zero(), 0, 0);
+    MoveIntent move_intent_other = MoveIntent(0, Point(), Angle::zero(), 0, 0);
+
+    EXPECT_EQ(move_intent, move_intent_other);
+}
+
+TEST(MoveIntentTest, test_inequality_operator_with_mismatched_priorities)
+{
+    MoveIntent move_intent       = MoveIntent(0, Point(), Angle::zero(), 0, 1);
+    MoveIntent move_intent_other = MoveIntent(0, Point(), Angle::zero(), 0, 3);
+
+    EXPECT_NE(move_intent, move_intent_other);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/intent/movespin_intent.cpp
+++ b/src/thunderbots/software/test/intent/movespin_intent.cpp
@@ -1,0 +1,40 @@
+/**
+ * This file contains unit tests for the MoveSpin Intent class
+ */
+
+#include "ai/intent/movespin_intent.h"
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(MoveSpinIntentTest, intent_name_test)
+{
+    MoveSpinIntent movespin_intent = MoveSpinIntent(0, Point(), Angle::zero(), 0);
+
+    EXPECT_EQ("MoveSpin Intent", movespin_intent.getIntentName());
+}
+
+// For equality operators, we only check for cases not covered in the Primitive tests,
+// since Intents inherit from Primitives
+TEST(MoveSpinIntentTest, test_equality_operator_intents_equal)
+{
+    MoveSpinIntent movespin_intent       = MoveSpinIntent(0, Point(), Angle::zero(), 0);
+    MoveSpinIntent movespin_intent_other = MoveSpinIntent(0, Point(), Angle::zero(), 0);
+
+    EXPECT_EQ(movespin_intent, movespin_intent_other);
+}
+
+TEST(MoveSpinIntentTest, test_inequality_operator_with_mismatched_priorities)
+{
+    MoveSpinIntent movespin_intent       = MoveSpinIntent(0, Point(), Angle::zero(), 1);
+    MoveSpinIntent movespin_intent_other = MoveSpinIntent(0, Point(), Angle::zero(), 3);
+
+    EXPECT_NE(movespin_intent, movespin_intent_other);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/intent/pivot_intent.cpp
+++ b/src/thunderbots/software/test/intent/pivot_intent.cpp
@@ -1,0 +1,40 @@
+/**
+ * This file contains unit tests for the Pivot Intent class
+ */
+
+#include "ai/intent/pivot_intent.h"
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(PivotIntentTest, intent_name_test)
+{
+    PivotIntent pivot_intent = PivotIntent(0, Point(), Angle::zero(), 0, 0);
+
+    EXPECT_EQ("Pivot Intent", pivot_intent.getIntentName());
+}
+
+// For equality operators, we only check for cases not covered in the Primitive tests,
+// since Intents inherit from Primitives
+TEST(PivotIntentTest, test_equality_operator_intents_equal)
+{
+    PivotIntent pivot_intent       = PivotIntent(0, Point(), Angle::zero(), 0, 0);
+    PivotIntent pivot_intent_other = PivotIntent(0, Point(), Angle::zero(), 0, 0);
+
+    EXPECT_EQ(pivot_intent, pivot_intent_other);
+}
+
+TEST(PivotIntentTest, test_inequality_operator_with_mismatched_priorities)
+{
+    PivotIntent pivot_intent       = PivotIntent(0, Point(), Angle::zero(), 0, 1);
+    PivotIntent pivot_intent_other = PivotIntent(0, Point(), Angle::zero(), 0, 3);
+
+    EXPECT_NE(pivot_intent, pivot_intent_other);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/intent/stop_intent.cpp
+++ b/src/thunderbots/software/test/intent/stop_intent.cpp
@@ -1,0 +1,40 @@
+/**
+ * This file contains unit tests for the Stop Intent class
+ */
+
+#include "ai/intent/stop_intent.h"
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(StopIntentTest, intent_name_test)
+{
+    StopIntent stop_intent = StopIntent(0, false, 0);
+
+    EXPECT_EQ("Stop Intent", stop_intent.getIntentName());
+}
+
+// For equality operators, we only check for cases not covered in the Primitive tests,
+// since Intents inherit from Primitives
+TEST(StopIntentTest, test_equality_operator_intents_equal)
+{
+    StopIntent stop_intent       = StopIntent(0, false, 0);
+    StopIntent stop_intent_other = StopIntent(0, false, 0);
+
+    EXPECT_EQ(stop_intent, stop_intent_other);
+}
+
+TEST(StopIntentTest, test_inequality_operator_with_mismatched_priorities)
+{
+    StopIntent stop_intent       = StopIntent(0, false, 1);
+    StopIntent stop_intent_other = StopIntent(0, false, 3);
+
+    EXPECT_NE(stop_intent, stop_intent_other);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Added equality and inequality operators for the `Intent` classes. Also has to explicitly initialize the `priority` values in the constructors since they were not being initialized before.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Added unit tests for `Intent` equality and inequality operators, and Intent names.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #378 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
Had to add some missing Intents which added quite a few lines.

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
