### PR TITLE
Implemented MoveSpin Action

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -537,13 +537,17 @@ if (CATKIN_ENABLE_TESTING)
     catkin_add_gtest(action_test
             ai/hl/stp/action/action.cpp
             ai/hl/stp/action/move_action.cpp
+            ai/hl/stp/action/movespin_action.cpp
             ai/intent/intent.cpp
             ai/intent/move_intent.cpp
+            ai/intent/movespin_intent.cpp
             ai/primitive/move_primitive.cpp
+            ai/primitive/movespin_primitive.cpp
             ai/primitive/primitive.cpp
             ai/world/robot.cpp
             test/ai/hl/stp/action/main.cpp
             test/ai/hl/stp/action/move_action.cpp
+            test/ai/hl/stp/action/movespin_action.cpp
             util/logger/custom_g3log_sinks.h
             util/logger/init.h
             util/time/duration.cpp

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -546,6 +546,8 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/primitive.cpp
             ai/world/robot.cpp
             test/ai/hl/stp/action/main.cpp
+            test/ai/hl/stp/test_actions/move_test_action.cpp
+            test/ai/hl/stp/action/action.cpp
             test/ai/hl/stp/action/move_action.cpp
             test/ai/hl/stp/action/movespin_action.cpp
             util/logger/custom_g3log_sinks.h

--- a/src/thunderbots/software/ai/hl/stp/action/movespin_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/movespin_action.cpp
@@ -1,0 +1,34 @@
+#include "ai/hl/stp/action/movespin_action.h"
+
+#include "ai/intent/movespin_intent.h"
+
+MoveSpinAction::MoveSpinAction(double close_to_dest_threshold)
+    : Action(), close_to_dest_threshold(close_to_dest_threshold)
+{
+}
+
+std::unique_ptr<Intent> MoveSpinAction::updateStateAndGetNextIntent(
+    const Robot& robot, Point destination, AngularVelocity angular_velocity)
+{
+    // Update the parameters stored by this Action
+    this->robot            = robot;
+    this->destination      = destination;
+    this->angular_velocity = angular_velocity;
+
+    return getNextIntent();
+}
+
+std::unique_ptr<Intent> MoveSpinAction::calculateNextIntent(
+    intent_coroutine::push_type& yield)
+{
+    // We use a do-while loop so that we return the Intent at least once. If the robot was
+    // already moving somewhere else, but was told to run the MoveSpinAction to a
+    // destination while it happened to be crossing that point, we want to make sure we
+    // send the Intent so we don't report the Action as done while still moving to a
+    // different location
+    do
+    {
+        yield(std::make_unique<MoveSpinIntent>(robot->id(), destination, angular_velocity,
+                                               0));
+    } while ((robot->position() - destination).len() > close_to_dest_threshold);
+}

--- a/src/thunderbots/software/ai/hl/stp/action/movespin_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/movespin_action.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "ai/hl/stp/action/action.h"
+#include "geom/angle.h"
+#include "geom/point.h"
+
+/**
+ * The MoveSpinAction will move the given Robot to the specified destination while
+ * spinning with the desired angular velocity
+ */
+class MoveSpinAction : public Action
+{
+   public:
+    // We consider the robot close to a destination when it is within 2 cm.
+    // The robot should be able to reach within 1cm of the destination even with
+    // camera and positioning noise
+    static constexpr double ROBOT_CLOSE_TO_DEST_THRESHOLD = 0.02;
+
+    /**
+     * Creates a new MoveSpinAction
+     *
+     * @param close_to_dest_threshold How far from the destination the robot must be
+     * before the action is considered done
+     */
+    explicit MoveSpinAction(
+        double close_to_dest_threshold = ROBOT_CLOSE_TO_DEST_THRESHOLD);
+
+    /**
+     * Returns the next Intent this MoveSpinAction wants to run, given the parameters.
+     *
+     * @param robot The robot to move
+     * @param destination The destination to move to (in global coordinates)
+     * @param angular_velocity The how fast the robot should spin, in radians per second.
+     * A positive value spins counterclockwise, and a negative value spins clockwise
+     *
+     * @return A unique pointer to the Intent the MoveSpinAction wants to run. If the
+     * MoveSpinAction is done, returns an empty/null pointer
+     */
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot,
+                                                        Point destination,
+                                                        AngularVelocity angular_velocity);
+
+   private:
+    std::unique_ptr<Intent> calculateNextIntent(
+        intent_coroutine::push_type& yield) override;
+
+    // Action parameters
+    Point destination;
+    AngularVelocity angular_velocity;
+    double close_to_dest_threshold;
+};

