### PR TITLE
Implement BlockShotPathTactic

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -593,6 +593,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/hl/stp/action/action.cpp
             ai/hl/stp/action/move_action.cpp
             ai/hl/stp/tactic/move_tactic.cpp
+            ai/hl/stp/tactic/block_shot_path_tactic.cpp
             ai/hl/stp/tactic/tactic.cpp
             ai/intent/intent.cpp
             ai/intent/move_intent.cpp
@@ -606,9 +607,11 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/world.cpp
             test/ai/hl/stp/tactic/main.cpp
             test/ai/hl/stp/tactic/move_tactic.cpp
+            test/ai/hl/stp/tactic/block_shot_path_tactic.cpp
             test/ai/hl/stp/tactic/tactic.cpp
             test/ai/hl/stp/test_tactics/move_test_tactic.cpp
             test/test_util/test_util.cpp
+            geom/util.cpp
             util/logger/custom_g3log_sinks.h
             util/logger/init.h
             util/parameter/dynamic_parameters.cpp

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
@@ -1,0 +1,55 @@
+#include "ai/hl/stp/tactic/block_shot_path_tactic.h"
+#include "geom/util.h"
+#include "shared/constants.h"
+#include "util/logger/init.h"
+
+BlockShotPathTactic::BlockShotPathTactic(bool loop_forever) : Tactic(loop_forever) {}
+
+std::string BlockShotPathTactic::getName() const
+{
+    return "Block Shot Path Tactic";
+}
+
+void BlockShotPathTactic::updateParams(const Robot& enemy_robot, const Field& field) {
+    updateParams(enemy_robot.position(), field);
+}
+
+void BlockShotPathTactic::updateParams(const Point& shot_origin, const Field& field) {
+    // Update the parameters stored by this Tactic
+    this->shot_origin = shot_origin;
+    this->field = field;
+}
+
+double BlockShotPathTactic::calculateRobotCost(const Robot &robot, const World &world)
+{
+    // Prefer robots closer to the block position
+    // We normalize with the total field length so that robots that are within the field
+    // have a cost less than 1
+    Point block_position = getBlockPosition();
+    double cost = (robot.position() - block_position).len() / world.field().totalLength();
+    return std::clamp<double>(cost, 0, 1);
+}
+
+Point BlockShotPathTactic::getBlockPosition() {
+    if(!this->field) {
+        LOG(WARNING) << "The Field for the " << getName() << " was not initialized" << std::endl;
+        return this->robot->position();
+    }
+
+    Point block_position = calcBlockCone(this->field->friendlyGoalpostPos(), this->field->friendlyGoalpostNeg(), this->shot_origin, ROBOT_MAX_RADIUS_METERS);
+    return block_position;
+}
+
+std::unique_ptr<Intent> BlockShotPathTactic::calculateNextIntent(
+    intent_coroutine::push_type &yield)
+{
+    MoveAction move_action = MoveAction();
+    do
+    {
+        Point block_position = getBlockPosition();
+        // We want to face the shot
+        Angle block_orientation = (this->shot_origin - block_position).orientation();
+        yield(move_action.updateStateAndGetNextIntent(*robot, block_position,
+                                                      block_orientation, 0.0));
+    } while (!move_action.done());
+}

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
@@ -14,16 +14,15 @@ std::string BlockShotPathTactic::getName() const
     return "Block Shot Path Tactic";
 }
 
-void BlockShotPathTactic::updateParams(const Robot& enemy_robot, const Field& field)
+void BlockShotPathTactic::updateParams(const Robot& enemy_robot)
 {
-    updateParams(enemy_robot.position(), field);
+    updateParams(enemy_robot.position());
 }
 
-void BlockShotPathTactic::updateParams(const Point& shot_origin, const Field& field)
+void BlockShotPathTactic::updateParams(const Point& shot_origin)
 {
     // Update the parameters stored by this Tactic
     this->shot_origin = shot_origin;
-    this->field       = field;
 }
 
 double BlockShotPathTactic::calculateRobotCost(const Robot& robot, const World& world)

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
@@ -1,4 +1,5 @@
 #include "ai/hl/stp/tactic/block_shot_path_tactic.h"
+
 #include "geom/util.h"
 #include "shared/constants.h"
 #include "util/logger/init.h"
@@ -10,17 +11,19 @@ std::string BlockShotPathTactic::getName() const
     return "Block Shot Path Tactic";
 }
 
