### PR TITLE
Make nodes callback-based rather than polling

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -287,7 +287,10 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/robot.cpp
             ai/world/field.cpp
             ai/world/team.cpp
+            ai/world/world.cpp
+            ai/world/game_state.cpp
             util/timestamp.cpp
+            util/parameter/dynamic_parameters.cpp
             geom/point.h
             geom/angle.h)
 

--- a/src/thunderbots/software/ai/ai.cpp
+++ b/src/thunderbots/software/ai/ai.cpp
@@ -1,23 +1,14 @@
-#include "ai.h"
+#include "ai/ai.h"
 
-#include "util/logger/init.h"
+#include "ai/hl/stp/stp_hl.h"
+#include "ai/navigator/rrt/rrt.h"
 
-AI::AI(const World &world)
-    : world(world),
-      navigator(std::make_unique<RRTNav>()),
-      high_level(std::make_unique<STP_HL>())
+AI::AI() : navigator(std::make_unique<RRTNav>()), high_level(std::make_unique<STP_HL>())
 {
 }
 
-std::vector<std::unique_ptr<Primitive>> AI::getPrimitives(
-    const Timestamp &timestamp) const
+std::vector<std::unique_ptr<Primitive>> AI::getPrimitives(const World &world) const
 {
-    // NOTE: The only thing the AI really needs an updated timestamp for (updated relative
-    // to the timestamp when the state/world was last updated) is to update the
-    // "zero-time"
-    // for any predictors (ie. modules that predict Robot, Ball position etc.). When those
-    // are implemented we can update them in some way from here, if necessary.
-
     std::vector<std::unique_ptr<Intent>> assignedIntents =
         high_level->getIntentAssignment(world);
 
@@ -25,29 +16,4 @@ std::vector<std::unique_ptr<Primitive>> AI::getPrimitives(
         navigator->getAssignedPrimitives(world, assignedIntents);
 
     return assignedPrimitives;
-}
-
-void AI::updateWorldBallState(const Ball &new_ball_data)
-{
-    world.updateBallState(new_ball_data);
-}
-
-void AI::updateWorldFieldState(const Field &new_field_data)
-{
-    world.updateFieldGeometry(new_field_data);
-}
-
-void AI::updateWorldFriendlyTeamState(const Team &new_friendly_team_data)
-{
-    world.updateFriendlyTeamState(new_friendly_team_data);
-}
-
-void AI::updateWorldEnemyTeamState(const Team &new_enemy_team_data)
-{
-    world.updateEnemyTeamState(new_enemy_team_data);
-}
-
-void AI::updateWorldRefboxGameState(const RefboxGameState &game_state)
-{
-    world.updateRefboxGameState(game_state);
 }

--- a/src/thunderbots/software/ai/ai.h
+++ b/src/thunderbots/software/ai/ai.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include "ai/hl/stp/stp_hl.h"
-#include "ai/navigator/rrt/rrt.h"
+#include "ai/hl/hl.h"
+#include "ai/navigator/navigator.h"
 #include "ai/primitive/primitive.h"
 #include "ai/world/world.h"
-#include "thunderbots_msgs/Field.h"
-#include "thunderbots_msgs/Team.h"
-#include "util/timestamp.h"
 
 /**
  * This class wraps all our AI logic and decision making to help separate our
@@ -17,58 +14,21 @@ class AI final
    public:
     /**
      * Creates a new AI
-     *
-     * @param world The initial state of the world for the AI
      */
-    explicit AI(const World& world);
+    explicit AI();
 
     /**
      * Calculates the Primitives that should be run by our Robots given the current
      * state of the world.
      *
-     * @param timestamp The timestamp at which this function call is being made
+     * @param world The state of the World with which to make the decisions
      *
      * @return the Primitives that should be run by our Robots given the current state
      * of the world.
      */
-    std::vector<std::unique_ptr<Primitive>> getPrimitives(
-        const Timestamp& timestamp) const;
-
-    /**
-     * Updates the state of the ball in the AI's world with the new ball data
-     *
-     * @param new_ball_data A Ball containing new ball information
-     */
-    void updateWorldBallState(const Ball& new_ball_data);
-
-    /**
-     * Updates the state of the field in the AI's world with the new field data
-     *
-     * @param new_field_data A Field containing new field information
-     */
-    void updateWorldFieldState(const Field& new_field_data);
-
-    /**
-     * Given a message containing new information about the friendly team, updates
-     * the state of the friendly team in the world
-     *
-     * @param new_friendly_team_msg The message containing new friendly team information
-     */
-    void updateWorldFriendlyTeamState(const Team& new_friendly_team_data);
-
-    /**
-     * Given a message containing new information about the enemy team, updates
-     * the state of the enemy team in the world
-     *
-     * @param new_enemy_team_msg The message containing new enemy team information
-     */
-    void updateWorldEnemyTeamState(const Team& new_enemy_team_data);
-
-    void updateWorldRefboxGameState(const RefboxGameState& game_state);
-
+    std::vector<std::unique_ptr<Primitive>> getPrimitives(const World& world) const;
 
    private:
-    World world;
     std::unique_ptr<HL> high_level;
     std::unique_ptr<Navigator> navigator;
 };

--- a/src/thunderbots/software/ai/main.cpp
+++ b/src/thunderbots/software/ai/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char **argv)
     // Initialize the draw visualizer messenger
     Util::VisualizerMessenger::getInstance()->initializePublisher(node_handle);
 
+    // Services any ROS calls in a separate thread "behind the scenes". Does not return
+    // until the node is shutdown
+    // http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning
     ros::spin();
 
     return 0;

--- a/src/thunderbots/software/ai/main.cpp
+++ b/src/thunderbots/software/ai/main.cpp
@@ -1,12 +1,8 @@
 #include <ros/ros.h>
-#include <thunderbots_msgs/RefboxData.h>
 
 #include "ai/ai.h"
-#include "thunderbots_msgs/Ball.h"
-#include "thunderbots_msgs/Field.h"
-#include "thunderbots_msgs/Primitive.h"
 #include "thunderbots_msgs/PrimitiveArray.h"
-#include "thunderbots_msgs/Team.h"
+#include "thunderbots_msgs/World.h"
 #include "util/constants.h"
 #include "util/logger/init.h"
 #include "util/parameter/dynamic_parameters.h"
@@ -19,58 +15,32 @@
 // file and are not created as global static variables.
 namespace
 {
-    // Initialize our AI, which is the main object that maintains state
-    AI ai = AI(World(
-        Field(0, 0, 0, 0, 0, 0, 0), Ball(Point(), Vector(), Timestamp::fromSeconds(0)),
-        Team(Duration::fromMilliseconds(
-            Util::DynamicParameters::robot_expiry_buffer_milliseconds.value())),
-        Team(Duration::fromMilliseconds(
-            Util::DynamicParameters::robot_expiry_buffer_milliseconds.value()))));
+    // The publisher used to send new Primitive commands
+    ros::Publisher primitive_publisher;
+    // Our instance of the AI that decides what Primitives to run
+    AI ai;
 }  // namespace
 
-// Callbacks to update the state of the world
-void fieldUpdateCallback(const thunderbots_msgs::Field::ConstPtr &msg)
+// Runs the AI and sends new Primitive commands every time we get new information
+// about the World
+void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr &msg)
 {
-    thunderbots_msgs::Field field_msg = *msg;
+    thunderbots_msgs::World world_msg = *msg;
+    World world = Util::ROSMessages::createWorldFromROSMessage(world_msg);
 
-    Field field = Util::ROSMessages::createFieldFromROSMessage(field_msg);
+    // Get the Primitives the Robots should run from the AI
+    std::vector<std::unique_ptr<Primitive>> assignedPrimitives = ai.getPrimitives(world);
 
-    ai.updateWorldFieldState(field);
-}
+    // Put these Primitives into a message and publish it
+    thunderbots_msgs::PrimitiveArray primitive_array_message;
+    for (auto const &prim : assignedPrimitives)
+    {
+        primitive_array_message.primitives.emplace_back(prim->createMsg());
+    }
+    primitive_publisher.publish(primitive_array_message);
 
