### PR TITLE
Implemented Kick and Chip Actions

### DIFF
--- a/src/thunderbots/shared/constants.h
+++ b/src/thunderbots/shared/constants.h
@@ -10,6 +10,8 @@
 const double BALL_MAX_SPEED_METERS_PER_SECOND = 6.5;
 // The max allowed radius of the robots, in metres
 const double ROBOT_MAX_RADIUS_METERS = 0.09;
+// The distance from the center of the robot to the front face (the flat part), in meters
+const double DIST_TO_FRONT_OF_ROBOT_METERS = 0.07;
 // The approximate radius of the ball according to the SSL rulebook
 const double BALL_MAX_RADIUS_METERS = 0.0215;
 // The maximum number of robots we can communicate with over radio.

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -542,13 +542,16 @@ if (CATKIN_ENABLE_TESTING)
             ai/hl/stp/action/move_action.cpp
             ai/hl/stp/action/movespin_action.cpp
             ai/hl/stp/action/kick_action.cpp
+            ai/hl/stp/action/chip_action.cpp
             ai/intent/intent.cpp
             ai/intent/move_intent.cpp
             ai/intent/movespin_intent.cpp
             ai/intent/kick_intent.cpp
+            ai/intent/chip_intent.cpp
             ai/primitive/move_primitive.cpp
             ai/primitive/movespin_primitive.cpp
             ai/primitive/kick_primitive.cpp
+            ai/primitive/chip_primitive.cpp
             ai/primitive/primitive.cpp
             ai/world/robot.cpp
             test/ai/hl/stp/action/main.cpp
@@ -557,6 +560,7 @@ if (CATKIN_ENABLE_TESTING)
             test/ai/hl/stp/action/move_action.cpp
             test/ai/hl/stp/action/movespin_action.cpp
             test/ai/hl/stp/action/kick_action.cpp
+            test/ai/hl/stp/action/chip_action.cpp
             geom/polygon.cpp
             geom/util.cpp
             util/logger/custom_g3log_sinks.h

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -541,11 +541,14 @@ if (CATKIN_ENABLE_TESTING)
             ai/hl/stp/action/action.cpp
             ai/hl/stp/action/move_action.cpp
             ai/hl/stp/action/movespin_action.cpp
+            ai/hl/stp/action/kick_action.cpp
             ai/intent/intent.cpp
             ai/intent/move_intent.cpp
             ai/intent/movespin_intent.cpp
+            ai/intent/kick_intent.cpp
             ai/primitive/move_primitive.cpp
             ai/primitive/movespin_primitive.cpp
+            ai/primitive/kick_primitive.cpp
             ai/primitive/primitive.cpp
             ai/world/robot.cpp
             test/ai/hl/stp/action/main.cpp
@@ -553,6 +556,9 @@ if (CATKIN_ENABLE_TESTING)
             test/ai/hl/stp/action/action.cpp
             test/ai/hl/stp/action/move_action.cpp
             test/ai/hl/stp/action/movespin_action.cpp
+            test/ai/hl/stp/action/kick_action.cpp
+            geom/polygon.cpp
+            geom/util.cpp
             util/logger/custom_g3log_sinks.h
             util/logger/init.h
             util/time/duration.cpp

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
@@ -1,0 +1,110 @@
+#include "ai/hl/stp/action/chip_action.h"
+
+#include "ai/intent/chip_intent.h"
+#include "ai/intent/move_intent.h"
+#include "geom/polygon.h"
+#include "geom/util.h"
+
+ChipAction::ChipAction(double length_of_region_behind_ball)
+    : Action(), length_of_region_behind_ball(length_of_region_behind_ball)
+{
+}
+
+std::unique_ptr<Intent> ChipAction::updateStateAndGetNextIntent(
+    const Robot& robot, Point chip_origin, Point chip_target, double chip_distance_meters)
+{
+    return updateStateAndGetNextIntent(robot, chip_origin,
+                                       (chip_target - chip_origin).orientation(),
+                                       chip_distance_meters);
+}
+
+std::unique_ptr<Intent> ChipAction::updateStateAndGetNextIntent(
+    const Robot& robot, Point chip_origin, Angle chip_direction,
+    double chip_distance_meters)
+{
+    // Update the parameters stored by this Action
+    this->robot                = robot;
+    this->chip_origin          = chip_origin;
+    this->chip_direction       = chip_direction;
+    this->chip_distance_meters = chip_distance_meters;
+
+    return getNextIntent();
+}
+
+std::unique_ptr<Intent> ChipAction::calculateNextIntent(
+    intent_coroutine::push_type& yield)
+{
+    // TODO: replace with real constant
+    double DIST_TO_FRONT_OF_ROBOT = 0.05;
+    // ASCII art showing the region behind the ball
+    //
+    //              X
+    //       v-------------v
+    //
+    //    >  \-------------/
+    //    |   \           /
+    //    |    \         /
+    //    |     \       /       <- Region considered "behind ball"
+    // 2X |      \     /
+    //    |       \   /
+    //    |        \ /
+    //    >         v
+    //
+    //
+    //
+    //              O
+    //             O O          <- Ball
+    //              O
+    //
+    //              |
+    //              V
+    //       direction of chip
+
+    do
+    {
+        // A vector in the direction opposite the chip (behind the ball)
+        Vector behind_ball =
+            Vector::createFromAngle(this->chip_direction + Angle::half());
+        // We make the closest point of the region close enough to the ball so that the
+        // robot will still be inside it when it's taking the chip.
+        // This point is the "top" of the Isosceles triangle
+        Point behind_ball_close =
+            chip_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5);
+        // These points form the "base" of the Isosceles triangle
+        Point behind_ball_far_1 =
+            chip_origin +
+            behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5 +
+                             length_of_region_behind_ball) +
+            behind_ball.perp().norm(length_of_region_behind_ball / 2);
+        Point behind_ball_far_2 =
+            chip_origin +
+            behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5 +
+                             length_of_region_behind_ball) -
+            behind_ball.perp().norm(length_of_region_behind_ball / 2);
+        // Forms an Isosceles triangle that represents the region behind the ball. This
+        // region is close enough to the ball that the robot will still be inside it
+        // even if the ball is in the robot's dribbler, since we don't want the robot
+        // to think it's no longer behind the ball right when it's going to take the chip
+        // The height of this triangle is equal to the specified length of the region
+        // behind the ball. The base of the triangle is also equal to this length.
+        Polygon behind_ball_region =
+            Polygon({behind_ball_close, behind_ball_far_1, behind_ball_far_2});
+
+        bool robot_behind_ball = behind_ball_region.containsPoint(robot->position());
+        // The point in the middle of the region behind the ball
+        Point point_behind_ball =
+            chip_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5 +
+                                           length_of_region_behind_ball / 2);
+
+        if (!robot_behind_ball)
+        {
+            yield(std::make_unique<MoveIntent>(robot->id(), point_behind_ball,
+                                               chip_direction, 0.0, 0));
+        }
+        else
+        {
+            yield(std::make_unique<ChipIntent>(robot->id(), chip_origin, chip_direction,
+                                               chip_distance_meters, 0));
+        }
+    } while (true);
+}

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
@@ -6,9 +6,7 @@
 #include "geom/util.h"
 #include "shared/constants.h"
 
