### PR TITLE
Update the Tactic interface

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -485,6 +485,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/world.cpp
             test/ai/hl/stp/tactic/main.cpp
             test/ai/hl/stp/tactic/move_tactic.cpp
+            test/ai/hl/stp/tactic/tactic.cpp
             test/test_util/test_util.cpp
             util/logger/custom_g3log_sinks.h
             util/logger/init.h

--- a/src/thunderbots/software/ai/hl/stp/action/action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/action.h
@@ -26,7 +26,9 @@ class Action
     explicit Action(const Robot &robot);
 
     /**
-     * Returns true if the Action is done and false otherwise
+     * Returns true if the Action is done and false otherwise. The Action is considered
+     * done when its coroutine is done (the calculateNextIntent() function has no more
+     * work to do).
      *
      * @return true if the Action is done and false otherwise
      */

--- a/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.cpp
@@ -2,38 +2,33 @@
 
 #include <algorithm>
 
-MoveTactic::MoveTactic(const Robot &robot) : Tactic(robot) {}
+MoveTactic::MoveTactic() : Tactic() {}
 
-std::unique_ptr<Intent> MoveTactic::updateStateAndGetNextIntent(const Robot &robot,
-                                                                Point destination,
-                                                                Angle final_orientation,
-                                                                double final_speed)
+void MoveTactic::updateParams(Point destination, Angle final_orientation,
+                              double final_speed)
 {
     // Update the parameters stored by this Tactic
-    this->robot             = robot;
     this->destination       = destination;
     this->final_orientation = final_orientation;
     this->final_speed       = final_speed;
-
-    return getNextIntent();
 }
 
-double MoveTactic::calculateRobotCost(const Robot &robot, const Field &field)
+double MoveTactic::calculateRobotCost(const Robot &robot, const World &world)
 {
     // Prefer robots closer to the destination
     // We normalize with the total field length so that robots that are within the field
     // have a cost less than 1
-    double cost = (robot.position() - destination).len() / field.totalLength();
+    double cost = (robot.position() - destination).len() / world.field().totalLength();
     return std::clamp<double>(cost, 0, 1);
 }
 
 std::unique_ptr<Intent> MoveTactic::calculateNextIntent(
     intent_coroutine::push_type &yield)
 {
-    MoveAction move_action = MoveAction(robot);
+    MoveAction move_action = MoveAction(*robot);
     do
     {
-        yield(move_action.updateStateAndGetNextIntent(robot, destination,
+        yield(move_action.updateStateAndGetNextIntent(*robot, destination,
                                                       final_orientation, final_speed));
     } while (!move_action.done());
 }

--- a/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.h
@@ -6,34 +6,44 @@
 class MoveTactic : public Tactic
 {
    public:
-    explicit MoveTactic(const Robot& robot);
+    /**
+     * Creates a new MoveTactic
+     *
+     * The MoveTactic will move the assigned robot to the given destination and arrive
+     * with the specified final orientation and speed
+     */
+    explicit MoveTactic();
 
     /**
-     * Returns the next Intent this MoveTactic wants to run, given the parameters.
-     * Moves the robot in a straight line to the given destination.
+     * Updates the parameters for this MoveTactic.
      *
-     * @param robot The robot to move
      * @param destination The destination to move to (in global coordinates)
      * @param final_orientation The final orientation the robot should have at
      * the destination
      * @param final_speed The final speed the robot should have at the destination
-     *
-     * @return A unique pointer to the Intent the MoveAction wants to run. If the
-     * MoveAction is done, returns an empty/null pointer
      */
-    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot,
-                                                        Point destination,
-                                                        Angle final_orientation,
-                                                        double final_speed);
+    void updateParams(Point destination, Angle final_orientation, double final_speed);
 
-    double calculateRobotCost(const Robot& robot, const Field& field) override;
+    /**
+     * Calculates the cost of assigning the given robot to this Tactic. Prefers robots
+     * closer to the destination
+     *
+     * @param robot The robot to evaluate the cost for
+     * @param world The state of the world with which to perform the evaluation
+     * @return A cost in the range [0,1] indicating the cost of assigning the given robot
+     * to this tactic. Lower cost values indicate a more preferred robot.
+     */
+    double calculateRobotCost(const Robot& robot, const World& world) override;
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
         intent_coroutine::push_type& yield) override;
 
     // Tactic parameters
+    // The point the robot is trying to move to
     Point destination;
+    // The orientation the robot should have when it arrives at its destination
     Angle final_orientation;
+    // The speed the robot should have when it arrives at its destination
     double final_speed;
 };