-void ballUpdateCallback(const thunderbots_msgs::Ball::ConstPtr &msg)
-{
-    thunderbots_msgs::Ball ball_msg = *msg;
-
-    Ball ball = Util::ROSMessages::createBallFromROSMessage(ball_msg);
-
-    ai.updateWorldBallState(ball);
-}
-
-void friendlyTeamUpdateCallback(const thunderbots_msgs::Team::ConstPtr &msg)
-{
-    thunderbots_msgs::Team friendly_team_msg = *msg;
-
-    Team friendly_team = Util::ROSMessages::createTeamFromROSMessage(friendly_team_msg);
-
-    ai.updateWorldFriendlyTeamState(friendly_team);
-}
-
-void enemyTeamUpdateCallback(const thunderbots_msgs::Team::ConstPtr &msg)
-{
-    thunderbots_msgs::Team enemy_team_msg = *msg;
-
-    Team enemy_team = Util::ROSMessages::createTeamFromROSMessage(enemy_team_msg);
-
-    ai.updateWorldEnemyTeamState(enemy_team);
-}
-
-void refboxGameStateUpdateCallback(const thunderbots_msgs::RefboxData::ConstPtr &msg)
-{
-    thunderbots_msgs::RefboxCommand command = msg->command;
-    RefboxGameState game_state =
-        Util::ROSMessages::createGameStateFromROSMessage(command);
-    ai.updateWorldRefboxGameState(game_state);
+    // On every tick, send the layer messages
+    Util::VisualizerMessenger::getInstance()->publishAndClearLayers();
 }
 
 int main(int argc, char **argv)
@@ -80,23 +50,12 @@ int main(int argc, char **argv)
     ros::NodeHandle node_handle;
 
     // Create publishers
-    ros::Publisher primitive_publisher =
-        node_handle.advertise<thunderbots_msgs::PrimitiveArray>(
-            Util::Constants::AI_PRIMITIVES_TOPIC, 1);
+    primitive_publisher = node_handle.advertise<thunderbots_msgs::PrimitiveArray>(
+        Util::Constants::AI_PRIMITIVES_TOPIC, 1);
 
     // Create subscribers
-    ros::Subscriber field_sub = node_handle.subscribe(
-        Util::Constants::NETWORK_INPUT_FIELD_TOPIC, 1, fieldUpdateCallback);
-    ros::Subscriber ball_sub = node_handle.subscribe(
-        Util::Constants::NETWORK_INPUT_BALL_TOPIC, 1, ballUpdateCallback);
-    ros::Subscriber friendly_team_sub =
-        node_handle.subscribe(Util::Constants::NETWORK_INPUT_FRIENDLY_TEAM_TOPIC, 1,
-                              friendlyTeamUpdateCallback);
-    ros::Subscriber enemy_team_sub = node_handle.subscribe(
-        Util::Constants::NETWORK_INPUT_ENEMY_TEAM_TOPIC, 1, enemyTeamUpdateCallback);
-    ros::Subscriber game_state_sub =
-        node_handle.subscribe(Util::Constants::NETWORK_INPUT_GAMECONTROLLER_TOPIC, 1,
-                              refboxGameStateUpdateCallback);
+    ros::Subscriber world_subscriber = node_handle.subscribe(
+        Util::Constants::NETWORK_INPUT_WORLD_TOPIC, 1, worldUpdateCallback);
 
     // Initialize the logger
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
@@ -104,43 +63,7 @@ int main(int argc, char **argv)
     // Initialize the draw visualizer messenger
     Util::VisualizerMessenger::getInstance()->initializePublisher(node_handle);
 
-    // Main loop
-    while (ros::ok())
-    {
-        // Spin once to let all necessary callbacks run
-        // These callbacks will update the AI's world state
-        ros::spinOnce();
-        try
-        {
-            // Get the Primitives the Robots should run from the AI
-            // We pass a timestamp with the current time (the time we initiate the call)
-            // to let the AI update its predictors so that decisions are always made with
-            // the most up to date predicted data (eg. future Robot or Ball position),
-            // even if some time has passed since the AI's state was last updated.
-            // TODO: This is a placeholder timestamp. It should be removed as part of
-            // https://github.com/UBC-Thunderbots/Software/issues/227
-            Timestamp timestamp = Timestamp::fromSeconds(0);
-            std::vector<std::unique_ptr<Primitive>> assignedPrimitives =
-                ai.getPrimitives(timestamp);
-
-            // Put these Primitives into a message and publish it
-            thunderbots_msgs::PrimitiveArray primitive_array_message;
-            for (auto const &prim : assignedPrimitives)
-            {
-                thunderbots_msgs::Primitive msg = prim->createMsg();
-                primitive_array_message.primitives.emplace_back(msg);
-                LOG(INFO) << msg << std::endl;
-            }
-            primitive_publisher.publish(primitive_array_message);
-
-            // On every tick, send the layer messages
-            Util::VisualizerMessenger::getInstance()->publishAndClearLayers();
-        }
-        catch (const std::invalid_argument &e)
-        {
-            std::cout << e.what() << std::endl;
-        }
-    }
+    ros::spin();
 
     return 0;
 }

--- a/src/thunderbots/software/grsim_communication/main.cpp
+++ b/src/thunderbots/software/grsim_communication/main.cpp
@@ -1,61 +1,43 @@
 #include <ros/ros.h>
-#include <ros/time.h>
 #include <thunderbots_msgs/Primitive.h>
 #include <thunderbots_msgs/PrimitiveArray.h>
+#include <thunderbots_msgs/World.h>
 
 #include "ai/primitive/primitive.h"
 #include "ai/primitive/primitive_factory.h"
-#include "geom/point.h"
 #include "grsim_communication/grsim_backend.h"
 #include "util/constants.h"
 #include "util/logger/init.h"
 #include "util/ros_messages.h"
-
-// Constants
-const std::string NETWORK_ADDRESS       = "127.0.0.1";
-static constexpr short NETWORK_PORT     = 20011;
-static constexpr unsigned int TICK_RATE = 60;
 
 // Member variables we need to maintain state
 // They are kept in an anonymous namespace so they are not accessible outside this
 // file and are not created as global static variables.
 namespace
 {
-    // A vector of primitives. It is cleared each tick, populated by the callbacks
-    // that receive primitive commands, and is processed by the backend to simulate
-    // the Primitives in grSim
-    std::vector<std::unique_ptr<Primitive>> primitives;
-
-    Team friendly_team = Team(Duration::fromMilliseconds(1000));
-    Ball ball          = Ball(Point(0, 0), Vector(), Timestamp::fromSeconds(0));
+    // The GrSimBackend responsible for handling communication with grSim
+    GrSimBackend grsim_backend(Util::Constants::GRSIM_COMMAND_NETWORK_ADDRESS,
+                               Util::Constants::GRSIM_COMMAND_NETWORK_PORT);
+    // The current state of the world
+    World world;
 }  // namespace
 
-// Callbacks
 void primitiveUpdateCallback(const thunderbots_msgs::PrimitiveArray::ConstPtr& msg)
 {
+    std::vector<std::unique_ptr<Primitive>> primitives;
     thunderbots_msgs::PrimitiveArray prim_array_msg = *msg;
     for (const thunderbots_msgs::Primitive& prim_msg : prim_array_msg.primitives)
     {
         primitives.emplace_back(AI::Primitive::createPrimitiveFromROSMessage(prim_msg));
     }
+
+    grsim_backend.sendPrimitives(primitives, world.friendlyTeam(), world.ball());
 }
 
-void ballUpdateCallback(const thunderbots_msgs::Ball::ConstPtr& msg)
+void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
 {
-    thunderbots_msgs::Ball ball_msg = *msg;
-    Ball updated_ball = Util::ROSMessages::createBallFromROSMessage(ball_msg);
-    ball.updateState(updated_ball);
-}
-
-// Update the friendly team
-void friendlyTeamUpdateCallback(const thunderbots_msgs::Team::ConstPtr& msg)
-{
-    thunderbots_msgs::Team friendly_team_msg = *msg;
-
-    Team updated_friendly_team =
-        Util::ROSMessages::createTeamFromROSMessage(friendly_team_msg);
-
-    friendly_team.updateState(updated_friendly_team);
+    thunderbots_msgs::World world_msg = *msg;
+    world = Util::ROSMessages::createWorldFromROSMessage(world_msg);
 }
 
 int main(int argc, char** argv)
@@ -65,38 +47,15 @@ int main(int argc, char** argv)
     ros::NodeHandle node_handle;
 
     // Create subscribers to topics we care about
