### PR TITLE
Revert "VisualizerMessenger with Websocket (#445)"

### DIFF
--- a/environment_setup/setup_software.sh
+++ b/environment_setup/setup_software.sh
@@ -14,6 +14,7 @@
 # unit tests
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
+
 # Save the parent dir of this so we can always run commands relative to the
 # location of this script, no matter where it is called from. This
 # helps prevent bugs and odd behaviour if this script is run through a symlink
@@ -157,10 +158,6 @@ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 \
                          --slave /usr/bin/g++ g++ /usr/bin/g++-7 
 sudo update-alternatives --config gcc
 
-echo "================================================================"
-echo "Installing g3log"
-echo "================================================================"
-
 # Clone, build, and install g3log. Adapted from instructions at:
 # https://github.com/KjellKod/g3log
 g3log_path="/tmp/g3log"
@@ -177,25 +174,6 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 make
 sudo make install
 cd $CURR_DIR
-
-echo "================================================================"
-echo "Installing beast"
-echo "================================================================"
-
-beast_path="/tmp/beast"
-if [ -d $beast_path ]; then
-    echo "Removing old beast..."
-    sudo rm -r $beast_path 
-fi
-mkdir $beast_path
-cd $beast_path
-
-wget https://github.com/boostorg/beast/archive/v124.zip
-sudo apt-get install unzip
-unzip v124.zip
-cd beast-124
-# Note that we use `\cp` here instead of `cp` to force overwrite without prompt
-sudo \cp -r include/boost /usr/include
 
 # Clone, build, and install munkres-cpp (Our Hungarian library algorithm)
 hungarian_path="/tmp/hungarian-cpp"

--- a/src/thunderbots/software/ai/main.cpp
+++ b/src/thunderbots/software/ai/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
 
     // Initialize the draw visualizer messenger
-    Util::VisualizerMessenger::getInstance()->initializeWebsocket();
+    Util::VisualizerMessenger::getInstance()->initializePublisher(node_handle);
 
     // Initialize Dynamic Parameters
     auto update_subscribers =

--- a/src/thunderbots/software/util/constants.h
+++ b/src/thunderbots/software/util/constants.h
@@ -16,9 +16,10 @@ namespace Util
         static const std::string NETWORK_INPUT_ENEMY_TEAM_TOPIC = "backend/enemy_team";
         static const std::string NETWORK_INPUT_GAMECONTROLLER_TOPIC =
             "backend/gamecontroller";
-        static const std::string NETWORK_INPUT_WORLD_TOPIC = "backend/world";
-        static const std::string AI_PRIMITIVES_TOPIC       = "backend/primitives";
-        static const std::string ROBOT_STATUS_TOPIC        = "log/robot_status";
+        static const std::string NETWORK_INPUT_WORLD_TOPIC   = "backend/world";
+        static const std::string AI_PRIMITIVES_TOPIC         = "backend/primitives";
+        static const std::string ROBOT_STATUS_TOPIC          = "log/robot_status";
+        static const std::string VISUALIZER_DRAW_LAYER_TOPIC = "visualizer/layers";
         // The topic published by the joy_node that contains information about any plugged
         // in joysticks / controllers
         static const std::string JOY_NODE_TOPIC = "joy";
@@ -48,9 +49,5 @@ namespace Util
         // How many milliseconds a robot must not be seen in vision before it is
         // considered as "gone" and no longer reported.
         static const unsigned int ROBOT_DEBOUNCE_DURATION_MILLISECONDS = 200;
-
-        // Visualizer websocket IP and port
-        static const std::string VISUALIZER_WEBSOCKET_ADDRESS = "127.0.0.1";
-        static const unsigned int VISUALIZER_WEBSOCKET_PORT   = 9091;
     }  // namespace Constants
 }  // namespace Util

--- a/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.cpp
+++ b/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.cpp
@@ -1,16 +1,7 @@
 #include "visualizer_messenger.h"
 
-#include <boost/asio/io_service.hpp>
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/beast/core.hpp>
-#include <boost/beast/websocket.hpp>
-
 #include "util/constants.h"
 #include "util/logger/init.h"
