### PR TITLE
Added ability to charge and discharge capacitors based on EStop state

### DIFF
--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -533,10 +533,19 @@ void MRFDongle::encode_primitive(const std::unique_ptr<Primitive> &prim, void *o
     //         words[1] |= 2 << 14;
     //         break;
     // }
-    // charged by default
+
     // Once we stop sending radio packets to the robots, they have a failsafe to discharge
     // after 1 second. For now we rely on that to discharge the robots.
-    words[1] |= 2 << 14;
+    switch (estop_state)
+    {
+        case EStopState::BROKEN:
+        case EStopState::STOP:
+            words[1] |= 1 << 14;
+            break;
+        case EStopState::RUN:
+            words[1] |= 2 << 14;
+            break;
+    }
 
     // Encode extra data plus the slow flag.
     // TODO: do we actually use the slow flag?

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -521,28 +521,17 @@ void MRFDongle::encode_primitive(const std::unique_ptr<Primitive> &prim, void *o
     words[0] = static_cast<uint16_t>(words[0] |
                                      static_cast<unsigned int>(r_prim.prim_type) << 12);
 
-    // Encode the charger state. TODO add this (#223)
-    // switch (charger_state)
-    // {
-    //     case ChargerState::DISCHARGE:
-    //         words[1] |= 1 << 14;
-    //         break;
-    //     case ChargerState::FLOAT:
-    //         break;
-    //     case ChargerState::CHARGE:
-    //         words[1] |= 2 << 14;
-    //         break;
-    // }
-
-    // Once we stop sending radio packets to the robots, they have a failsafe to discharge
-    // after 1 second. For now we rely on that to discharge the robots.
+    // Encode charge state
+    // Robots are always charged if the estop is in RUN state; otherwise discharge them.
     switch (estop_state)
     {
         case EStopState::BROKEN:
         case EStopState::STOP:
+            // Discharge`
             words[1] |= 1 << 14;
             break;
         case EStopState::RUN:
+            // Charge
             words[1] |= 2 << 14;
             break;
     }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Currently robots are charged by default when communicating over MRF. Although robots automatically discharge after receiving no commands for a second, it would be safer to discharge them automatically when the estop is tripped.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Tested with a robot and estop.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #223 
### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