-    ros::Subscriber prim_array_sub = node_handle.subscribe(
+    ros::Subscriber primitive_subscriber = node_handle.subscribe(
         Util::Constants::AI_PRIMITIVES_TOPIC, 1, primitiveUpdateCallback);
-    ros::Subscriber friendly_team_subscriber =
-        node_handle.subscribe(Util::Constants::NETWORK_INPUT_FRIENDLY_TEAM_TOPIC, 10,
-                              friendlyTeamUpdateCallback);
+    ros::Subscriber world_subscriber = node_handle.subscribe(
+        Util::Constants::NETWORK_INPUT_WORLD_TOPIC, 1, worldUpdateCallback);
 
     // Initialize the logger
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
 
-    // Initialize variables
-    primitives                      = std::vector<std::unique_ptr<Primitive>>();
-    GrSimBackend grsim_backend      = GrSimBackend(NETWORK_ADDRESS, NETWORK_PORT);
-    ros::Subscriber ball_subscriber = node_handle.subscribe(
-        Util::Constants::NETWORK_INPUT_BALL_TOPIC, 1, ballUpdateCallback);
-
-    // We loop at a set rate so that we don't overload the network with too many packets
-    ros::Rate tick_rate(TICK_RATE);
-
-    // Main loop
-    while (ros::ok())
-    {
-        // Clear all primitives each tick
-        primitives.clear();
-
-        // Spin once to let all necessary callbacks run
-        // The callbacks will populate the primitives vector
-        ros::spinOnce();
-
-        grsim_backend.sendPrimitives(primitives, friendly_team, ball);
-
-        tick_rate.sleep();
-    }
+    ros::spin();
 
     return 0;
 }

--- a/src/thunderbots/software/grsim_communication/main.cpp
+++ b/src/thunderbots/software/grsim_communication/main.cpp
@@ -55,6 +55,9 @@ int main(int argc, char** argv)
     // Initialize the logger
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
 
+    // Services any ROS calls in a separate thread "behind the scenes". Does not return
+    // until the node is shutdown
+    // http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning
     ros::spin();
 
     return 0;

--- a/src/thunderbots/software/network_input/backend.cpp
+++ b/src/thunderbots/software/network_input/backend.cpp
@@ -213,8 +213,7 @@ Team Backend::getFilteredEnemyTeamData(const std::vector<SSL_DetectionFrame> &de
     return enemy_team_state;
 }
 
-std::optional<thunderbots_msgs::RefboxData> Backend::getRefboxDataMsg(
-    const Referee &packet)
+thunderbots_msgs::RefboxData Backend::getRefboxDataMsg(const Referee &packet)
 {
     thunderbots_msgs::RefboxData refbox_data;
     refbox_data.command.command = getTeamCommand(packet.command());
@@ -239,7 +238,7 @@ std::optional<thunderbots_msgs::RefboxData> Backend::getRefboxDataMsg(
         refbox_data.them = blue;
     }
 
-    return std::make_optional<thunderbots_msgs::RefboxData>(refbox_data);
+    return refbox_data;
 }
 
 // this maps a protobuf Referee_Command enum to its ROS message equivalent

--- a/src/thunderbots/software/network_input/backend.h
+++ b/src/thunderbots/software/network_input/backend.h
@@ -70,7 +70,7 @@ class Backend
      */
     Team getFilteredEnemyTeamData(const std::vector<SSL_DetectionFrame> &detections);
 
-    std::optional<thunderbots_msgs::RefboxData> getRefboxDataMsg(const Referee &packet);
+    thunderbots_msgs::RefboxData getRefboxDataMsg(const Referee &packet);
 
     virtual ~Backend() = default;
 

--- a/src/thunderbots/software/network_input/main.cpp
+++ b/src/thunderbots/software/network_input/main.cpp
@@ -4,6 +4,7 @@
 
 #include "geom/point.h"
 #include "network_input/backend.h"
+#include "network_input/networking/network_client.h"
 #include "network_input/networking/ssl_gamecontroller_client.h"
 #include "network_input/networking/ssl_vision_client.h"
 #include "thunderbots_msgs/Ball.h"
@@ -21,131 +22,11 @@ int main(int argc, char** argv)
     ros::init(argc, argv, "network_input");
     ros::NodeHandle node_handle;
 
-    // Create publishers
-    ros::Publisher gamecontroller_publisher =
-        node_handle.advertise<thunderbots_msgs::RefboxData>(
-            Util::Constants::NETWORK_INPUT_GAMECONTROLLER_TOPIC, 1);
-    ros::Publisher world_publisher = node_handle.advertise<thunderbots_msgs::World>(
-        Util::Constants::NETWORK_INPUT_WORLD_TOPIC, 1);
-
     // Initialize the logger
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
 
-    // Init our backend class
-    Backend backend = Backend();
-
-    // Store the state of the most up to date World message
-    thunderbots_msgs::World world_msg;
-
-    // Create the io_service that will be used to service all network requests
-    boost::asio::io_service io_service;
-
-    // The function that will be run on every received SSL_WrapperPacket
-    auto filter_and_publish_vision_data = [&backend, world_publisher,
-                                           &world_msg](SSL_WrapperPacket packet) {
-        // A map used to store the latest detection data for each camera
-        static std::map<unsigned int, SSL_DetectionFrame> latest_detection_data;
-
-        if (packet.has_geometry())
-        {
-            const auto& latest_geometry_data = packet.geometry();
-            Field field                      = backend.getFieldData(latest_geometry_data);
-            thunderbots_msgs::Field field_msg =
-                Util::ROSMessages::convertFieldToROSMessage(field);
-            world_msg.field = field_msg;
-        }
-
-        if (packet.has_detection())
-        {
-            auto detection = packet.detection();
-            // add the detection to the map, replacing any existing values
-            auto ret = latest_detection_data.insert(
-                std::make_pair(detection.camera_id(), detection));
-            // check if we inserted successfully. if not, modify the existing
-            // entry to be our new value
-            if (!ret.second)
-            {
-                ret.first->second = detection;
-            }
-
-            // Create a vector of the latest detection data for each camera
-            std::vector<SSL_DetectionFrame> latest_detections;
-            for (auto it = latest_detection_data.begin();
-                 it != latest_detection_data.end(); it++)
-            {
-                latest_detections.push_back(it->second);
-            }
-
-            Ball ball = backend.getFilteredBallData(latest_detections);
-            thunderbots_msgs::Ball ball_msg =
-                Util::ROSMessages::convertBallToROSMessage(ball);
-            world_msg.ball = ball_msg;
-
-            Team friendly_team = backend.getFilteredFriendlyTeamData(latest_detections);
-            thunderbots_msgs::Team friendly_team_msg =
-                Util::ROSMessages::convertTeamToROSMessage(friendly_team);
-            world_msg.friendly_team = friendly_team_msg;
-
-            Team enemy_team = backend.getFilteredEnemyTeamData(latest_detections);
-            thunderbots_msgs::Team enemy_team_msg =
-                Util::ROSMessages::convertTeamToROSMessage(enemy_team);
-            world_msg.enemy_team = enemy_team_msg;
-        }
-
-        world_publisher.publish(world_msg);
-    };
-
-    // Set up our connection over udp to receive camera packets
-    // NOTE: We do this before initializing the ROS node so that if it
-    // fails because there is another instance of this node running
-    // and connected to the port we want, we don't kill that other node.
-    std::unique_ptr<SSLVisionClient> ssl_vision_client;
-    try
-    {
-        ssl_vision_client = std::make_unique<SSLVisionClient>(
-            io_service, Util::Constants::SSL_VISION_MULTICAST_ADDRESS,
-            Util::Constants::SSL_VISION_MULTICAST_PORT, filter_and_publish_vision_data);
-    }
-    catch (const boost::exception& ex)
-    {
-        // LOG(FATAL) will terminate the network_input process
-        LOG(FATAL) << "An error occured while setting up the SSL Vision Client:"
-                   << std::endl
-                   << boost::diagnostic_information(ex) << std::endl;
-    }
-
-    // The function that will be run on every received Referee packet
-    auto filter_and_publish_gamecontroller_data = [&backend, gamecontroller_publisher,
-                                                   &world_msg](Referee packet) {
-        auto gamecontroller_data_msg = backend.getRefboxDataMsg(packet);
-        gamecontroller_publisher.publish(gamecontroller_data_msg);
-        world_msg.refbox_data = gamecontroller_data_msg;
-    };
-
-    // Set up our connection over udp to receive gamecontroller packets
-    // NOTE: We do this before initializing the ROS node so that if it
-    // fails because there is another instance of this node running
-    // and connected to the port we want, we don't kill that other node.
-    std::unique_ptr<SSLGameControllerClient> ssl_gamecontroller_client;
-    try
-    {
-        ssl_gamecontroller_client = std::make_unique<SSLGameControllerClient>(
-            io_service, Util::Constants::SSL_GAMECONTROLLER_MULTICAST_ADDRESS,
-            Util::Constants::SSL_GAMECONTROLLER_MULTICAST_PORT,
-            filter_and_publish_gamecontroller_data);
-    }
-    catch (const boost::exception& ex)
-    {
-        // LOG(FATAL) will terminate the network_input process
-        LOG(FATAL) << "An error occured while setting up the SSL GameController Client:"
-                   << std::endl
-                   << boost::diagnostic_information(ex) << std::endl;
-    }
-
-    // Run the io_service in a separate thread so it doesn't block the ros::spin()
-    // call. This runs the IO services for BOTH the SSLVisionClient and
-    // SSLGameControllerClient
-    std::thread network_thread([&io_service]() { io_service.run(); });
+    // Create and start our NetworkClient
+    NetworkClient client = NetworkClient(node_handle);
 
     // Services any ROS calls in a separate thread "behind the scenes". Does not return
     // until the node is shutdown

