### PR TITLE
Improvements To Handle More Cases In Ball Interception

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/evaluation/intercept.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/intercept.cpp
@@ -46,15 +46,16 @@ std::optional<std::pair<Point, Duration>> findBestInterceptForBall(Ball ball, Fi
         // We want to get to the ball at the earliest opportunity possible, so
         // aim for a time diff of zero. We use a smooth approximation of
         // the maximum here
-        return std::sqrt(std::pow(ball_robot_time_diff,2) + smooth_abs_eps);
+        return std::sqrt(std::pow(ball_robot_time_diff, 2) + smooth_abs_eps);
     };
 
     // Figure out when/where to intercept the ball. We do this by optimizing over
     // the ball position as a function of it's travel time
     // We make the weight here an inverse of the ball speed, so that the gradient descent
     // takes smaller steps when the ball is moving faster
-    double descent_weight = 1 / (std::exp(ball.velocity().len()*0.5));
-    Util::GradientDescentOptimizer<1> optimizer({descent_weight}, gradient_approx_step_size);
+    double descent_weight = 1 / (std::exp(ball.velocity().len() * 0.5));
+    Util::GradientDescentOptimizer<1> optimizer({descent_weight},
+                                                gradient_approx_step_size);
     Duration best_ball_travel_duration = Duration::fromSeconds(
         std::abs(optimizer.minimize(objective_function, {0}, 50).at(0)));
 