-void BlockShotPathTactic::updateParams(const Robot& enemy_robot, const Field& field) {
+void BlockShotPathTactic::updateParams(const Robot& enemy_robot, const Field& field)
+{
     updateParams(enemy_robot.position(), field);
 }
 
-void BlockShotPathTactic::updateParams(const Point& shot_origin, const Field& field) {
+void BlockShotPathTactic::updateParams(const Point& shot_origin, const Field& field)
+{
     // Update the parameters stored by this Tactic
     this->shot_origin = shot_origin;
-    this->field = field;
+    this->field       = field;
 }
 
-double BlockShotPathTactic::calculateRobotCost(const Robot &robot, const World &world)
+double BlockShotPathTactic::calculateRobotCost(const Robot& robot, const World& world)
 {
     // Prefer robots closer to the block position
     // We normalize with the total field length so that robots that are within the field
@@ -30,18 +33,23 @@ double BlockShotPathTactic::calculateRobotCost(const Robot &robot, const World &
     return std::clamp<double>(cost, 0, 1);
 }
 
-Point BlockShotPathTactic::getBlockPosition() {
-    if(!this->field) {
-        LOG(WARNING) << "The Field for the " << getName() << " was not initialized" << std::endl;
+Point BlockShotPathTactic::getBlockPosition()
+{
+    if (!this->field)
+    {
+        LOG(WARNING) << "The Field for the " << getName() << " was not initialized"
+                     << std::endl;
         return this->robot->position();
     }
 
-    Point block_position = calcBlockCone(this->field->friendlyGoalpostPos(), this->field->friendlyGoalpostNeg(), this->shot_origin, ROBOT_MAX_RADIUS_METERS);
+    Point block_position = calcBlockCone(this->field->friendlyGoalpostPos(),
+                                         this->field->friendlyGoalpostNeg(),
+                                         this->shot_origin, ROBOT_MAX_RADIUS_METERS);
     return block_position;
 }
 
 std::unique_ptr<Intent> BlockShotPathTactic::calculateNextIntent(
-    intent_coroutine::push_type &yield)
+    intent_coroutine::push_type& yield)
 {
     MoveAction move_action = MoveAction();
     do

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
@@ -4,7 +4,10 @@
 #include "shared/constants.h"
 #include "util/logger/init.h"
 
-BlockShotPathTactic::BlockShotPathTactic(bool loop_forever) : Tactic(loop_forever) {}
+BlockShotPathTactic::BlockShotPathTactic(const Field& field, bool loop_forever)
+    : field(field), Tactic(loop_forever)
+{
+}
 
 std::string BlockShotPathTactic::getName() const
 {
@@ -35,15 +38,8 @@ double BlockShotPathTactic::calculateRobotCost(const Robot& robot, const World& 
 
 Point BlockShotPathTactic::getBlockPosition()
 {
-    if (!this->field)
-    {
-        LOG(WARNING) << "The Field for the " << getName() << " was not initialized"
-                     << std::endl;
-        return this->robot->position();
-    }
-
-    Point block_position = calcBlockCone(this->field->friendlyGoalpostPos(),
-                                         this->field->friendlyGoalpostNeg(),
+    Point block_position = calcBlockCone(this->field.friendlyGoalpostPos(),
+                                         this->field.friendlyGoalpostNeg(),
                                          this->shot_origin, ROBOT_MAX_RADIUS_METERS);
     return block_position;
 }

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.h
@@ -25,17 +25,15 @@ class BlockShotPathTactic : public Tactic
      * Updates the parameters for this BlockShotPathTactic.
      *
      * @param enemy_robot The enemy robot to block from shooting on the friendly net
-     * @param field the Field we are playing on
      */
-    void updateParams(const Robot& enemy_robot, const Field& field);
+    void updateParams(const Robot& enemy_robot);
 
     /**
      * Updates the parameters for this BlockShotPathTactic.
      *
      * @param shot_origin The origin of the shot to block
-     * @param field the Field we are playing on
      */
-    void updateParams(const Point& shot_origin, const Field& field);
+    void updateParams(const Point& shot_origin);
 
     /**
      * Calculates the cost of assigning the given robot to this Tactic. Prefers robots

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.h
@@ -13,10 +13,11 @@ class BlockShotPathTactic : public Tactic
     /**
      * Creates a new BlockShotPathTactic
      *
+     * @param field the Field we are playing on
      * @param loop_forever Whether or not this Tactic should never complete. If true, the
      * tactic will be restarted every time it completes
      */
-    explicit BlockShotPathTactic(bool loop_forever = false);
+    explicit BlockShotPathTactic(const Field& field, bool loop_forever = false);
 
     std::string getName() const override;
 
@@ -61,5 +62,5 @@ class BlockShotPathTactic : public Tactic
     // The point the shot to block will be starting from
     Point shot_origin;
     // The field we are playing on
-    std::optional<Field> field;
+    Field field;
 };

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "ai/hl/stp/action/move_action.h"
+#include "ai/hl/stp/tactic/tactic.h"
+
+/**
+ * The BlockShotPathTactic will move the robot to block the entire friendly net from
+ * the shot
+ */
+class BlockShotPathTactic : public Tactic
+{
+   public:
+    /**
+     * Creates a new BlockShotPathTactic
+     *
+     * @param loop_forever Whether or not this Tactic should never complete. If true, the
+     * tactic will be restarted every time it completes
+     */
+    explicit BlockShotPathTactic(bool loop_forever = false);
+
+    std::string getName() const override;
+
+    /**
+     * Updates the parameters for this BlockShotPathTactic.
+     *
+     * @param enemy_robot The enemy robot to block from shooting on the friendly net
+     * @param field the Field we are playing on
+     */
+    void updateParams(const Robot& enemy_robot, const Field& field);
+
+    /**
+     * Updates the parameters for this BlockShotPathTactic.
+     *
+     * @param shot_origin The origin of the shot to block
+     * @param field the Field we are playing on
+     */
+    void updateParams(const Point& shot_origin, const Field& field);
+
+    /**
+     * Calculates the cost of assigning the given robot to this Tactic. Prefers robots
+     * closer to the block destination
+     *
+     * @param robot The robot to evaluate the cost for
+     * @param world The state of the world with which to perform the evaluation
+     * @return A cost in the range [0,1] indicating the cost of assigning the given robot
+     * to this tactic. Lower cost values indicate a more preferred robot.
+     */
+    double calculateRobotCost(const Robot& robot, const World& world) override;
+
+   private:
+    std::unique_ptr<Intent> calculateNextIntent(
+        intent_coroutine::push_type& yield) override;
+
+    /**
+     * Calculates the location to move to in order to block the shot.
+     * @return the Point to move to in order to block the shot
+     */
+    Point getBlockPosition();
+
+    // Tactic parameters
+    // The point the shot to block will be starting from
+    Point shot_origin;
+    // The field we are playing on
+    std::optional<Field> field;
+};

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/block_shot_path_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/block_shot_path_tactic.cpp
@@ -17,7 +17,7 @@ TEST(BlockShotPathTacticTest, shot_starts_close_to_net)
     tactic.updateRobot(friendly_robot);
     // Shoot from 2m in front of the goal
     Point shot_origin = field.friendlyGoal() + Point(2, 0);
-    tactic.updateParams(shot_origin, field);
+    tactic.updateParams(shot_origin);
     auto intent_ptr = tactic.getNextIntent();
 
     // Check an intent was returned (the pointer is not null)
@@ -47,7 +47,7 @@ TEST(BlockShotPathTacticTest, shot_starts_far_from_the_net)
 
     BlockShotPathTactic tactic = BlockShotPathTactic(field);
     tactic.updateRobot(friendly_robot);
-    tactic.updateParams(enemy_robot, field);
+    tactic.updateParams(enemy_robot);
     auto intent_ptr = tactic.getNextIntent();
 
     // Check an intent was returned (the pointer is not null)
@@ -74,7 +74,7 @@ TEST(BlockShotPathTacticTest, test_calculate_robot_cost)
                         Timestamp::fromSeconds(0));
 
     BlockShotPathTactic tactic = BlockShotPathTactic(world.field());
-    tactic.updateParams(Point(), world.field());
+    tactic.updateParams(Point());
 
     // The robot is a little over 2 meters away from where we expect it to block, so the
     // cost should be relatively low

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/block_shot_path_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/block_shot_path_tactic.cpp
@@ -1,0 +1,78 @@
+#include "ai/hl/stp/tactic/block_shot_path_tactic.h"
+
+#include <gtest/gtest.h>
+
+#include "ai/intent/move_intent.h"
+#include "test/test_util/test_util.h"
+#include "geom/util.h"
+
+TEST(BlockShotPathTacticTest, shot_starts_close_to_net)
+{
+    Field field = ::Test::TestUtil::createSSLDivBField();
+
+    Robot friendly_robot = Robot(0, Point(1, 0.5), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+
+    BlockShotPathTactic tactic = BlockShotPathTactic();
+    tactic.updateRobot(friendly_robot);
+    // Shoot from 2m in front of the goal
+    Point shot_origin = field.friendlyGoal() + Point(2, 0);
+    tactic.updateParams(shot_origin, field);
+    auto intent_ptr = tactic.getNextIntent();
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    // Check the robot is moving somewhere on the line segment between the shot origin
+    // and the goal
+    EXPECT_LE(dist(Segment(shot_origin, field.friendlyGoal()), move_intent.getDestination()), 0.1);
+    // Make sure the robot is facing the shot
+    EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
+    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}
+
+TEST(BlockShotPathTacticTest, shot_starts_far_from_the_net)
+{
+    Field field = ::Test::TestUtil::createSSLDivBField();
+
+    Robot friendly_robot = Robot(0, Point(1, 0.5), Vector(), Angle::zero(), AngularVelocity::zero(),
+                                 Timestamp::fromSeconds(0));
+
+    BlockShotPathTactic tactic = BlockShotPathTactic();
+    tactic.updateRobot(friendly_robot);
+    // Shoot from the enemy corner
+    Point shot_origin = field.enemyCornerNeg();
+    tactic.updateParams(shot_origin, field);
+    auto intent_ptr = tactic.getNextIntent();
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    // Check the robot is moving somewhere on the line segment between the shot origin
+    // and the goal
+    EXPECT_LE(dist(Segment(shot_origin, field.friendlyGoal()), move_intent.getDestination()), 0.1);
+    // Make sure the robot is facing the shot
+    EXPECT_NEAR((shot_origin - field.friendlyGoal()).orientation().toRadians(), move_intent.getFinalAngle().toRadians(), 0.001);
+    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}
+
+TEST(BlockShotPathTacticTest, test_calculate_robot_cost)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+
+    Robot robot = Robot(0, Point(1, 1), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+
+    BlockShotPathTactic tactic = BlockShotPathTactic();
+    tactic.updateParams(Point(), world.field());
+
+    // The robot is a little over 2 meters away from where we expect it to block, so the
+    // cost should be relatively low
+    double cost = tactic.calculateRobotCost(robot, world);
+
+    EXPECT_NEAR(0.2, cost, 0.1);
+}

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/block_shot_path_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/block_shot_path_tactic.cpp
@@ -3,15 +3,15 @@
 #include <gtest/gtest.h>
 
 #include "ai/intent/move_intent.h"
-#include "test/test_util/test_util.h"
 #include "geom/util.h"
+#include "test/test_util/test_util.h"
 
 TEST(BlockShotPathTacticTest, shot_starts_close_to_net)
 {
     Field field = ::Test::TestUtil::createSSLDivBField();
 
-    Robot friendly_robot = Robot(0, Point(1, 0.5), Vector(), Angle::zero(), AngularVelocity::zero(),
-                        Timestamp::fromSeconds(0));
+    Robot friendly_robot = Robot(0, Point(1, 0.5), Vector(), Angle::zero(),
+                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
     BlockShotPathTactic tactic = BlockShotPathTactic();
     tactic.updateRobot(friendly_robot);
@@ -27,7 +27,9 @@ TEST(BlockShotPathTacticTest, shot_starts_close_to_net)
     EXPECT_EQ(0, move_intent.getRobotId());
     // Check the robot is moving somewhere on the line segment between the shot origin
     // and the goal
-    EXPECT_LE(dist(Segment(shot_origin, field.friendlyGoal()), move_intent.getDestination()), 0.1);
+    EXPECT_LE(
+        dist(Segment(shot_origin, field.friendlyGoal()), move_intent.getDestination()),
+        0.1);
     // Make sure the robot is facing the shot
     EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
@@ -37,8 +39,8 @@ TEST(BlockShotPathTacticTest, shot_starts_far_from_the_net)
 {
     Field field = ::Test::TestUtil::createSSLDivBField();
 
-    Robot friendly_robot = Robot(0, Point(1, 0.5), Vector(), Angle::zero(), AngularVelocity::zero(),
-                                 Timestamp::fromSeconds(0));
+    Robot friendly_robot = Robot(0, Point(1, 0.5), Vector(), Angle::zero(),
+                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
     BlockShotPathTactic tactic = BlockShotPathTactic();
     tactic.updateRobot(friendly_robot);
@@ -54,9 +56,12 @@ TEST(BlockShotPathTacticTest, shot_starts_far_from_the_net)
     EXPECT_EQ(0, move_intent.getRobotId());
     // Check the robot is moving somewhere on the line segment between the shot origin
     // and the goal
-    EXPECT_LE(dist(Segment(shot_origin, field.friendlyGoal()), move_intent.getDestination()), 0.1);
+    EXPECT_LE(
+        dist(Segment(shot_origin, field.friendlyGoal()), move_intent.getDestination()),
+        0.1);
     // Make sure the robot is facing the shot
-    EXPECT_NEAR((shot_origin - field.friendlyGoal()).orientation().toRadians(), move_intent.getFinalAngle().toRadians(), 0.001);
+    EXPECT_NEAR((shot_origin - field.friendlyGoal()).orientation().toRadians(),
+                move_intent.getFinalAngle().toRadians(), 0.001);
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Implemented the BlockShotPathTactic. It moves the robot into position to block the entire friendly net from the shot (exactly what it sounds like).

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests for the Tactic added, and I verified it behaves as expected in grsim.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #460 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
