### PR TITLE
Implement nearest enemy evaluation function

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/evaluation/team.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/team.cpp
@@ -24,3 +24,27 @@ std::optional<Robot> Evaluation::nearest_friendly(const Team friendly_team,
 
     return friendly_team.getRobotById(nearestRobotId).value();
 }
+
+std::optional<Robot> Evaluation::nearest_enemy(const Team enemy_team,
+                                               const Point ref_point)
+{
+    if (enemy_team.getAllRobots().empty())
+    {
+        return std::nullopt;
+    }
+
+    unsigned nearestRobotId = enemy_team.getAllRobots()[0].id();
+    double minDist          = (ref_point - enemy_team.getAllRobots()[0].position()).len();
+
+    for (const Robot &curRobot : enemy_team.getAllRobots())
+    {
+        double curDistance = (ref_point - curRobot.position()).len();
+        if (curDistance < minDist)
+        {
+            nearestRobotId = curRobot.id();
+            minDist        = curDistance;
+        }
+    }
+
+    return enemy_team.getRobotById(nearestRobotId).value();
+}

--- a/src/thunderbots/software/ai/hl/stp/evaluation/team.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/team.cpp
@@ -4,39 +4,26 @@
 std::optional<Robot> Evaluation::nearest_friendly(const Team friendly_team,
                                                   const Point ref_point)
 {
-    if (friendly_team.getAllRobots().empty())
-    {
-        return std::nullopt;
-    }
-
-    unsigned nearestRobotId = friendly_team.getAllRobots()[0].id();
-    double minDist = (ref_point - friendly_team.getAllRobots()[0].position()).len();
-
-    for (const Robot &curRobot : friendly_team.getAllRobots())
-    {
-        double curDistance = (ref_point - curRobot.position()).len();
-        if (curDistance < minDist)
-        {
-            nearestRobotId = curRobot.id();
-            minDist        = curDistance;
-        }
-    }
-
-    return friendly_team.getRobotById(nearestRobotId).value();
+    return nearest_robot(friendly_team, ref_point);
 }
 
 std::optional<Robot> Evaluation::nearest_enemy(const Team enemy_team,
                                                const Point ref_point)
 {
-    if (enemy_team.getAllRobots().empty())
+    return nearest_robot(enemy_team, ref_point);
+}
+
+std::optional<Robot> Evaluation::nearest_robot(const Team team, const Point ref_point)
+{
+    if (team.getAllRobots().empty())
     {
         return std::nullopt;
     }
 
-    unsigned nearestRobotId = enemy_team.getAllRobots()[0].id();
-    double minDist          = (ref_point - enemy_team.getAllRobots()[0].position()).len();
+    unsigned nearestRobotId = team.getAllRobots()[0].id();
+    double minDist          = (ref_point - team.getAllRobots()[0].position()).len();
 
-    for (const Robot &curRobot : enemy_team.getAllRobots())
+    for (const Robot &curRobot : team.getAllRobots())
     {
         double curDistance = (ref_point - curRobot.position()).len();
         if (curDistance < minDist)
@@ -46,5 +33,5 @@ std::optional<Robot> Evaluation::nearest_enemy(const Team enemy_team,
         }
     }
 
-    return enemy_team.getRobotById(nearestRobotId).value();
+    return team.getRobotById(nearestRobotId).value();
 }

--- a/src/thunderbots/software/ai/hl/stp/evaluation/team.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/team.cpp
@@ -1,18 +1,5 @@
 #include "ai/hl/stp/evaluation/team.h"
 
