### PR TITLE
WIP:  Implement Communication to ROS Param Server w/ Visualizer to Start AI Logic #392 

### DIFF
--- a/src/corner_kick/src/App.tsx
+++ b/src/corner_kick/src/App.tsx
@@ -18,7 +18,9 @@ const store = createStore();
 export const App = () => (
     <Provider store={store}>
         <Theme>
-            <Portal portalLocation={PortalLocation.SIDEBAR}>This is the sidebar</Portal>
+            <Portal portalLocation={PortalLocation.SIDEBAR}>
+                <button>Start AI logic</button>
+            </Portal>
             <Portal portalLocation={PortalLocation.MAIN}>This is main</Portal>
             <Portal portalLocation={PortalLocation.CONSOLE}>This is the console</Portal>
         </Theme>

--- a/src/corner_kick/src/store/actions/__tests__/params.test.ts
+++ b/src/corner_kick/src/store/actions/__tests__/params.test.ts
@@ -1,0 +1,50 @@
+/**
+ * This file is for testing the Params actions
+ * Each test case has a description of what it tests
+ */
+
+import configureMockStore from 'redux-mock-store';
+import * as paramsActions from '../params';
+
+const mockStore = configureMockStore();
+const store = mockStore();
+
+describe('paramsActions', () => {
+    beforeEach(() => {
+        store.clearActions();
+    });
+
+    describe('when we hydrate ROS params to state', () => {
+        test('Dispatches the correct hydrateROSParam action and payload', () => {
+            const expectedActions = [
+                {
+                    payload: {
+                        settings: { color: 'blue' },
+                    },
+                    type: 'param_HYDRATE_PARAM',
+                },
+            ];
+
+            store.dispatch(paramsActions.hydrateROSParam({ color: 'blue' }));
+            expect(store.getActions()).toEqual(expectedActions);
+        });
+    });
+
+    describe('when we send ROS params to update state', () => {
+        test('Dispatches the correct send settings action and payload', () => {
+            const expectedActions = [
+                {
+                    payload: {
+                        key: 'dog',
+                        value: 'bark',
+                    },
+                    type: 'param_SET_PARAM',
+                },
+            ];
+
+            store.dispatch(paramsActions.setROSParam('dog', 'bark'));
+            expect(store.getActions()).toEqual(expectedActions);
+        });
+    });
+    // How would I test getROSParam?
+});

--- a/src/corner_kick/src/store/actions/__tests__/params.test.ts
+++ b/src/corner_kick/src/store/actions/__tests__/params.test.ts
@@ -19,13 +19,13 @@ describe('paramsActions', () => {
             const expectedActions = [
                 {
                     payload: {
-                        settings: { color: 'blue' },
+                        params: { color: 'blue' },
                     },
-                    type: 'param_HYDRATE_PARAM',
+                    type: 'param_HYDRATE_PARAMS',
                 },
             ];
 
-            store.dispatch(paramsActions.hydrateROSParam({ color: 'blue' }));
+            store.dispatch(paramsActions.hydrateROSParams({ color: 'blue' }));
             expect(store.getActions()).toEqual(expectedActions);
         });
     });
@@ -38,13 +38,12 @@ describe('paramsActions', () => {
                         key: 'dog',
                         value: 'bark',
                     },
-                    type: 'param_SET_PARAM',
+                    type: 'param_UPDATE_PARAMS',
                 },
             ];
 
-            store.dispatch(paramsActions.setROSParam('dog', 'bark'));
+            store.dispatch(paramsActions.updateROSParams('dog', 'bark'));
             expect(store.getActions()).toEqual(expectedActions);
         });
     });
-    // How would I test getROSParam?
 });

--- a/src/corner_kick/src/store/actions/__tests__/params.test.ts
+++ b/src/corner_kick/src/store/actions/__tests__/params.test.ts
@@ -21,7 +21,7 @@ describe('paramsActions', () => {
                     payload: {
                         params: { color: 'blue' },
                     },
-                    type: 'param_HYDRATE_PARAMS',
+                    type: 'params_HYDRATE_PARAMS',
                 },
             ];
 
@@ -38,7 +38,7 @@ describe('paramsActions', () => {
                         key: 'dog',
                         value: 'bark',
                     },
-                    type: 'param_UPDATE_PARAMS',
+                    type: 'params_UPDATE_PARAMS',
                 },
             ];
 

