### PR TITLE
velocity obstacle

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -343,6 +343,25 @@ if (CATKIN_ENABLE_TESTING)
 
     target_link_libraries(nav_ph_obstacle_test ${catkin_LIBRARIES})
 
+    catkin_add_gtest(nav_vel_obstacle_test
+            test/ai/navigator/obstacle/velocity_obstacle.cpp
+            ai/world/robot.cpp
+            ai/navigator/obstacle/velocity_obstacle.cpp
+            ai/navigator/obstacle/velocity_obstacle.h
+            ai/navigator/obstacle/obstacle.h
+            util/time/duration.cpp
+            util/time/time.cpp
+            util/time/timestamp.cpp
+            geom/polygon.h
+            geom/angle.h
+            geom/polygon.cpp
+            geom/point.h
+            geom/util.cpp
+            ../shared/constants.h
+            )
+
+    target_link_libraries(nav_vel_obstacle_test ${catkin_LIBRARIES})
+
     catkin_add_gtest(shared_util_test
             ../shared/test/util.cpp
             ../shared/util.c

--- a/src/thunderbots/software/ai/navigator/obstacle/velocity_obstacle.cpp
+++ b/src/thunderbots/software/ai/navigator/obstacle/velocity_obstacle.cpp
@@ -1,0 +1,43 @@
+#include "ai/navigator/obstacle/velocity_obstacle.h"
+Polygon VelocityObstacle::getBoundaryPolygon(const Robot& robot,
+                                             double robot_radius_scaling,
+                                             double velocity_projection_scaling)
+{
+    double radius             = ROBOT_MAX_RADIUS_METERS * robot_radius_scaling;
+    Point velocity_projection = robot.velocity() * velocity_projection_scaling;
+    Point velocity_direction  = robot.velocity().norm();
+
+    if (velocity_projection.len() > radius)
+    {
+        return Polygon(
+            {// sides of robot
+             robot.position() + radius * velocity_direction.rotate(Angle::quarter()),
+             robot.position() + radius * velocity_direction.rotate(Angle::threeQuarter()),
+             // velocity projections
+             robot.position() + radius * velocity_direction.rotate(Angle::quarter()) +
+                 velocity_projection,
+             robot.position() +
+                 radius * velocity_direction.rotate(Angle::threeQuarter()) +
+                 velocity_projection,
+             // back of robot
+             robot.position() + radius * velocity_direction.rotate(Angle::ofDegrees(150)),
+             robot.position() +
+                 radius * velocity_direction.rotate(Angle::ofDegrees(210))});
+    }
+    else
+    {
+        // force velocity direction to the +x direction (arbitrary)
+        velocity_direction = Point(1, 0);
+        return Polygon(
+            {// sides of robot
+             robot.position() + radius * velocity_direction.rotate(Angle::quarter()),
+             robot.position() + radius * velocity_direction.rotate(Angle::threeQuarter()),
+             // front of robot
+             robot.position() + radius * velocity_direction.rotate(Angle::ofDegrees(30)),
+             robot.position() + radius * velocity_direction.rotate(Angle::ofDegrees(330)),
+             // back of robot
+             robot.position() + radius * velocity_direction.rotate(Angle::ofDegrees(150)),
+             robot.position() +
+                 radius * velocity_direction.rotate(Angle::ofDegrees(210))});
+    }
+}

--- a/src/thunderbots/software/ai/navigator/obstacle/velocity_obstacle.cpp
+++ b/src/thunderbots/software/ai/navigator/obstacle/velocity_obstacle.cpp
@@ -3,41 +3,47 @@ Polygon VelocityObstacle::getBoundaryPolygon(const Robot& robot,
                                              double robot_radius_scaling,
                                              double velocity_projection_scaling)
 {
-    double radius             = ROBOT_MAX_RADIUS_METERS * robot_radius_scaling;
-    Point velocity_projection = robot.velocity() * velocity_projection_scaling;
-    Point velocity_direction  = robot.velocity().norm();
+    double radius = ROBOT_MAX_RADIUS_METERS * robot_radius_scaling;
+    Vector velocity_projection =
+        robot.velocity().norm(velocity_projection_scaling * robot.velocity().len());
 
     if (velocity_projection.len() > radius)
     {
+        Vector velocity_direction_norm_radius = robot.velocity().norm(radius);
         return Polygon(
             {// sides of robot
-             robot.position() + radius * velocity_direction.rotate(Angle::quarter()),
-             robot.position() + radius * velocity_direction.rotate(Angle::threeQuarter()),
+             robot.position() + velocity_direction_norm_radius.rotate(Angle::quarter()),
+             robot.position() +
+                 velocity_direction_norm_radius.rotate(Angle::threeQuarter()),
              // velocity projections
-             robot.position() + radius * velocity_direction.rotate(Angle::quarter()) +
+             robot.position() + velocity_direction_norm_radius.rotate(Angle::quarter()) +
                  velocity_projection,
              robot.position() +
-                 radius * velocity_direction.rotate(Angle::threeQuarter()) +
+                 velocity_direction_norm_radius.rotate(Angle::threeQuarter()) +
                  velocity_projection,
              // back of robot
-             robot.position() + radius * velocity_direction.rotate(Angle::ofDegrees(150)),
              robot.position() +
-                 radius * velocity_direction.rotate(Angle::ofDegrees(210))});
+                 velocity_direction_norm_radius.rotate(Angle::ofDegrees(150)),
+             robot.position() +
+                 velocity_direction_norm_radius.rotate(Angle::ofDegrees(210))});
     }
     else
     {
-        // force velocity direction to the +x direction (arbitrary)
-        velocity_direction = Point(1, 0);
+        // force the robot to face in +x direction
+        Vector facing_direction_norm_radius = Point(1, 0).norm(radius);
         return Polygon(
             {// sides of robot
-             robot.position() + radius * velocity_direction.rotate(Angle::quarter()),
-             robot.position() + radius * velocity_direction.rotate(Angle::threeQuarter()),
-             // front of robot
-             robot.position() + radius * velocity_direction.rotate(Angle::ofDegrees(30)),
-             robot.position() + radius * velocity_direction.rotate(Angle::ofDegrees(330)),
-             // back of robot
-             robot.position() + radius * velocity_direction.rotate(Angle::ofDegrees(150)),
+             robot.position() + facing_direction_norm_radius.rotate(Angle::quarter()),
              robot.position() +
-                 radius * velocity_direction.rotate(Angle::ofDegrees(210))});
+                 facing_direction_norm_radius.rotate(Angle::threeQuarter()),
+             // front of robot
+             robot.position() + facing_direction_norm_radius.rotate(Angle::ofDegrees(30)),
+             robot.position() +
+                 facing_direction_norm_radius.rotate(Angle::ofDegrees(330)),
+             // back of robot
+             robot.position() +
+                 facing_direction_norm_radius.rotate(Angle::ofDegrees(150)),
+             robot.position() +
+                 facing_direction_norm_radius.rotate(Angle::ofDegrees(210))});
     }
 }