-
-
-using tcp           = boost::asio::ip::tcp;     // from <boost/asio/ip/tcp.hpp>
-namespace websocket = boost::beast::websocket;  // from <boost/beast/websocket.hpp>
 
 namespace Util
 {
@@ -20,60 +11,24 @@ namespace Util
         return vm;
     }
 
-    void VisualizerMessenger::receiveWebsocketConnections()
+    void VisualizerMessenger::initializePublisher(ros::NodeHandle node_handle)
     {
-        // The io_context is required for all I/O
-        boost::asio::io_service ioc{1};
-
-        // The acceptor receives incoming connections
-        auto const address = boost::asio::ip::address::from_string(
-            Util::Constants::VISUALIZER_WEBSOCKET_ADDRESS);
-        auto const port =
-            static_cast<unsigned short>(Util::Constants::VISUALIZER_WEBSOCKET_PORT);
-        tcp::acceptor acceptor{ioc, {address, port}};
-        for (;;)
+        if (this->publisher)
         {
-            // This will receive the new connection
-            tcp::socket socket{ioc};
-
-            // Block until we get a connection
-            acceptor.accept(socket);
-
-            // Move the connection to a websocket stream
-            websocket::stream<tcp::socket> websocket(std::move(socket));
-
-            // Accept the websocket handshake
-            websocket.accept();
-
-            // Set the websocket to talk in binary
-            websocket.binary(true);
-
-            LOG(INFO) << "Visualizer websocket connection received." << std::endl;
-
-            // Lock the current list of sockets
-            websocket_mutex.lock();
-
-            // Save this new websocket connection
-            websocket_connections.emplace_back(std::move(websocket));
-
-            // Unlock the current list of sockets
-            websocket_mutex.unlock();
-
-            LOG(INFO) << "Visualizer websocket connection added." << std::endl;
+            LOG(WARNING) << "Re-initializing visualizer messenger singleton publisher";
         }
+
+        this->publisher = node_handle.advertise<LayerMsg>(
+            Util::Constants::VISUALIZER_DRAW_LAYER_TOPIC, 8);
     }
 
-    void VisualizerMessenger::initializeWebsocket()
+    const LayerMsgMap& VisualizerMessenger::getLayerMap() const
     {
-        websocket_thread =
-            std::thread([this]() { return receiveWebsocketConnections(); });
+        return this->layers_name_to_msg_map;
     }
 
     void VisualizerMessenger::publishAndClearLayers()
     {
-        // Take ownership of list of websockets for the duration of this function
-        std::lock_guard<std::mutex> websocket_list_lock(websocket_mutex);
-
         // Limit rate of the message publishing
         // Get the time right now
         const time_point now     = std::chrono::system_clock::now();
@@ -87,156 +42,169 @@ namespace Util
         if (elapsed_ms < DESIRED_PERIOD_MS)
             return;
 
-        // Send a payload per layer of messages
-        for (const std::pair<uint8_t, ShapeVector>& layer_pair : this->layer_shapes_map)
+        // Check if publisher is initialized before publishing messages
+        if (!this->publisher)
         {
-            // First is the layer number
-            const uint8_t layer_number = layer_pair.first;
-
-            // Second is the vector that contains the shapes
-            const ShapeVector& shapes = layer_pair.second;
-
-            // Only send the non-empty layers
-            if (!layer_pair.second.empty())
+            LOG(WARNING)
+                << "Publishing requested when visualizer messenger publisher is not initialized";
+        }
+        else
+        {
+            // Send layer messages
+            for (const std::pair<std::string, LayerMsg>& layer_msg_pair : getLayerMap())
             {
-                this->publishPayload(layer_number, shapes);
+                if (!layer_msg_pair.second.shapes.empty())
+                {
+                    this->publisher.publish(layer_msg_pair.second);
+                }
             }
         }
 
         // Clear shapes in layers of current frame/tick
-        this->clearShapes();
+        clearLayers();
 
         // Update last published time
         time_last_published = now;
-
-        LOG(DEBUG) << "Published shapes" << std::endl;
     }
 