--- a/src/thunderbots/software/network_input/main.cpp
+++ b/src/thunderbots/software/network_input/main.cpp
@@ -147,6 +147,9 @@ int main(int argc, char** argv)
     // SSLGameControllerClient
     std::thread network_thread([&io_service]() { io_service.run(); });
 
+    // Services any ROS calls in a separate thread "behind the scenes". Does not return
+    // until the node is shutdown
+    // http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning
     ros::spin();
 
     return 0;

--- a/src/thunderbots/software/network_input/main.cpp
+++ b/src/thunderbots/software/network_input/main.cpp
@@ -22,24 +22,6 @@ int main(int argc, char** argv)
     ros::NodeHandle node_handle;
 
     // Create publishers
-    // We give the publishers queue sizes equal to the number of cameras being used with
-    // the SSL Vision system. This is to be able to buffer data from each camera if we are
-    // receiving data faster than we can publish. This way the buffered data will contain
-    // data for the entire field (something from each camera) and we don't lose any
-    // information
-    ros::Publisher ball_publisher = node_handle.advertise<thunderbots_msgs::Ball>(
-        Util::Constants::NETWORK_INPUT_BALL_TOPIC,
-        Util::Constants::NUMBER_OF_SSL_VISION_CAMERAS);
-    ros::Publisher field_publisher = node_handle.advertise<thunderbots_msgs::Field>(
-        Util::Constants::NETWORK_INPUT_FIELD_TOPIC,
-        Util::Constants::NUMBER_OF_SSL_VISION_CAMERAS);
-    ros::Publisher friendly_team_publisher =
-        node_handle.advertise<thunderbots_msgs::Team>(
-            Util::Constants::NETWORK_INPUT_FRIENDLY_TEAM_TOPIC,
-            Util::Constants::NUMBER_OF_SSL_VISION_CAMERAS);
-    ros::Publisher enemy_team_publisher = node_handle.advertise<thunderbots_msgs::Team>(
-        Util::Constants::NETWORK_INPUT_ENEMY_TEAM_TOPIC,
-        Util::Constants::NUMBER_OF_SSL_VISION_CAMERAS);
     ros::Publisher gamecontroller_publisher =
         node_handle.advertise<thunderbots_msgs::RefboxData>(
             Util::Constants::NETWORK_INPUT_GAMECONTROLLER_TOPIC, 1);
@@ -49,17 +31,80 @@ int main(int argc, char** argv)
     // Initialize the logger
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
 
+    // Init our backend class
+    Backend backend = Backend();
+
+    // Store the state of the most up to date World message
+    thunderbots_msgs::World world_msg;
+
+    // Create the io_service that will be used to service all network requests
+    boost::asio::io_service io_service;
+
+    // The function that will be run on every received SSL_WrapperPacket
+    auto filter_and_publish_vision_data = [&backend, world_publisher,
+                                           &world_msg](SSL_WrapperPacket packet) {
+        // A map used to store the latest detection data for each camera
+        static std::map<unsigned int, SSL_DetectionFrame> latest_detection_data;
+
+        if (packet.has_geometry())
+        {
+            const auto& latest_geometry_data = packet.geometry();
+            Field field                      = backend.getFieldData(latest_geometry_data);
+            thunderbots_msgs::Field field_msg =
+                Util::ROSMessages::convertFieldToROSMessage(field);
+            world_msg.field = field_msg;
+        }
+
+        if (packet.has_detection())
+        {
+            auto detection = packet.detection();
+            // add the detection to the map, replacing any existing values
+            auto ret = latest_detection_data.insert(
+                std::make_pair(detection.camera_id(), detection));
+            // check if we inserted successfully. if not, modify the existing
+            // entry to be our new value
+            if (!ret.second)
+            {
+                ret.first->second = detection;
+            }
+
+            // Create a vector of the latest detection data for each camera
+            std::vector<SSL_DetectionFrame> latest_detections;
+            for (auto it = latest_detection_data.begin();
+                 it != latest_detection_data.end(); it++)
+            {
+                latest_detections.push_back(it->second);
+            }
+
+            Ball ball = backend.getFilteredBallData(latest_detections);
+            thunderbots_msgs::Ball ball_msg =
+                Util::ROSMessages::convertBallToROSMessage(ball);
+            world_msg.ball = ball_msg;
+
+            Team friendly_team = backend.getFilteredFriendlyTeamData(latest_detections);
+            thunderbots_msgs::Team friendly_team_msg =
+                Util::ROSMessages::convertTeamToROSMessage(friendly_team);
+            world_msg.friendly_team = friendly_team_msg;
+
+            Team enemy_team = backend.getFilteredEnemyTeamData(latest_detections);
+            thunderbots_msgs::Team enemy_team_msg =
+                Util::ROSMessages::convertTeamToROSMessage(enemy_team);
+            world_msg.enemy_team = enemy_team_msg;
+        }
+
+        world_publisher.publish(world_msg);
+    };
+
     // Set up our connection over udp to receive camera packets
     // NOTE: We do this before initializing the ROS node so that if it
     // fails because there is another instance of this node running
     // and connected to the port we want, we don't kill that other node.
-
     std::unique_ptr<SSLVisionClient> ssl_vision_client;
     try
     {
         ssl_vision_client = std::make_unique<SSLVisionClient>(
-            Util::Constants::SSL_VISION_MULTICAST_ADDRESS,
-            Util::Constants::SSL_VISION_MULTICAST_PORT);
+            io_service, Util::Constants::SSL_VISION_MULTICAST_ADDRESS,
+            Util::Constants::SSL_VISION_MULTICAST_PORT, filter_and_publish_vision_data);
     }
     catch (const boost::exception& ex)
     {
@@ -69,116 +114,40 @@ int main(int argc, char** argv)
                    << boost::diagnostic_information(ex) << std::endl;
     }
 
+    // The function that will be run on every received Referee packet
+    auto filter_and_publish_gamecontroller_data = [&backend, gamecontroller_publisher,
+                                                   &world_msg](Referee packet) {
+        auto gamecontroller_data_msg = backend.getRefboxDataMsg(packet);
+        gamecontroller_publisher.publish(gamecontroller_data_msg);
+        world_msg.refbox_data = gamecontroller_data_msg;
+    };
+
+    // Set up our connection over udp to receive gamecontroller packets
+    // NOTE: We do this before initializing the ROS node so that if it
+    // fails because there is another instance of this node running
+    // and connected to the port we want, we don't kill that other node.
     std::unique_ptr<SSLGameControllerClient> ssl_gamecontroller_client;
     try
     {
         ssl_gamecontroller_client = std::make_unique<SSLGameControllerClient>(
-            Util::Constants::SSL_GAMECONTROLLER_MULTICAST_ADDRESS,
-            Util::Constants::SSL_GAMECONTROLLER_MULTICAST_PORT);
+            io_service, Util::Constants::SSL_GAMECONTROLLER_MULTICAST_ADDRESS,
+            Util::Constants::SSL_GAMECONTROLLER_MULTICAST_PORT,
+            filter_and_publish_gamecontroller_data);
     }
     catch (const boost::exception& ex)
     {
         // LOG(FATAL) will terminate the network_input process
-        LOG(FATAL) << "An error occured while setting up the SSL Game Controller Client:"
+        LOG(FATAL) << "An error occured while setting up the SSL GameController Client:"
                    << std::endl
                    << boost::diagnostic_information(ex) << std::endl;
     }
 