@@ -78,7 +79,8 @@ std::optional<std::pair<Point, Duration>> findBestInterceptForBall(Ball ball, Fi
     Duration ball_robot_time_diff = time_to_ball_pos - best_ball_travel_duration;
     // NOTE: if ball velocity is 0 then bal travel duration is infinite, so this
     // check isn't relevent in that case
-    if (ball.velocity().len() != 0 && std::abs(ball_robot_time_diff.getSeconds()) > descent_weight)
+    if (ball.velocity().len() != 0 &&
+        std::abs(ball_robot_time_diff.getSeconds()) > descent_weight)
     {
         return std::nullopt;
     }

--- a/src/thunderbots/software/ai/hl/stp/evaluation/intercept.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/intercept.cpp
@@ -10,8 +10,14 @@
 std::optional<std::pair<Point, Duration>> findBestInterceptForBall(Ball ball, Field field,
                                                                    Robot robot)
 {
-    // This is the function that we want to minimize, finding the shortest duration in
-    // the future at which we can feasibly intercept the ball
+    static const double gradient_approx_step_size = 0.000001;
+
+    // We use this to take a smooth absolute value in our objective function
+    static const double smooth_abs_eps = 1000 * gradient_approx_step_size;
+
+    // This is the objective function that we want to minimize, finding the
+    // shortest duration in the future at which we can feasibly intercept the
+    // ball
     auto objective_function = [&](std::array<double, 1> x) {
         // We take the absolute value here because a negative time makes no sense
         double duration = std::abs(x.at(0));
@@ -37,23 +43,20 @@ std::optional<std::pair<Point, Duration>> findBestInterceptForBall(Ball ball, Fi
         // time that the ball will get there (ie. will we get there in time?)
         double ball_robot_time_diff = duration - time_to_ball_pos.getSeconds();
 
-        // Figure out how soon we can get to the ball, but also accounting for the time
-        // it will take the robot to make it to the destination. This ensures we're
-        // minimizing so that we get to the ball as soon as possible
-        return duration - ball_robot_time_diff;
+        // We want to get to the ball at the earliest opportunity possible, so
+        // aim for a time diff of zero. We use a smooth approximation of
+        // the maximum here
+        return std::sqrt(std::pow(ball_robot_time_diff,2) + smooth_abs_eps);
     };
 
     // Figure out when/where to intercept the ball. We do this by optimizing over
     // the ball position as a function of it's travel time
     // We make the weight here an inverse of the ball speed, so that the gradient descent
     // takes smaller steps when the ball is moving faster
-    // We add a small amount to the ball velocity here to prevent division by 0, and also
-    // to prevent the weight from getting two small, which would make gradient descent
-    // take really large time steps
-    double descent_weight = 1 / (ball.velocity().len() + 0.01);
-    Util::GradientDescentOptimizer<1> optimizer({descent_weight}, 0.001);
+    double descent_weight = 1 / (std::exp(ball.velocity().len()*0.5));
+    Util::GradientDescentOptimizer<1> optimizer({descent_weight}, gradient_approx_step_size);
     Duration best_ball_travel_duration = Duration::fromSeconds(
-        std::abs(optimizer.minimize(objective_function, {0}, 100).at(0)));
+        std::abs(optimizer.minimize(objective_function, {0}, 50).at(0)));
 
     // In the objective function above, if the robot timestamp > ball timestamp, we
     // add on the difference so we get a intercept time after the robot timestamp, so we
@@ -72,8 +75,10 @@ std::optional<std::pair<Point, Duration>> findBestInterceptForBall(Ball ball, Fi
     Duration time_to_ball_pos = AI::Evaluation::getTimeToPositionForRobot(
         robot, best_ball_intercept_pos, ROBOT_MAX_SPEED_METERS_PER_SECOND,
         ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED);
-    // NOTE: We have an addtional check here for 0 ball velocity
-    if (ball.velocity().len() != 0 && time_to_ball_pos > best_ball_travel_duration)
+    Duration ball_robot_time_diff = time_to_ball_pos - best_ball_travel_duration;
+    // NOTE: if ball velocity is 0 then bal travel duration is infinite, so this
+    // check isn't relevent in that case
+    if (ball.velocity().len() != 0 && std::abs(ball_robot_time_diff.getSeconds()) > descent_weight)
     {
         return std::nullopt;
     }

--- a/src/thunderbots/software/ai/hl/stp/evaluation/intercept.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/intercept.cpp
@@ -77,7 +77,7 @@ std::optional<std::pair<Point, Duration>> findBestInterceptForBall(Ball ball, Fi
         robot, best_ball_intercept_pos, ROBOT_MAX_SPEED_METERS_PER_SECOND,
         ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED);
     Duration ball_robot_time_diff = time_to_ball_pos - best_ball_travel_duration;
-    // NOTE: if ball velocity is 0 then bal travel duration is infinite, so this
+    // NOTE: if ball velocity is 0 then ball travel duration is infinite, so this
     // check isn't relevent in that case
     if (ball.velocity().len() != 0 &&
         std::abs(ball_robot_time_diff.getSeconds()) > descent_weight)

--- a/src/thunderbots/software/test/ai/hl/stp/evaluation/pass.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/evaluation/pass.cpp
@@ -8,11 +8,37 @@
 #include "ai/hl/stp/evaluation/intercept.h"
 #include "test/test_util/test_util.h"
 
-TEST(InterceptEvaluationTest, findBestInterceptForBall_robot_on_ball_path)
+TEST(InterceptEvaluationTest, findBestInterceptForBall_robot_on_ball_path_ball_3_m_per_s)
 {
     // Test where the robot is just sitting on the path the ball is travelling along
     Field field = ::Test::TestUtil::createSSLDivBField();
     Ball ball({0, 0}, {3, 0}, Timestamp::fromSeconds(0));
+    Robot robot(0, {2, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+
+    // We should be able to find an intercept
+    auto best_intercept = findBestInterceptForBall(ball, field, robot);
+    ASSERT_TRUE(best_intercept);
+
+    // We expect that the best intercept is going to be somewhere between x=0 and x=2,
+    // The ball is travelling fast enough that we expect the best intercept to be
+    // somewhere between x=1.75 and x=2.25 (with some tolerance allowed because of how we
+    // do the optimisation here), with y = 0, and will occur sometime between 0 and
+    // 2/3 seconds in the future (the time for the ball to reach the robots initial
+    // position).
+    auto [intercept_pos, robot_time_to_move_to_intercept] = *best_intercept;
+    EXPECT_DOUBLE_EQ(0, intercept_pos.y());
+    EXPECT_LE(1.5, intercept_pos.x());
+    EXPECT_GE(2.25, intercept_pos.x());
+    EXPECT_LE(0, robot_time_to_move_to_intercept.getSeconds());
+    EXPECT_LE(2 / 3, robot_time_to_move_to_intercept.getSeconds());
+}
+
+TEST(InterceptEvaluationTest, findBestInterceptForBall_robot_on_ball_path_ball_6_m_per_s)
+{
+    // This is the max speed the ball should ever be traveling at
+    Field field = ::Test::TestUtil::createSSLDivBField();
+    Ball ball({0, 0}, {6, 0}, Timestamp::fromSeconds(0));
     Robot robot(0, {2, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
                 Timestamp::fromSeconds(0));
 
@@ -57,6 +83,29 @@ TEST(InterceptEvaluationTest, findBestInterceptForBall_robot_right_beside_ball_p
     EXPECT_GE(2.25, intercept_pos.x());
     EXPECT_LE(0, robot_time_to_move_to_intercept.getSeconds());
     EXPECT_GE(2, robot_time_to_move_to_intercept.getSeconds());
+}
+
+TEST(InterceptEvaluationTest, findBestInterceptForBall_robot_chasing_ball)
+{
+    // Test where the ball starts ahead of the robot, but moving slowly so that
+    // the robot can catch up to it. Both the robot and the ball start at one
+    // end of the field moving towards the other end
+    Field field = ::Test::TestUtil::createSSLDivBField();
+    Ball ball({0, 3}, {0, -0.5}, Timestamp::fromSeconds(0));
+    Robot robot(0, {0, 4}, {0, -1}, Angle::zero(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+
+    // We should be able to find an intercept
+    auto best_intercept = findBestInterceptForBall(ball, field, robot);
+    ASSERT_TRUE(best_intercept);
+
+    // We expect the intercept will occur somewhere in x:[1,2], y:[1,2], t:[0, 3]
+    auto [intercept_pos, robot_time_to_move_to_intercept] = *best_intercept;
+    EXPECT_DOUBLE_EQ(0, intercept_pos.x());
+    EXPECT_GE(3, intercept_pos.y());
+    EXPECT_LE(1, intercept_pos.y());
+    EXPECT_LE(0, robot_time_to_move_to_intercept.getSeconds());
+    EXPECT_GE(3, robot_time_to_move_to_intercept.getSeconds());
 }
 
 TEST(InterceptEvaluationTest, findBestInterceptForBall_ball_on_diagonal_trajectory)


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
See title.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
NA
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification
NA
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