-
-std::optional<Robot> Evaluation::nearest_friendly(const Team friendly_team,
-                                                  const Point ref_point)
-{
-    return nearest_robot(friendly_team, ref_point);
-}
-
-std::optional<Robot> Evaluation::nearest_enemy(const Team enemy_team,
-                                               const Point ref_point)
-{
-    return nearest_robot(enemy_team, ref_point);
-}
-
 std::optional<Robot> Evaluation::nearest_robot(const Team team, const Point ref_point)
 {
     if (team.getAllRobots().empty())

--- a/src/thunderbots/software/ai/hl/stp/evaluation/team.h
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/team.h
@@ -11,7 +11,7 @@ namespace Evaluation
      * @param friendly_team
      * @param ref_point The point where the distance to each robot will be measured.
      *
-     * @return Robot that is closest to the reference point.
+     * @return Robot on friendly team that is closest to the reference point.
      */
     std::optional<Robot> nearest_friendly(const Team friendly_team,
                                           const Point ref_point);
@@ -22,8 +22,17 @@ namespace Evaluation
      * @param enemy_team
      * @param ref_point The point where the distance to each robot will be measured.
      *
-     * @return Robot that is closest to the reference point.
+     * @return Robot on enemy team that is closest to the reference point.
      */
     std::optional<Robot> nearest_enemy(const Team enemy_team, const Point ref_point);
+
+    /**
+     * Given a team, finds the robot on that team that is closest to a reference point.
+     *
+     * @param team
+     * @param ref_point The point where the distance to each robot will be measured.
+     * @return Robot that is closest to the reference point.
+     */
+    std::optional<Robot> nearest_robot(const Team team, const Point ref_point);
 
 };  // namespace Evaluation

--- a/src/thunderbots/software/ai/hl/stp/evaluation/team.h
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/team.h
@@ -6,27 +6,6 @@
 namespace Evaluation
 {
     /**
-     * Finds the robot on the friendly team that is closest to some reference point.
-     *
-     * @param friendly_team
-     * @param ref_point The point where the distance to each robot will be measured.
-     *
-     * @return Robot on friendly team that is closest to the reference point.
-     */
-    std::optional<Robot> nearest_friendly(const Team friendly_team,
-                                          const Point ref_point);
-
-    /**
-     * Finds the robot on the enemy team that is closest to some reference point.
-     *
-     * @param enemy_team
-     * @param ref_point The point where the distance to each robot will be measured.
-     *
-     * @return Robot on enemy team that is closest to the reference point.
-     */
-    std::optional<Robot> nearest_enemy(const Team enemy_team, const Point ref_point);
-
-    /**
      * Given a team, finds the robot on that team that is closest to a reference point.
      *
      * @param team

--- a/src/thunderbots/software/ai/hl/stp/evaluation/team.h
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/team.h
@@ -16,4 +16,14 @@ namespace Evaluation
     std::optional<Robot> nearest_friendly(const Team friendly_team,
                                           const Point ref_point);
 
+    /**
+     * Finds the robot on the enemy team that is closest to some reference point.
+     *
+     * @param enemy_team
+     * @param ref_point The point where the distance to each robot will be measured.
+     *
+     * @return Robot that is closest to the reference point.
+     */
+    std::optional<Robot> nearest_enemy(const Team enemy_team, const Point ref_point);
+
 };  // namespace Evaluation

--- a/src/thunderbots/software/test/ai/evaluation/team.cpp
+++ b/src/thunderbots/software/test/ai/evaluation/team.cpp
@@ -24,7 +24,7 @@ TEST_F(TeamEvaluationTest, nearest_friendy_one_robot)
 
     team.updateRobots({robot_0});
 
-    EXPECT_EQ(robot_0, Evaluation::nearest_friendly(team, Point(0, 0)));
+    EXPECT_EQ(robot_0, Evaluation::nearest_robot(team, Point(0, 0)));
 }
 
 TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots)
@@ -43,7 +43,7 @@ TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots)
 
     team.updateRobots({robot_0, robot_1, robot_2});
 
-    EXPECT_EQ(robot_1, Evaluation::nearest_friendly(team, Point(0, 0)));
+    EXPECT_EQ(robot_1, Evaluation::nearest_robot(team, Point(0, 0)));
 }
 
 TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots_closest_is_moving)
@@ -62,7 +62,7 @@ TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots_closest_is_moving)
 
     team.updateRobots({robot_0, robot_1, robot_2});
 