--- a/src/thunderbots/software/ai/navigator/obstacle/velocity_obstacle.h
+++ b/src/thunderbots/software/ai/navigator/obstacle/velocity_obstacle.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../shared/constants.h"
 #include "ai/navigator/obstacle/obstacle.h"
+#include "shared/constants.h"
 
 // Placeholder obstacle represents a stationary robot centred at (0,0)
 class VelocityObstacle : public Obstacle

--- a/src/thunderbots/software/ai/navigator/obstacle/velocity_obstacle.h
+++ b/src/thunderbots/software/ai/navigator/obstacle/velocity_obstacle.h
@@ -1,17 +1,14 @@
-/**
- * An obstacle is an area to avoid based on the size of the robot and its velocity
- */
 #pragma once
 
-#include "ai/world/robot.h"
-#include "geom/angle.h"
-#include "geom/point.h"
-#include "geom/polygon.h"
-#include "geom/util.h"
+#include "../shared/constants.h"
+#include "ai/navigator/obstacle/obstacle.h"
 
-class Obstacle
+// Placeholder obstacle represents a stationary robot centred at (0,0)
+class VelocityObstacle : public Obstacle
 {
    public:
+    explicit VelocityObstacle();
+
     /*
      * Gets the boundary polygon around the given robot obstacle that other robots
      * should not enter with a buffer scaled by radiusScaling and

--- a/src/thunderbots/software/test/ai/navigator/obstacle/velocity_obstacle.cpp
+++ b/src/thunderbots/software/test/ai/navigator/obstacle/velocity_obstacle.cpp
@@ -1,0 +1,142 @@
+#include "ai/navigator/obstacle/velocity_obstacle.h"
+
+#include <gtest/gtest.h>
+#include <math.h>
+
+#include <cmath>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <sstream>
+
+#include "../shared/constants.h"
+#include "geom/point.h"
+
+// velocity obstacle with robot radius factor = 1, velocity projection factor = 1
+// centred at (0,0) and with (0,0) velocity
+TEST(NavigatorVelocityObstacleTest, default_velocity_obstacle_polygon)
+{
+    double TEST_EPSILON    = 1e-3;
+    Timestamp current_time = Timestamp::fromSeconds(123);
+    Robot robot = Robot(3, Point(0.0, 0.0), Vector(0.0, 0.0), Angle::ofRadians(2.2),
+                        AngularVelocity::ofRadians(-0.6), current_time);
+    Polygon pg  = VelocityObstacle::getBoundaryPolygon(robot, 1.0, 1.0);
+    Point pt0   = Point(0, ROBOT_MAX_RADIUS_METERS);
+    Point pt1   = Point(0, -ROBOT_MAX_RADIUS_METERS);
+    // visually verified
+    Point pt2 = Point(0.078, 0.045);
+    Point pt3 = Point(0.078, -0.045);
+    Point pt4 = Point(-0.078, 0.045);
+    Point pt5 = Point(-0.078, -0.045);
+    EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
+    EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+}
+
+// velocity obstacle with robot radius factor = 1, velocity projection factor = 1
+// centred at (1,2) and with (3,2) velocity
+TEST(NavigatorVelocityObstacleTest, shifted_velocity_obstacle_polygon)
+{
+    double TEST_EPSILON    = 1e-3;
+    Timestamp current_time = Timestamp::fromSeconds(123);
+    Robot robot            = Robot(3, Point(1, 2), Vector(3, 2), Angle::ofRadians(2.2),
+                        AngularVelocity::ofRadians(-0.6), current_time);
+    Polygon pg             = VelocityObstacle::getBoundaryPolygon(robot, 1.0, 1.0);
+    // visually verified
+    Point pt0 = Point(0.950, 2.075);
+    Point pt1 = Point(1.05, 1.925);
+    Point pt2 = Point(3.95, 4.075);
+    Point pt3 = Point(4.05, 3.925);
+    Point pt4 = Point(0.910, 1.994);
+    Point pt5 = Point(0.96, 1.919);
+    EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
+    EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+}
+
+// velocity obstacle with robot radius factor = 1.2, velocity projection factor = 1.4
+// centred at (-1,-2) and with (-3,2) velocity
+TEST(NavigatorVelocityObstacleTest, shifted_scaled_up_velocity_obstacle_polygon)
+{
+    double TEST_EPSILON    = 1e-3;
+    Timestamp current_time = Timestamp::fromSeconds(123);
+    Robot robot            = Robot(3, Point(-1, -2), Vector(-3, 2), Angle::ofRadians(2.2),
+                        AngularVelocity::ofRadians(-0.6), current_time);
+    Polygon pg             = VelocityObstacle::getBoundaryPolygon(robot, 1.2, 1.4);
+    Point pt0              = Point(-1.06, -2.09);
+    Point pt1              = Point(-0.94, -1.91);
+    Point pt2              = Point(-5.26, 0.71);
+    Point pt3              = Point(-5.14, 0.89);
+    Point pt4              = Point(-0.952, -2.097);
+    Point pt5              = Point(-0.892, -2.006);
+    EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
+    EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+}
+
+// velocity obstacle with robot radius factor = 0.3, velocity projection factor = 0.4
+// centred at (-1,-2) and with (-3,2) velocity
+TEST(NavigatorVelocityObstacleTest, shifted_scaled_down_velocity_obstacle_polygon)
+{
+    double TEST_EPSILON    = 1e-3;
+    Timestamp current_time = Timestamp::fromSeconds(123);
+    Robot robot            = Robot(3, Point(-1, -2), Vector(-3, 2), Angle::ofRadians(2.2),
+                        AngularVelocity::ofRadians(-0.6), current_time);
+    Polygon pg             = VelocityObstacle::getBoundaryPolygon(robot, .3, .4);
+    Point pt0              = Point(-1.014, -2.022);
+    Point pt1              = Point(-0.985, -1.977);
+    Point pt2              = Point(-2.215, -1.222);
+    Point pt3              = Point(-2.185, -1.178);
+    Point pt4              = Point(-0.988, -2.024);
+    Point pt5              = Point(-0.973, -2.002);
+    EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
+    EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
+    EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+}
+
+int main(int argc, char **argv)
+{
+    std::cout << argv[0] << std::endl;
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Add velocity obstacles, which is the full implementation of obstacles for robots.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
units tests
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
#513
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