--- a/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.h
@@ -3,14 +3,15 @@
 #include "ai/hl/stp/action/move_action.h"
 #include "ai/hl/stp/tactic/tactic.h"
 
+/**
+ * The MoveTactic will move the assigned robot to the given destination and arrive
+ * with the specified final orientation and speed
+ */
 class MoveTactic : public Tactic
 {
    public:
     /**
      * Creates a new MoveTactic
-     *
-     * The MoveTactic will move the assigned robot to the given destination and arrive
-     * with the specified final orientation and speed
      */
     explicit MoveTactic();
 

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
@@ -1,8 +1,10 @@
 #include "ai/hl/stp/tactic/tactic.h"
 
-Tactic::Tactic(const Robot &robot)
-    : robot(robot),
-      intent_sequence(boost::bind(&Tactic::calculateNextIntentWrapper, this, _1))
+#include "util/logger/init.h"
+
+Tactic::Tactic()
+    : intent_sequence(boost::bind(&Tactic::calculateNextIntentWrapper, this, _1)),
+      done_(false)
 {
 }
 
@@ -11,11 +13,37 @@ bool Tactic::done() const
     // If the coroutine "iterator" is done (ie. evaluates to false, has no more values
     // to iterate), the calculateNextIntent function has completed and therefore
     // the Tactic is done
-    return !static_cast<bool>(intent_sequence);
+    //
+    // We also check out internal done_ variable. This is set automatically by the
+    // getNextIntent function if we ever return a nullptr. We do this extra check because
+    // Tactics can return a nullptr one "tick" (aka function call) before the coroutine
+    // actually evaluates as done. This way we ensure that the Tactic::done() function
+    // will always evaluate to true on the exact same call a nullptr is returned.
+    //
+    // This is important since higher-level functions rely on the done() function, and
+    // returning nullptr values "out of sync" with this could cause problems
+    return done_ || !static_cast<bool>(intent_sequence);
+}
+
+std::optional<Robot> Tactic::getAssignedRobot() const
+{
+    return robot;
+}
+
+void Tactic::updateRobot(const Robot &robot)
+{
+    this->robot = robot;
 }
 
 std::unique_ptr<Intent> Tactic::getNextIntent()
 {
+    if (!robot)
+    {
+        LOG(WARNING) << "Requesting the next Intent for a Tactic without a Robot assigned"
+                     << std::endl;
+        return std::unique_ptr<Intent>{};
+    }
+
     // If the coroutine "iterator" is done, the calculateNextIntent function has completed
     // and therefore the Tactic is done, so we return a null pointer
     if (intent_sequence)
@@ -23,6 +51,8 @@ std::unique_ptr<Intent> Tactic::getNextIntent()
         // Calculate and return the next Intent
         intent_sequence();
         auto next_intent = intent_sequence.get();
+        // The tactic is considered done once a nullptr is returned
+        done_ = !static_cast<bool>(next_intent);
         return next_intent;
     }
     return std::unique_ptr<Intent>{};

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
@@ -14,6 +14,20 @@
  * and they tend to rely a lot on our Evaluation functions. Ultimately, Tactics will
  * return the next Intent that the Robot assigned to this Tactic should run in order
  * to work towards its objective.