-ChipAction::ChipAction() : Action()
-{
-}
+ChipAction::ChipAction() : Action() {}
 
 std::unique_ptr<Intent> ChipAction::updateStateAndGetNextIntent(
     const Robot& robot, Point chip_origin, Point chip_target, double chip_distance_meters)
@@ -72,7 +70,7 @@ std::unique_ptr<Intent> ChipAction::calculateNextIntent(
     {
         // A vector in the direction opposite the chip (behind the ball)
         Vector behind_ball =
-                Vector::createFromAngle(this->chip_direction + Angle::half());
+            Vector::createFromAngle(this->chip_direction + Angle::half());
 
 
         // The points below make up the triangle that defines the region we treat as
@@ -82,20 +80,22 @@ std::unique_ptr<Intent> ChipAction::calculateNextIntent(
         // We make the region close enough to the ball so that the robot will still be
         // inside it when taking the chip.
         Point behind_ball_vertex_A =
-                chip_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT_METERS * 0.5);
-        Point behind_ball_vertex_B = behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) +
-                                     behind_ball.perp().norm(size_of_region_behind_ball / 2);
-        Point behind_ball_vertex_C = behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) -
-                                     behind_ball.perp().norm(size_of_region_behind_ball / 2);
+            chip_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT_METERS * 0.5);
+        Point behind_ball_vertex_B =
+            behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) +
+            behind_ball.perp().norm(size_of_region_behind_ball / 2);
+        Point behind_ball_vertex_C =
+            behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) -
+            behind_ball.perp().norm(size_of_region_behind_ball / 2);
 
         Polygon behind_ball_region =
-                Polygon({behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C});
+            Polygon({behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C});
 
         bool robot_behind_ball = behind_ball_region.containsPoint(robot->position());
         // The point in the middle of the region behind the ball
         Point point_behind_ball =
-                chip_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT_METERS * 0.5 +
-                                               size_of_region_behind_ball / 2);
+            chip_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT_METERS * 0.5 +
+                                           size_of_region_behind_ball / 2);
 
         // If we're not in position to chip, move into position
         if (!robot_behind_ball)

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.h
@@ -3,10 +3,9 @@
 #include "ai/hl/stp/action/action.h"
 #include "geom/angle.h"
 #include "geom/point.h"
-#include "shared/constants.h"
 
 /**
- * The ChipAction makes the robot chip at the given location in the given
+ * The ChipAction makes the robot chip from the given location in the given
  * direction, with the given power
  */
 class ChipAction : public Action
@@ -14,15 +13,8 @@ class ChipAction : public Action
    public:
     /**
      * Creates a new ChipAction
-     *
-     * @param length_of_region_behind_ball The distance behind the ball the robot must be
-     * before it can chip. The default value is 3 robot diameters. We want to keep the
-     * region small enough that we won't use the ChipIntent from too far away (since we
-     * risk colliding with something since the ChipIntent doesn't avoid obstacles), but
-     * large enough we can reasonable get in the region and chip the ball successfully.
      */