--- a/src/corner_kick/src/store/actions/index.ts
+++ b/src/corner_kick/src/store/actions/index.ts
@@ -3,15 +3,18 @@
  */
 
 import * as consoleActions from './console';
+import * as paramsActions from './params';
 import * as rosActions from './ros';
 
 import { ConsoleAction } from '../reducers/console';
+import { ParamsActions } from '../reducers/params';
 import { ROSAction } from '../reducers/ros';
 
 export const actions = {
     console: consoleActions,
+    params: paramsActions,
     ros: rosActions,
 };
 
 // We combine all action types for convenient access throughout the application
-export type RootAction = ConsoleAction | ROSAction;
+export type RootAction = ConsoleAction | ParamsActions | ROSAction;

--- a/src/corner_kick/src/store/actions/params.ts
+++ b/src/corner_kick/src/store/actions/params.ts
@@ -2,26 +2,19 @@
  * This files specifies param server specific actions
  */
 
+import { IROSSettings } from 'SRC/types';
 import { createAction } from 'typesafe-actions';
-import { IROSSettings } from '../../types';
 
 /**
  * Hydrates ROS param settings
  */
-export const hydrateROSParam = createAction('param_HYDRATE_PARAM', (resolve) => {
+export const hydrateROSParams = createAction('param_HYDRATE_PARAMS', (resolve) => {
     return (params: IROSSettings) => resolve({ params });
 });
 
 /**
  * Adds ROS params from ROS Param Server
  */
-export const setROSParam = createAction('param_SET_PARAM', (resolve) => {
+export const updateROSParams = createAction('param_UPDATE_PARAMS', (resolve) => {
     return (key: string, value: string) => resolve({ key, value });
-});
-
-/**
- * Retrieves a ROS param value
- */
-export const getROSParam = createAction('param_GET_PARAM', (resolve) => {
-    return (value: string) => resolve({ value }); // some callback
 });

--- a/src/corner_kick/src/store/actions/params.ts
+++ b/src/corner_kick/src/store/actions/params.ts
@@ -1,0 +1,27 @@
+/**
+ * This files specifies param server specific actions
+ */
+
+import { createAction } from 'typesafe-actions';
+import { IROSSettings } from '../../types';
+
+/**
+ * Hydrates ROS param settings
+ */
+export const hydrateROSParam = createAction('param_HYDRATE_PARAM', (resolve) => {
+    return (params: IROSSettings) => resolve({ params });
+});
+
+/**
+ * Adds ROS params from ROS Param Server
+ */
+export const setROSParam = createAction('param_SET_PARAM', (resolve) => {
+    return (key: string, value: string) => resolve({ key, value });
+});
+
+/**
+ * Retrieves a ROS param value
+ */
+export const getROSParam = createAction('param_GET_PARAM', (resolve) => {
+    return (value: string) => resolve({ value }); // some callback
+});

--- a/src/corner_kick/src/store/actions/params.ts
+++ b/src/corner_kick/src/store/actions/params.ts
@@ -8,13 +8,13 @@ import { createAction } from 'typesafe-actions';
 /**
  * Hydrates ROS param settings
  */
-export const hydrateROSParams = createAction('param_HYDRATE_PARAMS', (resolve) => {
+export const hydrateROSParams = createAction('params_HYDRATE_PARAMS', (resolve) => {
     return (params: IROSSettings) => resolve({ params });
 });
 
 /**
  * Adds ROS params from ROS Param Server
  */
-export const updateROSParams = createAction('param_UPDATE_PARAMS', (resolve) => {
+export const updateROSParams = createAction('params_UPDATE_PARAMS', (resolve) => {
     return (key: string, value: string) => resolve({ key, value });
 });

--- a/src/corner_kick/src/store/reducers/__tests__/params.test.ts
+++ b/src/corner_kick/src/store/reducers/__tests__/params.test.ts
@@ -7,29 +7,32 @@ import * as params from '../../actions/params';
 import paramsReducer from '../params';
 
 describe('settings reducer', () => {
-    describe('when we receive action param_HYDRATE_PARAM', () => {
+    describe('when we receive action param_HYDRATE_PARAMS', () => {
         it('should hydrate ROS params to state', () => {
-            const mockAction = params.hydrateROSParam({ color: 'blue' });
+            const mockAction = params.hydrateROSParams({ color: 'blue' });
 
             const state = paramsReducer(undefined, mockAction);
 
             expect(state['color']).toEqual('blue');
         });
     });
-    describe('when we receive action param_SET_PARAM', () => {
+    describe('when we receive action param_UPDATE_PARAMS', () => {
         it('should push ROS params to the state', () => {
-            const mockAction = params.setROSParam('testKey', 'testValue');
+            const mockAction = params.updateROSParams('testKey', 'testValue');
 
             const state = paramsReducer(undefined, mockAction);
 
             expect(state['testKey']).toEqual('testValue');
         });
     });
-    describe('when we receive action param_GET_PARAM', () => {
-        it('should retrieve a ROS param and return same state', () => {
-            const mockAction = params.getROSParam('retrieveKey');
+    describe('when we receive any other action', () => {
+        it('should return the same state', () => {
+            const mockAction = {
+                payload: null,
+                type: 'test_ACTION',
+            };
 
-            const state = paramsReducer(undefined, mockAction);
+            const state = paramsReducer(undefined, mockAction as any);
 
             expect(state).toEqual({ testKey: 'testValue' });
         });

--- a/src/corner_kick/src/store/reducers/__tests__/params.test.ts
+++ b/src/corner_kick/src/store/reducers/__tests__/params.test.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is for testing Params reducers
+ * Each test case has a description of what it tests
+ */
+
+import * as params from '../../actions/params';
+import paramsReducer from '../params';
+
+describe('settings reducer', () => {
+    describe('when we receive action param_HYDRATE_PARAM', () => {
+        it('should hydrate ROS params to state', () => {
+            const mockAction = params.hydrateROSParam({ color: 'blue' });
+
+            const state = paramsReducer(undefined, mockAction);
+
+            expect(state['color']).toEqual('blue');
+        });
+    });
+    describe('when we receive action param_SET_PARAM', () => {
+        it('should push ROS params to the state', () => {
+            const mockAction = params.setROSParam('testKey', 'testValue');
+
+            const state = paramsReducer(undefined, mockAction);
+
+            expect(state['testKey']).toEqual('testValue');
+        });
+    });
+    describe('when we receive action param_GET_PARAM', () => {
+        it('should retrieve a ROS param and return same state', () => {
+            const mockAction = params.getROSParam('retrieveKey');
+
+            const state = paramsReducer(undefined, mockAction);
+
+            expect(state).toEqual({ testKey: 'testValue' });
+        });
+    });
+});

--- a/src/corner_kick/src/store/reducers/index.ts
+++ b/src/corner_kick/src/store/reducers/index.ts
@@ -5,6 +5,7 @@
 import { combineReducers } from 'redux';
 
 import consoleReducer from './console';
+import paramsReducer from './params';
 import rosReducer from './ros';
 
 /**
@@ -13,5 +14,6 @@ import rosReducer from './ros';
  */
 export default combineReducers({
     console: consoleReducer,
+    params: paramsReducer,
     ros: rosReducer,
 });

--- a/src/corner_kick/src/store/reducers/params.ts
+++ b/src/corner_kick/src/store/reducers/params.ts
@@ -4,7 +4,7 @@
 
 import { ActionType, getType } from 'typesafe-actions';
 
-import { IROSSettings } from '../../types';
+import { IROSSettings } from 'SRC/types';
 
 import * as params from '../actions/params';
 export type ParamsActions = ActionType<typeof params>;
@@ -19,22 +19,18 @@ const defaultState: IROSSettings = {
 export default (state: IROSSettings = defaultState, action: ParamsActions) => {
     switch (action.type) {
         // Read key-value ROS params into state
-        case getType(params.hydrateROSParam):
+        case getType(params.hydrateROSParams):
             return {
                 ...state,
                 ...action.payload.params,
             };
 
         // Push key-value ROS params to state
-        case getType(params.setROSParam):
+        case getType(params.updateROSParams):
             return {
                 ...state,
                 [action.payload.key]: action.payload.value,
             };
-
-        // Retrieve value from ROS params
-        case getType(params.getROSParam):
-            return state;
 
         default:
             return state;

--- a/src/corner_kick/src/store/reducers/params.ts
+++ b/src/corner_kick/src/store/reducers/params.ts
@@ -1,0 +1,42 @@
+/*
+ * This file specifies the Params reducer
+ */
+
+import { ActionType, getType } from 'typesafe-actions';
+
+import { IROSSettings } from '../../types';
+
+import * as params from '../actions/params';
+export type ParamsActions = ActionType<typeof params>;
+
+const defaultState: IROSSettings = {
+    testKey: 'testValue',
+};
+
+/**
+ * Reducer function for Params
+ */
+export default (state: IROSSettings = defaultState, action: ParamsActions) => {
+    switch (action.type) {
+        // Read key-value ROS params into state
+        case getType(params.hydrateROSParam):
+            return {
+                ...state,
+                ...action.payload.params,
+            };
+
+        // Push key-value ROS params to state
+        case getType(params.setROSParam):
+            return {
+                ...state,
+                [action.payload.key]: action.payload.value,
+            };
+
+        // Retrieve value from ROS params
+        case getType(params.getROSParam):
+            return state;
+
+        default:
+            return state;
+    }
+};

--- a/src/corner_kick/src/store/sagas/params.ts
+++ b/src/corner_kick/src/store/sagas/params.ts
@@ -1,35 +1,81 @@
 /*
  * This file specifies the saga for Params
  */
-import { call, put, spawn, takeEvery } from 'redux-saga/effects';
+/*
+import { channel } from 'redux-saga';
+import { call, put, spawn, takeEvery, takeLatest } from 'redux-saga/effects';
+import { getType } from 'typesafe-actions';
+*/
+
+import { channel } from 'redux-saga';
+import { put, spawn, take, takeLatest } from 'redux-saga/effects';
+import ROSLIB from 'roslib';
 import { getType } from 'typesafe-actions';
 
-import * as params from '../actions/params';
+import { TOPIC_ROSOUT, TOPIC_ROSOUT_TYPE } from '../../constants';
+import { IRosoutMessage } from '../../types';
 
-export default function* init() {
-    yield spawn(startROSParams);
-    // Listen for updateRosParams
-    yield takeEvery(getType(params.updateROSParams), updateROSParams);
-}
+import { actions } from '../actions';
+import ros from '../reducers/ros';
+
+let rosbridge: ROSLIB.Ros | null = null;
+let rosParam: ROSLIB.Param | null = null;
+const paramChannel = channel();
 
 let rosParamsStored = {};
 
+export default function* init() {
+    // Listen to start actions and start ROS params
+    yield takeLatest(getType(actions.ros.connected), startROSParams);
+
+    // Start listening to ROS param server
+    yield spawn(listenToParamChannel);
+}
+
 /**
- * Hydrate ROS params upon starting
+ * Take any updates from ROS param and push them as Redux actions
  */
-function* startROSParams() {
-    // Retrieve settings from ROS param server
-    const rosParamsStoredString = localStorage.getItem('rosparams');
-    if (rosParamsStoredString !== null) {
-        rosParamsStored = JSON.parse(rosParamsStoredString);
-        // Put hydrateROSParams action from item
-        yield put(params.hydrateROSParams(rosParamsStored));
+function* listenToParamChannel() {
+    while (true) {
+        const action = yield take(paramChannel);
+        if (getType(action.type) === 'param_UPDATE_PARAMS') {
+            // update the stored state
+            rosParamsStored = {
+                ...rosParamsStored,
+                [action.payload.key]: action.payload.value,
+            };
+            rosParam = new ROSLIB.Param({ ros: rosbridge, name: action.payload.key });
+            rosParam.set(action.payload.value);
+        }
+        yield put(action);
     }
 }
 
 /**
- * Update settings by putting into local storage
+ * Hydrate ROS param server state
  */
+function startROSParams() {
+    // Get params from ROS param server
+    rosbridge = new ROSLIB.Ros({});
+    rosParam = new ROSLIB.Param({ ros: rosbridge, name: 'testParam' });
+    rosParam.getParams(function(params) {
+        // add each param to object
+        rosParamsStored = {
+            ...rosParamsStored,
+            [params.key]: params.value, // check these properties
+        };
+    });
+    actions.params.hydrateROSParams({ rosparams: rosParamsStored });
+}
+/*
+function* startROSParams() {
+    const rosParamsStoredString = localStorage.getItem('rosparams');
+    if (rosParamsStoredString !== null) {
+        rosParamsStored = JSON.parse(rosParamsStoredString);
+        yield put(params.hydrateROSParams(rosParamsStored));
+    }
+}
+
 export function* updateROSParams(action: ReturnType<typeof params.updateROSParams>) {
     rosParamsStored = {
         ...rosParamsStored,
@@ -37,3 +83,4 @@ export function* updateROSParams(action: ReturnType<typeof params.updateROSParam
     };
     yield call(localStorage.setItem, 'rosparams', JSON.stringify(rosParamsStored));
 }
+*/

--- a/src/corner_kick/src/store/sagas/params.ts
+++ b/src/corner_kick/src/store/sagas/params.ts
@@ -1,0 +1,40 @@
+/*
+ * This file specifies the saga for Params
+ */
+import { call, put, spawn, takeEvery } from 'redux-saga/effects';
+import { getType } from 'typesafe-actions';
+
+import * as params from '../actions/params';
+
+export default function* init() {
+    yield spawn(startROSParams);
+    // Listen for updateRosParams
+    yield takeEvery(getType(params.updateROSParams), updateROSParams);
+}
+
+let settingsStored = {};
+
+/**
+ * Hydrate ROS params upon starting
+ */
+function* startROSParams() {
+    // Retrieve settings from local storage
+    const settingsStoredBuffer = localStorage.getItem('settings');
+    if (settingsStoredBuffer !== null) {
+        settingsStored = JSON.parse(settingsStoredBuffer);
+        // Put hydrateSettings action from item
+        yield put(settings.hydrateSettings(settingsStored));
+    }
+}
+
+/**
+ * Update settings by putting into local storage
+ */
+export function* updateROSParams(action: ReturnType<typeof settings.updateSettings>) {
+    // Use localStorage.setItem
+    settingsStored = {
+        ...settingsStored,
+        [action.payload.key]: action.payload.value,
+    };
+    yield call(localStorage.setItem, 'settings', JSON.stringify(settingsStored));
+}

--- a/src/corner_kick/src/store/sagas/params.ts
+++ b/src/corner_kick/src/store/sagas/params.ts
@@ -12,29 +12,28 @@ export default function* init() {
     yield takeEvery(getType(params.updateROSParams), updateROSParams);
 }
 
-let settingsStored = {};
+let rosParamsStored = {};
 
 /**
  * Hydrate ROS params upon starting
  */
 function* startROSParams() {
-    // Retrieve settings from local storage
-    const settingsStoredBuffer = localStorage.getItem('settings');
-    if (settingsStoredBuffer !== null) {
-        settingsStored = JSON.parse(settingsStoredBuffer);
-        // Put hydrateSettings action from item
-        yield put(settings.hydrateSettings(settingsStored));
+    // Retrieve settings from ROS param server
+    const rosParamsStoredString = localStorage.getItem('rosparams');
+    if (rosParamsStoredString !== null) {
+        rosParamsStored = JSON.parse(rosParamsStoredString);
+        // Put hydrateROSParams action from item
+        yield put(params.hydrateROSParams(rosParamsStored));
     }
 }
 
 /**
  * Update settings by putting into local storage
  */
-export function* updateROSParams(action: ReturnType<typeof settings.updateSettings>) {
-    // Use localStorage.setItem
-    settingsStored = {
-        ...settingsStored,
+export function* updateROSParams(action: ReturnType<typeof params.updateROSParams>) {
+    rosParamsStored = {
+        ...rosParamsStored,
         [action.payload.key]: action.payload.value,
     };
-    yield call(localStorage.setItem, 'settings', JSON.stringify(settingsStored));
+    yield call(localStorage.setItem, 'rosparams', JSON.stringify(rosParamsStored));
 }

--- a/src/corner_kick/src/types/index.ts
+++ b/src/corner_kick/src/types/index.ts
@@ -5,5 +5,5 @@
 export { Color } from './primitives';
 export { IThemeProvider } from './theme';
 export { IRosoutMessage } from './standardROSMessages';
-export { IRootState, IROSState, IMessagesState } from './state';
+export { IRootState, IROSState, IMessagesState, IROSSettings } from './state';
 export { ILayer, ILayerMessage, IShape } from './visualizer';

--- a/src/corner_kick/src/types/state.ts
+++ b/src/corner_kick/src/types/state.ts
@@ -25,3 +25,10 @@ export interface IROSState {
 export interface IMessagesState {
     rosout: IRosoutMessage[];
 }
+
+/**
+ * The state object for ROS params
+ */
+export interface IROSSettings {
+    [key: string]: string;
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description
This ticket will be used for adding communication between the ROS Param Server and the Visualizer.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests have been written for the actions (sans getROSParam) and reducers. Working on sagas.
To fully run the application, run `yarn test` to start the Visualizer, `roslaunch rosbridge_server rosbridge_websocket.launch` to start RosBridge, and `roslaunch launch.ai` to start the ROS Param Server.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
Resolves #392 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