+ *
+ * HOW THIS CLASS IS USED:
+ * Plays will construct and return the Tactics they want to be running. Every time a play
+ * is run, it will update the parameters of each tactic with the updateParams(...)
+ * function (see the concrete implementations of this class for examples). This is done
+ * every time in order fo the Tactics to have the most up to date information when they
+ * calculate the next Intent they want to run (for example if we were following a moving
+ * robot, we need to constantly update our destination).
+ *
+ * The calulateRobotCost() and getNextIntent() functions will be called after the params
+ * are updated. Params must be updated first so that these functions can make the correct
+ * decisions.
+ *
+ * See the Play and PlayExecutor classes for more details on how Tactics are used
  */
 class Tactic
 {

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <boost/coroutine2/all.hpp>
+#include <optional>
 
 #include "ai/hl/stp/action/action.h"
 #include "ai/intent/intent.h"
-#include "ai/world/field.h"
+#include "ai/world/world.h"
 
 /**
  * In the STP framework, a Tactic represents a role or objective for a single robot. For
@@ -18,18 +19,34 @@ class Tactic
 {
    public:
     /**
-     * Creates a new Tactic with the given robot
-     *
-     * @param robot The robot that should perform this Tactic
+     * Creates a new Tactic. The Tactic will initially have no Robot assigned to it.
      */
-    explicit Tactic(const Robot &robot);
+    explicit Tactic();
 
     /**
-     * Returns true if the Tactic is done and false otherwise
+     * Returns true if the Tactic is done and false otherwise. The tactic is considered
+     * done when either its coroutine is done (the calculateNextIntent() function has no
+     * more work to do), or a nullptr has been returned
      *
      * @return true if the Tactic is done and false otherwise
      */
     bool done() const;
+
+    /**
+     * Returns the Robot assigned to this Tactic
+     *
+     * @return an std::optional containing the Robot assigned to this Tactic if one has
+     * been assigned, otherwise returns std::nullopt
+     */
+    std::optional<Robot> getAssignedRobot() const;
+
+    /**
+     * Updates the robot assigned to this Tactic
+     *
+     * @param robot The updated state of the Robot that should be performing
+     * this Tactic
+     */
+    void updateRobot(const Robot &robot);
 
     /**
      * Calculates the cost of assigning the given robot to this Tactic. The returned cost
@@ -40,16 +57,13 @@ class Tactic
      * costs for robots closer to the ball than for robots far from the ball.
      *
      * @param robot The Robot to calculate the cost for
-     * @param field The field the Robot is on
+     * @param world The state of the world used to perform the cost calculation
      *
      * @return A cost value in the range [0, 1] indicating the cost of assigning the given
      * robot to this Tactic. Lower cost values indicate more preferred robots.
      */
-    virtual double calculateRobotCost(const Robot &robot, const Field &field) = 0;
+    virtual double calculateRobotCost(const Robot &robot, const World &world) = 0;
 
-    virtual ~Tactic() = default;
-
-   protected:
     /**
      * Runs the coroutine and get the next Intent to run from the calculateNextIntent
      * function. If the Tactic is not done, the next Intent is returned. If the Tactic
@@ -60,10 +74,13 @@ class Tactic
      */
     std::unique_ptr<Intent> getNextIntent();
 
+    virtual ~Tactic() = default;
+
+   protected:
     // The coroutine that sequentially returns the Intents the Tactic wants to run
     intent_coroutine::pull_type intent_sequence;
     // The robot performing this Tactic
-    Robot robot;
+    std::optional<Robot> robot;
 
    private:
     /**
@@ -103,4 +120,7 @@ class Tactic
      */
     virtual std::unique_ptr<Intent> calculateNextIntent(
         intent_coroutine::push_type &yield) = 0;
+
+    // Whether or not this Tactic is done
+    bool done_;
 };