-    void VisualizerMessenger::publishPayload(uint8_t layer, const ShapeVector& shapes)
+    void VisualizerMessenger::clearLayers()
     {
-        // Payload is a list of int32s
-        std::vector<int16_t> payload;
-
-        // Add layer number and layer flags that prepend shape data
-        const uint8_t layer_flags = 0x00;
-        payload.insert(payload.end(), pack16BitData(layer, layer_flags));
-
-        // Unpack all the shape data and make a payload
-        for (const Shape& shape : shapes)
+        // Clears all shape vector in all the layers
+        for (auto& layer : this->layers_name_to_msg_map)
         {
-            // Packing texture (8 bit) and flag (8 bit) data into a single 16 bit int
-            payload.insert(payload.end(), pack16BitData(shape.texture, shape.flags));
-
-            // These are all 16 bits
-            payload.insert(payload.end(), shape.x);
-            payload.insert(payload.end(), shape.y);
-            payload.insert(payload.end(), shape.width);
-            payload.insert(payload.end(), shape.height);
-            payload.insert(payload.end(), shape.rotation);
-
-            // Split the 32 bit data into two parts
-            payload.insert(payload.end(), static_cast<uint16_t>(shape.tint >> 16));
-            payload.insert(payload.end(), static_cast<uint16_t>(shape.tint & 0xFF));
-        }
-
-        // Send all the shapes to all the websocket connections we have
-        for (websocket::stream<tcp::socket>& websocket : websocket_connections)
-        {
-            try
-            {
-                websocket.write(boost::asio::buffer(payload));
-            }
-            // TODO: non-generic exception type
-            catch (std::exception const& e)
-            {
-                LOG(WARNING) << e.what() << std::endl;
-            }
+            layer.second.shapes.clear();
         }
     }
 