--- a/src/thunderbots/software/test/ai/hl/stp/action/action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/action.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+
+#include "ai/intent/move_intent.h"
+#include "test/ai/hl/stp/test_actions/move_test_action.h"
+
+/**
+ * This file contains the unit tests for the Action class (NOTE: `Action` is virtual, so
+ * we use `MoveTestAction` instead, but we're only testing the generic functionality of
+ * the `Tactic` class)
+ */
+
+TEST(ActionTest, test_action_reports_done_at_same_time_nullptr_returned)
+{
+    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+    MoveTestAction action = MoveTestAction(0.05);
+
+    // The first time the Action runs it will always return an Intent to make sure we
+    // are doing the correct thing
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point());
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    // For subsequent calls, we expect the Action to be done (in this case)
+    // We make sure that when a nullptr is returned, the action also evaluates to "done"
+    // This is important since higher-level functionality relies on the Action::done()
+    // function but returning nullptr values out of sync with this done() function could
+    // cause problems
+    intent_ptr = action.updateStateAndGetNextIntent(robot, Point());
+    EXPECT_FALSE(intent_ptr);
+    EXPECT_TRUE(action.done());
+}

--- a/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
@@ -2,8 +2,6 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/coroutine2/all.hpp>
-
 #include "ai/intent/move_intent.h"
 
 TEST(MoveActionTest, robot_far_from_destination)
@@ -60,27 +58,4 @@ TEST(MoveActionTest, test_action_does_not_prematurely_report_done)
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
-}
-
-TEST(MoveActionTest, test_action_reports_done_at_same_time_nullptr_returned)
-{
-    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
-                        Timestamp::fromSeconds(0));
-    MoveAction action = MoveAction(0.05);
-
-    // The first time the Action runs it will always return an Intent to make sure we
-    // are doing the correct thing
-    auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(), Angle::zero(), 0.0);
-    EXPECT_TRUE(intent_ptr);
-    EXPECT_FALSE(action.done());
-
-    // For subsequent calls, we expect the Action to be done (in this case)
-    // We make sure that when a nullptr is returned, the action also evaluates to "done"
-    // This is important since higher-level functionality relies on the Action::done()
-    // function but returning nullptr values out of sync with this done() function could
-    // cause problems
-    intent_ptr = action.updateStateAndGetNextIntent(robot, Point(), Angle::zero(), 0.0);
-    EXPECT_FALSE(intent_ptr);
-    EXPECT_TRUE(action.done());
 }