-    EXPECT_EQ(robot_1, Evaluation::nearest_friendly(team, Point(0, 0)));
+    EXPECT_EQ(robot_1, Evaluation::nearest_robot(team, Point(0, 0)));
 }
 
 TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots_all_moving)
@@ -81,7 +81,7 @@ TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots_all_moving)
 
     team.updateRobots({robot_0, robot_1, robot_2});
 
-    EXPECT_EQ(robot_2, Evaluation::nearest_friendly(team, Point(0, 0)));
+    EXPECT_EQ(robot_2, Evaluation::nearest_robot(team, Point(0, 0)));
 }
 
 TEST_F(TeamEvaluationTest, nearest_friendy_one_robot_on_ball)
@@ -100,97 +100,12 @@ TEST_F(TeamEvaluationTest, nearest_friendy_one_robot_on_ball)
 
     team.updateRobots({robot_0, robot_1, robot_2});
 
-    EXPECT_EQ(robot_0, Evaluation::nearest_friendly(team, Point(0, 0)));
+    EXPECT_EQ(robot_0, Evaluation::nearest_robot(team, Point(0, 0)));
 }
 
-TEST_F(TeamEvaluationTest, nearest_friendly_zero_robots)
+TEST_F(TeamEvaluationTest, nearest_robot_zero_robots)
 {
     Team team = Team(Duration::fromMilliseconds(1000));
 
-    EXPECT_EQ(std::nullopt, Evaluation::nearest_friendly(team, Point(0, 0)));
-}
-
-
-
-TEST_F(TeamEvaluationTest, nearest_enemy_multiple_robots)
-{
-    Team team = Team(Duration::fromMilliseconds(1000));
-
-    Robot robot_0 = Robot(0, Point(3, -1), Vector(), Angle::half(),
-                          AngularVelocity::threeQuarter(), current_time);
-
-    Robot robot_1 = Robot(1, Point(1, 0), Vector(), Angle::zero(),
-                          AngularVelocity::zero(), current_time);
-
-    Robot robot_2 = Robot(2, Point(4, 6), Vector(), Angle::zero(),
-                          AngularVelocity::zero(), current_time);
-
-
-    team.updateRobots({robot_0, robot_1, robot_2});
-
-    EXPECT_EQ(robot_1, Evaluation::nearest_enemy(team, Point(0, 0)));
-}
-
-TEST_F(TeamEvaluationTest, nearest_enemy_multiple_robots_closest_is_moving)
-{
-    Team team = Team(Duration::fromMilliseconds(1000));
-
-    Robot robot_0 = Robot(0, Point(3, -1), Vector(), Angle::half(),
-                          AngularVelocity::threeQuarter(), current_time);
-
-    Robot robot_1 = Robot(1, Point(1, 0), Vector(3, 3), Angle::zero(),
-                          AngularVelocity::zero(), current_time);
-
-    Robot robot_2 = Robot(2, Point(4, 6), Vector(), Angle::zero(),
-                          AngularVelocity::zero(), current_time);
-
-
-    team.updateRobots({robot_0, robot_1, robot_2});
-
-    EXPECT_EQ(robot_1, Evaluation::nearest_enemy(team, Point(0, 0)));
-}
-
-TEST_F(TeamEvaluationTest, nearest_enemy_multiple_robots_all_moving)
-{
-    Team team = Team(Duration::fromMilliseconds(1000));
-
-    Robot robot_0 = Robot(0, Point(3, -1), Vector(3, 3), Angle::half(),
-                          AngularVelocity::threeQuarter(), current_time);
-
-    Robot robot_1 = Robot(1, Point(4, 6), Vector(3, 3), Angle::zero(),
-                          AngularVelocity::zero(), current_time);
-
-    Robot robot_2 = Robot(2, Point(0, 1), Vector(3, 3), Angle::zero(),
-                          AngularVelocity::zero(), current_time);
-
-
-    team.updateRobots({robot_0, robot_1, robot_2});
-
-    EXPECT_EQ(robot_2, Evaluation::nearest_enemy(team, Point(0, 0)));
-}
-
-TEST_F(TeamEvaluationTest, nearest_enemy_one_robot_on_ball)
-{
-    Team team = Team(Duration::fromMilliseconds(1000));
-
-    Robot robot_0 = Robot(0, Point(0, 0), Vector(), Angle::half(),
-                          AngularVelocity::threeQuarter(), current_time);
-
-    Robot robot_1 = Robot(1, Point(1, 0), Vector(), Angle::zero(),
-                          AngularVelocity::zero(), current_time);
-
-    Robot robot_2 = Robot(2, Point(4, 6), Vector(), Angle::zero(),
-                          AngularVelocity::zero(), current_time);
-
-
-    team.updateRobots({robot_0, robot_1, robot_2});
-
-    EXPECT_EQ(robot_0, Evaluation::nearest_enemy(team, Point(0, 0)));
-}
-
-TEST_F(TeamEvaluationTest, nearest_enemy_zero_robots)
-{
-    Team team = Team(Duration::fromMilliseconds(1000));
-
-    EXPECT_EQ(std::nullopt, Evaluation::nearest_enemy(team, Point(0, 0)));
+    EXPECT_EQ(std::nullopt, Evaluation::nearest_robot(team, Point(0, 0)));
 }

