### PR TITLE
PathPlanner interface

### DIFF
--- a/src/thunderbots/software/ai/navigator/path_planner/path_planner.h
+++ b/src/thunderbots/software/ai/navigator/path_planner/path_planner.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <ai/world/world.h>
+
+#include <optional>
+#include <vector>
+
+#include "geom/point.h"
+
+class PathPlanner
+{
+   public:
+    /**
+     * Finds a path from start to dest if it exists, otherwise return std::nullopt.
+     * @param start the start point.
+     * @param dest the destination point.
+     * @return a path from start to dest if it exists, otherwise std::nullopt.
+     */
+    virtual std::optional<std::vector<Point>> findPath(const Point &start,
+                                                       const Point &dest) = 0;
+    virtual ~PathPlanner()                                                = default;
+};


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Pushing a refined path planner interface from the A* code review to allow high level logic work around the navigator to be done in parallel with the path planner algorithm itself.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
None. This is just an interface.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
#443 
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