-    explicit ChipAction(double length_of_region_behind_ball = 6 *
-                                                              ROBOT_MAX_RADIUS_METERS);
+    explicit ChipAction();
 
     /**
      * Returns the next Intent this ChipAction wants to run, given the parameters.
@@ -66,7 +58,4 @@ class ChipAction : public Action
     Point chip_origin;
     Angle chip_direction;
     double chip_distance_meters;
-    // How far behind the ball the region stretches within which we treat things
-    // as being "behind the ball"
-    const double length_of_region_behind_ball;
 };

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "ai/hl/stp/action/action.h"
+#include "geom/angle.h"
+#include "geom/point.h"
+#include "shared/constants.h"
+
+/**
+ * The ChipAction makes the robot chip at the given location in the given
+ * direction, with the given power
+ */
+class ChipAction : public Action
+{
+   public:
+    /**
+     * Creates a new ChipAction
+     *
+     * @param length_of_region_behind_ball The distance behind the ball the robot must be
+     * before it can chip. The default value is 3 robot diameters. We want to keep the
+     * region small enough that we won't use the ChipIntent from too far away (since we
+     * risk colliding with something since the ChipIntent doesn't avoid obstacles), but
+     * large enough we can reasonable get in the region and chip the ball successfully.
+     */
+    explicit ChipAction(double length_of_region_behind_ball = 6 *
+                                                              ROBOT_MAX_RADIUS_METERS);
+
+    /**
+     * Returns the next Intent this ChipAction wants to run, given the parameters.
+     *
+     * @param robot The robot that should perform the chip
+     * @param chip_origin The location where the chip will be taken
+     * @param chip_direction The direction the Robot will chip in
+     * @param chip_distance_meters The distance between the starting location
+     * of the chip and the location of the first bounce
+     *
+     * @return A unique pointer to the Intent the ChipAction wants to run. If the
+     * ChipAction is done, returns an empty/null pointer
+     */
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot,
+                                                        Point chip_origin,
+                                                        Angle chip_direction,
+                                                        double chip_distance_meters);
+
+    /**
+     * Returns the next Intent this ChipAction wants to run, given the parameters.
+     *
+     * @param robot The robot that should perform the chip
+     * @param chip_origin The location where the chip will be taken
+     * @param chip_target The target to chip at
+     * @param chip_distance_meters The distance between the starting location
+     * of the chip and the location of the first bounce
+     *
+     * @return A unique pointer to the Intent the ChipAction wants to run. If the
+     * ChipAction is done, returns an empty/null pointer
+     */
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot,
+                                                        Point chip_origin,
+                                                        Point chip_target,
+                                                        double chip_distance_meters);
+
+   private:
+    std::unique_ptr<Intent> calculateNextIntent(
+        intent_coroutine::push_type& yield) override;
+
+    // Action parameters
+    Point chip_origin;
+    Angle chip_direction;
+    double chip_distance_meters;
+    // How far behind the ball the region stretches within which we treat things
+    // as being "behind the ball"
+    const double length_of_region_behind_ball;
+};

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -6,9 +6,7 @@
 #include "geom/util.h"
 #include "shared/constants.h"
 
-KickAction::KickAction() : Action()
-{
-}
+KickAction::KickAction() : Action() {}
 
 std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(
     const Robot& robot, Point kick_origin, Point kick_target,
@@ -42,7 +40,7 @@ std::unique_ptr<Intent> KickAction::calculateNextIntent(
     // with something), but large enough we can reasonably get in the region and kick the
     // ball successfully.
     // This value is 'X' in the ASCII art below
-     double size_of_region_behind_ball = 6 * ROBOT_MAX_RADIUS_METERS;
+    double size_of_region_behind_ball = 6 * ROBOT_MAX_RADIUS_METERS;
 
     // ASCII art showing the region behind the ball
     // Diagram not to scale
@@ -84,10 +82,12 @@ std::unique_ptr<Intent> KickAction::calculateNextIntent(
         // inside it when taking the kick.
         Point behind_ball_vertex_A =
             kick_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT_METERS * 0.5);
-        Point behind_ball_vertex_B = behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) +
+        Point behind_ball_vertex_B =
+            behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) +
             behind_ball.perp().norm(size_of_region_behind_ball / 2);
-        Point behind_ball_vertex_C = behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) -
-                                     behind_ball.perp().norm(size_of_region_behind_ball / 2);
+        Point behind_ball_vertex_C =
+            behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) -
+            behind_ball.perp().norm(size_of_region_behind_ball / 2);
 
         Polygon behind_ball_region =
             Polygon({behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C});

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -1,0 +1,111 @@
+#include "ai/hl/stp/action/kick_action.h"
+
+#include "ai/intent/kick_intent.h"
+#include "ai/intent/move_intent.h"
+#include "geom/polygon.h"
+#include "geom/util.h"
+
+KickAction::KickAction(double length_of_region_behind_ball)
+    : Action(), length_of_region_behind_ball(length_of_region_behind_ball)
+{
+}
+
+std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(
+    const Robot& robot, Point kick_origin, Point kick_target,
+    double kick_speed_meters_per_second)
+{
+    return updateStateAndGetNextIntent(robot, kick_origin,
+                                       (kick_target - kick_origin).orientation(),
+                                       kick_speed_meters_per_second);
+}
+
+std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(
+    const Robot& robot, Point kick_origin, Angle kick_direction,
+    double kick_speed_meters_per_second)
+{
+    // Update the parameters stored by this Action
+    this->robot                        = robot;
+    this->kick_origin                  = kick_origin;
+    this->kick_direction               = kick_direction;
+    this->kick_speed_meters_per_second = kick_speed_meters_per_second;
+
+    return getNextIntent();
+}
+
+std::unique_ptr<Intent> KickAction::calculateNextIntent(
+    intent_coroutine::push_type& yield)
+{
+    // TODO: replace with real constant
+    double DIST_TO_FRONT_OF_ROBOT = 0.05;
+    // ASCII art showing the region behind the ball
+    //
+    //              X
+    //       v-------------v
+    //
+    //    >  \-------------/
+    //    |   \           /
+    //    |    \         /
+    //    |     \       /       <- Region considered "behind ball"
+    // 2X |      \     /
+    //    |       \   /
+    //    |        \ /
+    //    >         v
+    //
+    //
+    //
+    //              O
+    //             O O          <- Ball
+    //              O
+    //
+    //              |
+    //              V
+    //       direction of kick
+
+    do
+    {
+        // A vector in the direction opposite the kick (behind the ball)
+        Vector behind_ball =
+            Vector::createFromAngle(this->kick_direction + Angle::half());
+        // We make the closest point of the region close enough to the ball so that the
+        // robot will still be inside it when it's taking the kick.
+        // This point is the "top" of the Isosceles triangle
+        Point behind_ball_close =
+            kick_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5);
+        // These points form the "base" of the Isosceles triangle
+        Point behind_ball_far_1 =
+            kick_origin +
+            behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5 +
+                             length_of_region_behind_ball) +
+            behind_ball.perp().norm(length_of_region_behind_ball / 2);
+        Point behind_ball_far_2 =
+            kick_origin +
+            behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5 +
+                             length_of_region_behind_ball) -
+            behind_ball.perp().norm(length_of_region_behind_ball / 2);
+        // Forms an Isosceles triangle that represents the region behind the ball. This
+        // region is close enough to the ball that the robot will still be inside it
+        // even if the ball is in the robot's dribbler, since we don't want the robot
+        // to think it's no longer behind the ball right when it's going to take the kick
+        // The height of this triangle is equal to the specified length of the region
+        // behind the ball. The base of the triangle is also equal to this length.
+        Polygon behind_ball_region =
+            Polygon({behind_ball_close, behind_ball_far_1, behind_ball_far_2});
+
+        bool robot_behind_ball = behind_ball_region.containsPoint(robot->position());
+        // The point in the middle of the region behind the ball
+        Point point_behind_ball =
+            kick_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5 +
+                                           length_of_region_behind_ball / 2);
+
+        if (!robot_behind_ball)
+        {
+            yield(std::make_unique<MoveIntent>(robot->id(), point_behind_ball,
+                                               kick_direction, 0.0, 0));
+        }
+        else
+        {
+            yield(std::make_unique<KickIntent>(robot->id(), kick_origin, kick_direction,
+                                               kick_speed_meters_per_second, 0));
+        }
+    } while (true);
+}

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -4,9 +4,9 @@
 #include "ai/intent/move_intent.h"
 #include "geom/polygon.h"
 #include "geom/util.h"