--- a/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
@@ -17,6 +17,7 @@ TEST(MoveActionTest, robot_far_from_destination)
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
 
     MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
     EXPECT_EQ(0, move_intent.getRobotId());
@@ -39,9 +40,7 @@ TEST(MoveActionTest, robot_at_destination)
     intent_ptr =
         action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 0.0);
 
-    // We expect the resultant pointer to be null since the Action is done and has no more
-    // Intents to return, since the robot is already at the destination
-    EXPECT_FALSE(intent_ptr);
+    EXPECT_TRUE(action.done());
 }
 
 TEST(MoveActionTest, test_action_does_not_prematurely_report_done)
@@ -60,40 +59,28 @@ TEST(MoveActionTest, test_action_does_not_prematurely_report_done)
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
-}
-
-TEST(MoveActionTest, test_action_done)
-{
-    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
-                        Timestamp::fromSeconds(0));
-    MoveAction action = MoveAction(robot, 0.05);
-
-    // Run the Action several times
-    auto intent_ptr = std::unique_ptr<Intent>{};
-    for (int i = 0; i < 5; i++)
-    {
-        intent_ptr =
-            action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 0.0);
-    }
-
-    // Check an intent was returned (the pointer is not null)
-    EXPECT_TRUE(action.done());
-}
-
-TEST(MoveActionTest, test_action_not_done)
-{
-    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
-                        Timestamp::fromSeconds(0));
-    MoveAction action = MoveAction(robot, 0.05);
-
-    // Run the Action several times
-    auto intent_ptr = std::unique_ptr<Intent>{};
-    for (int i = 0; i < 5; i++)
-    {
-        intent_ptr =
-            action.updateStateAndGetNextIntent(robot, Point(2, -1), Angle::zero(), 0.0);
-    }
-
-    // Check an intent was returned (the pointer is not null)
     EXPECT_FALSE(action.done());
+}
+
+TEST(MoveActionTest, test_action_reports_done_at_same_time_nullptr_returned)
+{
+    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+    MoveAction action = MoveAction(robot, 0.05);
+
+    // The first time the Action runs it will always return an Intent to make sure we
+    // are doing the correct thing
+    auto intent_ptr =
+        action.updateStateAndGetNextIntent(robot, Point(), Angle::zero(), 0.0);
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    // For subsequent calls, we expect the Action to be done (in this case)
+    // We make sure that when a nullptr is returned, the action also evaluates to "done"
+    // This is important since higher-level functionality relies on the Action::done()
+    // function but returning nullptr values out of sync with this done() function could
+    // cause problems
+    intent_ptr = action.updateStateAndGetNextIntent(robot, Point(), Angle::zero(), 0.0);
+    EXPECT_FALSE(intent_ptr);
+    EXPECT_TRUE(action.done());
 }

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/move_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/move_tactic.cpp
@@ -2,8 +2,6 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/coroutine2/all.hpp>
-
 #include "ai/intent/move_intent.h"
 #include "test/test_util/test_util.h"
 
@@ -11,10 +9,11 @@ TEST(MoveTacticTest, robot_far_from_destination)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveTactic tactic = MoveTactic(robot);
 
-    auto intent_ptr =
-        tactic.updateStateAndGetNextIntent(robot, Point(1, 0), Angle::quarter(), 1.0);
+    MoveTactic tactic = MoveTactic();
+    tactic.updateRobot(robot);
+    tactic.updateParams(Point(1, 0), Angle::quarter(), 1.0);
+    auto intent_ptr = tactic.getNextIntent();
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -26,88 +25,34 @@ TEST(MoveTacticTest, robot_far_from_destination)
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
 }
 