-    void VisualizerMessenger::clearShapes()
+    void VisualizerMessenger::drawEllipse(const std::string& layer, double cx, double cy,
+                                          double r1, double r2, DrawStyle draw_style,
+                                          DrawTransform draw_transform)
     {
-        for (auto& layer : this->layer_shapes_map)
+        ShapeMsg new_shape;
+        new_shape.type = "ellipse";
+        new_shape.data.clear();
+        new_shape.data.push_back(cx);
+        new_shape.data.push_back(cy);
+        new_shape.data.push_back(r1);
+        new_shape.data.push_back(r2);
+
+        applyDrawStyleToMsg(new_shape, draw_style);
+        applyDrawTransformToMsg(new_shape, draw_transform);
+        addShapeToLayer(layer, new_shape);
+    }
+
+    void VisualizerMessenger::drawRect(const std::string& layer, double x, double y,
+                                       double w, double h, DrawStyle draw_style,
+                                       DrawTransform draw_transform)
+    {
+        ShapeMsg new_shape;
+        new_shape.type = "rect";
+        new_shape.data.clear();
+        new_shape.data.push_back(x);
+        new_shape.data.push_back(y);
+        new_shape.data.push_back(w);
+        new_shape.data.push_back(h);
+
+        applyDrawStyleToMsg(new_shape, draw_style);
+        applyDrawTransformToMsg(new_shape, draw_transform);
+        addShapeToLayer(layer, new_shape);
+    }
+
+    void VisualizerMessenger::drawPoly(const std::string& layer,
+                                       std::vector<Point>& vertices, DrawStyle draw_style,
+                                       DrawTransform draw_transform)
+    {
+        ShapeMsg new_shape;
+        new_shape.type = "poly";
+        new_shape.data.clear();
+
+        for (auto vertexIter = vertices.begin(); vertexIter != vertices.end();
+             vertexIter++)
         {
-            layer.second.clear();
+            new_shape.data.push_back((*vertexIter).x());
+            new_shape.data.push_back((*vertexIter).y());
+        }
+
+        applyDrawStyleToMsg(new_shape, draw_style);
+        applyDrawTransformToMsg(new_shape, draw_transform);
+        addShapeToLayer(layer, new_shape);
+    }
+
+    void VisualizerMessenger::drawArc(const std::string& layer, double cx, double cy,
+                                      double radius, double theta_start, double theta_end,
+                                      DrawStyle draw_style, DrawTransform draw_transform)
+    {
+        ShapeMsg new_shape;
+        new_shape.type = "arc";
+        new_shape.data.clear();
+        new_shape.data.push_back(cx);
+        new_shape.data.push_back(cy);
+        new_shape.data.push_back(radius);
+        new_shape.data.push_back(theta_start);
+        new_shape.data.push_back(theta_end);
+
+        applyDrawStyleToMsg(new_shape, draw_style);
+        applyDrawTransformToMsg(new_shape, draw_transform);
+        addShapeToLayer(layer, new_shape);
+    }
+
+    void VisualizerMessenger::drawLine(const std::string& layer, double x1, double y1,
+                                       double x2, double y2, DrawStyle draw_style,
+                                       DrawTransform draw_transform)
+    {
+        ShapeMsg new_shape;
+        new_shape.type = "line";
+        new_shape.data.clear();
+        new_shape.data.push_back(x1);
+        new_shape.data.push_back(y1);
+        new_shape.data.push_back(x2);
+        new_shape.data.push_back(y2);
+
+        applyDrawStyleToMsg(new_shape, draw_style);
+        applyDrawTransformToMsg(new_shape, draw_transform);
+        addShapeToLayer(layer, new_shape);
+    }
+
+    void VisualizerMessenger::buildLayers()
+    {
+        // TODO: #268 list these existing layer names elsewhere where it's more obvious
+        std::vector<std::string> layer_names = std::vector<std::string>(
+            {"field", "ball", "ball_vel", "friendly_robot", "friendly_robot_vel",
+             "enemy_robot", "enemy_robot_vel", "nav", "rule", "passing", "test", "misc"});
+
+        for (std::string layer_name : layer_names)
+        {
+            LayerMsg new_layer_msg;
+            new_layer_msg.layer_name = layer_name;
+            this->layers_name_to_msg_map.insert(
+                std::pair<std::string, LayerMsg>(layer_name, new_layer_msg));
         }
     }
 
-    void VisualizerMessenger::drawEllipse(uint8_t layer, uint16_t cx, uint16_t cy,
-                                          int16_t r1, int16_t r2, int16_t rotation,
-                                          ShapeStyle style)
+    void VisualizerMessenger::applyDrawStyleToMsg(ShapeMsg& shape_msg, DrawStyle& style)
     {
-        const uint8_t texture = style.texture;
-        const uint32_t tint   = style.tint;
-
-        Shape new_shape;
-        new_shape.texture = texture;
-
-        // Since x and y of the shape definition is top left, we need to shift to respect
-        // the center of the ellipse
-        new_shape.x = cx - r1;
-        new_shape.y = cy - r2;
-
-        new_shape.width  = r1 * 2;
-        new_shape.height = r2 * 2;
-
-        new_shape.rotation = rotation;
-        new_shape.tint     = tint;
-
-        this->addShapeToLayer(layer, new_shape);
+        shape_msg.fill          = style.fill;
+        shape_msg.stroke        = style.stroke;
+        shape_msg.stroke_weight = style.stroke_weight;
     }
 
-    void VisualizerMessenger::drawRect(uint8_t layer, int16_t x, int16_t y, int16_t w,
-                                       int16_t h, int16_t rotation, ShapeStyle style)
+    void VisualizerMessenger::applyDrawTransformToMsg(ShapeMsg& shape_msg,
+                                                      DrawTransform& transform)
     {
-        const uint8_t texture = style.texture;
-        const uint32_t tint   = style.tint;
-
-        Shape new_shape;
-        new_shape.texture  = texture;
-        new_shape.x        = x;
-        new_shape.y        = y;
-        new_shape.width    = w;
-        new_shape.height   = h;
-        new_shape.rotation = rotation;
-        new_shape.tint     = tint;
-
-        this->addShapeToLayer(layer, new_shape);
+        shape_msg.transform_rotation = transform.rotation;
+        shape_msg.transform_scale    = transform.scale;
     }
 