+#include "shared/constants.h"
 
-KickAction::KickAction(double length_of_region_behind_ball)
-    : Action(), length_of_region_behind_ball(length_of_region_behind_ball)
+KickAction::KickAction() : Action()
 {
 }
 
@@ -35,68 +35,70 @@ std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(
 std::unique_ptr<Intent> KickAction::calculateNextIntent(
     intent_coroutine::push_type& yield)
 {
-    // TODO: replace with real constant
-    double DIST_TO_FRONT_OF_ROBOT = 0.05;
+    // How large the triangle is that defines the region where the robot is
+    // behind the ball and ready to kick.
+    // We want to keep the region small enough that we won't use the KickIntent from too
+    // far away (since the KickIntent doesn't avoid obstacles and we risk colliding
+    // with something), but large enough we can reasonably get in the region and kick the
+    // ball successfully.
+    // This value is 'X' in the ASCII art below
+     double size_of_region_behind_ball = 6 * ROBOT_MAX_RADIUS_METERS;
+
     // ASCII art showing the region behind the ball
+    // Diagram not to scale
     //
-    //              X
-    //       v-------------v
+    //                             X
+    //                      v-------------v
     //
-    //    >  \-------------/
-    //    |   \           /
-    //    |    \         /
-    //    |     \       /       <- Region considered "behind ball"
-    // 2X |      \     /
-    //    |       \   /
-    //    |        \ /
-    //    >         v
+    //                   >  B-------------C
+    //                   |   \           /
+    //                   |    \         /
+    //                   |     \       /       <- Region considered "behind ball"
+    //                 X |      \     /
+    //                   |       \   /
+    //                   |        \ /
+    //                   >         A       <
+    //                                     |
+    //                                     | DIST_TO_FRONT_OF_ROBOT / 2
+    //                                     |
+    //                             O       |
+    //             ball ->        O O      <
+    //                             O
     //
-    //
-    //
-    //              O
-    //             O O          <- Ball
-    //              O
-    //
-    //              |
-    //              V
-    //       direction of kick
+    //                             |
+    //                             V
+    //                     direction of kick
 
     do
     {
         // A vector in the direction opposite the kick (behind the ball)
         Vector behind_ball =
             Vector::createFromAngle(this->kick_direction + Angle::half());
-        // We make the closest point of the region close enough to the ball so that the
-        // robot will still be inside it when it's taking the kick.
-        // This point is the "top" of the Isosceles triangle
-        Point behind_ball_close =
-            kick_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5);
-        // These points form the "base" of the Isosceles triangle
-        Point behind_ball_far_1 =
-            kick_origin +
-            behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5 +
-                             length_of_region_behind_ball) +
-            behind_ball.perp().norm(length_of_region_behind_ball / 2);
-        Point behind_ball_far_2 =
-            kick_origin +
-            behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5 +
-                             length_of_region_behind_ball) -
-            behind_ball.perp().norm(length_of_region_behind_ball / 2);
-        // Forms an Isosceles triangle that represents the region behind the ball. This
-        // region is close enough to the ball that the robot will still be inside it
-        // even if the ball is in the robot's dribbler, since we don't want the robot
-        // to think it's no longer behind the ball right when it's going to take the kick
-        // The height of this triangle is equal to the specified length of the region
-        // behind the ball. The base of the triangle is also equal to this length.
+
+
+        // The points below make up the triangle that defines the region we treat as
+        // "behind the ball". They correspond to the vertices labeled 'A', 'B', and 'C'
+        // in the ASCII diagram
+
+        // We make the region close enough to the ball so that the robot will still be
+        // inside it when taking the kick.
+        Point behind_ball_vertex_A =
+            kick_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT_METERS * 0.5);
+        Point behind_ball_vertex_B = behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) +
+            behind_ball.perp().norm(size_of_region_behind_ball / 2);
+        Point behind_ball_vertex_C = behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) -
+                                     behind_ball.perp().norm(size_of_region_behind_ball / 2);
+
         Polygon behind_ball_region =