-TEST(MoveActionTest, robot_at_destination)
+TEST(MoveTacticTest, robot_at_destination)
 {
     Robot robot = Robot(0, Point(), Vector(0, 0), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveTactic tactic = MoveTactic(robot);
+
+    MoveTactic tactic = MoveTactic();
+    tactic.updateRobot(robot);
+    tactic.updateParams(Point(0, 0), Angle::zero(), 0.0);
 
     // We call the Tactic twice. The first time the Intent will always be returned to
     // ensure the Robot is doing the right thing. In all future calls, the action will be
     // done and so will return a null pointer
-    auto intent_ptr =
-        tactic.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 0.0);
-    intent_ptr =
-        tactic.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 0.0);
+    auto intent_ptr = tactic.getNextIntent();
+    intent_ptr      = tactic.getNextIntent();
 
-    // We expect the resultant pointer to be null since the Action is done and has no more
-    // Intents to return, since the robot is already at the destination
-    EXPECT_FALSE(intent_ptr);
-}
-
-TEST(MoveActionTest, test_action_does_not_prematurely_report_done)
-{
-    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
-                        Timestamp::fromSeconds(0));
-    MoveTactic tactic = MoveTactic(robot);
-
-    // Run the Tactic several times
-    auto intent_ptr = std::unique_ptr<Intent>{};
-    for (int i = 0; i < 10; i++)
-    {
-        intent_ptr =
-            tactic.updateStateAndGetNextIntent(robot, Point(1, 0), Angle::quarter(), 1.0);
-    }
-
-    // Check an intent was returned (the pointer is not null)
-    EXPECT_TRUE(intent_ptr);
-}
-
-TEST(MoveActionTest, test_action_done)
-{
-    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
-                        Timestamp::fromSeconds(0));
-    MoveTactic tactic = MoveTactic(robot);
-
-    // Run the Tactic several times
-    auto intent_ptr = std::unique_ptr<Intent>{};
-    for (int i = 0; i < 5; i++)
-    {
-        intent_ptr =
-            tactic.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 0.0);
-    }
-
-    // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(tactic.done());
 }
 
