### PR TITLE
Removed the Robot from the Action constructor

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/action/action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/action.cpp
@@ -1,8 +1,9 @@
 #include "ai/hl/stp/action/action.h"
 
-Action::Action(const Robot &robot)
-    : robot(robot),
-      intent_sequence(boost::bind(&Action::calculateNextIntentWrapper, this, _1))
+#include "util/logger/init.h"
+
+Action::Action()
+    : intent_sequence(boost::bind(&Action::calculateNextIntentWrapper, this, _1))
 {
 }
 
@@ -13,6 +14,14 @@ bool Action::done() const
 
 std::unique_ptr<Intent> Action::getNextIntent()
 {
+    if (!robot)
+    {
+        LOG(WARNING)
+            << "Requesting the next Intent for an Action without a Robot assigned"
+            << std::endl;
+        return std::unique_ptr<Intent>{};
+    }
+
     // If the coroutine "iterator" is done, the calculateNextIntent function has completed
     // and therefore the Action is done, so we return a null pointer
     if (intent_sequence)

--- a/src/thunderbots/software/ai/hl/stp/action/action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/action.h
@@ -20,10 +20,8 @@ class Action
    public:
     /**
      * Creates a new Action for the given robot.
-     *
-     * @param robot The robot that will be performing this Action
      */
-    explicit Action(const Robot &robot);
+    explicit Action();
 
     /**
      * Returns true if the Action is done and false otherwise. The Action is considered
@@ -50,7 +48,7 @@ class Action
     // The coroutine that sequentially returns the Intents the Action wants to run
     intent_coroutine::pull_type intent_sequence;
     // The robot performing this Action
-    Robot robot;
+    std::optional<Robot> robot;
 
    private:
     /**

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
@@ -2,8 +2,8 @@
 
 #include "ai/intent/move_intent.h"
 
-MoveAction::MoveAction(const Robot& robot, double close_to_dest_threshold)
-    : Action(robot), close_to_dest_threshold(close_to_dest_threshold)
+MoveAction::MoveAction(double close_to_dest_threshold)
+    : Action(), close_to_dest_threshold(close_to_dest_threshold)
 {
 }
 
@@ -31,7 +31,7 @@ std::unique_ptr<Intent> MoveAction::calculateNextIntent(
     // location
     do
     {
-        yield(std::make_unique<MoveIntent>(robot.id(), destination, final_orientation,
+        yield(std::make_unique<MoveIntent>(robot->id(), destination, final_orientation,
                                            final_speed, 0));
-    } while ((robot.position() - destination).len() > close_to_dest_threshold);
+    } while ((robot->position() - destination).len() > close_to_dest_threshold);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.h
@@ -15,12 +15,10 @@ class MoveAction : public Action
     /**
      * Creates a new MoveAction
      *
-     * @param robot The robot that will be performing the action
      * @param close_to_dest_threshold How far from the destination the robot must be
      * before the action is considered done
      */
-    explicit MoveAction(const Robot& robot,
-                        double close_to_dest_threshold = ROBOT_CLOSE_TO_DEST_THRESHOLD);
+    explicit MoveAction(double close_to_dest_threshold = ROBOT_CLOSE_TO_DEST_THRESHOLD);
 
     /**
      * Returns the next Intent this MoveAction wants to run, given the parameters.

--- a/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.cpp
@@ -30,7 +30,7 @@ double MoveTactic::calculateRobotCost(const Robot &robot, const World &world)
 std::unique_ptr<Intent> MoveTactic::calculateNextIntent(
     intent_coroutine::push_type &yield)
 {
-    MoveAction move_action = MoveAction(*robot);
+    MoveAction move_action = MoveAction();
     do
     {
         yield(move_action.updateStateAndGetNextIntent(*robot, destination,

--- a/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
@@ -10,7 +10,7 @@ TEST(MoveActionTest, robot_far_from_destination)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveAction action = MoveAction(robot, 0.05);
+    MoveAction action = MoveAction(0.05);
 
     auto intent_ptr =
         action.updateStateAndGetNextIntent(robot, Point(1, 0), Angle::quarter(), 1.0);
@@ -30,7 +30,7 @@ TEST(MoveActionTest, robot_at_destination)
 {
     Robot robot = Robot(0, Point(), Vector(0, 0), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveAction action = MoveAction(robot, 0.02);
+    MoveAction action = MoveAction(0.02);
 
     // We call the action twice. The first time the Intent will always be returned to
     // ensure the Robot is doing the right thing. In all future calls, the action will be
@@ -47,7 +47,7 @@ TEST(MoveActionTest, test_action_does_not_prematurely_report_done)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveAction action = MoveAction(robot, 0.05);
+    MoveAction action = MoveAction(0.05);
 
     // Run the Action several times
     auto intent_ptr = std::unique_ptr<Intent>{};
@@ -66,7 +66,7 @@ TEST(MoveActionTest, test_action_reports_done_at_same_time_nullptr_returned)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveAction action = MoveAction(robot, 0.05);
+    MoveAction action = MoveAction(0.05);
 
     // The first time the Action runs it will always return an Intent to make sure we
     // are doing the correct thing


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Removed the `Robot` from the generic `Action` constructor in order to be more consistent with how `Tactics` are constructed (and it served no purpose).

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Existing unit tests updated and pass.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
None

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