-            Polygon({behind_ball_close, behind_ball_far_1, behind_ball_far_2});
+            Polygon({behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C});
 
         bool robot_behind_ball = behind_ball_region.containsPoint(robot->position());
         // The point in the middle of the region behind the ball
         Point point_behind_ball =
-            kick_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT * 0.5 +
-                                           length_of_region_behind_ball / 2);
+            kick_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT_METERS * 0.5 +
+                                           size_of_region_behind_ball / 2);
 
+        // If we're not in position to kick, move into position
         if (!robot_behind_ball)
         {
             yield(std::make_unique<MoveIntent>(robot->id(), point_behind_ball,

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -3,10 +3,9 @@
 #include "ai/hl/stp/action/action.h"
 #include "geom/angle.h"
 #include "geom/point.h"
-#include "shared/constants.h"
 
 /**
- * The KickAction makes the robot take a kick at the given location in the given
+ * The KickAction makes the robot take a kick from the given location in the given
  * direction, with the given power
  */
 class KickAction : public Action
@@ -14,15 +13,8 @@ class KickAction : public Action
    public:
     /**
      * Creates a new KickAction
-     *
-     * @param length_of_region_behind_ball The distance behind the ball the robot must be
-     * before it can kick. The default value is 3 robot diameters. We want to keep the
-     * region small enough that we won't use the KickIntent from too far away (since we
-     * risk colliding with something since the KickIntent doesn't avoid obstacles), but
-     * large enough we can reasonable get in the region and kick the ball successfully.
      */
-    explicit KickAction(double length_of_region_behind_ball = 6 *
-                                                              ROBOT_MAX_RADIUS_METERS);
+    explicit KickAction();
 
     /**
      * Returns the next Intent this KickAction wants to run, given the parameters.
@@ -64,7 +56,4 @@ class KickAction : public Action
     Point kick_origin;
     Angle kick_direction;
     double kick_speed_meters_per_second;
-    // How far behind the ball the region stretches within which we treat things
-    // as being "behind the ball"
-    const double length_of_region_behind_ball;
 };

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "ai/hl/stp/action/action.h"
+#include "geom/angle.h"
+#include "geom/point.h"
+#include "shared/constants.h"
+
+/**
+ * The KickAction makes the robot take a kick at the given location in the given
+ * direction, with the given power
+ */
+class KickAction : public Action
+{
+   public:
+    /**
+     * Creates a new KickAction
+     *
+     * @param length_of_region_behind_ball The distance behind the ball the robot must be
+     * before it can kick. The default value is 3 robot diameters. We want to keep the
+     * region small enough that we won't use the KickIntent from too far away (since we
+     * risk colliding with something since the KickIntent doesn't avoid obstacles), but
+     * large enough we can reasonable get in the region and kick the ball successfully.
+     */
+    explicit KickAction(double length_of_region_behind_ball = 6 *
+                                                              ROBOT_MAX_RADIUS_METERS);
+
+    /**
+     * Returns the next Intent this KickAction wants to run, given the parameters.
+     *
+     * @param robot The robot that should perform the kick
+     * @param kick_origin The location where the kick will be taken
+     * @param kick_direction The direction the Robot will kick in
+     * @param kick_speed_meters_per_second The speed of how fast the Robot
+     * will kick the ball in meters per second
+     *
+     * @return A unique pointer to the Intent the KickAction wants to run. If the
+     * KickAction is done, returns an empty/null pointer
+     */
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(
+        const Robot& robot, Point kick_origin, Angle kick_direction,
+        double kick_speed_meters_per_second);
+
+    /**
+     * Returns the next Intent this KickAction wants to run, given the parameters.
+     *
+     * @param robot The robot that should perform the kick
+     * @param kick_origin The location where the kick will be taken
+     * @param kick_target The target to kick at
+     * @param kick_speed_meters_per_second The speed of how fast the Robot
+     * will kick the ball in meters per second
+     *
+     * @return A unique pointer to the Intent the KickAction wants to run. If the
+     * KickAction is done, returns an empty/null pointer
+     */
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(
+        const Robot& robot, Point kick_origin, Point kick_target,
+        double kick_speed_meters_per_second);
+
+   private:
+    std::unique_ptr<Intent> calculateNextIntent(
+        intent_coroutine::push_type& yield) override;
+
+    // Action parameters
+    Point kick_origin;
+    Angle kick_direction;
+    double kick_speed_meters_per_second;
+    // How far behind the ball the region stretches within which we treat things
+    // as being "behind the ball"
+    const double length_of_region_behind_ball;
+};

--- a/src/thunderbots/software/grsim_communication/main.cpp
+++ b/src/thunderbots/software/grsim_communication/main.cpp
@@ -41,10 +41,6 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
 {
     thunderbots_msgs::World world_msg = *msg;
     world = Util::ROSMessages::createWorldFromROSMessage(world_msg);
-
-    std::vector<std::unique_ptr<Primitive>> primitives;
-    primitives.emplace_back(new ChipPrimitive(0, Point(0, 0), Angle::zero(), 1));
-    grsim_backend.sendPrimitives(primitives, world.friendlyTeam(), world.ball());
 }
 
 int main(int argc, char** argv)

--- a/src/thunderbots/software/test/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/chip_action.cpp
@@ -8,11 +8,11 @@
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-0.5, 0), Vector(), Angle::zero(),
-                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
     auto intent_ptr =
-            action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -28,7 +28,7 @@ TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_positive_y)
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-2.3, 2.1), Vector(), Angle::quarter(),
-                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
@@ -48,7 +48,7 @@ TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_positive_y)
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_negative_y)
 {
     Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
-                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-0.1, -0.4),
@@ -68,7 +68,7 @@ TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_negative_y)
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_negative_y)
 {
     Robot robot       = Robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
-                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
@@ -88,11 +88,11 @@ TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_negative_y)
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-1, 0.0), Vector(), Angle::zero(),
-                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
     auto intent_ptr =