--- a/src/thunderbots/software/test/ai/hl/stp/action/movespin_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/movespin_action.cpp
@@ -1,0 +1,60 @@
+#include "ai/hl/stp/action/movespin_action.h"
+
+#include <gtest/gtest.h>
+
+#include "ai/intent/movespin_intent.h"
+
+TEST(MoveSpinActionTest, robot_far_from_destination)
+{
+    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+    MoveSpinAction action = MoveSpinAction(0.05);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(1, 0),
+                                                         AngularVelocity::quarter());
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveSpinIntent movespin_intent = dynamic_cast<MoveSpinIntent &>(*intent_ptr);
+    EXPECT_EQ(0, movespin_intent.getRobotId());
+    EXPECT_EQ(Point(1, 0), movespin_intent.getDestination());
+    EXPECT_EQ(AngularVelocity::quarter(), movespin_intent.getAngularVelocity());
+}
+
+TEST(MoveSpinActionTest, robot_at_destination)
+{
+    Robot robot = Robot(0, Point(), Vector(0, 0), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+    MoveSpinAction action = MoveSpinAction(0.02);
+
+    // We call the action twice. The first time the Intent will always be returned to
+    // ensure the Robot is doing the right thing. In all future calls, the action will be
+    // done and so will return a null pointer
+    auto intent_ptr =
+        action.updateStateAndGetNextIntent(robot, Point(0, 0), AngularVelocity::full());
+    intent_ptr =
+        action.updateStateAndGetNextIntent(robot, Point(0, 0), AngularVelocity::full());
+
+    EXPECT_TRUE(action.done());
+}
+
+TEST(MoveSpinActionTest, test_action_does_not_prematurely_report_done)
+{
+    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+    MoveSpinAction action = MoveSpinAction(0.05);
+
+    // Run the Action several times
+    auto intent_ptr = std::unique_ptr<Intent>{};
+    for (int i = 0; i < 10; i++)
+    {
+        intent_ptr = action.updateStateAndGetNextIntent(robot, Point(1, 0),
+                                                        AngularVelocity::quarter());
+    }
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+}

--- a/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.cpp
@@ -1,0 +1,33 @@
+#include "test/ai/hl/stp/test_actions/move_test_action.h"
+
+#include "ai/intent/move_intent.h"
+
+MoveTestAction::MoveTestAction(double close_to_dest_threshold)
+    : Action(), close_to_dest_threshold(close_to_dest_threshold)
+{
+}
+
+std::unique_ptr<Intent> MoveTestAction::updateStateAndGetNextIntent(const Robot& robot,
+                                                                    Point destination)
+{
+    // Update the parameters stored by this Action
+    this->robot       = robot;
+    this->destination = destination;
+
+    return getNextIntent();
+}
+
+std::unique_ptr<Intent> MoveTestAction::calculateNextIntent(
+    intent_coroutine::push_type& yield)
+{
+    // We use a do-while loop so that we return the Intent at least once. If the robot was
+    // already moving somewhere else, but was told to run the MoveTestAction to a
+    // destination while it happened to be crossing that point, we want to make sure we
+    // send the Intent so we don't report the Action as done while still moving to a
+    // different location
+    do
+    {
+        yield(std::make_unique<MoveIntent>(robot->id(), destination, Angle::zero(), 0.0,
+                                           0));
+    } while ((robot->position() - destination).len() > close_to_dest_threshold);
+}

--- a/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "ai/hl/stp/action/action.h"
+#include "geom/angle.h"
+#include "geom/point.h"
+
+/**
+ * A test Action used for unit tests
+ *
+ * Moves the given robot to the given destination
+ */
+class MoveTestAction : public Action
+{
+   public:
+    /**
+     * Creates a new MoveTestAction
+     *
+     * @param close_to_dest_threshold How far from the destination the robot must be
+     * before the action is considered done
+     */
+    explicit MoveTestAction(double close_to_dest_threshold);
+
+    /**
+     * Returns the next Intent this MoveTestAction wants to run, given the parameters.
+     * Moves the robot in a straight line to the given destination.
+     *
+     * @param robot The robot to move
+     * @param destination The destination to move to (in global coordinates)
+     *
+     * @return A unique pointer to the Intent the MoveTestAction wants to run. If the
+     * MoveTestAction is done, returns an empty/null pointer
+     */
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot,
+                                                        Point destination);
+
+   private:
+    std::unique_ptr<Intent> calculateNextIntent(
+        intent_coroutine::push_type& yield) override;
+
+    // Action parameters
+    Point destination;
+    double close_to_dest_threshold;
+};


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Implemented the MoveSpin Action. Also created a TestAction and move the generic Action tests to their own file.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests added.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #427 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