-    void VisualizerMessenger::drawLine(uint8_t layer, int16_t x1, int16_t y1, int16_t x2,
-                                       int16_t y2, uint8_t width, ShapeStyle style)
+    void VisualizerMessenger::addShapeToLayer(const std::string& layer, ShapeMsg& shape)
     {
-        const uint8_t texture = style.texture;
-        const uint32_t tint   = style.tint;
-
-        const int16_t dx     = x2 - x1;
-        const int16_t dy     = y2 - y1;
-        const int16_t length = static_cast<int16_t>(sqrt(dx * dx + dy * dy));
-        const int16_t angle  = static_cast<int16_t>(atan2(dy, dx));
-
-        Shape new_shape;
-        new_shape.texture  = texture;
-        new_shape.x        = x1;
-        new_shape.y        = y1;
-        new_shape.width    = width;
-        new_shape.height   = length;
-        new_shape.rotation = angle;
-        new_shape.tint     = tint;
-
-        this->addShapeToLayer(layer, new_shape);
-    }
-
-    void VisualizerMessenger::addShapeToLayer(uint8_t layer, Shape& shape)
-    {
-        if (this->layer_shapes_map.find(layer) != this->layer_shapes_map.end())
+        if (this->layers_name_to_msg_map.find(layer) !=
+            this->layers_name_to_msg_map.end())
         {
-            this->layer_shapes_map[layer].emplace_back(shape);
+            this->layers_name_to_msg_map[layer].shapes.emplace_back(shape);
         }
         else
         {
-            LOG(WARNING) << "Referenced layer (" << layer << ") is undefined."
-                         << std::endl;
+            LOG(WARNING) << "Referenced layer (" << layer << ") is undefined\n";
         }
     }
 

--- a/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.h
+++ b/src/thunderbots/software/util/visualizer_messenger/visualizer_messenger.h
@@ -2,27 +2,26 @@
  * The Visualizer messenger is a singleton object that receives draw calls
  * to draw shapes such as ellipse and rectangle.
  *
- * Lasted edited by Muchen He on 2019-03-09
+ * The messenger constructs and queues the shapes into shape messages and layer
+ * messages to be sent via ROS visualizer topics (VISUALIZER_DRAW_LAYER_TOPIC)
+ *
+ * Lasted edited by Muchen He on 2019-01-30
  */
 
 #pragma once
 
 #include <ros/ros.h>
 
-#include <boost/asio/io_service.hpp>
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/beast/core.hpp>
-#include <boost/beast/websocket.hpp>
 #include <chrono>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
-#include <thread>
-#include <vector>
 
 #include "geom/point.h"
+#include "thunderbots_msgs/DrawLayer.h"
+#include "thunderbots_msgs/DrawShape.h"
 #include "util/constants.h"
+
 
 // Forward declaration
 namespace ros