-            action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -109,7 +109,7 @@ TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_positive_
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-2, 5), Vector(), Angle::quarter(),
-                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
@@ -130,7 +130,7 @@ TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_positive_
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_negative_y)
 {
     Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
-                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-1, -4),
@@ -151,7 +151,7 @@ TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_negative_
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_negative_y)
 {
     Robot robot       = Robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
-                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),

--- a/src/thunderbots/software/test/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/chip_action.cpp
@@ -5,7 +5,7 @@
 #include "ai/intent/chip_intent.h"
 #include "ai/intent/move_intent.h"
 
-TEST(ChipActionTest, robot_behind_ball_chiping_towards_positive_x_positive_y)
+TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-0.5, 0), Vector(), Angle::zero(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
@@ -25,7 +25,7 @@ TEST(ChipActionTest, robot_behind_ball_chiping_towards_positive_x_positive_y)
     EXPECT_EQ(5.0, chip_intent.getChipDistance());
 }
 
-TEST(ChipActionTest, robot_behind_ball_chiping_towards_negative_x_positive_y)
+TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-2, 1.5), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
@@ -45,7 +45,7 @@ TEST(ChipActionTest, robot_behind_ball_chiping_towards_negative_x_positive_y)
     EXPECT_EQ(5.0, chip_intent.getChipDistance());
 }
 
-TEST(ChipActionTest, robot_behind_ball_chiping_towards_negative_x_negative_y)
+TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_negative_y)
 {
     Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
@@ -65,7 +65,7 @@ TEST(ChipActionTest, robot_behind_ball_chiping_towards_negative_x_negative_y)
     EXPECT_EQ(3.0, chip_intent.getChipDistance());
 }
 
-TEST(ChipActionTest, robot_behind_ball_chiping_towards_positive_x_negative_y)
+TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_negative_y)
 {
     Robot robot       = Robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
@@ -85,7 +85,7 @@ TEST(ChipActionTest, robot_behind_ball_chiping_towards_positive_x_negative_y)
     EXPECT_EQ(5.0, chip_intent.getChipDistance());
 }
 
-TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_positive_x_positive_y)
+TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-1, 0.0), Vector(), Angle::zero(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
@@ -106,7 +106,7 @@ TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_positive_x_positive_y
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
 
-TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_negative_x_positive_y)
+TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-2, 5), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
@@ -127,7 +127,7 @@ TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_negative_x_positive_y
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
 
-TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_negative_x_negative_y)
+TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_negative_y)
 {
     Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
@@ -148,7 +148,7 @@ TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_negative_x_negative_y
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
 
-TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_positive_x_negative_y)
+TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_negative_y)
 {
     Robot robot       = Robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));

--- a/src/thunderbots/software/test/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/chip_action.cpp
@@ -1,0 +1,170 @@
+#include "ai/hl/stp/action/chip_action.h"
+
+#include <gtest/gtest.h>
+
+#include "ai/intent/chip_intent.h"
+#include "ai/intent/move_intent.h"
+
+TEST(ChipActionTest, robot_behind_ball_chiping_towards_positive_x_positive_y)
+{
+    Robot robot       = Robot(0, Point(-0.5, 0), Vector(), Angle::zero(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction(1);
+
+    auto intent_ptr =
+        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    ChipIntent chip_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
+    EXPECT_EQ(0, chip_intent.getRobotId());
+    EXPECT_EQ(Point(0, 0), chip_intent.getChipOrigin());
+    EXPECT_EQ(Angle::zero(), chip_intent.getChipDirection());
+    EXPECT_EQ(5.0, chip_intent.getChipDistance());
+}
+
+TEST(ChipActionTest, robot_behind_ball_chiping_towards_negative_x_positive_y)
+{
+    Robot robot       = Robot(0, Point(-2, 1.5), Vector(), Angle::quarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction(1);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
+                                                         Angle::ofDegrees(105), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    ChipIntent chip_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
+    EXPECT_EQ(0, chip_intent.getRobotId());
+    EXPECT_EQ(Point(-2.5, 2.5), chip_intent.getChipOrigin());
+    EXPECT_EQ(Angle::ofDegrees(105), chip_intent.getChipDirection());
+    EXPECT_EQ(5.0, chip_intent.getChipDistance());
+}
+
+TEST(ChipActionTest, robot_behind_ball_chiping_towards_negative_x_negative_y)
+{
+    Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction(0.5);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-0.1, -0.4),
+                                                         Angle::ofDegrees(255), 3.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    ChipIntent chip_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
+    EXPECT_EQ(0, chip_intent.getRobotId());
+    EXPECT_EQ(Point(-0.1, -0.4), chip_intent.getChipOrigin());
+    EXPECT_EQ(Angle::ofDegrees(255), chip_intent.getChipDirection());
+    EXPECT_EQ(3.0, chip_intent.getChipDistance());
+}
+
+TEST(ChipActionTest, robot_behind_ball_chiping_towards_positive_x_negative_y)
+{
+    Robot robot       = Robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction(2);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
+                                                         Angle::ofDegrees(306), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    ChipIntent chip_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
+    EXPECT_EQ(0, chip_intent.getRobotId());
+    EXPECT_EQ(Point(0, 0), chip_intent.getChipOrigin());
+    EXPECT_EQ(Angle::ofDegrees(306), chip_intent.getChipDirection());
+    EXPECT_EQ(5.0, chip_intent.getChipDistance());
+}
+
+TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_positive_x_positive_y)
+{
+    Robot robot       = Robot(0, Point(-1, 0.0), Vector(), Angle::zero(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction(0.3);
+
+    auto intent_ptr =
+        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    // Check the MoveIntent is moving roughly behind the ball
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0), 0.1));
+    EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
+    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}
+
+TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_negative_x_positive_y)
+{
+    Robot robot       = Robot(0, Point(-2, 5), Vector(), Angle::quarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction(0.3);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
+                                                         Angle::ofDegrees(105), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    // Check the MoveIntent is moving roughly behind the ball
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-2.45, 2.35), 0.1));
+    EXPECT_EQ(Angle::ofDegrees(105), move_intent.getFinalAngle());
+    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}
+
+TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_negative_x_negative_y)
+{
+    Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction(0.3);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-1, -4),
+                                                         Angle::ofDegrees(255), 3.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    // Check the MoveIntent is moving roughly behind the ball
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.92, -3.85), 0.1));
+    EXPECT_EQ(Angle::ofDegrees(255), move_intent.getFinalAngle());
+    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}
+
+TEST(ChipActionTest, robot_not_behind_ball_chiping_towards_positive_x_negative_y)
+{
+    Robot robot       = Robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction(0.3);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
+                                                         Angle::ofDegrees(306), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    // Check the MoveIntent is moving roughly behind the ball
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.05, 0.1), 0.1));
+    EXPECT_EQ(Angle::ofDegrees(306), move_intent.getFinalAngle());
+    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}

