### PR TITLE
Add XBox Controller Demo

### DIFF
--- a/environment_setup/setup_software.sh
+++ b/environment_setup/setup_software.sh
@@ -14,41 +14,6 @@
 # unit tests
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
-# Here we handle arguments provided to the script. Because this script allows
-# the installation of different versions of ROS, we use a parameter to let the
-# user decide which one to install.
-function show_help()
-{
-    echo "Thunderbots software setup script. Installs the programs"
-    echo "and dependencies required to build and run our code"
-    echo ""
-}
-
-# This script only accepts 1 argument
-if [ "$#" -ne 0 ]; then
-    echo "Error: Illegal number of arguments provided. Expected 0 arguments"
-    show_help
-    exit 1
-fi
-
-while [ "$1" != "" ]; do
-    PARAM=`echo $1 | awk -F= '{print $1}'`
-    VALUE=`echo $1 | awk -F= '{print $2}'`
-    case $PARAM in
-        -h | --help)
-            show_help
-            exit
-            ;;
-        *)
-            echo "ERROR: unknown parameter \"$PARAM\""
-            echo ""
-            show_help
-            exit 1
-            ;;
-    esac
-    shift
-done
-
 
 # Save the parent dir of this so we can always run commands relative to the
 # location of this script, no matter where it is called from. This

--- a/src/thunderbots/shared/constants.h
+++ b/src/thunderbots/shared/constants.h
@@ -18,7 +18,7 @@ const unsigned MAX_ROBOTS_OVER_RADIO = 8;
 // The maximum speed achievable by our robots, in metres per second.
 const double ROBOT_MAX_SPEED_METERS_PER_SECOND = 2.0;
 // The maximum angular speed achievable by our robots, in rad/sec
-const double ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND = 4.0;
+const double ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND = 4 * M_PI;
 // The maximum acceleration achievable by our robots, in metres per seconds squared.
 const double ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED = 3.0;
 // The maximum angular acceleration achievable by our robots, in radians per second