--- a/src/thunderbots/software/test/ai/evaluation/team.cpp
+++ b/src/thunderbots/software/test/ai/evaluation/team.cpp
@@ -14,7 +14,7 @@ class TeamEvaluationTest : public ::testing::Test
     Timestamp current_time;
 };
 
-TEST_F(TeamEvaluationTest, one_robot)
+TEST_F(TeamEvaluationTest, nearest_friendy_one_robot)
 {
     Team team = Team(Duration::fromMilliseconds(1000));
 
@@ -27,7 +27,7 @@ TEST_F(TeamEvaluationTest, one_robot)
     EXPECT_EQ(robot_0, Evaluation::nearest_friendly(team, Point(0, 0)));
 }
 
-TEST_F(TeamEvaluationTest, multiple_robots)
+TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots)
 {
     Team team = Team(Duration::fromMilliseconds(1000));
 
@@ -46,7 +46,7 @@ TEST_F(TeamEvaluationTest, multiple_robots)
     EXPECT_EQ(robot_1, Evaluation::nearest_friendly(team, Point(0, 0)));
 }
 
-TEST_F(TeamEvaluationTest, multiple_robots_closest_is_moving)
+TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots_closest_is_moving)
 {
     Team team = Team(Duration::fromMilliseconds(1000));
 
@@ -65,7 +65,7 @@ TEST_F(TeamEvaluationTest, multiple_robots_closest_is_moving)
     EXPECT_EQ(robot_1, Evaluation::nearest_friendly(team, Point(0, 0)));
 }
 
-TEST_F(TeamEvaluationTest, multiple_robots_all_moving)
+TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots_all_moving)
 {
     Team team = Team(Duration::fromMilliseconds(1000));
 
@@ -84,7 +84,7 @@ TEST_F(TeamEvaluationTest, multiple_robots_all_moving)
     EXPECT_EQ(robot_2, Evaluation::nearest_friendly(team, Point(0, 0)));
 }
 
-TEST_F(TeamEvaluationTest, one_robot_on_ball)
+TEST_F(TeamEvaluationTest, nearest_friendy_one_robot_on_ball)
 {
     Team team = Team(Duration::fromMilliseconds(1000));
 
@@ -103,9 +103,94 @@ TEST_F(TeamEvaluationTest, one_robot_on_ball)
     EXPECT_EQ(robot_0, Evaluation::nearest_friendly(team, Point(0, 0)));
 }
 