--- a/src/thunderbots/software/test/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/chip_action.cpp
@@ -8,11 +8,11 @@
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-0.5, 0), Vector(), Angle::zero(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    ChipAction action = ChipAction(1);
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction();
 
     auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+            action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -27,9 +27,9 @@ TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_positive_y)
 
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_positive_y)
 {
-    Robot robot       = Robot(0, Point(-2, 1.5), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    ChipAction action = ChipAction(1);
+    Robot robot       = Robot(0, Point(-2.3, 2.1), Vector(), Angle::quarter(),
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
                                                          Angle::ofDegrees(105), 5.0);
@@ -48,8 +48,8 @@ TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_positive_y)
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_negative_y)
 {
     Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    ChipAction action = ChipAction(0.5);
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-0.1, -0.4),
                                                          Angle::ofDegrees(255), 3.0);
@@ -68,8 +68,8 @@ TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_negative_y)
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_negative_y)
 {
     Robot robot       = Robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    ChipAction action = ChipAction(2);
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
                                                          Angle::ofDegrees(306), 5.0);
@@ -88,11 +88,11 @@ TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_negative_y)
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-1, 0.0), Vector(), Angle::zero(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    ChipAction action = ChipAction(0.3);
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction();
 
     auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+            action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -101,7 +101,7 @@ TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_positive_
     MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
     EXPECT_EQ(0, move_intent.getRobotId());
     // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0), 0.1));
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.28, 0), 0.1));
     EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
@@ -109,8 +109,8 @@ TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_positive_
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-2, 5), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    ChipAction action = ChipAction(0.3);
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
                                                          Angle::ofDegrees(105), 5.0);
@@ -122,7 +122,7 @@ TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_positive_
     MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
     EXPECT_EQ(0, move_intent.getRobotId());
     // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-2.45, 2.35), 0.1));
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-2.45, 2.25), 0.1));
     EXPECT_EQ(Angle::ofDegrees(105), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
@@ -130,8 +130,8 @@ TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_positive_
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_negative_y)
 {
     Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    ChipAction action = ChipAction(0.3);
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-1, -4),
                                                          Angle::ofDegrees(255), 3.0);
@@ -143,7 +143,7 @@ TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_negative_
     MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
     EXPECT_EQ(0, move_intent.getRobotId());
     // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.92, -3.85), 0.1));
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.85, -3.75), 0.1));
     EXPECT_EQ(Angle::ofDegrees(255), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
@@ -151,8 +151,8 @@ TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_negative_
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_negative_y)
 {
     Robot robot       = Robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    ChipAction action = ChipAction(0.3);
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    ChipAction action = ChipAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
                                                          Angle::ofDegrees(306), 5.0);
@@ -164,7 +164,7 @@ TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_negative_
     MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
     EXPECT_EQ(0, move_intent.getRobotId());
     // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.05, 0.1), 0.1));
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0.25), 0.1));
     EXPECT_EQ(Angle::ofDegrees(306), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }

--- a/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
@@ -9,7 +9,7 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
 {
     Robot robot       = Robot(0, Point(-0.5, 0), Vector(), Angle::zero(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    KickAction action = KickAction(1);
+    KickAction action = KickAction();
 
     auto intent_ptr =
         action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
@@ -27,9 +27,9 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_positive_y)
 {
-    Robot robot       = Robot(0, Point(-2, 1.5), Vector(), Angle::quarter(),
+    Robot robot       = Robot(0, Point(-2.3, 2.1), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    KickAction action = KickAction(1);
+    KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
                                                          Angle::ofDegrees(105), 5.0);
@@ -49,7 +49,7 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_negative_y)
 {
     Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    KickAction action = KickAction(0.5);
+    KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-0.1, -0.4),
                                                          Angle::ofDegrees(255), 3.0);
@@ -69,7 +69,7 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_negative_y)
 {
     Robot robot       = Robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    KickAction action = KickAction(2);
+    KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
                                                          Angle::ofDegrees(306), 5.0);
@@ -89,7 +89,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y
 {
     Robot robot       = Robot(0, Point(-1, 0.0), Vector(), Angle::zero(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    KickAction action = KickAction(0.3);
+    KickAction action = KickAction();
 
     auto intent_ptr =
         action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
@@ -101,7 +101,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y
     MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
     EXPECT_EQ(0, move_intent.getRobotId());
     // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0), 0.1));
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.28, 0), 0.1));
     EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
@@ -110,7 +110,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y
 {
     Robot robot       = Robot(0, Point(-2, 5), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    KickAction action = KickAction(0.3);
+    KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
                                                          Angle::ofDegrees(105), 5.0);
@@ -122,7 +122,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y
     MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
     EXPECT_EQ(0, move_intent.getRobotId());
     // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-2.45, 2.35), 0.1));
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-2.45, 2.25), 0.1));
     EXPECT_EQ(Angle::ofDegrees(105), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
@@ -131,7 +131,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y
 {
     Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    KickAction action = KickAction(0.3);
+    KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-1, -4),
                                                          Angle::ofDegrees(255), 3.0);