-    // Init our backend class
-    Backend backend = Backend();
+    // Run the io_service in a separate thread so it doesn't block the ros::spin()
+    // call. This runs the IO services for BOTH the SSLVisionClient and
+    // SSLGameControllerClient
+    std::thread network_thread([&io_service]() { io_service.run(); });
 
-    // Store the state of the most up to date World message
-    thunderbots_msgs::World world_msg;
-    // A map used to store the latest detection data for each camera
-    std::map<unsigned int, SSL_DetectionFrame> latest_detection_data;
-    // Stores the most recent geometry data received
-    SSL_GeometryData latest_geometry_data;
-
-    // Main loop
-    while (ros::ok())
-    {
-        auto ssl_vision_packets = ssl_vision_client->getVisionPacketVector();
-        for (const auto& packet : ssl_vision_packets)
-        {
-            if (packet.has_geometry())
-            {
-                latest_geometry_data = packet.geometry();
-            }
-
-            if (packet.has_detection())
-            {
-                auto detection = packet.detection();
-                // Add the detection to the map, replacing any existing values
-                auto ret = latest_detection_data.insert(
-                    std::make_pair(detection.camera_id(), detection));
-                // Check if we inserted successfully. If not, modify the existing
-                // entry to be our new value
-                if (!ret.second)
-                {
-                    ret.first->second = detection;
-                }
-            }
-        }
-
-        // Create a vector of the latest detection data for each camera
-        std::vector<SSL_DetectionFrame> latest_detections;
-        for (auto it = latest_detection_data.begin(); it != latest_detection_data.end();
-             it++)
-        {
-            latest_detections.push_back(it->second);
-        }
-
-        auto gamecontroller_packet_ptr =
-            ssl_gamecontroller_client->getGameControllerPacket();
-
-        // Update data and publish the World message if any data changed
-        if (!ssl_vision_packets.empty() || gamecontroller_packet_ptr)
-        {
-            if (!ssl_vision_packets.empty())
-            {
-                Field field = backend.getFieldData(latest_geometry_data);
-                thunderbots_msgs::Field field_msg =
-                    Util::ROSMessages::convertFieldToROSMessage(field);
-                field_publisher.publish(field_msg);
-                world_msg.field = field_msg;
-
-                Ball ball = backend.getFilteredBallData(latest_detections);
-                thunderbots_msgs::Ball ball_msg =
-                    Util::ROSMessages::convertBallToROSMessage(ball);
-                ball_publisher.publish(ball_msg);
-                world_msg.ball = ball_msg;
-
-                Team friendly_team =
-                    backend.getFilteredFriendlyTeamData(latest_detections);
-                thunderbots_msgs::Team friendly_team_msg =
-                    Util::ROSMessages::convertTeamToROSMessage(friendly_team);
-                friendly_team_publisher.publish(friendly_team_msg);
-                world_msg.friendly_team = friendly_team_msg;
-
-                Team enemy_team = backend.getFilteredEnemyTeamData(latest_detections);
-                thunderbots_msgs::Team enemy_team_msg =
-                    Util::ROSMessages::convertTeamToROSMessage(enemy_team);
-                enemy_team_publisher.publish(enemy_team_msg);
-                world_msg.enemy_team = enemy_team_msg;
-            }
-
-            if (gamecontroller_packet_ptr)
-            {
-                auto gamecontroller_data_msg =
-                    backend.getRefboxDataMsg(*gamecontroller_packet_ptr);
-                if (gamecontroller_data_msg)
-                {
-                    gamecontroller_publisher.publish(*gamecontroller_data_msg);
-                    world_msg.refbox_data = *gamecontroller_data_msg;
-                }
-            }
-
-            world_publisher.publish(world_msg);
-        }
-
-        // We spin once here so any callbacks in this node can run (if we ever add them)
-        ros::spinOnce();
-    }
+    ros::spin();
 
     return 0;
 }

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -1,0 +1,131 @@
+#include "network_input/networking/network_client.h"
+
+#include <boost/bind.hpp>
+
+#include "util/constants.h"
+#include "util/logger/init.h"
+#include "util/ros_messages.h"
+
+NetworkClient::NetworkClient(ros::NodeHandle& node_handle) : backend(), io_service()
+{
+    // Set up publishers
+    world_publisher = node_handle.advertise<thunderbots_msgs::World>(
+        Util::Constants::NETWORK_INPUT_WORLD_TOPIC, 1);
+    gamecontroller_publisher = node_handle.advertise<thunderbots_msgs::RefboxData>(
+        Util::Constants::NETWORK_INPUT_GAMECONTROLLER_TOPIC, 1);
+
+    // Set up our connection over udp to receive vision packets
+    // NOTE: We do this before initializing the ROS node so that if it
+    // fails because there is another instance of this node running
+    // and connected to the port we want, we don't kill that other node.
+    try
+    {
+        ssl_vision_client = std::make_unique<SSLVisionClient>(
+            io_service, Util::Constants::SSL_VISION_MULTICAST_ADDRESS,
+            Util::Constants::SSL_VISION_MULTICAST_PORT,
+            boost::bind(&NetworkClient::filterAndPublishVisionData, this, _1));
+    }
+    catch (const boost::exception& ex)
+    {
+        // LOG(FATAL) will terminate the network_input process
+        LOG(FATAL) << "An error occured while setting up the SSL Vision Client:"
+                   << std::endl
+                   << boost::diagnostic_information(ex) << std::endl;
+    }
+
+
+    // Set up our connection over udp to receive gamecontroller packets
+    // NOTE: We do this before initializing the ROS node so that if it
+    // fails because there is another instance of this node running
+    // and connected to the port we want, we don't kill that other node.
+    try
+    {
+        ssl_gamecontroller_client = std::make_unique<SSLGameControllerClient>(
+            io_service, Util::Constants::SSL_GAMECONTROLLER_MULTICAST_ADDRESS,
+            Util::Constants::SSL_GAMECONTROLLER_MULTICAST_PORT,
+            boost::bind(&NetworkClient::filterAndPublishGameControllerData, this, _1));
+    }
+    catch (const boost::exception& ex)
+    {
+        // LOG(FATAL) will terminate the network_input process
+        LOG(FATAL) << "An error occured while setting up the SSL GameController Client:"
+                   << std::endl
+                   << boost::diagnostic_information(ex) << std::endl;
+    }
+
+    // Start the thread to run the io_service in the background
+    io_service_thread = std::thread([this]() { io_service.run(); });
+}
+
+NetworkClient::~NetworkClient()
+{
+    // Stop the io_service. This is safe to call from another thread.
+    // https://stackoverflow.com/questions/4808848/boost-asio-stopping-io-service
+    // This MUST be done before attempting to join the thread because otherwise the
+    // io_service will not stop and the thread will not join
+    io_service.stop();
+
+    // Join the io_service_thread so that we wait for it to exit before destructing the
+    // thread object. If we do not wait for the thread to finish executing, it will call
+    // `std::terminate` when we deallocate the thread object and kill our whole program
+    io_service_thread.join();
+}
+
+
+void NetworkClient::filterAndPublishVisionData(SSL_WrapperPacket packet)
+{
+    if (packet.has_geometry())
+    {
+        const auto& latest_geometry_data = packet.geometry();
+        Field field                      = backend.getFieldData(latest_geometry_data);
+        thunderbots_msgs::Field field_msg =
+            Util::ROSMessages::convertFieldToROSMessage(field);
+        world_msg.field = field_msg;
+    }
+
+    if (packet.has_detection())
+    {
+        auto detection = packet.detection();
+        // add the detection to the map, replacing any existing values
+        auto ret = latest_detection_data.insert(
+            std::make_pair(detection.camera_id(), detection));
+        // check if we inserted successfully. if not, modify the existing
+        // entry to be our new value
+        if (!ret.second)
+        {
+            ret.first->second = detection;
+        }
+
+        // Create a vector of the latest detection data for each camera
+        std::vector<SSL_DetectionFrame> latest_detections;
+        for (auto it = latest_detection_data.begin(); it != latest_detection_data.end();
+             it++)
+        {
+            latest_detections.push_back(it->second);
+        }
+
+        Ball ball = backend.getFilteredBallData(latest_detections);
+        thunderbots_msgs::Ball ball_msg =
+            Util::ROSMessages::convertBallToROSMessage(ball);
+        world_msg.ball = ball_msg;
+
+        Team friendly_team = backend.getFilteredFriendlyTeamData(latest_detections);
+        thunderbots_msgs::Team friendly_team_msg =
+            Util::ROSMessages::convertTeamToROSMessage(friendly_team);
+        world_msg.friendly_team = friendly_team_msg;
+
+        Team enemy_team = backend.getFilteredEnemyTeamData(latest_detections);
+        thunderbots_msgs::Team enemy_team_msg =
+            Util::ROSMessages::convertTeamToROSMessage(enemy_team);
+        world_msg.enemy_team = enemy_team_msg;
+    }
+
+    world_publisher.publish(world_msg);
+}
+
+void NetworkClient::filterAndPublishGameControllerData(Referee packet)
+{
+    auto gamecontroller_data_msg = backend.getRefboxDataMsg(packet);
+    world_msg.refbox_data        = gamecontroller_data_msg;
+    world_publisher.publish(world_msg);
+}

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -15,9 +15,6 @@ NetworkClient::NetworkClient(ros::NodeHandle& node_handle) : backend(), io_servi
         Util::Constants::NETWORK_INPUT_GAMECONTROLLER_TOPIC, 1);
 
     // Set up our connection over udp to receive vision packets