-TEST(MoveActionTest, test_action_not_done)
+TEST(MoveTacticTest, test_calculate_robot_cost)
 {
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    world.updateFieldGeometry(::Test::TestUtil::createSSLDivBField());
+
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveTactic tactic = MoveTactic(robot);
 
-    // Run the Action several times
-    auto intent_ptr = std::unique_ptr<Intent>{};
-    for (int i = 0; i < 5; i++)
-    {
-        intent_ptr =
-            tactic.updateStateAndGetNextIntent(robot, Point(2, -1), Angle::zero(), 0.0);
-    }
+    MoveTactic tactic = MoveTactic();
+    tactic.updateParams(Point(3, -4), Angle::zero(), 0.0);
 
-    // Check an intent was returned (the pointer is not null)
-    EXPECT_FALSE(tactic.done());
-}
-
-TEST(MoveActionTest, test_evaluate_robot_function)
-{
-    Field field = ::Test::TestUtil::createSSLDivBField();
-    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
-                        Timestamp::fromSeconds(0));
-    MoveTactic tactic = MoveTactic(robot);
-
-    auto intent_ptr =
-        tactic.updateStateAndGetNextIntent(robot, Point(3, -4), Angle::zero(), 0.0);
-
-    EXPECT_EQ(5 / field.totalLength(), tactic.calculateRobotCost(robot, field));
+    EXPECT_EQ(5 / world.field().totalLength(), tactic.calculateRobotCost(robot, world));
 }

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/tactic.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include "ai/hl/stp/tactic/move_tactic.h"
+
+/**
+ * This file contains the unit tests for the Tactic class (NOTE: `Tactic` is virtual, so
+ * we use `MoveTactic` instead, but we're only testing the generic functionality of
+ * the `Tactic` class)
+ */
+
+TEST(TacticTest, test_get_assigned_robot_with_no_robot_and_no_params)
+{
+    MoveTactic tactic = MoveTactic();
+    auto robot        = tactic.getAssignedRobot();
+
+    EXPECT_EQ(robot, std::nullopt);
+}
+
+TEST(TacticTest, test_get_assigned_robot_with_no_robot)
+{
+    MoveTactic tactic = MoveTactic();
+    tactic.updateParams(Point(), Angle::quarter(), 1.2);
+    auto robot = tactic.getAssignedRobot();
+
+    EXPECT_EQ(robot, std::nullopt);
+}
+
+TEST(TacticTest, test_get_assigned_robot_with_a_robot_assigned)
+{
+    MoveTactic tactic = MoveTactic();
+    auto robot        = Robot(1, Point(1, 0), Vector(), Angle::threeQuarter(),
+                       AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    tactic.updateRobot(robot);
+
+    EXPECT_TRUE(tactic.getAssignedRobot());
+    EXPECT_EQ(robot, *(tactic.getAssignedRobot()));
+}
+
+TEST(TacticTest, test_nullptr_returned_when_no_robot_assigned)
+{
+    MoveTactic tactic = MoveTactic();
+    tactic.updateParams(Point(), Angle::quarter(), 1.2);
+
+    EXPECT_FALSE(tactic.getNextIntent());
+}
+
+TEST(TacticTest, test_tactic_not_done_after_run_with_no_robot_assigned)
+{
+    MoveTactic tactic = MoveTactic();
+    tactic.updateParams(Point(), Angle::quarter(), 1.2);
+
+    // Run the tactic several times
+    for (int i = 0; i < 5; i++)
+    {
+        tactic.getNextIntent();
+    }
+
+    EXPECT_FALSE(tactic.done());
+}
+
+TEST(TacticTest, test_tactic_does_not_prematurely_report_done)
+{
+    // This test is making sure we don't have any bugs with managing our coroutines that
+    // cause the tactic to end before we would expect
+
+    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+
+    // Create a MoveTactic with the final destination very far from where the robot
+    // currently is, so that we know the tactic should not report done
+    MoveTactic tactic = MoveTactic();
+    tactic.updateRobot(robot);
+    tactic.updateParams(Point(3, 4), Angle::quarter(), 2.2);
+
+    // Run the Tactic several times, leaving the robot and parameters as is so the
+    // tactic should not approach a "done" state
+    auto intent_ptr = std::unique_ptr<Intent>{};
+    for (int i = 0; i < 10; i++)
+    {
+        intent_ptr = tactic.getNextIntent();
+    }
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(tactic.done());
+}
+
+TEST(TacticTest, test_tactic_reports_done_at_same_time_nullptr_returned)
+{
+    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+
+    // Create a MoveTactic that wants to move the Robot to where it already is.
+    // Therefore we expect the tactic to be done
+    MoveTactic tactic = MoveTactic();
+    tactic.updateRobot(robot);
+    tactic.updateParams(Point(), Angle::zero(), 0.0);
+
+    // The tactic should always return an Intent the first time it is run to make sure we
+    // are doing the right thing (and just don't happen to be in the "done state" at the
+    // time while actually doing something else)
+    auto intent_ptr = tactic.getNextIntent();
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(tactic.done());
+
+    // Subsequent calls should return a nullptr since the Tactic is done, and the
+    // tactic should also report done()
+    intent_ptr = tactic.getNextIntent();
+    EXPECT_FALSE(intent_ptr);
+    EXPECT_TRUE(tactic.done());
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Updated the `Tactic` interface.
* Separated the `updateParams` functionality into its own function
* The `Robot` is now assigned/updated through its own function rather than being given with the Parameters
* How `done()` is calculated has been slightly changed to detect when the `getNextIntent()` function returns a `nullptr`. This is to make sure that Tactics can't return a `nullptr` without reporting `done()`
* Updated tests and separated generic `Tactic` tests into their own file

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
* Removed a few redundant unit tests
* Updated tests to use the new interface
* Added a new test to make sure `Tactics` and `Actions` don't return a `nullptr` without `done()` returning `true`

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
None, but required for #394

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