@@ -143,7 +143,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y
     MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
     EXPECT_EQ(0, move_intent.getRobotId());
     // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.92, -3.85), 0.1));
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.85, -3.75), 0.1));
     EXPECT_EQ(Angle::ofDegrees(255), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
@@ -152,7 +152,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y
 {
     Robot robot       = Robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    KickAction action = KickAction(0.3);
+    KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
                                                          Angle::ofDegrees(306), 5.0);
@@ -164,7 +164,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y
     MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
     EXPECT_EQ(0, move_intent.getRobotId());
     // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.05, 0.1), 0.1));
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0.25), 0.1));
     EXPECT_EQ(Angle::ofDegrees(306), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }

--- a/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
@@ -1,0 +1,170 @@
+#include "ai/hl/stp/action/kick_action.h"
+
+#include <gtest/gtest.h>
+
+#include "ai/intent/kick_intent.h"
+#include "ai/intent/move_intent.h"
+
+TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
+{
+    Robot robot       = Robot(0, Point(-0.5, 0), Vector(), Angle::zero(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    KickAction action = KickAction(1);
+
+    auto intent_ptr =
+        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
+    EXPECT_EQ(0, kick_intent.getRobotId());
+    EXPECT_EQ(Point(0, 0), kick_intent.getKickOrigin());
+    EXPECT_EQ(Angle::zero(), kick_intent.getKickDirection());
+    EXPECT_EQ(5.0, kick_intent.getKickSpeed());
+}
+
+TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_positive_y)
+{
+    Robot robot       = Robot(0, Point(-2, 1.5), Vector(), Angle::quarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    KickAction action = KickAction(1);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
+                                                         Angle::ofDegrees(105), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
+    EXPECT_EQ(0, kick_intent.getRobotId());
+    EXPECT_EQ(Point(-2.5, 2.5), kick_intent.getKickOrigin());
+    EXPECT_EQ(Angle::ofDegrees(105), kick_intent.getKickDirection());
+    EXPECT_EQ(5.0, kick_intent.getKickSpeed());
+}
+
+TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_negative_y)
+{
+    Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    KickAction action = KickAction(0.5);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-0.1, -0.4),
+                                                         Angle::ofDegrees(255), 3.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
+    EXPECT_EQ(0, kick_intent.getRobotId());
+    EXPECT_EQ(Point(-0.1, -0.4), kick_intent.getKickOrigin());
+    EXPECT_EQ(Angle::ofDegrees(255), kick_intent.getKickDirection());
+    EXPECT_EQ(3.0, kick_intent.getKickSpeed());
+}
+
+TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_negative_y)
+{
+    Robot robot       = Robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    KickAction action = KickAction(2);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
+                                                         Angle::ofDegrees(306), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
+    EXPECT_EQ(0, kick_intent.getRobotId());
+    EXPECT_EQ(Point(0, 0), kick_intent.getKickOrigin());
+    EXPECT_EQ(Angle::ofDegrees(306), kick_intent.getKickDirection());
+    EXPECT_EQ(5.0, kick_intent.getKickSpeed());
+}
+
+TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y)
+{
+    Robot robot       = Robot(0, Point(-1, 0.0), Vector(), Angle::zero(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    KickAction action = KickAction(0.3);
+
+    auto intent_ptr =
+        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    // Check the MoveIntent is moving roughly behind the ball
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0), 0.1));
+    EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
+    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}
+
+TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y)
+{
+    Robot robot       = Robot(0, Point(-2, 5), Vector(), Angle::quarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    KickAction action = KickAction(0.3);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
+                                                         Angle::ofDegrees(105), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    // Check the MoveIntent is moving roughly behind the ball
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-2.45, 2.35), 0.1));
+    EXPECT_EQ(Angle::ofDegrees(105), move_intent.getFinalAngle());
+    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}
+
+TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y)
+{
+    Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    KickAction action = KickAction(0.3);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-1, -4),
+                                                         Angle::ofDegrees(255), 3.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    // Check the MoveIntent is moving roughly behind the ball
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.92, -3.85), 0.1));
+    EXPECT_EQ(Angle::ofDegrees(255), move_intent.getFinalAngle());
+    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}
+
+TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y)
+{
+    Robot robot       = Robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    KickAction action = KickAction(0.3);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
+                                                         Angle::ofDegrees(306), 5.0);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    // Check the MoveIntent is moving roughly behind the ball
+    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.05, 0.1), 0.1));
+    EXPECT_EQ(Angle::ofDegrees(306), move_intent.getFinalAngle());
+    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Implemented the Kick and Chip Actions. I put them in the same PR since the are basically the same, so it made sense to keep them together.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests added.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #425, resolves #426 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
Both Actions have more tests than average (since there's more cases), and doing both together put it a bit over 500 lines. 

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