-    // NOTE: We do this before initializing the ROS node so that if it
-    // fails because there is another instance of this node running
-    // and connected to the port we want, we don't kill that other node.
     try
     {
         ssl_vision_client = std::make_unique<SSLVisionClient>(
@@ -35,9 +32,6 @@ NetworkClient::NetworkClient(ros::NodeHandle& node_handle) : backend(), io_servi
 
 
     // Set up our connection over udp to receive gamecontroller packets
-    // NOTE: We do this before initializing the ROS node so that if it
-    // fails because there is another instance of this node running
-    // and connected to the port we want, we don't kill that other node.
     try
     {
         ssl_gamecontroller_client = std::make_unique<SSLGameControllerClient>(

--- a/src/thunderbots/software/network_input/networking/network_client.h
+++ b/src/thunderbots/software/network_input/networking/network_client.h
@@ -37,8 +37,8 @@ class NetworkClient
     ~NetworkClient();
 
     // Delete the copy and assignment operators because this class really shouldn't need
-    // them and we don't want to risk doing anything nasty with the internal threading this
-    // class uses
+    // them and we don't want to risk doing anything nasty with the internal threading
+    // this class uses
     NetworkClient& operator=(const NetworkClient&) = delete;
     NetworkClient(const NetworkClient&)            = delete;
 

--- a/src/thunderbots/software/network_input/networking/network_client.h
+++ b/src/thunderbots/software/network_input/networking/network_client.h
@@ -37,7 +37,7 @@ class NetworkClient
     ~NetworkClient();
 
     // Delete the copy and assignment operators because this class really shouldn't need
-    // them and we don't want to risk doing anything nasty with the internal thready this
+    // them and we don't want to risk doing anything nasty with the internal threading this
     // class uses
     NetworkClient& operator=(const NetworkClient&) = delete;
     NetworkClient(const NetworkClient&)            = delete;

--- a/src/thunderbots/software/network_input/networking/network_client.h
+++ b/src/thunderbots/software/network_input/networking/network_client.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <ros/ros.h>
+#include <thunderbots_msgs/World.h>
+
+#include <boost/asio.hpp>
+#include <boost/exception/diagnostic_information.hpp>
+#include <thread>
+
+#include "network_input/backend.h"
+#include "network_input/networking/ssl_gamecontroller_client.h"
+#include "network_input/networking/ssl_vision_client.h"
+#include "proto/messages_robocup_ssl_wrapper.pb.h"
+#include "proto/ssl_referee.pb.h"
+
+/**
+ * This class encapsulates our SSLVisionClient and SSLGameController clients to abstract
+ * all networking operations behind a single interface. This also allows us to keep the
+ * "handle" functions we give to the clients as member functions rather than large lambda
+ * functions. Overall, this helps keep our main.cpp file shorter and more readable.
+ */
+class NetworkClient
+{
+   public:
+    /**
+     * Creates a new NetworkClient for the given NodeHandle. This allows this class to
+     * create and own its own publishers
+     *
+     * @param node_handle The NodeHandle this class should use to publish its messages
+     */
+    explicit NetworkClient(ros::NodeHandle& node_handle);
+
+    /**
+     * Safely destructs this NetworkClient object. Stops any running IO services and
+     * gracefully joins the thread before exiting.
+     */
+    ~NetworkClient();
+
+    // Delete the copy and assignment operators because this class really shouldn't need
+    // them and we don't want to risk doing anything nasty with the internal thready this
+    // class uses
+    NetworkClient& operator=(const NetworkClient&) = delete;
+    NetworkClient(const NetworkClient&)            = delete;
+
+   private:
+    /**
+     * Filters and publishes the new vision data
+     *
+     * This function contains all the work that is performed every time a new vision
+     * packet is received from the network. We give this function to the SSLVisionClient
+     * to call
+     *
+     * @param packet The newly received vision packet
+     */
+    void filterAndPublishVisionData(SSL_WrapperPacket packet);
+
+    /**
+     * Filters and publishes the new GameController data
+     *
+     * This function contains all the work that is performed every time a new
+     * GameController packet is received from the network. We give this function to the
+     * GameControllerClient to call
+     *
+     * @param packet The newly received GameController packet
+     */
+    void filterAndPublishGameControllerData(Referee packet);
+
+    // The publishers used to send data after it has been received and processed
+    ros::Publisher gamecontroller_publisher;
+    ros::Publisher world_publisher;
+
+    // The backend that handles data filtering and processing
+    Backend backend;
+
+    // The client that handles data reception, filtering, and publishing for vision data
+    std::unique_ptr<SSLVisionClient> ssl_vision_client;
+    // The client that handles data reception, filtering , and publishing for
+    // gamecontroller data
+    std::unique_ptr<SSLGameControllerClient> ssl_gamecontroller_client;
+
+    // The most up-to-date state of the world
+    thunderbots_msgs::World world_msg;
+
+    // A map used to store the latest detection data for each camera
+    std::map<unsigned int, SSL_DetectionFrame> latest_detection_data;
+
+    // The io_service that will be used to serivce all network requests
+    boost::asio::io_service io_service;
+
+    // The thread running the io_service in the background. This thread will run for the
+    // entire lifetime of the class
+    std::thread io_service_thread;
+};

--- a/src/thunderbots/software/network_input/networking/ssl_gamecontroller_client.h
+++ b/src/thunderbots/software/network_input/networking/ssl_gamecontroller_client.h
@@ -10,51 +10,46 @@ class SSLGameControllerClient
 {
    public:
     /**
-     * Creates an SSLGameControllerClient that will listen for data packets from SSL Game
-     * Controller on the given address and port
+     * Creates an SSLGameControllerClient that will listen for data packets from the SSL
+     * Game Controller on the given address and port. For every controller packet
+     * received, the handle_function will be cald to perform any operations desired by the
+     * caller
      *
+     * @param io_service The io_service to use to service incoming GameController data
      * @param ip_address The ip address of the multicast group on which to listen for
-     * SSL Vision packets
-     * @param port The port on which to listen for SSL Game Controller packets
+     * GameController packets
+     * @param port The port on which to listen for GameController packets
+     * @param handle_function The function to run for every GameController packet received
+     * from the network
      */
-    SSLGameControllerClient(std::string ip_address, unsigned short port);
-
-    /**
-     * Returns a unique_ptr to the latest SSL GameController Referee packet. If no new
-     * data was received since the last time this function was called, the unique_ptr will
-     * be empty
-     *
-     * @return A unique_ptr to an Referee packet if data was received since the last
-     * time this function was called, otherwise returns an empty unique_ptr
-     */
-    const std::unique_ptr<Referee> getGameControllerPacket();
+    SSLGameControllerClient(boost::asio::io_service& io_service, std::string ip_address,
+                            unsigned short port,
+                            std::function<void(Referee)> handle_function);
 
    private:
     /**
-     * The function that is called to process any data received by the io_service.
-     * This function will be called when poll() is called on the io_service.
+     * The function that is called to process any data received by the io_service. This
+     * function gets automatically called by the io_service for EVERY packet received by
+     * the network. These functions are handled synchronously, so we DO NOT need to worry
+     * about concurrency or thread-safety in this function. Because this function also
+     * calls the provided handle_function, this means the handle_function also does not
+     * need to be thread-safe
      *
      * @param error The error code obtained when receiving the incoming data
      * @param num_bytes_received How many bytes of data were received
      */
-    void handleDataReception(const boost::system::error_code &error,
+    void handleDataReception(const boost::system::error_code& error,
                              size_t num_bytes_received);
 
-    // provides core I/O functionality for boost asynchronous I/O objects such as a socket
-    boost::asio::io_service io_service;
-
-    // a UDP socket that we listen on for protobuf messages from SSL Game Controller
+    // A UDP socket that we listen on for protobuf messages from SSL Game Controller
     boost::asio::ip::udp::socket socket_;
-
-    // the endpoint for the sender, in this case SSL Game Controller
+    // The endpoint for the sender, in this case SSL Game Controller
     boost::asio::ip::udp::endpoint sender_endpoint_;
 
-    // We set the max buffer length to be the largest possible size of a UDP datagram.
-    // This way we don't need to worry about buffer overflow, or about our data getting
-    // truncated to fit into the buffer
-    static constexpr unsigned int max_buffer_length = 65535;
-    char raw_received_data_[max_buffer_length];
-
-    // Stores the most up to date packet data received by the client
-    std::unique_ptr<Referee> packet_data;
+    // The maximum length of the buffer we use to receive data packets from the network
+    static constexpr unsigned int max_buffer_length = 4096;
+    // Acts as a buffer to store the raw received data from the network
+    std::array<char, max_buffer_length> raw_received_data_;
+    // The function to call on every received packet of vision data
+    std::function<void(Referee)> handle_function;
 };

--- a/src/thunderbots/software/network_input/networking/ssl_vision_client.cpp
+++ b/src/thunderbots/software/network_input/networking/ssl_vision_client.cpp
@@ -2,8 +2,10 @@
 
 #include "util/logger/init.h"
 
-SSLVisionClient::SSLVisionClient(const std::string ip_address, const unsigned short port)
-    : socket_(io_service)
+SSLVisionClient::SSLVisionClient(boost::asio::io_service& io_service,
+                                 const std::string ip_address, const unsigned short port,
+                                 std::function<void(SSL_WrapperPacket)> handle_function)
+    : socket_(io_service), handle_function(handle_function)
 {
     boost::asio::ip::udp::endpoint listen_endpoint(
         boost::asio::ip::address::from_string(ip_address), port);
@@ -43,16 +45,10 @@ void SSLVisionClient::handleDataReception(const boost::system::error_code& error
 {
     if (!error)
     {
-        // This function will be run for EVERY packet received from the network since the
-        // last time poll() was called. This means that this function may be called
-        // several times to process several packets. This is why we immediately store any
-        // received and processed data into the packet_vector. If we didn't save the
-        // received data somewhere else, the data would be overwritten by the packet
-        // being handled in the next handleDataReception function call
         auto packet_data = SSL_WrapperPacket();
         packet_data.ParseFromArray(raw_received_data_.data(),
                                    static_cast<int>(num_bytes_received));
-        packet_vector.emplace_back(packet_data);
+        handle_function(packet_data);
 
         // Once we've handled the data, start listening again
         socket_.async_receive_from(
@@ -74,22 +70,4 @@ void SSLVisionClient::handleDataReception(const boost::system::error_code& error
             << "An unknown network error occurred when attempting to receive SSL Vision Data. The boost system error code is "
             << error << std::endl;
     }
-}
-
-const std::vector<SSL_WrapperPacket> SSLVisionClient::getVisionPacketVector()
-{
-    // Calling the poll() function will cause a handleDataReception() function to run for
-    // EVERY packet of data that was received since the last time poll() was called.
-    // Note that handleDataReception() may run multiple times in order to handle the
-    // multiple received packets. This is why we move the data from the buffer into the
-    // packet_vector, so that any subsequent handleDataReception() calls do not overwrite
-    // the data
-    io_service.poll();
-
-    // Make a copy of the data to return
-    std::vector<SSL_WrapperPacket> packet_vector_copy = packet_vector;
-    // Clear the packet_vector
-    packet_vector.clear();
-
-    return packet_vector_copy;
 }

--- a/src/thunderbots/software/network_input/networking/ssl_vision_client.h
+++ b/src/thunderbots/software/network_input/networking/ssl_vision_client.h
@@ -2,7 +2,6 @@
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
-#include <queue>
 #include <string>
 
 #include "proto/messages_robocup_ssl_wrapper.pb.h"
@@ -12,44 +11,44 @@ class SSLVisionClient
    public:
     /**
      * Creates an SSLVisionClient that will listen for data packets from SSL Vision
-     * on the given address and port
+     * on the given address and port. For every vision packet received, the
+     * handle_function will be called to perform any operations desired by the caller
      *
+     * @param io_service The io_service to use to service incoming vision data
      * @param ip_address The ip address of the multicast group on which to listen for
      * SSL Vision packets
      * @param port The port on which to listen for SSL Vision packets
+     * @param handle_function The function to run for every vision packet received from
+     * the network
      */
-    SSLVisionClient(const std::string ip_address, const unsigned short port);
-
-    /**
-     * Returns a vector of new SSL Vision WrapperPackets that were received since last
-     * time this function was called. If no new data was received since the last time this
-     * function was called, the vector will be empty
-     *
-     * @return A vector of SSL_WrapperPackets received since the last time this function
-     * was called.
-     */
-    const std::vector<SSL_WrapperPacket> getVisionPacketVector();
+    SSLVisionClient(boost::asio::io_service& io_service, std::string ip_address,
+                    unsigned short port,
+                    std::function<void(SSL_WrapperPacket)> handle_function);
 
    private:
     /**
-     * The function that is called to process any data received by the io_service.
-     * When io_service.poll() is called, this function will be run for EVERY packet
-     * received, which may be more than once.
+     * The function that is called to process any data received by the io_service. This
+     * function gets automatically called by the io_service for EVERY packet received by
+     * the network. These functions are handled synchronously, so we DO NOT need to worry
+     * about concurrency or thread-safety in this function. Because this function also
+     * calls the provided handle_function, this means the handle_function also does not
+     * need to be thread-safe
      *
      * @param error The error code obtained when receiving the incoming data
      * @param num_bytes_received How many bytes of data were received
      */
-    void handleDataReception(const boost::system::error_code &error,
+    void handleDataReception(const boost::system::error_code& error,
                              size_t num_bytes_received);
 
-    boost::asio::io_service io_service;
+    // A UDP socket that we listen on for protobuf messages from SSL Vision
     boost::asio::ip::udp::socket socket_;
+    // The endpoint for the sender, in this case SSL Vision
     boost::asio::ip::udp::endpoint sender_endpoint_;
 
     // The maximum length of the buffer we use to receive data packets from the network
     static constexpr unsigned int max_buffer_length = 4096;
     // Acts as a buffer to store the raw received data from the network
     std::array<char, max_buffer_length> raw_received_data_;
-    // Stores the SSL_WrapperPackets that were received
-    std::vector<SSL_WrapperPacket> packet_vector;
+    // The function to call on every received packet of vision data
+    std::function<void(SSL_WrapperPacket)> handle_function;
 };

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -2,6 +2,7 @@
 #include <thunderbots_msgs/Primitive.h>
 #include <thunderbots_msgs/PrimitiveArray.h>
 #include <thunderbots_msgs/World.h>
+
 #include "ai/primitive/primitive.h"
 #include "ai/primitive/primitive_factory.h"
 #include "mrf_backend.h"
@@ -55,6 +56,9 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
     backend.send_vision_packet();
 
     // Handle libusb events for the dongle
+    // TODO: How badly does this need to be in the main loop?
+    // Can it be here if we assume this function is called all the time?
+    // Investigate as part of https://github.com/UBC-Thunderbots/Software/issues/222
     backend.update_dongle_events();
 }
 
@@ -73,10 +77,10 @@ int main(int argc, char** argv)
     // Initialize the logger
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
 
-    ros::spin();
-
     // Services any ROS calls in a separate thread "behind the scenes". Does not return
     // until the node is shutdown
     // http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning
+    ros::spin();
+
     return 0;
 }

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -1,25 +1,19 @@
 #include <ros/ros.h>
-#include <ros/time.h>
 #include <thunderbots_msgs/Primitive.h>
 #include <thunderbots_msgs/PrimitiveArray.h>
 #include <thunderbots_msgs/World.h>
-
 #include "ai/primitive/primitive.h"
 #include "ai/primitive/primitive_factory.h"
-#include "geom/point.h"
 #include "mrf_backend.h"
 #include "util/constants.h"
 #include "util/logger/init.h"
 #include "util/ros_messages.h"
 
-
+// Member variables we need to maintain state
+// They are kept in an anonymous namespace so they are not accessible outside this
+// file and are not created as global static variables.
 namespace
 {
-    // A vector of primitives. It is cleared each tick, populated by the callbacks
-    // that receive primitive commands, and is processed by the backend to send primitives
-    // to the robots over radio.
-    std::vector<std::unique_ptr<Primitive>> primitives;
-
     // The MRFBackend instance that connects to the dongle
     MRFBackend backend = MRFBackend();
 }  // namespace
@@ -27,6 +21,7 @@ namespace
 // Callbacks
 void primitiveUpdateCallback(const thunderbots_msgs::PrimitiveArray::ConstPtr& msg)
 {
+    std::vector<std::unique_ptr<Primitive>> primitives;
     thunderbots_msgs::PrimitiveArray prim_array_msg = *msg;
     for (const thunderbots_msgs::Primitive& prim_msg : prim_array_msg.primitives)
     {
@@ -49,7 +44,7 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
     std::vector<std::tuple<uint8_t, Point, Angle>> robots;
     for (const Robot& r : friendly_team.getAllRobots())
     {
-        robots.push_back(std::make_tuple(r.id(), r.position(), r.orientation()));
+        robots.emplace_back(std::make_tuple(r.id(), r.position(), r.orientation()));
     }
 
     // Update robots and ball
@@ -58,6 +53,9 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
 
     // Send vision packet
     backend.send_vision_packet();
+
+    // Handle libusb events for the dongle
+    backend.update_dongle_events();
 }
 
 int main(int argc, char** argv)
@@ -67,7 +65,7 @@ int main(int argc, char** argv)
     ros::NodeHandle node_handle;
 
     // Create subscribers to topics we care about
-    ros::Subscriber prim_array_sub = node_handle.subscribe(
+    ros::Subscriber primitive_subscriber = node_handle.subscribe(
         Util::Constants::AI_PRIMITIVES_TOPIC, 1, primitiveUpdateCallback);
     ros::Subscriber world_sub = node_handle.subscribe(
         Util::Constants::NETWORK_INPUT_WORLD_TOPIC, 1, worldUpdateCallback);
@@ -75,22 +73,7 @@ int main(int argc, char** argv)
     // Initialize the logger
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
 
-    // Initialize variables
-    primitives = std::vector<std::unique_ptr<Primitive>>();
-
-    // Main loop
-    while (ros::ok())
-    {
-        // Clear all primitives each tick
-        primitives.clear();
-
-        // Handle libusb events for the dongle
-        backend.update_dongle_events();
-
-        // Spin once to let all necessary callbacks run
-        // The callbacks will populate the primitives vector
-        ros::spinOnce();
-    }
+    ros::spin();
 
     return 0;
 }

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -75,5 +75,8 @@ int main(int argc, char** argv)
 
     ros::spin();
 
+    // Services any ROS calls in a separate thread "behind the scenes". Does not return
+    // until the node is shutdown
+    // http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning
     return 0;
 }

--- a/src/thunderbots/software/test/ai/passing/evaluation.cpp
+++ b/src/thunderbots/software/test/ai/passing/evaluation.cpp
@@ -146,4 +146,3 @@ TEST(PassingEvaluationTest, sigmoid_negating_sig_width_flips_sigmoid)
     EXPECT_NEAR(sigmoid(-5, 0, -10), 0.982, 0.0001);
     EXPECT_NEAR(sigmoid(5, 0, -10), 0.018, 0.0001);
 }
-

--- a/src/thunderbots/software/test/ai/passing/pass.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass.cpp
@@ -27,4 +27,3 @@ TEST(PassTest, test_stream_operator)
     EXPECT_EQ("Receiver: (3, 4), Passer: (1, 2) Speed (m/s): 99.97 Start Time (s): 10",
               out.str());
 }
-

--- a/src/thunderbots/software/util/constants.h
+++ b/src/thunderbots/software/util/constants.h
@@ -28,6 +28,11 @@ namespace Util
         static const std::string SSL_VISION_MULTICAST_ADDRESS = "224.5.23.2";
         static const unsigned short SSL_VISION_MULTICAST_PORT = 10020;
 
+        // GrSim networking and communication
+        // TODO: BETTER NAMES
+        static const std::string GRSIM_COMMAND_NETWORK_ADDRESS = "127.0.0.1";
+        static const short GRSIM_COMMAND_NETWORK_PORT          = 20011;
+
         // Refbox address
         static const std::string SSL_GAMECONTROLLER_MULTICAST_ADDRESS = "224.5.23.1";
         static const unsigned short SSL_GAMECONTROLLER_MULTICAST_PORT = 10003;

--- a/src/thunderbots/software/util/ros_messages.cpp
+++ b/src/thunderbots/software/util/ros_messages.cpp
@@ -165,5 +165,20 @@ namespace Util
             // RefboxCommand.msg
             return (RefboxGameState)command.command;
         }
+
+        World createWorldFromROSMessage(const thunderbots_msgs::World& world_msg)
+        {
+            Ball ball          = createBallFromROSMessage(world_msg.ball);
+            Team friendly_team = createTeamFromROSMessage(world_msg.friendly_team);
+            Team enemy_team    = createTeamFromROSMessage(world_msg.enemy_team);
+            Field field        = createFieldFromROSMessage(world_msg.field);
+
+            // TODO: ???
+            //            RefboxGamState refbox_gamestate =
+            //            createGameStateFromROSMessage(world_msg.refbox_data);
+
+            World world(field, ball, friendly_team, enemy_team);
+            return world;
+        }
     }  // namespace ROSMessages
 }  // namespace Util

--- a/src/thunderbots/software/util/ros_messages.h
+++ b/src/thunderbots/software/util/ros_messages.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <thunderbots_msgs/World.h>
+
 #include "ai/world/ball.h"
 #include "ai/world/field.h"
 #include "ai/world/robot.h"
 #include "ai/world/team.h"
+#include "ai/world/world.h"
 #include "refbox_constants.h"
 #include "thunderbots_msgs/Ball.h"
 #include "thunderbots_msgs/Field.h"
@@ -91,5 +94,7 @@ namespace Util
          */
         RefboxGameState createGameStateFromROSMessage(
             const thunderbots_msgs::RefboxCommand& command);
+
+        World createWorldFromROSMessage(const thunderbots_msgs::World& world_msg);
     }  // namespace ROSMessages
 }  // namespace Util


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Made nodes run when callbacks are triggered rather than polling all the time.

`ai_logic`, `radio_communication`, and `grsim_communication` nodes now only run when they receive a new `World` message from the ROS callbacks. The `network_input` node has been rewritten to only filter and publish data when it is received from the socket, without polling for it.

TODO: Make sure the `network_input` node is able to shut down properly

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Manually verified nodes still run and that we can perform basic operations like sending a primitive to grsim.

CPU STATS
Before:
* ai_logic: 175% (WTF!?)
* network_input: 102%
* grsim_communication: 50%

After:
* network_input: 1%
* ai_logic: 1%
* grsim_communication: 1%
* CPU usage _looks_ way lower than before

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #227 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
