### PR TITLE
updated obstacle interface and placeholder obstacle

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -325,6 +325,24 @@ if (CATKIN_ENABLE_TESTING)
 
     target_link_libraries(nav_util_test ${catkin_LIBRARIES})
 
+    catkin_add_gtest(nav_ph_obstacle_test
+            test/ai/navigator/obstacle/placeholder_obstacle.cpp
+            ai/world/robot.cpp
+            ai/navigator/obstacle/placeholder_obstacle.cpp
+            ai/navigator/obstacle/placeholder_obstacle.h
+            ai/navigator/obstacle/obstacle.h
+            util/time/duration.cpp
+            util/time/time.cpp
+            util/time/timestamp.cpp
+            geom/polygon.h
+            geom/polygon.cpp
+            geom/point.h
+            geom/util.cpp
+            ../shared/constants.h
+            )
+
+    target_link_libraries(nav_ph_obstacle_test ${catkin_LIBRARIES})
+
     catkin_add_gtest(shared_util_test
             ../shared/test/util.cpp
             ../shared/util.c

--- a/src/thunderbots/software/ai/navigator/obstacle/obstacle.h
+++ b/src/thunderbots/software/ai/navigator/obstacle/obstacle.h
@@ -1,0 +1,25 @@
+// An obstacle is an area to avoid based on the size of the robot and its velocity
+#pragma once
+
+#include "ai/world/robot.h"
+#include "geom/point.h"
+#include "geom/polygon.h"
+#include "geom/util.h"
+
+class Obstacle
+{
+   public:
+    /*
+     * Gets the boundary polygon around the given robot obstacle that other robots
+     * should not enter with a buffer scaled by radiusScaling and
+     * velocityProjectionScaling
+     * @param robot robot to create obstacle boundary polygon around
+     * @param radiusScaling safety factor to vary the radius size of the buffer zone
+     * (1=default), must greater than 0
+     * @param velocityProjectionScaling scales the projection buffer in the direction of
+     * the velocity (1=default)
+     * @return a six-sided Polygon to represent the boundary around the obstacle
+     */
+    static Polygon getBoundaryPolygon(const Robot& robot, double robotRadiusScaling,
+                                      double velocityProjectionScaling);
+};

--- a/src/thunderbots/software/ai/navigator/obstacle/obstacle.h
+++ b/src/thunderbots/software/ai/navigator/obstacle/obstacle.h
@@ -15,9 +15,9 @@ class Obstacle
      * velocityProjectionScaling
      * @param robot robot to create obstacle boundary polygon around
      * @param radiusScaling safety factor to vary the radius size of the buffer zone
-     * (1=default), must greater than 0
+     * (1=default), must be greater than 0
      * @param velocityProjectionScaling scales the projection buffer in the direction of
-     * the velocity (1=default)
+     * the velocity (1=default), must be greater than 0
      * @return a six-sided Polygon to represent the boundary around the obstacle
      */
     static Polygon getBoundaryPolygon(const Robot& robot, double robotRadiusScaling,

--- a/src/thunderbots/software/ai/navigator/obstacle/obstacle.h
+++ b/src/thunderbots/software/ai/navigator/obstacle/obstacle.h
@@ -1,4 +1,6 @@
-// An obstacle is an area to avoid based on the size of the robot and its velocity
+/**
+ * An obstacle is an area to avoid based on the size of the robot and its velocity
+ */
 #pragma once
 
 #include "ai/world/robot.h"
@@ -12,14 +14,16 @@ class Obstacle
     /*
      * Gets the boundary polygon around the given robot obstacle that other robots
      * should not enter with a buffer scaled by radiusScaling and
-     * velocityProjectionScaling
+     * velocity_projection_scaling
+     *
      * @param robot robot to create obstacle boundary polygon around
      * @param radiusScaling safety factor to vary the radius size of the buffer zone
      * (1=default), must be greater than 0
-     * @param velocityProjectionScaling scales the projection buffer in the direction of
+     * @param velocity_projection_scaling scales the projection buffer in the direction of
      * the velocity (1=default), must be greater than 0
+     *
      * @return a six-sided Polygon to represent the boundary around the obstacle
      */
-    static Polygon getBoundaryPolygon(const Robot& robot, double robotRadiusScaling,
-                                      double velocityProjectionScaling);
+    static Polygon getBoundaryPolygon(const Robot& robot, double robot_radius_scaling,
+                                      double velocity_projection_scaling);
 };

--- a/src/thunderbots/software/ai/navigator/obstacle/placeholder_obstacle.cpp
+++ b/src/thunderbots/software/ai/navigator/obstacle/placeholder_obstacle.cpp
@@ -1,0 +1,21 @@
+#include "ai/navigator/obstacle/placeholder_obstacle.h"
+
+Polygon PlaceholderObstacle::getBoundaryPolygon(const Robot& robot,
+                                                double robotRadiusScaling,
+                                                double velocityProjectionScaling)
+{
+    (void)robot;
+    (void)velocityProjectionScaling;
+    static double ROOT_THREE_BY_TWO =
+        0.86602540378;  // static, so it's not recalculated 4 times per call
+    double radius = ROBOT_MAX_RADIUS_METERS * robotRadiusScaling;
+
+    return Polygon(std::vector<Point>({
+        Point(radius, 0),                                   // right
+        Point(-radius, 0),                                  // left
+        Point(radius / 2.0, radius * ROOT_THREE_BY_TWO),    // top right
+        Point(-radius / 2.0, radius * ROOT_THREE_BY_TWO),   // top left
+        Point(radius / 2.0, -radius * ROOT_THREE_BY_TWO),   // bot right
+        Point(-radius / 2.0, -radius * ROOT_THREE_BY_TWO),  // bot left
+    }));
+}

--- a/src/thunderbots/software/ai/navigator/obstacle/placeholder_obstacle.cpp
+++ b/src/thunderbots/software/ai/navigator/obstacle/placeholder_obstacle.cpp
@@ -1,14 +1,14 @@
 #include "ai/navigator/obstacle/placeholder_obstacle.h"
 
 Polygon PlaceholderObstacle::getBoundaryPolygon(const Robot& robot,
-                                                double robotRadiusScaling,
-                                                double velocityProjectionScaling)
+                                                double robot_radius_scaling,
+                                                double velocity_projection_scaling)
 {
     (void)robot;
-    (void)velocityProjectionScaling;
+    (void)velocity_projection_scaling;
     static double ROOT_THREE_BY_TWO =
         0.86602540378;  // static, so it's not recalculated 4 times per call
-    double radius = ROBOT_MAX_RADIUS_METERS * robotRadiusScaling;
+    double radius = ROBOT_MAX_RADIUS_METERS * robot_radius_scaling;
 
     return Polygon({
         Point(radius, 0),                                   // right

--- a/src/thunderbots/software/ai/navigator/obstacle/placeholder_obstacle.cpp
+++ b/src/thunderbots/software/ai/navigator/obstacle/placeholder_obstacle.cpp
@@ -10,12 +10,12 @@ Polygon PlaceholderObstacle::getBoundaryPolygon(const Robot& robot,
         0.86602540378;  // static, so it's not recalculated 4 times per call
     double radius = ROBOT_MAX_RADIUS_METERS * robotRadiusScaling;
 
-    return Polygon(std::vector<Point>({
+    return Polygon({
         Point(radius, 0),                                   // right
         Point(-radius, 0),                                  // left
         Point(radius / 2.0, radius * ROOT_THREE_BY_TWO),    // top right
         Point(-radius / 2.0, radius * ROOT_THREE_BY_TWO),   // top left
         Point(radius / 2.0, -radius * ROOT_THREE_BY_TWO),   // bot right
         Point(-radius / 2.0, -radius * ROOT_THREE_BY_TWO),  // bot left
-    }));
+    });
 }

--- a/src/thunderbots/software/ai/navigator/obstacle/placeholder_obstacle.h
+++ b/src/thunderbots/software/ai/navigator/obstacle/placeholder_obstacle.h
@@ -11,12 +11,14 @@ class PlaceholderObstacle : public Obstacle
 
     /*
      * Gets the boundary polygon around the centre scaled by radiusScaling
+     *
      * @param robot *ignored*
      * @param radiusScaling safety factor to vary the radius size of the buffer zone
      * (1=default), must greater than 0
-     * @param velocityProjectionScaling *ignored*
+     * @param velocity_projection_scaling *ignored*
+     *
      * @return a six-sided Polygon to represent the boundary around the obstacle
      */
-    static Polygon getBoundaryPolygon(const Robot& robot, double robotRadiusScaling,
-                                      double velocityProjectionScaling);
+    static Polygon getBoundaryPolygon(const Robot& robot, double robot_radius_scaling,
+                                      double velocity_projection_scaling);
 };

--- a/src/thunderbots/software/ai/navigator/obstacle/placeholder_obstacle.h
+++ b/src/thunderbots/software/ai/navigator/obstacle/placeholder_obstacle.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../shared/constants.h"
+#include "ai/navigator/obstacle/obstacle.h"
+
+// Placeholder obstacle represents a stationary robot centred at (0,0)
+class PlaceholderObstacle : public Obstacle
+{
+   public:
+    explicit PlaceholderObstacle();
+
+    /*
+     * Gets the boundary polygon around the centre scaled by radiusScaling
+     * @param robot *ignored*
+     * @param radiusScaling safety factor to vary the radius size of the buffer zone
+     * (1=default), must greater than 0
+     * @param velocityProjectionScaling *ignored*
+     * @return a six-sided Polygon to represent the boundary around the obstacle
+     */
+    static Polygon getBoundaryPolygon(const Robot& robot, double robotRadiusScaling,
+                                      double velocityProjectionScaling);
+};

--- a/src/thunderbots/software/test/ai/navigator/obstacle/placeholder_obstacle.cpp
+++ b/src/thunderbots/software/test/ai/navigator/obstacle/placeholder_obstacle.cpp
@@ -12,7 +12,7 @@
 #include "../shared/constants.h"
 #include "geom/point.h"
 
-//placeholder obstacle with robot radius factor = 1
+// placeholder obstacle with robot radius factor = 1
 TEST(NavigatorPlaceholderObstacleTest, default_placeholder_obstacle_polygon)
 {
     double ROOT_THREE_BY_TWO = 0.86602540378;
@@ -39,7 +39,7 @@ TEST(NavigatorPlaceholderObstacleTest, default_placeholder_obstacle_polygon)
     EXPECT_EQ(pg.getPoints()[5], pt5);
 }
 
-//placeholder obstacle with robot radius factor > 1
+// placeholder obstacle with robot radius factor > 1
 TEST(NavigatorPlaceholderObstacleTest, expanded_placeholder_obstacle_polygon)
 {
     double EXPANSION         = 1.4;
@@ -67,7 +67,7 @@ TEST(NavigatorPlaceholderObstacleTest, expanded_placeholder_obstacle_polygon)
     EXPECT_EQ(pg.getPoints()[5], pt5);
 }
 
-//placeholder obstacle with robot radius factor < 1
+// placeholder obstacle with robot radius factor < 1
 TEST(NavigatorPlaceholderObstacleTest, contracted_placeholder_obstacle_polygon)
 {
     double CONTRACTION       = .7;

--- a/src/thunderbots/software/test/ai/navigator/obstacle/placeholder_obstacle.cpp
+++ b/src/thunderbots/software/test/ai/navigator/obstacle/placeholder_obstacle.cpp
@@ -1,0 +1,100 @@
+#include "ai/navigator/obstacle/placeholder_obstacle.h"
+
+#include <gtest/gtest.h>
+#include <math.h>
+
+#include <cmath>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <sstream>
+
+#include "../shared/constants.h"
+#include "geom/point.h"
+
+TEST(NavPhObstTest, default_placeholder_obstacle_polygon)
+{
+    double ROOT_THREE_BY_TWO = 0.86602540378;
+    Timestamp current_time   = Timestamp::fromSeconds(123);
+    Robot robot = Robot(3, Point(1, 1), Vector(-0.3, 0), Angle::ofRadians(2.2),
+                        AngularVelocity::ofRadians(-0.6), current_time);
+    Polygon pg  = PlaceholderObstacle::getBoundaryPolygon(robot, 1.0, 3.0);
+    Point pt0   = Point(ROBOT_MAX_RADIUS_METERS, 0);
+    Point pt1   = Point(-ROBOT_MAX_RADIUS_METERS, 0);
+    Point pt2 =
+        Point(ROBOT_MAX_RADIUS_METERS / 2.0, ROBOT_MAX_RADIUS_METERS * ROOT_THREE_BY_TWO);
+    Point pt3 = Point(-ROBOT_MAX_RADIUS_METERS / 2.0,
+                      ROBOT_MAX_RADIUS_METERS * ROOT_THREE_BY_TWO);
+    Point pt4 = Point(ROBOT_MAX_RADIUS_METERS / 2.0,
+                      -ROBOT_MAX_RADIUS_METERS * ROOT_THREE_BY_TWO);
+    Point pt5 = Point(-ROBOT_MAX_RADIUS_METERS / 2.0,
+                      -ROBOT_MAX_RADIUS_METERS * ROOT_THREE_BY_TWO);
+    EXPECT_EQ(pg.getPoints().size(), 6);
+    EXPECT_EQ(pg.getPoints()[0], pt0);
+    EXPECT_EQ(pg.getPoints()[1], pt1);
+    EXPECT_EQ(pg.getPoints()[2], pt2);
+    EXPECT_EQ(pg.getPoints()[3], pt3);
+    EXPECT_EQ(pg.getPoints()[4], pt4);
+    EXPECT_EQ(pg.getPoints()[5], pt5);
+}
+
+TEST(NavPhObstTest, expanded_placeholder_obstacle_polygon)
+{
+    double EXPANSION         = 1.4;
+    double ROOT_THREE_BY_TWO = 0.86602540378;
+    Timestamp current_time   = Timestamp::fromSeconds(123);
+    Robot robot = Robot(3, Point(1, 1), Vector(-0.3, 0), Angle::ofRadians(2.2),
+                        AngularVelocity::ofRadians(-0.6), current_time);
+    Polygon pg  = PlaceholderObstacle::getBoundaryPolygon(robot, EXPANSION, 3.0);
+    Point pt0   = Point(ROBOT_MAX_RADIUS_METERS * EXPANSION, 0);
+    Point pt1   = Point(-ROBOT_MAX_RADIUS_METERS * EXPANSION, 0);
+    Point pt2   = Point(ROBOT_MAX_RADIUS_METERS * EXPANSION / 2.0,
+                      ROBOT_MAX_RADIUS_METERS * EXPANSION * ROOT_THREE_BY_TWO);
+    Point pt3   = Point(-ROBOT_MAX_RADIUS_METERS * EXPANSION / 2.0,
+                      ROBOT_MAX_RADIUS_METERS * EXPANSION * ROOT_THREE_BY_TWO);
+    Point pt4   = Point(ROBOT_MAX_RADIUS_METERS * EXPANSION / 2.0,
+                      -ROBOT_MAX_RADIUS_METERS * EXPANSION * ROOT_THREE_BY_TWO);
+    Point pt5   = Point(-ROBOT_MAX_RADIUS_METERS * EXPANSION / 2.0,
+                      -ROBOT_MAX_RADIUS_METERS * EXPANSION * ROOT_THREE_BY_TWO);
+    EXPECT_EQ(pg.getPoints().size(), 6);
+    EXPECT_EQ(pg.getPoints()[0], pt0);
+    EXPECT_EQ(pg.getPoints()[1], pt1);
+    EXPECT_EQ(pg.getPoints()[2], pt2);
+    EXPECT_EQ(pg.getPoints()[3], pt3);
+    EXPECT_EQ(pg.getPoints()[4], pt4);
+    EXPECT_EQ(pg.getPoints()[5], pt5);
+}
+
+TEST(NavPhObstTest, contracted_placeholder_obstacle_polygon)
+{
+    double CONTRACTION       = .7;
+    double ROOT_THREE_BY_TWO = 0.86602540378;
+    Timestamp current_time   = Timestamp::fromSeconds(123);
+    Robot robot = Robot(3, Point(1, 1), Vector(-0.3, 0), Angle::ofRadians(2.2),
+                        AngularVelocity::ofRadians(-0.6), current_time);
+    Polygon pg  = PlaceholderObstacle::getBoundaryPolygon(robot, CONTRACTION, 3.0);
+    Point pt0   = Point(ROBOT_MAX_RADIUS_METERS * CONTRACTION, 0);
+    Point pt1   = Point(-ROBOT_MAX_RADIUS_METERS * CONTRACTION, 0);
+    Point pt2   = Point(ROBOT_MAX_RADIUS_METERS * CONTRACTION / 2.0,
+                      ROBOT_MAX_RADIUS_METERS * CONTRACTION * ROOT_THREE_BY_TWO);
+    Point pt3   = Point(-ROBOT_MAX_RADIUS_METERS * CONTRACTION / 2.0,
+                      ROBOT_MAX_RADIUS_METERS * CONTRACTION * ROOT_THREE_BY_TWO);
+    Point pt4   = Point(ROBOT_MAX_RADIUS_METERS * CONTRACTION / 2.0,
+                      -ROBOT_MAX_RADIUS_METERS * CONTRACTION * ROOT_THREE_BY_TWO);
+    Point pt5   = Point(-ROBOT_MAX_RADIUS_METERS * CONTRACTION / 2.0,
+                      -ROBOT_MAX_RADIUS_METERS * CONTRACTION * ROOT_THREE_BY_TWO);
+    EXPECT_EQ(pg.getPoints().size(), 6);
+    EXPECT_EQ(pg.getPoints()[0], pt0);
+    EXPECT_EQ(pg.getPoints()[1], pt1);
+    EXPECT_EQ(pg.getPoints()[2], pt2);
+    EXPECT_EQ(pg.getPoints()[3], pt3);
+    EXPECT_EQ(pg.getPoints()[4], pt4);
+    EXPECT_EQ(pg.getPoints()[5], pt5);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/ai/navigator/obstacle/placeholder_obstacle.cpp
+++ b/src/thunderbots/software/test/ai/navigator/obstacle/placeholder_obstacle.cpp
@@ -12,7 +12,8 @@
 #include "../shared/constants.h"
 #include "geom/point.h"
 
-TEST(NavPhObstTest, default_placeholder_obstacle_polygon)
+//placeholder obstacle with robot radius factor = 1
+TEST(NavigatorPlaceholderObstacleTest, default_placeholder_obstacle_polygon)
 {
     double ROOT_THREE_BY_TWO = 0.86602540378;
     Timestamp current_time   = Timestamp::fromSeconds(123);
@@ -38,7 +39,8 @@ TEST(NavPhObstTest, default_placeholder_obstacle_polygon)
     EXPECT_EQ(pg.getPoints()[5], pt5);
 }
 
-TEST(NavPhObstTest, expanded_placeholder_obstacle_polygon)
+//placeholder obstacle with robot radius factor > 1
+TEST(NavigatorPlaceholderObstacleTest, expanded_placeholder_obstacle_polygon)
 {
     double EXPANSION         = 1.4;
     double ROOT_THREE_BY_TWO = 0.86602540378;
@@ -65,7 +67,8 @@ TEST(NavPhObstTest, expanded_placeholder_obstacle_polygon)
     EXPECT_EQ(pg.getPoints()[5], pt5);
 }
 
-TEST(NavPhObstTest, contracted_placeholder_obstacle_polygon)
+//placeholder obstacle with robot radius factor < 1
+TEST(NavigatorPlaceholderObstacleTest, contracted_placeholder_obstacle_polygon)
 {
     double CONTRACTION       = .7;
     double ROOT_THREE_BY_TWO = 0.86602540378;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
New updated obstacle interface resolving issues from https://github.com/UBC-Thunderbots/Software/pull/489 and added placeholder obstacle
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
#442
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