@@ -33,40 +32,41 @@ namespace ros
 
 namespace Util
 {
-    using time_point = std::chrono::time_point<std::chrono::system_clock>;
-    using websocket_connection_vector =
-        std::vector<boost::beast::websocket::stream<boost::asio::ip::tcp::socket>>;
+    using LayerMsg    = thunderbots_msgs::DrawLayer;
+    using LayerMsgMap = std::map<std::string, LayerMsg>;
+    using ShapeMsg    = thunderbots_msgs::DrawShape;
+    using time_point  = std::chrono::time_point<std::chrono::system_clock>;
 
     class VisualizerMessenger
     {
        public:
         /**
-         * ShapeStyle is a struct that packs the appearance properties that goes into a
+         * DrawStyle is a struct that packs the appearance properties that goes into a
          * shape message The default constructor contains the default value of the draw
          * style
          */
-        typedef struct ShapeStyle
+        typedef struct DrawStyle
         {
             // Struct constructor
-            ShapeStyle() : texture(0), tint(0xFFFFFFF) {}
+            DrawStyle() : fill("white"), stroke("black"), stroke_weight(1) {}
 
-            uint8_t texture;
-            uint32_t tint;
-        } ShapeStyle;
+            std::string fill;
+            std::string stroke;
+            uint8_t stroke_weight;
+        } DrawStyle;
 
-        typedef struct Shape
+        /**
+         * DrawTransform is a struct that packs the transform properties that goes into a
+         * shape message The default constructor contains the default value of the
+         * transformation
+         */
+        typedef struct DrawTransform
         {
-            uint8_t texture;
-            uint8_t flags;
-            int16_t x;
-            int16_t y;
-            int16_t width;
-            int16_t height;
-            int16_t rotation;
-            uint32_t tint;
-        } Shape;
-        using ShapeVector = std::vector<Shape>;
-        using LayerMap    = std::map<uint8_t, ShapeVector>;
+            DrawTransform() : rotation(0.0), scale(1.0) {}
+
+            double rotation;
+            double scale;
+        } DrawTransform;
 
        public:
         /**
@@ -77,9 +77,18 @@ namespace Util
         static std::shared_ptr<VisualizerMessenger> getInstance();
 
         /**
-         * Initialize websocket for the visualizer
+         * Initialize publisher for the visualizer
+         *
+         * @param node_handle: The ROS node handle to create the message publisher
          */
-        void initializeWebsocket();
+        void initializePublisher(ros::NodeHandle node_handle);
+
+        /**
+         * Get a constant reference of the map of existing layers
+         *
+         * @return Constant reference of the layer message map
+         */
+        const LayerMsgMap& getLayerMap() const;
 
         /**
          * Update call to the visualizer class
@@ -89,99 +98,136 @@ namespace Util
          */
         void publishAndClearLayers();
 
+        /**
+         * Clears the content (shape vector) in the layer message upon method call
+         */
+        void clearLayers();
+
         // Drawing methods
         /**
          * Request a message to draw a ellipse shape. The origin is the center of the
          * circle.
          *
-         * @param layer: The layer number this shape is being drawn to
-         * @param cx: Ellipse's center X             [mm]
-         * @param cy: Ellipse's center Y             [mm]
-         * @param r1: Ellipse's horizontal radius    [mm]
-         * @param r2: Ellipse's vertical radius      [mm]
-         * @param rotation: Shape's rotation         [deg]
-         * @param style: Shape style struct
+         * @param layer: The layer name this shape is being drawn to
+         * @param cx: Ellipse's center X
+         * @param cy: Ellipse's center Y
+         * @param r1: Ellipse's horizontal radius
+         * @param r2: Ellipse's vertical radius
+         * @param draw_style: the drawing style of the shape
+         * @param draw_transform: the transformation of the shape
          */
-        void drawEllipse(uint8_t layer, uint16_t cx, uint16_t cy, int16_t r1, int16_t r2,
-                         int16_t rotation, ShapeStyle style = ShapeStyle());
+        void drawEllipse(const std::string& layer, double cx, double cy, double r1,
+                         double r2, DrawStyle draw_style = DrawStyle(),
+                         DrawTransform draw_transform = DrawTransform());
 
         /**
          * Request a message to draw a rectangle shape. The rectangle has origin on the
          * upper left corner, this is also the point specified in the parameter.
          *
-         * @param layer: The layer number this shape is being drawn to
-         * @param x: Rectangle's starting point X   [mm]
-         * @param y: Rectangle's starting point Y   [mm]
-         * @param w: Rectangle width                [mm]
-         * @param h: Rectangle height               [mm]
-         * @param rotation: Shape's rotation        [deg]
-         * @param style: Shape style struct
+         * @param layer: The layer name this shape is being drawn to
+         * @param x: Rectangle's starting point X
+         * @param y: Rectangle's starting point Y
+         * @param w: Rectangle width
+         * @param h: Rectangle height
+         * @param draw_style: the drawing style of the shape
+         * @param draw_transform: the transformation of the shape
          */