-TEST_F(TeamEvaluationTest, zero_robots)
+TEST_F(TeamEvaluationTest, nearest_friendly_zero_robots)
 {
     Team team = Team(Duration::fromMilliseconds(1000));
 
     EXPECT_EQ(std::nullopt, Evaluation::nearest_friendly(team, Point(0, 0)));
+}
+
+
+
+TEST_F(TeamEvaluationTest, nearest_enemy_multiple_robots)
+{
+    Team team = Team(Duration::fromMilliseconds(1000));
+
+    Robot robot_0 = Robot(0, Point(3, -1), Vector(), Angle::half(),
+                          AngularVelocity::threeQuarter(), current_time);
+
+    Robot robot_1 = Robot(1, Point(1, 0), Vector(), Angle::zero(),
+                          AngularVelocity::zero(), current_time);
+
+    Robot robot_2 = Robot(2, Point(4, 6), Vector(), Angle::zero(),
+                          AngularVelocity::zero(), current_time);
+
+
+    team.updateRobots({robot_0, robot_1, robot_2});
+
+    EXPECT_EQ(robot_1, Evaluation::nearest_enemy(team, Point(0, 0)));
+}
+
+TEST_F(TeamEvaluationTest, nearest_enemy_multiple_robots_closest_is_moving)
+{
+    Team team = Team(Duration::fromMilliseconds(1000));
+
+    Robot robot_0 = Robot(0, Point(3, -1), Vector(), Angle::half(),
+                          AngularVelocity::threeQuarter(), current_time);
+
+    Robot robot_1 = Robot(1, Point(1, 0), Vector(3, 3), Angle::zero(),
+                          AngularVelocity::zero(), current_time);
+
+    Robot robot_2 = Robot(2, Point(4, 6), Vector(), Angle::zero(),
+                          AngularVelocity::zero(), current_time);
+
+
+    team.updateRobots({robot_0, robot_1, robot_2});
+
+    EXPECT_EQ(robot_1, Evaluation::nearest_enemy(team, Point(0, 0)));
+}
+
+TEST_F(TeamEvaluationTest, nearest_enemy_multiple_robots_all_moving)
+{
+    Team team = Team(Duration::fromMilliseconds(1000));
+
+    Robot robot_0 = Robot(0, Point(3, -1), Vector(3, 3), Angle::half(),
+                          AngularVelocity::threeQuarter(), current_time);
+
+    Robot robot_1 = Robot(1, Point(4, 6), Vector(3, 3), Angle::zero(),
+                          AngularVelocity::zero(), current_time);
+
+    Robot robot_2 = Robot(2, Point(0, 1), Vector(3, 3), Angle::zero(),
+                          AngularVelocity::zero(), current_time);
+
+
+    team.updateRobots({robot_0, robot_1, robot_2});
+
+    EXPECT_EQ(robot_2, Evaluation::nearest_enemy(team, Point(0, 0)));
+}
+
+TEST_F(TeamEvaluationTest, nearest_enemy_one_robot_on_ball)
+{
+    Team team = Team(Duration::fromMilliseconds(1000));
+
+    Robot robot_0 = Robot(0, Point(0, 0), Vector(), Angle::half(),
+                          AngularVelocity::threeQuarter(), current_time);
+
+    Robot robot_1 = Robot(1, Point(1, 0), Vector(), Angle::zero(),
+                          AngularVelocity::zero(), current_time);
+
+    Robot robot_2 = Robot(2, Point(4, 6), Vector(), Angle::zero(),
+                          AngularVelocity::zero(), current_time);
+
+
+    team.updateRobots({robot_0, robot_1, robot_2});
+
+    EXPECT_EQ(robot_0, Evaluation::nearest_enemy(team, Point(0, 0)));
+}
+
+TEST_F(TeamEvaluationTest, nearest_enemy_zero_robots)
+{
+    Team team = Team(Duration::fromMilliseconds(1000));
+
+    EXPECT_EQ(std::nullopt, Evaluation::nearest_enemy(team, Point(0, 0)));
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

Implemented the nearest enemy evaluation function

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests written

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #296 

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