--- a/src/thunderbots/shared/constants.h
+++ b/src/thunderbots/shared/constants.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <math.h>
 
 // This file contains all constants that are shared between our software (AI)
 // and firmware code. Since this needs to be compiled by both C and C++, everything

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -227,6 +227,8 @@ target_link_libraries(parameters  ${catkin_LIBRARIES}
 file(GLOB_RECURSE XBOX_CONTROLLER_MAPPING_SRC LIST_DIRECTORIES false CONFIGURE_DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/xbox_controller_mapping/*.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ai/primitive/direct_velocity_primitive.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ai/primitive/kick_primitive.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ai/primitive/chip_primitive.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ai/primitive/primitive.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ai/world/*.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/util/parameter/dynamic_parameters.cpp

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -241,7 +241,7 @@ add_executable (xbox_controller_mapping
         )
 # Depend on exported targets (other packages) so that the messages in our thunderbots_msgs package are built first.
 # This way the message headers are always generated before they are used in compilation here.
-add_dependencies(parameters thunderbots_gencfg ${catkin_EXPORTED_TARGETS})
+add_dependencies(xbox_controller_mapping ${catkin_EXPORTED_TARGETS})
 target_link_libraries(xbox_controller_mapping
         ${catkin_LIBRARIES}
         )

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -237,6 +237,9 @@ add_executable (xbox_controller_mapping
         ${XBOX_CONTROLLER_MAPPING_SRC}
         ${SHARED_UTIL_SRC}
         )
+# Depend on exported targets (other packages) so that the messages in our thunderbots_msgs package are built first.
+# This way the message headers are always generated before they are used in compilation here.
+add_dependencies(parameters thunderbots_gencfg ${catkin_EXPORTED_TARGETS})
 target_link_libraries(xbox_controller_mapping
         ${catkin_LIBRARIES}
         )

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -224,6 +224,24 @@ target_link_libraries(parameters  ${catkin_LIBRARIES}
         ${PROTOBUF_LIBRARIES}
         )
 
+file(GLOB_RECURSE XBOX_CONTROLLER_MAPPING_SRC LIST_DIRECTORIES false CONFIGURE_DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/xbox_controller_mapping/*.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ai/primitive/direct_velocity_primitive.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ai/primitive/primitive.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ai/world/*.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/util/parameter/dynamic_parameters.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/util/timestamp.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/util/ros_messages.cpp
+        )
+add_executable (xbox_controller_mapping
+        ${XBOX_CONTROLLER_MAPPING_SRC}
+        ${SHARED_UTIL_SRC}
+        )
+target_link_libraries(xbox_controller_mapping
+        ${catkin_LIBRARIES}
+        )
+
+
 #############
 ## Testing ##
 #############

--- a/src/thunderbots/software/grsim_communication/grsim_backend.cpp
+++ b/src/thunderbots/software/grsim_communication/grsim_backend.cpp
@@ -8,6 +8,7 @@
 #include "grsim_command_primitive_visitor.h"
 #include "motion_controller.h"
 #include "proto/grSim_Commands.pb.h"
+#include "shared/constants.h"
 #include "util/logger/init.h"
 
 using namespace boost::asio;
@@ -56,7 +57,10 @@ void GrSimBackend::sendPrimitives(
                 MotionController::bangBangVelocityController(
                     robot, motion_controller_command.global_destination,
                     motion_controller_command.final_speed_at_destination,
-                    motion_controller_command.final_orientation, delta_time.count());
+                    motion_controller_command.final_orientation, delta_time.count(),
+                    ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+                    ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+                    ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
             // send the velocity data via grsim_packet
             grSim_Packet grsim_packet = createGrSimPacketWithRobotVelocity(

--- a/src/thunderbots/software/grsim_communication/motion_controller.cpp
+++ b/src/thunderbots/software/grsim_communication/motion_controller.cpp
@@ -15,12 +15,15 @@
 
 #include <algorithm>
 
-#include "shared/constants.h"
 #include "util/logger/init.h"
 
 MotionController::Velocity MotionController::bangBangVelocityController(
     const Robot robot, const Point dest, const double desired_final_speed,
-    const Angle desired_final_orientation, const double delta_time)
+    const Angle desired_final_orientation, const double delta_time,
+    const double max_speed_meters_per_second,
+    const double max_angular_speed_radians_per_second,
+    const double max_acceleration_meters_per_second_squared,
+    const double max_angular_acceleration_meters_per_second_squared)
 {
     MotionController::Velocity robot_velocities;
 
@@ -36,16 +39,21 @@ MotionController::Velocity MotionController::bangBangVelocityController(
     else
     {
         robot_velocities.linear_velocity = MotionController::determineLinearVelocity(
-            robot, dest, desired_final_speed, delta_time);
+            robot, dest, desired_final_speed, delta_time, max_speed_meters_per_second,
+            max_angular_speed_radians_per_second);
         robot_velocities.angular_velocity = MotionController::determineAngularVelocity(
-            robot, desired_final_orientation, delta_time);
+            robot, desired_final_orientation, delta_time,
+            max_angular_speed_radians_per_second,
+            max_angular_acceleration_meters_per_second_squared);
     }
 
     return robot_velocities;
 }
 
 AngularVelocity MotionController::determineAngularVelocity(
-    const Robot robot, const Angle desired_final_orientation, const double delta_time)
+    const Robot robot, const Angle desired_final_orientation, const double delta_time,
+    const double max_angular_speed_radians_per_second,
+    const double max_angular_acceleration_radians_per_second_squared)
 {
     // Calculate the angular difference between us and a goal
     Angle angle_difference = (desired_final_orientation - robot.orientation()).angleMod();
@@ -59,10 +67,10 @@ AngularVelocity MotionController::determineAngularVelocity(
         3;
     // Cap our angular velocity at the robot's physical limit
     new_robot_angular_velocity_magnitude = std::min<double>(
-        new_robot_angular_velocity_magnitude, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND);
+        new_robot_angular_velocity_magnitude, max_angular_speed_radians_per_second);
     // Figure out the maximum acceleration the robot is physically capable of
     double max_additional_angular_velocity =
-        ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED * delta_time;
+        max_angular_acceleration_radians_per_second_squared * delta_time;
 
     // Compute the final velocity by taking the minimum of the physical max additional
     // turn rate and our desired additional turn rate
@@ -76,13 +84,14 @@ AngularVelocity MotionController::determineAngularVelocity(
     return AngularVelocity::ofRadians(new_angular_velocity);
 }
 
-Vector MotionController::determineLinearVelocity(const Robot robot, const Point dest,
-                                                 const double desired_final_speed,
-                                                 const double delta_time)
+Vector MotionController::determineLinearVelocity(
+    const Robot robot, const Point dest, const double desired_final_speed,
+    const double delta_time, const double max_speed_meters_per_second,
+    const double max_acceleration_meters_per_second_squared)
 {
     // Figure out the maximum (physically possible) velocity we can add to the robot
     double max_magnitude_of_velocity_to_apply =
-        ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED * delta_time;
+        max_acceleration_meters_per_second_squared * delta_time;
 
     // Calculate a unit vector from the robot to the destination
     Vector unit_vector_to_dest = (dest - robot.position()).norm();
@@ -127,9 +136,9 @@ Vector MotionController::determineLinearVelocity(const Robot robot, const Point 
     {
         new_robot_velocity_magnitude *= -1;
     }
-    new_robot_velocity_magnitude = std::clamp<double>(new_robot_velocity_magnitude,
-                                                      -ROBOT_MAX_SPEED_METERS_PER_SECOND,
-                                                      ROBOT_MAX_SPEED_METERS_PER_SECOND);
+    new_robot_velocity_magnitude =
+        std::clamp<double>(new_robot_velocity_magnitude, -max_speed_meters_per_second,
+                           max_speed_meters_per_second);
 
     Vector new_robot_velocity =
         new_robot_velocity_magnitude * (robot.velocity() + additional_velocity).norm();

--- a/src/thunderbots/software/grsim_communication/motion_controller.h
+++ b/src/thunderbots/software/grsim_communication/motion_controller.h
@@ -75,13 +75,24 @@ namespace MotionController
      * @param desired_final_speed The target final speed of the robot
      * @param desired_final_orientation The target final orientation of the robot
      * @param delta_time The change in time since the motion controller was run last
+     * @param max_speed_meters_per_second The maximum linear speed of the robot, in meters
+     * per second
+     * @param max_angular_speed_radians_per_second The maximum angular speed of the robot,
+     * in radians per second
+     * @param max_acceleration_meters_per_second_squared The maximum linear acceleration
+     * of the robot, in meters per second squared
+     * @param max_angular_acceleration_meters_per_second_squared The maximum angular
+     * acceleration of the robot, in radians per second squared
      * @return The linear velocity of the robot as a Vector(X,Y) and the angular velocity
      * of the robot as a AngularVelocity packaged in a vector
      */
-    Velocity bangBangVelocityController(const Robot robot, const Point dest,
-                                        const double desired_final_speed,
-                                        const Angle desired_final_orientation,
-                                        const double delta_time);
+    Velocity bangBangVelocityController(
+        const Robot robot, const Point dest, const double desired_final_speed,
+        const Angle desired_final_orientation, const double delta_time,
+        const double max_speed_meters_per_second,
+        const double max_angular_speed_radians_per_second,
+        const double max_acceleration_meters_per_second_squared,
+        const double max_angular_acceleration_meters_per_second_squared);
 
     /**
      * Calculate robot angular velocities based on current robot polar state and
@@ -92,9 +103,10 @@ namespace MotionController
      * @param delta_time The time that will be used to calculate the change in speed of
      * @return Angular velocity of the robot as a AngularVelocity packaged in a vector
      */
-    AngularVelocity determineAngularVelocity(const Robot robot,
-                                             const Angle desired_final_orientation,
-                                             const double delta_time);
+    AngularVelocity determineAngularVelocity(
+        const Robot robot, const Angle desired_final_orientation, const double delta_time,
+        const double max_angular_speed_radians_per_second,
+        const double max_angular_acceleration_radians_per_second_squared);
 
     /**
      * Calculate robot linear velocities based on current robot cartesian state and
@@ -105,8 +117,9 @@ namespace MotionController
      * @param delta_time The time that will be used to calculate the change in speed of
      * @return Linear velocity of the robot as a AngularVelocity packaged in a vector
      */
-    Vector determineLinearVelocity(const Robot robot, const Point dest,
-                                   const double desired_final_speed,
-                                   const double delta_time);
+    Vector determineLinearVelocity(
+        const Robot robot, const Point dest, const double desired_final_speed,
+        const double delta_time, const double max_speed_meters_per_second,
+        const double max_acceleration_meters_per_second_squared);
 
 }  // namespace MotionController

--- a/src/thunderbots/software/launch/xbox_controller.launch
+++ b/src/thunderbots/software/launch/xbox_controller.launch
@@ -1,0 +1,31 @@
+<launch>
+
+    <!-- Launch the Joystick receiver node -->
+    <node name="joy_node" pkg="joy" type="joy_node" output="screen">
+        <!-- See http://wiki.ros.org/joy section 3.2 for parameters -->
+
+        <!-- The name of the device the XBox controller shows up as on the system -->
+        <param name="dev" value="/dev/input/js0" />
+
+        <!-- Amount by which the joystick has to move before it is considered to be off-center -->
+        <!-- Empirically determined 0.5 to be a reasonable value -->
+        <param name="deadzone" value="0.5" />
+
+        <!-- Rate in Hz at which a joystick that has a non-changing state will resend the previously sent message -->
+        <param name="autorepeat_rate" value="10" />
+
+        <!-- Axis events that are received within coalesce_interval (seconds) of each other are sent out in a single ROS message -->
+        <param name="coalesce_interval" value="0.001" />
+    </node>
+
+    <!-- Launch the XBox controller mapper node -->
+    <node name="xbox_controller_mapping" pkg="thunderbots" type="xbox_controller_mapping" output="screen">
+    </node>
+
+    <!-- Launch the dynamic parameters node -->
+    <node name="parameters" pkg="thunderbots" type="parameters" output="screen"/>
+
+    <!-- Launch the rqt_reconfigure gui -->
+    <node name="rqt_reconfigure" pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen"/>
+
+</launch>

--- a/src/thunderbots/software/launch/xbox_controller_grsim.launch
+++ b/src/thunderbots/software/launch/xbox_controller_grsim.launch
@@ -1,0 +1,10 @@
+<launch>
+
+    <!-- Find and include the generic XBox controller launchfile from our thunderbots package -->
+    <include file="$(find thunderbots)/launch/xbox_controller.launch" />
+
+    <!-- Launch the grsim_communication node -->
+    <node name="grsim_communication" pkg="thunderbots" type="grsim_communication" output="screen">
+    </node>
+
+</launch>

--- a/src/thunderbots/software/launch/xbox_controller_radio.launch
+++ b/src/thunderbots/software/launch/xbox_controller_radio.launch
@@ -1,0 +1,10 @@
+<launch>
+
+    <!-- Find and include the generic XBox controller launchfile from our thunderbots package -->
+    <include file="$(find thunderbots)/launch/xbox_controller.launch" />
+
+    <!-- Launch the radio_communication node -->
+    <node name="radio_communication" pkg="thunderbots" type="radio_communication" output="screen">
+    </node>
+
+</launch>

--- a/src/thunderbots/software/package.xml
+++ b/src/thunderbots/software/package.xml
@@ -62,6 +62,8 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>thunderbots_msgs</exec_depend>
+  <!-- The node we use to interact with the XBox Controller -->
+  <exec_depend>joy</exec_depend>
 
   <depend>dynamic_reconfigure</depend>
   <test_depend>rostest</test_depend>

--- a/src/thunderbots/software/param_server/cfg/Params.cfg
+++ b/src/thunderbots/software/param_server/cfg/Params.cfg
@@ -39,7 +39,7 @@ gen.add("robot_expiry_buffer_milliseconds", int_t, 0, "brief description", 50, 0
 
 navigator_params = gen.add_group("Navigator")
 navigator_params.add("default_avoid_dist", double_t, 0, "brief description", 50,  0, 100)
-navigator_params.add("collision_avoid_velocity_scale", double_t, 0, "brief description", .5, 0,  1)
+navigator_params.add("collision_avoid_velocity_scale", double_t, 0, "brief description", 0.5, 0,  1)
 # add more navigator parameters here
 
 #######################################################################
@@ -56,6 +56,17 @@ navigator_params.add("number_of_gradient_descent_steps_per_iter", int_t, 0, "", 
 navigator_params.add("pass_equality_max_position_difference_meters", double_t, 0, "", 0.1, 0, 4)
 navigator_params.add("pass_equality_max_start_time_difference_seconds", double_t, 0, "", 0.5, 0, 3)
 navigator_params.add("pass_equality_max_speed_difference_meters_per_second", double_t, 0, "", 0.3, 0, 4)
+
+#######################################################################
+#                         XBOX CONTROLLER DEMO                        #
+#######################################################################
+xbox_controller_demo_params = gen.add_group("XBox Controller Demo")
+xbox_controller_demo_params.add("xbox_demo_robot_ID", int_t, 0, "The ID of the robot being controller by the XBox Controller", 0, 0, 16)
+xbox_controller_demo_params.add("xbox_demo_kick_speed_meters_per_second", double_t, 0, "The robot's kick speed in meters per second", 4.0, 0.0, 6.5)
+xbox_controller_demo_params.add("xbox_demo_chip_distance_meters", double_t, 0, "How far in meters the robot will chip", 1.0, 0.0, 5.0)
+xbox_controller_demo_params.add("xbox_demo_dribbler_rpm", double_t, 0, "The RPM of the robot's dribbler when turned on", 1000, 0, 10000)
+xbox_controller_demo_params.add("xbox_demo_linear_sensitivity", double_t, 0, "The amount to scale the x and y output values by to make the robot more or less sensitive to control linearly", 1.0, 0.0, 1.0)
+xbox_controller_demo_params.add("xbox_demo_angular_sensitivity", double_t, 0, "The amount to scale the theta output values to make the robot more or less sensitive to control rotationaly", 1.0, 0.0, 1.0)
 
 #######################################################################
 #                              EXAMPLES                               #

--- a/src/thunderbots/software/param_server/cfg/Params.cfg
+++ b/src/thunderbots/software/param_server/cfg/Params.cfg
@@ -39,7 +39,7 @@ gen.add("robot_expiry_buffer_milliseconds", int_t, 0, "brief description", 50, 0
 
 navigator_params = gen.add_group("Navigator")
 navigator_params.add("default_avoid_dist", double_t, 0, "brief description", 50,  0, 100)
-navigator_params.add("collision_avoid_velocity_scale", double_t, 0, "brief description", 0.5, 0,  1)
+navigator_params.add("collision_avoid_velocity_scale", double_t, 0, "brief description", .5, 0,  1)
 # add more navigator parameters here
 
 #######################################################################

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -1,20 +1,25 @@
 #include <ros/ros.h>
+#include <ros/time.h>
 #include <thunderbots_msgs/Primitive.h>
 #include <thunderbots_msgs/PrimitiveArray.h>
 #include <thunderbots_msgs/World.h>
 
 #include "ai/primitive/primitive.h"
 #include "ai/primitive/primitive_factory.h"
+#include "geom/point.h"
 #include "mrf_backend.h"
 #include "util/constants.h"
 #include "util/logger/init.h"
 #include "util/ros_messages.h"
 
-// Member variables we need to maintain state
-// They are kept in an anonymous namespace so they are not accessible outside this
-// file and are not created as global static variables.
+
 namespace
 {
+    // A vector of primitives. It is cleared each tick, populated by the callbacks
+    // that receive primitive commands, and is processed by the backend to send primitives
+    // to the robots over radio.
+    std::vector<std::unique_ptr<Primitive>> primitives;
+
     // The MRFBackend instance that connects to the dongle
     MRFBackend backend = MRFBackend();
 }  // namespace
@@ -22,7 +27,6 @@ namespace
 // Callbacks
 void primitiveUpdateCallback(const thunderbots_msgs::PrimitiveArray::ConstPtr& msg)
 {
-    std::vector<std::unique_ptr<Primitive>> primitives;
     thunderbots_msgs::PrimitiveArray prim_array_msg = *msg;
     for (const thunderbots_msgs::Primitive& prim_msg : prim_array_msg.primitives)
     {
@@ -45,7 +49,7 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
     std::vector<std::tuple<uint8_t, Point, Angle>> robots;
     for (const Robot& r : friendly_team.getAllRobots())
     {
-        robots.emplace_back(std::make_tuple(r.id(), r.position(), r.orientation()));
+        robots.push_back(std::make_tuple(r.id(), r.position(), r.orientation()));
     }
 
     // Update robots and ball
@@ -54,12 +58,6 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
 
     // Send vision packet
     backend.send_vision_packet();
-
-    // Handle libusb events for the dongle
-    // TODO: How badly does this need to be in the main loop?
-    // Can it be here if we assume this function is called all the time?
-    // Investigate as part of https://github.com/UBC-Thunderbots/Software/issues/222
-    backend.update_dongle_events();
 }
 
 int main(int argc, char** argv)
@@ -69,7 +67,7 @@ int main(int argc, char** argv)
     ros::NodeHandle node_handle;
 
     // Create subscribers to topics we care about
-    ros::Subscriber primitive_subscriber = node_handle.subscribe(
+    ros::Subscriber prim_array_sub = node_handle.subscribe(
         Util::Constants::AI_PRIMITIVES_TOPIC, 1, primitiveUpdateCallback);
     ros::Subscriber world_sub = node_handle.subscribe(
         Util::Constants::NETWORK_INPUT_WORLD_TOPIC, 1, worldUpdateCallback);
@@ -77,10 +75,22 @@ int main(int argc, char** argv)
     // Initialize the logger
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
 
-    // Services any ROS calls in a separate thread "behind the scenes". Does not return
-    // until the node is shutdown
-    // http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning
-    ros::spin();
+    // Initialize variables
+    primitives = std::vector<std::unique_ptr<Primitive>>();
+
+    // Main loop
+    while (ros::ok())
+    {
+        // Clear all primitives each tick
+        primitives.clear();
+
+        // Handle libusb events for the dongle
+        backend.update_dongle_events();
+
+        // Spin once to let all necessary callbacks run
+        // The callbacks will populate the primitives vector
+        ros::spinOnce();
+    }
 
     return 0;
 }

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -533,7 +533,10 @@ void MRFDongle::encode_primitive(const std::unique_ptr<Primitive> &prim, void *o
     //         words[1] |= 2 << 14;
     //         break;
     // }
-    words[1] |= 1 << 14;  // discharged for now
+    // charged by default
+    // Once we stop sending radio packets to the robots, they have a failsafe to discharge
+    // after 1 second. For now we rely on that to discharge the robots.
+    words[1] |= 2 << 14;
 
     // Encode extra data plus the slow flag.
     // TODO: do we actually use the slow flag?
@@ -541,7 +544,7 @@ void MRFDongle::encode_primitive(const std::unique_ptr<Primitive> &prim, void *o
     bool slow     = false;
     if (extra > 127)
     {
-        throw std::invalid_argument("extra greater than 127");
+//        throw std::invalid_argument("extra greater than 127");
     }
     uint8_t extra_encoded = static_cast<uint8_t>(extra | (slow ? 0x80 : 0x00));
 

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -544,7 +544,7 @@ void MRFDongle::encode_primitive(const std::unique_ptr<Primitive> &prim, void *o
     bool slow     = false;
     if (extra > 127)
     {
-//        throw std::invalid_argument("extra greater than 127");
+        throw std::invalid_argument("extra greater than 127");
     }
     uint8_t extra_encoded = static_cast<uint8_t>(extra | (slow ? 0x80 : 0x00));
 

--- a/src/thunderbots/software/radio_communication/mrf_backend.cpp
+++ b/src/thunderbots/software/radio_communication/mrf_backend.cpp
@@ -6,7 +6,7 @@
 
 MRFBackend::MRFBackend()
     : dongle(MRFDongle()),
-      ball(Ball(Point(0, 0), Vector(0, 0), Timestamp::fromSeconds(1)))
+      ball(Ball(Point(0, 0), Vector(0, 0), Timestamp::fromSeconds(0)))
 {
 }
 

--- a/src/thunderbots/software/test/ai/grsim_communication/motion_controller.cpp
+++ b/src/thunderbots/software/test/ai/grsim_communication/motion_controller.cpp
@@ -52,7 +52,10 @@ TEST_F(MotionControllerTest, calc_correct_velocity_zeros)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     Vector expected_vector          = Point(0, 0);
     Angle expected_angular_velocity = Angle::ofRadians(0);
@@ -72,7 +75,10 @@ TEST_F(MotionControllerTest, calc_correct_velocity_ones)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     Vector expected_vector =
         Point(1 - ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED, 0);
@@ -94,7 +100,10 @@ TEST_F(MotionControllerTest, over_speed_test)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     double expected_speed = ROBOT_MAX_SPEED_METERS_PER_SECOND;
 
@@ -115,7 +124,10 @@ TEST_F(MotionControllerTest, no_overspeed_acceleration_test)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     double expected_speed = ROBOT_MAX_SPEED_METERS_PER_SECOND;
 
@@ -134,9 +146,16 @@ TEST_F(MotionControllerTest, no_overspeed_ang_acceleration_test)
     Angle destination_angle  = Angle::ofDegrees(210);
     double destination_speed = 0;
 
+    // We use a custom MAX_ANGULAR_SPEED value because if this value is too high, the
+    // controller will always try decelerate because it thinks it will overshoot its
+    // orientation target at the current velocity. Using a lower value lets us actually
+    // hit the maximum and test that case
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, 4.0,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     double expected_speed = 0;
 
@@ -157,7 +176,10 @@ TEST_F(MotionControllerTest, negative_time_test)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     Vector expected_velocity = Vector(-1, 2);
 
@@ -178,7 +200,10 @@ TEST_F(MotionControllerTest, zero_time_test)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     Vector expected_velocity = Vector(-1, 1.6);
 
@@ -201,7 +226,10 @@ TEST_F(MotionControllerTest, negative_x_velocity_test)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     Vector expected_velocity = Vector(
         initialSpeed - ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED * delta_time, 0);
@@ -221,7 +249,10 @@ TEST_F(MotionControllerTest, negative_y_velocity_test)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     Vector expected_velocity = Vector(
         0, initialSpeed - ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED * delta_time);
@@ -241,14 +272,17 @@ TEST_F(MotionControllerTest, negative_desired_orientation_test)
     Robot robot = Robot(4, Point(0, 0), Vector(0, 0), Angle::ofRadians(0),
                         initial_ang_speed, current_time);
 
-
+    // We use a lower MAX_ANGULAR_SPEED threshold here so it's easier to check the final
+    // value (since it will just hit the maximum)
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, 4.0,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     // expect -4 because of angular speed cap
-    AngularVelocity expected_velocity =
-        AngularVelocity::ofRadians(-ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND);
+    AngularVelocity expected_velocity = AngularVelocity::ofRadians(-4);
 
     EXPECT_EQ(expected_velocity, robot_velocities.angular_velocity);
 }
@@ -265,13 +299,17 @@ TEST_F(MotionControllerTest, positive_desired_orientation_test)
     Robot robot = Robot(4, Point(0, 0), Vector(0, 0), Angle::ofRadians(0),
                         initial_ang_speed, current_time);
 
+    // We use a lower MAX_ANGULAR_SPEED threshold here so it's easier to check the final
+    // value (since it will just hit the maximum)
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, 4.0,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
-    // expect -4 because of angular speed cap
-    AngularVelocity expected_velocity =
-        AngularVelocity::ofRadians(ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND);
+    // expect 4 because of angular speed cap
+    AngularVelocity expected_velocity = AngularVelocity::ofRadians(4.0);
 
     EXPECT_EQ(expected_velocity, robot_velocities.angular_velocity);
 }
@@ -288,7 +326,10 @@ TEST_F(MotionControllerTest, negative_y_positive_x_velocity_test)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     Vector expected_velocity = Vector(sqrt(ROBOT_MAX_SPEED_METERS_PER_SECOND),
                                       -sqrt(ROBOT_MAX_SPEED_METERS_PER_SECOND));
@@ -307,7 +348,10 @@ TEST_F(MotionControllerTest, positive_y_negative_x_velocity_test)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     Vector expected_velocity = Vector(-sqrt(ROBOT_MAX_SPEED_METERS_PER_SECOND),
                                       sqrt(ROBOT_MAX_SPEED_METERS_PER_SECOND));
@@ -326,7 +370,10 @@ TEST_F(MotionControllerTest, positive_y_positive_x_velocity_test)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     Vector expected_velocity = Vector(sqrt(ROBOT_MAX_SPEED_METERS_PER_SECOND),
                                       sqrt(ROBOT_MAX_SPEED_METERS_PER_SECOND));
@@ -345,7 +392,10 @@ TEST_F(MotionControllerTest, negative_y_negative_x_velocity_test)
 
     MotionController::Velocity robot_velocities =
         MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
     Vector expected_velocity = Vector(-sqrt(ROBOT_MAX_SPEED_METERS_PER_SECOND),
                                       -sqrt(ROBOT_MAX_SPEED_METERS_PER_SECOND));
@@ -370,7 +420,10 @@ TEST_F(MotionControllerTest, zero_final_speed_positive_x_positive_y_position_tes
     for (iteration_count = 0; iteration_count < TOTAL_STEPS; iteration_count++)
     {
         robot_velocities = MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
         new_x_position = robot.position().x() + robot.velocity().x() * delta_time;
         new_y_position = robot.position().y() + robot.velocity().y() * delta_time;
@@ -410,7 +463,10 @@ TEST_F(MotionControllerTest, zero_final_speed_positive_x_negative_y_position_tes
     for (iteration_count = 0; iteration_count < TOTAL_STEPS; iteration_count++)
     {
         robot_velocities = MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
         new_x_position = robot.position().x() + robot.velocity().x() * delta_time;
         new_y_position = robot.position().y() + robot.velocity().y() * delta_time;
@@ -445,7 +501,10 @@ TEST_F(MotionControllerTest, zero_final_speed_negative_x_positive_y_position_tes
     for (iteration_count = 0; iteration_count < TOTAL_STEPS; iteration_count++)
     {
         robot_velocities = MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
         new_x_position = robot.position().x() + robot.velocity().x() * delta_time;
         new_y_position = robot.position().y() + robot.velocity().y() * delta_time;
@@ -483,7 +542,10 @@ TEST_F(MotionControllerTest, zero_final_speed_negative_x_negative_y_position_tes
     for (iteration_count = 0; iteration_count < TOTAL_STEPS; iteration_count++)
     {
         robot_velocities = MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
         new_x_position = robot.position().x() + robot.velocity().x() * delta_time;
         new_y_position = robot.position().y() + robot.velocity().y() * delta_time;
@@ -521,7 +583,10 @@ TEST_F(MotionControllerTest, asymetric_reach_des_test)
     for (iteration_count = 0; iteration_count < TOTAL_STEPS; iteration_count++)
     {
         robot_velocities = MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
         new_x_position = robot.position().x() + robot.velocity().x() * delta_time;
         new_y_position = robot.position().y() + robot.velocity().y() * delta_time;
@@ -561,7 +626,10 @@ TEST_F(MotionControllerTest, positive_final_speed_position_test)
     for (iteration_count = 0; iteration_count < TOTAL_STEPS; iteration_count++)
     {
         robot_velocities = MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
         new_x_position = robot.position().x() + robot.velocity().x() * delta_time;
         new_y_position = robot.position().y() + robot.velocity().y() * delta_time;
@@ -602,7 +670,10 @@ TEST_F(MotionControllerTest, negative_final_speed_position_test)
     for (iteration_count = 0; iteration_count < TOTAL_STEPS; iteration_count++)
     {
         robot_velocities = MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
         new_x_position = robot.position().x() + robot.velocity().x() * delta_time;
         new_y_position = robot.position().y() + robot.velocity().y() * delta_time;
@@ -641,7 +712,10 @@ TEST_F(MotionControllerTest, positive_rotation_position_test)
     for (iteration_count = 0; iteration_count < TOTAL_STEPS; iteration_count++)
     {
         robot_velocities = MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
         new_orientation =
             robot.orientation() +
@@ -677,7 +751,10 @@ TEST_F(MotionControllerTest, negative_rotation_position_test)
     for (iteration_count = 0; iteration_count < TOTAL_STEPS; iteration_count++)
     {
         robot_velocities = MotionController::bangBangVelocityController(
-            robot, destination, destination_speed, destination_angle, delta_time);
+            robot, destination, destination_speed, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
 
         new_orientation =
             robot.orientation() +
@@ -711,8 +788,11 @@ TEST_F(MotionControllerTest,
     Angle destination_angle = Angle::ofRadians(0);
 
     MotionController::Velocity robot_velocities =
-        MotionController::bangBangVelocityController(robot, destination, 2,
-                                                     destination_angle, delta_time);
+        MotionController::bangBangVelocityController(
+            robot, destination, 2, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
     // if the destination is on the +x side of the robot, the velocity should always have
     // x > 0
     EXPECT_GT(robot_velocities.linear_velocity.x(), initial_velocity.x());
@@ -730,8 +810,11 @@ TEST_F(MotionControllerTest,
     Angle destination_angle = Angle::ofRadians(0);
 
     MotionController::Velocity robot_velocities =
-        MotionController::bangBangVelocityController(robot, destination, 2,
-                                                     destination_angle, delta_time);
+        MotionController::bangBangVelocityController(
+            robot, destination, 2, destination_angle, delta_time,
+            ROBOT_MAX_SPEED_METERS_PER_SECOND, ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND,
+            ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED,
+            ROBOT_MAX_ANG_ACCELERATION_RAD_PER_SECOND_SQUARED);
     // if the destination is on the +x side of the robot, the velocity should always have
     // x > 0
     EXPECT_GT(robot_velocities.linear_velocity.x(), initial_velocity.x());

--- a/src/thunderbots/software/util/constants.h
+++ b/src/thunderbots/software/util/constants.h
@@ -20,6 +20,9 @@ namespace Util
         static const std::string AI_PRIMITIVES_TOPIC         = "backend/primitives";
         static const std::string ROBOT_STATUS_TOPIC          = "log/robot_status";
         static const std::string VISUALIZER_DRAW_LAYER_TOPIC = "visualizer/layers";
+        // The topic published by the joy_node that contains information about any plugged
+        // in joysticks / controllers
+        static const std::string JOY_NODE_TOPIC = "joy";
 
         // TODO: Make this a tuneable parameter
         static const TeamColour FRIENDLY_TEAM_COLOUR = YELLOW;

--- a/src/thunderbots/software/util/parameter/dynamic_parameters.cpp
+++ b/src/thunderbots/software/util/parameter/dynamic_parameters.cpp
@@ -1,4 +1,5 @@
 #include "util/parameter/dynamic_parameters.h"
+#include "shared/constants.h"
 
 namespace Util::DynamicParameters
 {
@@ -34,6 +35,16 @@ namespace Util::DynamicParameters
                                                          2.0);
     }  // namespace Navigator
 
+    // Default avoid distance around robots.
+    Parameter<double> default_avoid_dist("default_avoid_dist", 0.15);
+
+        // Scaling factor for collision avoidance.
+        // TODO this is arbitrary for now; could be determined as part of
+        // #23: https://github.com/UBC-Thunderbots/Software/issues/23
+        Parameter<double> collision_avoid_velocity_scale(
+            "collision_avoid_velocity_scale", 2.0);
+    }  // namespace Navigator
+
     namespace AI
     {
         namespace Passing
@@ -58,5 +69,15 @@ namespace Util::DynamicParameters
         }  // namespace Passing
     }      // namespace AI
 
-
-}  // namespace Util::DynamicParameters
+    namespace XBoxControllerDemo
+    {
+        Parameter<int32_t> robot_id("xbox_demo_robot_ID", 0);
+        Parameter<double> kick_speed_meters_per_second(
+            "xbox_demo_kick_speed_meters_per_second",
+            BALL_MAX_SPEED_METERS_PER_SECOND);
+        Parameter<double> chip_distance_meters("xbox_demo_chip_distance_meters", 1.0);
+        Parameter<double> dribbler_rpm("xbox_demo_dribbler_rpm", 1000.0);
+        Parameter<double> linear_sensitivity("xbox_demo_linear_sensitivity", 1.0);
+        Parameter<double> angular_sensitivity("xbox_demo_angular_sensitivity", 1.0);
+    }  // namespace XBoxControllerDemo
+}  // namespace Util

--- a/src/thunderbots/software/util/parameter/dynamic_parameters.cpp
+++ b/src/thunderbots/software/util/parameter/dynamic_parameters.cpp
@@ -1,4 +1,5 @@
 #include "util/parameter/dynamic_parameters.h"
+
 #include "shared/constants.h"
 
 namespace Util::DynamicParameters
@@ -35,16 +36,6 @@ namespace Util::DynamicParameters
                                                          2.0);
     }  // namespace Navigator
 
-    // Default avoid distance around robots.
-    Parameter<double> default_avoid_dist("default_avoid_dist", 0.15);
-
-        // Scaling factor for collision avoidance.
-        // TODO this is arbitrary for now; could be determined as part of
-        // #23: https://github.com/UBC-Thunderbots/Software/issues/23
-        Parameter<double> collision_avoid_velocity_scale(
-            "collision_avoid_velocity_scale", 2.0);
-    }  // namespace Navigator
-
     namespace AI
     {
         namespace Passing
@@ -73,11 +64,11 @@ namespace Util::DynamicParameters
     {
         Parameter<int32_t> robot_id("xbox_demo_robot_ID", 0);
         Parameter<double> kick_speed_meters_per_second(
-            "xbox_demo_kick_speed_meters_per_second",
-            BALL_MAX_SPEED_METERS_PER_SECOND);
+            "xbox_demo_kick_speed_meters_per_second", BALL_MAX_SPEED_METERS_PER_SECOND);
         Parameter<double> chip_distance_meters("xbox_demo_chip_distance_meters", 1.0);
         Parameter<double> dribbler_rpm("xbox_demo_dribbler_rpm", 1000.0);
         Parameter<double> linear_sensitivity("xbox_demo_linear_sensitivity", 1.0);
         Parameter<double> angular_sensitivity("xbox_demo_angular_sensitivity", 1.0);
     }  // namespace XBoxControllerDemo
-}  // namespace Util
+
+}  // namespace Util::DynamicParameters

--- a/src/thunderbots/software/util/parameter/dynamic_parameters.h
+++ b/src/thunderbots/software/util/parameter/dynamic_parameters.h
@@ -71,5 +71,15 @@ namespace Util
 
             }  // namespace Passing
         }      // namespace AI
-    }          // namespace DynamicParameters
+
+        namespace XBoxControllerDemo
+        {
+            extern Parameter<int32_t> robot_id;
+            extern Parameter<double> kick_speed_meters_per_second;
+            extern Parameter<double> chip_distance_meters;
+            extern Parameter<double> dribbler_rpm;
+            extern Parameter<double> linear_sensitivity;
+            extern Parameter<double> angular_sensitivity;
+        }  // namespace XBoxControllerDemo
+    }      // namespace DynamicParameters
 }  // namespace Util

--- a/src/thunderbots/software/xbox_controller_mapping/main.cpp
+++ b/src/thunderbots/software/xbox_controller_mapping/main.cpp
@@ -1,0 +1,176 @@
+#include <ros/ros.h>
+#include <sensor_msgs/Joy.h>
+#include <thunderbots_msgs/Primitive.h>
+#include <thunderbots_msgs/PrimitiveArray.h>
+#include <thunderbots_msgs/Robot.h>
+
+#include "ai/primitive/direct_velocity_primitive.h"
+#include "shared/constants.h"
+#include "util/constants.h"
+#include "util/parameter/dynamic_parameters.h"
+#include "util/ros_messages.h"
+
+// Member variables we need to maintain state
+// They are kept in an anonymous namespace so they are not accessible outside this
+// file and are not created as global static variables.
+namespace
+{
+    // The publisher to send our custom Primitive commands based on the controller
+    // information
+    ros::Publisher primitive_publisher;
+    // Publishers to spoof network_input data
+    ros::Publisher friendly_team_publisher;
+    ros::Publisher ball_publisher;
+
+    // Button mappings for a Microsoft Xbox 360 Wired Controller for Linux
+    // http://wiki.ros.org/joy section 5.3
+    enum ControllerButtons_t
+    {
+        A = 0,
+        B,
+        X,
+        Y,
+        LEFT_BUMPER,
+        RIGHT_BUMPER,
+        BACK,
+        START,
+        POWER,
+        BUTTON_STICK_LEFT,
+        BUTTON_STICK_RIGHT
+    } ControllerButtons;
+
+    // Axis mappings for a Microsoft Xbox 360 Wired Controller for Linux
+    // http://wiki.ros.org/joy section 5.3
+    enum ControllerAxes_t
+    {
+        LEFTRIGHT_AXIS_STICK_LEFT = 0,
+        UPDOWN_AXIS_STICK_LEFT,
+        LEFT_TRIGGER,
+        LEFTRIGHT_AXIS_STICK_RIGHT,
+        UPDOWN_AXIS_STICK_RIGHT,
+        RIGHT_TRIGGER,
+        CROSS_PAD_LEFT_RIGHT,
+        CROSS_PAD_UP_DOWN
+    } ControllerAxes;
+}  // namespace
+
+/**
+ * Toggles whether or not the dribbler is running every time the given button is pressed
+ * (value of 1 for pressed, 0 for not pressed). Acts like a D Flip-Flop.
+ *
+ * @param button_pressed The value indicating if the button is pressed. 1 indicates the
+ * button is pressed, 0 indicates the button is not pressed
+ *
+ * @return 1 if the dribbler should be enabled, and 0 if the dribbler should not be
+ * enabled
+ */
+unsigned int toggleDribble(unsigned int button_pressed)
+{
+    static unsigned int dribble_enabled  = 0;
+    static bool button_has_been_released = true;
+
+    if (button_pressed == 1 && button_has_been_released)
+    {
+        dribble_enabled          = dribble_enabled == 1 ? 0 : 1;
+        button_has_been_released = false;
+    }
+    else if (button_pressed == 0 && !button_has_been_released)
+    {
+        button_has_been_released = true;
+    }
+
+    return dribble_enabled;
+}
+
+void joystickUpdateCallback(const sensor_msgs::Joy::ConstPtr &msg)
+{
+    sensor_msgs::Joy::_axes_type axes       = msg->axes;
+    sensor_msgs::Joy::_buttons_type buttons = msg->buttons;
+
+    // Axes values report values in the range [-1.0, 1.0]. Values are 1.0 when the
+    // joystick is pushed all the way up, -1.0 when the joystick is all the way down,
+    // 1.0 when the joystick is pushed all the way left, and -1.0 when the joystick is
+    // pushed all the way right
+    double robot_x_velocity =
+        axes[UPDOWN_AXIS_STICK_LEFT] * ROBOT_MAX_SPEED_METERS_PER_SECOND *
+        Util::DynamicParameters::XBoxControllerDemo::linear_sensitivity.value();
+    double robot_y_velocity =
+        axes[LEFTRIGHT_AXIS_STICK_LEFT] * ROBOT_MAX_SPEED_METERS_PER_SECOND *
+        Util::DynamicParameters::XBoxControllerDemo::linear_sensitivity.value();
+    double robot_angular_velocity =
+        axes[LEFTRIGHT_AXIS_STICK_RIGHT] * ROBOT_MAX_ANG_SPEED_RAD_PER_SECOND *
+        Util::DynamicParameters::XBoxControllerDemo::angular_sensitivity.value();
+
+    // The Y button reports an integer of 1 when pressed, and 0 when not pressed
+    double robot_dribbler_rpm =
+        toggleDribble(static_cast<unsigned int>(buttons[Y])) *
+        Util::DynamicParameters::XBoxControllerDemo::dribbler_rpm.value();
+
+    // The triggers report values in the range [-1.0, 1.0]. Values are < 0 when the
+    // trigger is pressed/held down more than halfway, and > 0 otherwise
+    double robot_kick_speed_meters_per_second =
+        (axes[RIGHT_TRIGGER] < 0.0)
+            ? Util::DynamicParameters::XBoxControllerDemo::kick_speed_meters_per_second
+                  .value()
+            : 0.0;
+    double robot_chip_distance_meters =
+        (axes[LEFT_TRIGGER] < 0.0)
+            ? Util::DynamicParameters::XBoxControllerDemo::chip_distance_meters.value()
+            : 0.0;
+
+    // We spoof the information about the state of the robot because it is unnecessary for
+    // the XBox controller demos. These demos typically run where we have no vision, so we
+    // just simply report the robot is always at Point(0, 0), and just set the velocities
+    // directly. The network_input node can't be used since there is no vision data
+    Robot robot =
+        Robot(static_cast<unsigned int>(
+                  Util::DynamicParameters::XBoxControllerDemo::robot_id.value()),
+              Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+              Timestamp::fromSeconds(0));
+    Team team = Team(Duration::fromMilliseconds(
+        Util::Constants::ROBOT_DEBOUNCE_DURATION_MILLISECONDS));
+    team.updateRobots({robot});
+    thunderbots_msgs::Team team_msg = Util::ROSMessages::convertTeamToROSMessage(team);
+    friendly_team_publisher.publish(team_msg);
+
+    // We spoof the information about the state of the ball for similar reasons to the
+    // robot above. Since the AI is not running (a human is controlling the robot) we
+    // don't need to report the real ball information.
+    Ball ball                       = Ball(Point(), Vector(), Timestamp::fromSeconds(0));
+    thunderbots_msgs::Ball ball_msg = Util::ROSMessages::convertBallToROSMessage(ball);
+    ball_publisher.publish(ball_msg);
+
+    // Create and send the DirectVelocityPrimitive constructed from the commands received
+    // from the XBox Controller
+    DirectVelocityPrimitive primitive =
+        DirectVelocityPrimitive(0, robot_x_velocity, robot_y_velocity,
+                                robot_angular_velocity, robot_dribbler_rpm);
+    thunderbots_msgs::Primitive primitive_msg = primitive.createMsg();
+    thunderbots_msgs::PrimitiveArray primitive_array;
+    primitive_array.primitives.emplace_back(primitive_msg);
+
+    primitive_publisher.publish(primitive_array);
+}
+
+int main(int argc, char **argv)
+{
+    // Init ROS node
+    ros::init(argc, argv, "xbox_controller_mapping");
+    ros::NodeHandle node_handle;
+
+    // Create publishers
+    primitive_publisher = node_handle.advertise<thunderbots_msgs::PrimitiveArray>(
+        Util::Constants::AI_PRIMITIVES_TOPIC, 1);
+    friendly_team_publisher = node_handle.advertise<thunderbots_msgs::Team>(
+        Util::Constants::NETWORK_INPUT_FRIENDLY_TEAM_TOPIC, 1);
+    ball_publisher = node_handle.advertise<thunderbots_msgs::Ball>(
+        Util::Constants::NETWORK_INPUT_BALL_TOPIC, 1);
+
+    // Create subscribers
+    ros::Subscriber joy_node_subscriber =
+        node_handle.subscribe(Util::Constants::JOY_NODE_TOPIC, 1, joystickUpdateCallback);
+
+    ros::spin();
+
+    return 0;
+}

--- a/src/thunderbots/software/xbox_controller_mapping/main.cpp
+++ b/src/thunderbots/software/xbox_controller_mapping/main.cpp
@@ -164,21 +164,24 @@ void joystickUpdateCallback(const sensor_msgs::Joy::ConstPtr &msg)
     // Create and send the DirectVelocityPrimitive constructed from the commands received
     // from the XBox Controller
     std::unique_ptr<Primitive> primitive = std::make_unique<DirectVelocityPrimitive>(
-        static_cast<unsigned int>(Util::DynamicParameters::XBoxControllerDemo::robot_id.value()), robot_x_velocity, robot_y_velocity, robot_angular_velocity,
-        robot_dribbler_rpm);
+        static_cast<unsigned int>(
+            Util::DynamicParameters::XBoxControllerDemo::robot_id.value()),
+        robot_x_velocity, robot_y_velocity, robot_angular_velocity, robot_dribbler_rpm);
 
     // Send a KickPrimitive if we want to kick
     if (robot_kick_speed_meters_per_second != 0.0)
     {
         primitive = std::make_unique<KickPrimitive>(
-            Util::DynamicParameters::XBoxControllerDemo::robot_id.value(), robot.position(), robot.orientation(), robot_kick_speed_meters_per_second);
+            Util::DynamicParameters::XBoxControllerDemo::robot_id.value(),
+            robot.position(), robot.orientation(), robot_kick_speed_meters_per_second);
     }
 
     // Send a ChipPrimitive if we want to chip
     if (robot_chip_distance_meters != 0.0)
     {
         primitive = std::make_unique<ChipPrimitive>(
-            Util::DynamicParameters::XBoxControllerDemo::robot_id.value(), robot.position(), robot.orientation(), robot_chip_distance_meters);
+            Util::DynamicParameters::XBoxControllerDemo::robot_id.value(),
+            robot.position(), robot.orientation(), robot_chip_distance_meters);
     }
 
     // Publish the primitive


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
* Added a new node to read commands from connected XBox controllers
* Added a new node to convert the controller commands to Primitives

Robots can now be controlled with the XBox controller

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Manual testing with grSim

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #322 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