-        void drawRect(uint8_t layer, int16_t x, int16_t y, int16_t w, int16_t h,
-                      int16_t rotation, ShapeStyle style = ShapeStyle());
+        void drawRect(const std::string& layer, double x, double y, double w, double h,
+                      DrawStyle draw_style         = DrawStyle(),
+                      DrawTransform draw_transform = DrawTransform());
+
+        /**
+         * Request a message to draw a polygon shape. The origin is the
+         * first vertex passed in.
+         *
+         * @param layer: The layer name this shape is being drawn to
+         * @param vertices: A vector of Points that specifies x and y of vertices
+         * @param draw_style: the drawing style of the shape
+         * @param draw_transform: the transformation of the shape
+         */
+        void drawPoly(const std::string& layer, std::vector<Point>& vertices,
+                      DrawStyle draw_style         = DrawStyle(),
+                      DrawTransform draw_transform = DrawTransform());
+
+        /**
+         * Request a message to draw an arc. The origin is the center point
+         *
+         * @param layer: The layer name this shape is being drawn to
+         * @param cx: Arc's center point X
+         * @param cy: Arc's center point Y
+         * @param radius: Arc's radius
+         * @param theta_start: The starting angle of the arc in rad (where 0 is pointed to
+         * +X horizontal heading, and PI/2 is south)
+         * @param theta_end: The ending angle of the arc in rad
+         * @param draw_style: the drawing style of the shape
+         * @param draw_transform: the transformation of the shape
+         */
+        void drawArc(const std::string& layer, double cx, double cy, double radius,
+                     double theta_start, double theta_end,
+                     DrawStyle draw_style         = DrawStyle(),
+                     DrawTransform draw_transform = DrawTransform());
 
         /**
          * Request a message to draw a line. The origin is the first point
          *
-         * @param layer: The layer number this shape is being drawn to
-         * @param x1: Starting point X              [mm]
-         * @param y1: Starting point Y              [mm]
-         * @param x2: Ending point X                [mm]
-         * @param y2: Ending point Y                [mm]
-         * @param rotation: Shape's rotation        [deg]
-         * @param style: Shape style struct
+         * @param layer: The layer name this shape is being drawn to
+         * @param x1: Starting point X
+         * @param y1: Starting point Y
+         * @param x2: Ending point X
+         * @param y2: Ending point Y
+         * @param draw_style: the drawing style of the shape
+         * @param draw_transform: the transformation of the shape
          */
-        void drawLine(uint8_t layer, int16_t x1, int16_t y1, int16_t x2, int16_t y2,
-                      uint8_t width, ShapeStyle style = ShapeStyle());
+        void drawLine(const std::string& layer, double x1, double y1, double x2,
+                      double y2, DrawStyle draw_style = DrawStyle(),
+                      DrawTransform draw_transform = DrawTransform());
 
        private:
         /**
          * Constructor; initializes an empty layers map then populates it
          */
         explicit VisualizerMessenger()
-            : layer_shapes_map(),
-              time_last_published(),
-              websocket_thread(),
-              websocket_mutex(),
-              websocket_connections()
+            : layers_name_to_msg_map(), publisher(), time_last_published()
         {
+            buildLayers();
         }
 
         /**
-         * Handles any connections
+         * Populates the layers map with some pre-defined layers
          */
-        void receiveWebsocketConnections();
+        void buildLayers();
 
         /**
-         * Sends a layer of shape data through websocket
-         * @param layer: The layer number to be "published" on websocket
-         * @param shapes: A const reference of the vector of shapes that belong to the
-         * layer
+         * Helper function for the shape draw methods that copies the attributes in
+         * DrawStyle struct into the actual shape message
+         *
+         * @param shape_msg: Reference to the shape message
+         * @param style: The DrawStyle to be extracted
          */
-        void publishPayload(uint8_t layer, const ShapeVector& shapes);
+        void applyDrawStyleToMsg(ShapeMsg& shape_msg, DrawStyle& style);
 
         /**
-         * Clears the shapes array in the layer to shape map for this frame
+         * Helper function for the shape draw methods that copies the attributes in
+         * DrawTransform struct into the actual shape message
+         *
+         * @param shape_msg: Reference to the shape message
+         * @param transform: The DrawTransform struct to be extracted
          */
-        void clearShapes();
+        void applyDrawTransformToMsg(ShapeMsg& shape_msg, DrawTransform& transform);
 
         /**
-         * Add shape to layer
-         * @param layer: The layer which the shape is to be added to
-         * @param shape: The shape
+         * Helper function that checks if the layer exists,
+         * and push the shape message to the corresponding layer's shape vector.
+         *
+         * @param layer: The name of the layer to push to
+         * @param shape: The shape message
          */
-        void addShapeToLayer(uint8_t layer, Shape& shape);
+        void addShapeToLayer(const std::string& layer, ShapeMsg& shape);
 
-        /**
-         * Pack two 8-bit data to a single 16-bit data
-         * @param in1: first data
-         * @param in2: second data
-         * @return 16 bit concatenated data <first><second>
-         */
-        inline uint16_t pack16BitData(uint8_t in1, uint8_t in2)
-        {
-            return ((static_cast<uint16_t>(in1)) << 8) | (in2 & 0x00FF);
-        }
+       private:
+        // string to LayerMsg map
+        LayerMsgMap layers_name_to_msg_map;
+        ros::Publisher publisher;
 
         // Period in nanoseconds
         const double DESIRED_PERIOD_MS =
@@ -189,18 +235,6 @@ namespace Util
 
         // Time point
         time_point time_last_published;
-
-        // Thread on which we watch for websocket connections
-        std::thread websocket_thread;
-
-        // Mutex on the list of current websocket connections
-        std::mutex websocket_mutex;
-
-        // All the current websocket connections we have
-        websocket_connection_vector websocket_connections;
-
-        // A map that contains the layers and shapes of this frame
-        LayerMap layer_shapes_map;
     };
 
 }  // namespace Util

--- a/src/thunderbots_msgs/CMakeLists.txt
+++ b/src/thunderbots_msgs/CMakeLists.txt
@@ -18,6 +18,8 @@ add_message_files(
     FILES
     Ball.msg
     Circle2D.msg
+    DrawShape.msg
+    DrawLayer.msg
     Field.msg
     Point2D.msg
     Primitive.msg

--- a/src/thunderbots_msgs/msg/DrawLayer.msg
+++ b/src/thunderbots_msgs/msg/DrawLayer.msg
@@ -1,0 +1,8 @@
+# This message is for basic communication from AI to the visualizer
+# regarding shape drawing
+
+# Name of layer
+string layer_name
+
+# Shape contained in this layer
+DrawShape[] shapes

--- a/src/thunderbots_msgs/msg/DrawShape.msg
+++ b/src/thunderbots_msgs/msg/DrawShape.msg
@@ -1,0 +1,27 @@
+# This message is for basic communication from AI to the visualizr
+# regarding shape drawing
+
+# Type of the shape
+# Can be one of: "ellipse" | "rect" | "poly" | "arc" | "line"
+string type
+
+# Data associated with the shape; expect different form depending on type:
+# If "ellipse": [center_x, center_y, r1, r2]
+# If "rect":   [x, y, width, height]
+# If "poly":   [x1, y1, x2, y2, ...]
+# If "arc":    [center_x, center_y, radius, theta_start, theta_end]
+# If "line":   [x1, y1, x2, y2]
+float64[] data
+
+# Fill of the shape, which is colour filled into the shape
+string fill
+
+# Stroke of the shape, which is the colour that outlines the shape
+string stroke
+
+# Weight of the stroke
+uint8 stroke_weight
+
+# Transformations
+float64 transform_rotation
+float64 transform_scale


### PR DESCRIPTION
This reverts commit 6d39f14234ce259f8227c933e382167eea04076f.

<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Revert due to issues where we aren't handling thread's stopping properly, leading to the websocket being permanently locked up, which means that any further launches of AI immediately crash.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
