### PR TITLE
Implemented getNumPassesToRobot evaluation function

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -528,6 +528,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/hl/stp/evaluation/ball.cpp
             ai/hl/stp/evaluation/calc_best_shot.cpp
             ai/hl/stp/evaluation/possession.cpp
+            ai/hl/stp/evaluation/enemy_threat.cpp
             ai/hl/stp/evaluation/deflect_off_enemy_target.cpp
             ai/hl/stp/evaluation/indirect_chip.cpp
             ai/hl/stp/evaluation/intercept.cpp
@@ -545,6 +546,7 @@ if (CATKIN_ENABLE_TESTING)
             test/ai/evaluation/calc_best_shot.cpp
             test/ai/hl/stp/evaluation/ball.cpp
             test/ai/hl/stp/evaluation/possession.cpp
+            test/ai/hl/stp/evaluation/enemy_threat.cpp
             test/ai/hl/stp/evaluation/deflect_off_enemy_target.cpp
             test/ai/hl/stp/evaluation/main.cpp
             test/ai/hl/stp/evaluation/intercept.cpp

--- a/src/thunderbots/software/ai/hl/stp/evaluation/enemy_threat.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/enemy_threat.cpp
@@ -91,9 +91,9 @@ std::optional<std::pair<int, std::optional<Robot>>> Evaluation::getNumPassesToRo
     unvisited_robots.erase(
         std::remove(unvisited_robots.begin(), unvisited_robots.end(), initial_passer),
         unvisited_robots.end());
-    std::vector<Robot> all_robots = passing_team.getAllRobots();
-    all_robots.insert(all_robots.end(), other_team.getAllRobots().begin(),
-                      other_team.getAllRobots().end());
+    std::vector<Robot> all_robots   = passing_team.getAllRobots();
+    std::vector<Robot> other_robots = other_team.getAllRobots();
+    all_robots.insert(all_robots.end(), other_robots.begin(), other_robots.end());
 
     // On each iteration, check what robots can be passed to. These receivers will
     // become the passers on the next iteration. This is like expanding the frontier

--- a/src/thunderbots/software/ai/hl/stp/evaluation/enemy_threat.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/enemy_threat.cpp
@@ -1,0 +1,169 @@
+#include "ai/hl/stp/evaluation/enemy_threat.h"
+
+#include <deque>
+
+#include "ai/hl/stp/evaluation/intercept.h"
+#include "ai/hl/stp/evaluation/possession.h"
+#include "ai/hl/stp/evaluation/team.h"
+#include "ai/world/world.h"
+#include "geom/util.h"
+#include "shared/constants.h"
+
+std::optional<std::pair<int, std::optional<Robot>>> Evaluation::getNumPassesToRobot(
+    const Robot& initial_passer, const Robot& final_receiver, const Team& team,
+    const std::vector<Robot>& other_robots)
+{
+    if (initial_passer == final_receiver)
+    {
+        return std::make_pair(0, std::nullopt);
+    }
+
+    // We calculate the minimum number of passes it would take for the initial_passer
+    // robot to pass the ball to the final_receiver, assuming both robots are on the given
+    // team
+    //
+    // This algorithm essentially treats the team of robots like a Directed Acyclic
+    // Graph and "traverses" the graph to find the shortest path to the robot
+
+    // The robots that could have the ball and make a pass at each iteration. They
+    // are on the "frontier" of the graph search
+    std::vector<Robot> current_passers{initial_passer};
+    // The remaining robots we haven't checked yet
+    std::vector<Robot> unvisited_robots = team.getAllRobots();
+    // Remove the robot already in the current_passers since it starts off as visited
+    unvisited_robots.erase(
+        std::remove(unvisited_robots.begin(), unvisited_robots.end(), initial_passer),
+        unvisited_robots.end());
+
+    // On each iteration, check what robots can be passed to. These receivers will
+    // become the passers on the next iteration. This is like expanding the frontier
+    // of the graph
+    //
+    // We continue to iterate and check greater numbers of passes until one of the
+    // following cases:
+    // * There are no more passers at the end of the iteration. This means no more
+    //   unvisited robots can be passed to
+    // * There are no more unvisited robots
+    // * We have iterated up to the size of the team. This is a fallback case to
+    //   prevent any infinite loops, just in case
+    //
+    // The pass_num starts at one since the 0-th pass would be when the robot already
+    // has the ball
+    for (int pass_num = 1; pass_num < team.numRobots() && !current_passers.empty() &&
+                           !unvisited_robots.empty();
+         pass_num++)
+    {
+        // A comparator for the map below that stores passer and receiver robots.
+        // This comparator is necessary for the Robot class to be used as a key in the
+        // map. This comparator compares robots by ID.
+        // See
+        // https://stackoverflow.com/questions/6573225/what-requirements-must-stdmap-key-classes-meet-to-be-valid-keys
+        // and
+        // https://stackoverflow.com/questions/5733254/how-can-i-create-my-own-comparator-for-a-map
+        //
+        // This "custom" comparator is defined here rather than in the Robot class
+        // as the '<' operator because there are many possible ways to order robots,
+        // so it doesn't really make sense to define a single "correct" way in the
+        // class, so we just define it as we need it here.
+        struct cmpRobotByID
+        {
+            bool operator()(const Robot& r1, const Robot& r2) const
+            {
+                return r1.id() < r2.id();
+            }
+        };
+
+        // Store a map of robots that can receive the ball, and the list of all robots
+        // that could pass to them
+        std::map<Robot, std::vector<Robot>, cmpRobotByID> receiver_passer_pairs;
+
+        // For each of the current passers, check which unvisited robots they can
+        // pass to
+        for (const auto& current_passer : current_passers)
+        {
+            // Check if the current passer could pass to each unvisited robot
+            for (const auto& unvisited_robot : unvisited_robots)
+            {
+                // Create a vector of obstacles that includes all robots except the
+                // current passer and unvisited robot (aka the receiver)
+                std::vector<Robot> obstacles = team.getAllRobots();
+                obstacles.erase(
+                    std::remove(obstacles.begin(), obstacles.end(), current_passer),
+                    obstacles.end());
+                obstacles.erase(
+                    std::remove(obstacles.begin(), obstacles.end(), unvisited_robot),
+                    obstacles.end());
+                obstacles.insert(obstacles.end(), other_robots.begin(),
+                                 other_robots.end());
+
+                // Check if the pass from the current passer to the unvisited robot
+                // would be blocked by any obstacle (other robot)
+                bool pass_blocked = std::any_of(
+                    obstacles.begin(), obstacles.end(),
+                    [current_passer, unvisited_robot](const Robot& obstacle) {
+                        return intersects(
+                            Circle(obstacle.position(), ROBOT_MAX_RADIUS_METERS),
+                            Segment(current_passer.position(),
+                                    unvisited_robot.position()));
+                    });
+
+                if (!pass_blocked)
+                {
+                    if (receiver_passer_pairs.count(unvisited_robot) > 0)
+                    {
+                        // This unvisited_robot already exists in the map and can
+                        // already be passed to by another robot. We add the passer
+                        // to the list of possible passers for this robot
+                        receiver_passer_pairs.at(unvisited_robot)
+                            .emplace_back(current_passer);
+                    }
+                    else
+                    {
+                        // This unvisited robot does not exist in the map. Create a
+                        // new entry to track this receiver and add the passer
+                        receiver_passer_pairs.insert(std::make_pair(
+                            unvisited_robot, std::vector<Robot>{current_passer}));
+                    }
+                }
+            }
+        }
+
+        // If the robot we are looking for is a receiver, return the number of
+        // passes and the passer to this robot
+        if (receiver_passer_pairs.count(final_receiver) > 0)
+        {
+            // If there are multiple robots that can pass to the robot, we assume
+            // it will receive the ball from the closest one since this is more
+            // likely
+            auto closest_passer = Evaluation::nearestRobot(
+                receiver_passer_pairs.at(final_receiver), final_receiver.position());
+            return std::make_pair(pass_num, closest_passer);
+        }
+
+        // Create a list of all robots that could receive the ball this iteration
+        std::vector<Robot> all_receivers;
+        for (auto it = receiver_passer_pairs.begin(); it != receiver_passer_pairs.end();
+             it++)
+        {
+            all_receivers.emplace_back(it->first);
+        }
+
+        // All robots that could have received the ball now become passers
+        current_passers = all_receivers;
+
+        // Remove any receivers from the unvisited robots, since they have
+        // now been visited
+        unvisited_robots.erase(remove_if(unvisited_robots.begin(), unvisited_robots.end(),
+                                         [&](auto x) {
+                                             return find(all_receivers.begin(),
+                                                         all_receivers.end(),
+                                                         x) != all_receivers.end();
+                                         }),
+                               unvisited_robots.end());
+    }
+
+    // If we have checked all the robots we can and still haven't found the robot we
+    // are looking for, it must be blocked and unable to be passed to in the current
+    // state. Therefore, we return an std::nullopt
+    return std::nullopt;
+}

--- a/src/thunderbots/software/ai/hl/stp/evaluation/enemy_threat.h
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/enemy_threat.h
@@ -7,6 +7,22 @@
 namespace Evaluation
 {
     /**
+     * Returns a map of robots that can receive a pass from a passer, and the list of
+     * passers that could pass to each receiver.
+     *
+     * @param possible_passers Robots that could pass the ball
+     * @param possible_receivers Robots that could receive the ball
+     * @param all_robots All robots on the field, both friendly and enemy, including the
+     * possible passers and receivers
+     * @return A map of robots that can receive a pass from a passer, and the list of
+     * passers that could pass to each receiver
+     */
+    std::map<Robot, std::vector<Robot>, Robot::cmpRobotByID> findAllReceiverPasserPairs(
+        const std::vector<Robot> &possible_passers,
+        const std::vector<Robot> &possible_receivers,
+        const std::vector<Robot> &all_robots);
+
+    /**
      * Returns how many passes it would take for the given passer to pass the ball to the
      * receiver so the receiver gains possession of the ball, and returns the intermediate
      * passer the receiver is most likely to receive the ball from.
@@ -17,15 +33,14 @@ namespace Evaluation
      *
      * @param initial_passer The robot the passes start from
      * @param final_receiver The robot trying to be passed to
-     * @param team The team the robots are a part of
-     * @param other_robots Any other robots (in addition to the given team) that may be on
-     * the field acting as obstacles
+     * @param passing_team The team the passer and receiver robots are a part of
+     * @param other_team The other team (the enemy of the passing team)
      *
      * @return a pair containing the number of passes it will take for the passer robot to
      * pass the ball to the receiver robot, and the intermediate robot the receiver will
      * receive the pass from
      */
     std::optional<std::pair<int, std::optional<Robot>>> getNumPassesToRobot(
-        const Robot &initial_passer, const Robot &final_receiver, const Team &team,
-        const std::vector<Robot> &other_robots);
+        const Robot &initial_passer, const Robot &final_receiver,
+        const Team &passing_team, const Team &other_team);
 }  // namespace Evaluation

--- a/src/thunderbots/software/ai/hl/stp/evaluation/enemy_threat.h
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/enemy_threat.h
@@ -1,0 +1,31 @@
+#include <optional>
+#include <vector>
+
+#include "ai/world/world.h"
+
+
+namespace Evaluation
+{
+    /**
+     * Returns how many passes it would take for the given passer to pass the ball to the
+     * receiver so the receiver gains possession of the ball, and returns the intermediate
+     * passer the receiver is most likely to receive the ball from.
+     *
+     * If the passing and receiving robot are the same, the number of passes is 0 and the
+     * passer value is an std::nullopt. If the receiver cannot be passed to at all
+     * (all passing routes are blocked), then an std::nullopt is returned
+     *
+     * @param initial_passer The robot the passes start from
+     * @param final_receiver The robot trying to be passed to
+     * @param team The team the robots are a part of
+     * @param other_robots Any other robots (in addition to the given team) that may be on
+     * the field acting as obstacles
+     *
+     * @return a pair containing the number of passes it will take for the passer robot to
+     * pass the ball to the receiver robot, and the intermediate robot the receiver will
+     * receive the pass from
+     */
+    std::optional<std::pair<int, std::optional<Robot>>> getNumPassesToRobot(
+        const Robot &initial_passer, const Robot &final_receiver, const Team &team,
+        const std::vector<Robot> &other_robots);
+}  // namespace Evaluation

--- a/src/thunderbots/software/ai/hl/stp/evaluation/possession.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/possession.cpp
@@ -41,7 +41,7 @@ namespace Evaluation
         }
         else
         {
-            return Evaluation::nearest_robot(team, ball.position());
+            return Evaluation::nearestRobot(team, ball.position());
         }
     }
 }  // namespace Evaluation

--- a/src/thunderbots/software/ai/hl/stp/evaluation/team.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/team.cpp
@@ -1,24 +1,28 @@
 #include "ai/hl/stp/evaluation/team.h"
 
-std::optional<Robot> Evaluation::nearest_robot(const Team team, const Point ref_point)
+
+std::optional<Robot> Evaluation::nearestRobot(const Team &team, const Point &ref_point)
 {
-    if (team.getAllRobots().empty())
+    return nearestRobot(team.getAllRobots(), ref_point);
+}
+
+std::optional<Robot> Evaluation::nearestRobot(const std::vector<Robot> &robots,
+                                              const Point &ref_point)
+{
+    if (robots.empty())
     {
         return std::nullopt;
     }
 
-    unsigned nearestRobotId = team.getAllRobots()[0].id();
-    double minDist          = (ref_point - team.getAllRobots()[0].position()).len();
-
-    for (const Robot &curRobot : team.getAllRobots())
+    Robot nearest_robot = robots.at(0);
+    for (const Robot &curRobot : robots)
     {
         double curDistance = (ref_point - curRobot.position()).len();
-        if (curDistance < minDist)
+        if (curDistance < (nearest_robot.position() - ref_point).len())
         {
-            nearestRobotId = curRobot.id();
-            minDist        = curDistance;
+            nearest_robot = curRobot;
         }
     }
 
-    return team.getRobotById(nearestRobotId).value();
+    return nearest_robot;
 }

--- a/src/thunderbots/software/ai/hl/stp/evaluation/team.h
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/team.h
@@ -8,10 +8,21 @@ namespace Evaluation
     /**
      * Given a team, finds the robot on that team that is closest to a reference point.
      *
-     * @param team
+     * @param team the team of robots
      * @param ref_point The point where the distance to each robot will be measured.
      * @return Robot that is closest to the reference point.
      */
-    std::optional<Robot> nearest_robot(const Team team, const Point ref_point);
+    std::optional<Robot> nearestRobot(const Team &team, const Point &ref_point);
+
+    /**
+     * Given a list of robots, finds the robot on that team that is closest to a
+     * reference point.
+     *
+     * @param robots the list of robots
+     * @param ref_point The point where the distance to each robot will be measured.
+     * @return Robot that is closest to the reference point.
+     */
+    std::optional<Robot> nearestRobot(const std::vector<Robot> &robots,
+                                      const Point &ref_point);
 
 };  // namespace Evaluation

--- a/src/thunderbots/software/ai/world/robot.h
+++ b/src/thunderbots/software/ai/world/robot.h
@@ -196,6 +196,26 @@ class Robot
      */
     bool operator!=(const Robot &other) const;
 
+    // A comparator for the Robot class that compares Robots by ID. This is equivalent
+    // to the "less-than" operator.
+    // This comparator is necessary for the Robot class to be used as a key in maps. See
+    // https://stackoverflow.com/questions/6573225/what-requirements-must-stdmap-key-classes-meet-to-be-valid-keys
+    // and
+    // https://stackoverflow.com/questions/5733254/how-can-i-create-my-own-comparator-for-a-map
+    //
+    // We define this "custom" comparator rather than define the '<' operator for this
+    // class because there are many possible ways to order robots, so it doesn't make
+    // sense to define a single "normal" way with the '<' operator. Defining this
+    // comparator struct lets us use it explicitly when necessary and maintain multiple
+    // ways of comparing robots
+    struct cmpRobotByID
+    {
+        bool operator()(const Robot &r1, const Robot &r2) const
+        {
+            return r1.id() < r2.id();
+        }
+    };
+
    private:
     // The id of this robot
     unsigned int id_;

--- a/src/thunderbots/software/test/ai/hl/stp/evaluation/enemy_threat.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/evaluation/enemy_threat.cpp
@@ -1,0 +1,143 @@
+#include "ai/hl/stp/evaluation/enemy_threat.h"
+
+#include <gtest/gtest.h>
+
+#include "test/test_util/test_util.h"
+
+TEST(GetNumPassesToRobotTest, robot_passing_to_itself)
+{
+    Robot friendly_robot_0 = Robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_robot_1 = Robot(1, Point(-5, -5), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Team friendly_team     = Team(Duration::fromSeconds(1));
+    friendly_team.updateRobots({friendly_robot_0, friendly_robot_1});
+
+    auto result = Evaluation::getNumPassesToRobot(friendly_robot_0, friendly_robot_0,
+                                                  friendly_team, {});
+
+    // A valid result should have been found
+    EXPECT_TRUE(result);
+
+    int num_passes              = result.value().first;
+    std::optional<Robot> passer = result.value().second;
+
+    EXPECT_EQ(0, num_passes);
+    EXPECT_FALSE(passer);
+}
+
+TEST(GetNumPassesToRobotTest, one_simple_pass_to_robot_with_no_obstacles)
+{
+    Robot friendly_robot_0 = Robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_robot_1 = Robot(1, Point(-5, -5), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Team friendly_team     = Team(Duration::fromSeconds(1));
+    friendly_team.updateRobots({friendly_robot_0, friendly_robot_1});
+
+    auto result = Evaluation::getNumPassesToRobot(friendly_robot_0, friendly_robot_1,
+                                                  friendly_team, {});
+
+    // A valid result should have been found
+    EXPECT_TRUE(result);
+
+    int num_passes              = result.value().first;
+    std::optional<Robot> passer = result.value().second;
+
+    // Robot 0 should be able to pass to robot 1 in a single pass
+    EXPECT_EQ(1, num_passes);
+    EXPECT_TRUE(passer);
+    EXPECT_EQ(passer.value(), friendly_robot_0);
+}
+
+TEST(GetNumPassesToRobotTest, two_passes_around_a_single_obstacle)
+{
+    Robot friendly_robot_0 = Robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_robot_1 = Robot(1, Point(3, 1.5), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_robot_2 = Robot(2, Point(5, 0), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Team friendly_team     = Team(Duration::fromSeconds(1));
+    friendly_team.updateRobots({friendly_robot_0, friendly_robot_1, friendly_robot_2});
+
+    Robot enemy_robot_0 = Robot(0, Point(2, 0), Vector(0, 0), Angle::zero(),
+                                AngularVelocity::zero(), Timestamp::fromSeconds(0));
+
+    // The enemy robot is blocking the pass from robot 0 to robot 2, so we expect an
+    // intermediate pass via robot 1
+    auto result = Evaluation::getNumPassesToRobot(friendly_robot_0, friendly_robot_2,
+                                                  friendly_team, {enemy_robot_0});
+
+    // A valid result should have been found
+    EXPECT_TRUE(result);
+
+    int num_passes              = result.value().first;
+    std::optional<Robot> passer = result.value().second;
+
+    // Robot 0 should be able to pass to robot 1 in a single pass
+    EXPECT_EQ(2, num_passes);
+    EXPECT_TRUE(passer);
+    EXPECT_EQ(passer.value(), friendly_robot_1);
+}
+
+TEST(GetNumPassesToRobotTest, multiple_friendly_robots_and_blocking_enemies)
+{
+    Robot friendly_robot_0 = Robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_robot_1 = Robot(1, Point(1, 1.5), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_robot_2 = Robot(2, Point(3.5, -2), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_robot_3 = Robot(3, Point(5, 0), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Team friendly_team     = Team(Duration::fromSeconds(1));
+    friendly_team.updateRobots(
+        {friendly_robot_0, friendly_robot_1, friendly_robot_2, friendly_robot_3});
+
+    // Blocks the pass between robot 0 and robot 3
+    Robot enemy_robot_0 = Robot(0, Point(4, 0), Vector(0, 0), Angle::zero(),
+                                AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    // Blocks the pass between robot 1 and 3
+    Robot enemy_robot_1 = Robot(1, Point(1.25, 1.4), Vector(0, 0), Angle::zero(),
+                                AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    // Blocks the pass between robot 0 and 2
+    Robot enemy_robot_2 = Robot(2, Point(1.75, -1), Vector(0, 0), Angle::zero(),
+                                AngularVelocity::zero(), Timestamp::fromSeconds(0));
+
+    // The only way for robot 3 to get the ball is to receive a pass from
+    // robot 0 -> robot 1 -> robot 2 -> robot 3
+    auto result =
+        Evaluation::getNumPassesToRobot(friendly_robot_0, friendly_robot_3, friendly_team,
+                                        {enemy_robot_0, enemy_robot_1, enemy_robot_2});
+
+    // A valid result should have been found
+    EXPECT_TRUE(result);
+
+    int num_passes              = result.value().first;
+    std::optional<Robot> passer = result.value().second;
+
+    // Robot 0 should be able to pass to robot 1 in a single pass
+    EXPECT_EQ(3, num_passes);
+    EXPECT_TRUE(passer);
+    EXPECT_EQ(passer.value(), friendly_robot_2);
+}
+
+TEST(GetNumPassesToRobotTest, all_passes_blocked)
+{
+    Robot friendly_robot_0 = Robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_robot_1 = Robot(1, Point(5, 0), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Team friendly_team     = Team(Duration::fromSeconds(1));
+    friendly_team.updateRobots({friendly_robot_0, friendly_robot_1});
+
+    Robot enemy_robot_0 = Robot(0, Point(2, 0), Vector(0, 0), Angle::zero(),
+                                AngularVelocity::zero(), Timestamp::fromSeconds(0));
+
+    auto result = Evaluation::getNumPassesToRobot(friendly_robot_0, friendly_robot_1,
+                                                  friendly_team, {enemy_robot_0});
+
+    // We don't expect any pass info to be returned
+    EXPECT_FALSE(result);
+}

--- a/src/thunderbots/software/test/ai/hl/stp/evaluation/team.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/evaluation/team.cpp
@@ -24,7 +24,7 @@ TEST_F(TeamEvaluationTest, nearest_friendy_one_robot)
 
     team.updateRobots({robot_0});
 
-    EXPECT_EQ(robot_0, Evaluation::nearest_robot(team, Point(0, 0)));
+    EXPECT_EQ(robot_0, Evaluation::nearestRobot(team, Point(0, 0)));
 }
 
 TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots)
@@ -43,7 +43,7 @@ TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots)
 
     team.updateRobots({robot_0, robot_1, robot_2});
 
-    EXPECT_EQ(robot_1, Evaluation::nearest_robot(team, Point(0, 0)));
+    EXPECT_EQ(robot_1, Evaluation::nearestRobot(team, Point(0, 0)));
 }
 
 TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots_closest_is_moving)
@@ -62,7 +62,7 @@ TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots_closest_is_moving)
 
     team.updateRobots({robot_0, robot_1, robot_2});
 
-    EXPECT_EQ(robot_1, Evaluation::nearest_robot(team, Point(0, 0)));
+    EXPECT_EQ(robot_1, Evaluation::nearestRobot(team, Point(0, 0)));
 }
 
 TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots_all_moving)
@@ -81,7 +81,7 @@ TEST_F(TeamEvaluationTest, nearest_friendy_multiple_robots_all_moving)
 
     team.updateRobots({robot_0, robot_1, robot_2});
 
-    EXPECT_EQ(robot_2, Evaluation::nearest_robot(team, Point(0, 0)));
+    EXPECT_EQ(robot_2, Evaluation::nearestRobot(team, Point(0, 0)));
 }
 
 TEST_F(TeamEvaluationTest, nearest_friendy_one_robot_on_ball)
@@ -100,12 +100,12 @@ TEST_F(TeamEvaluationTest, nearest_friendy_one_robot_on_ball)
 
     team.updateRobots({robot_0, robot_1, robot_2});
 
-    EXPECT_EQ(robot_0, Evaluation::nearest_robot(team, Point(0, 0)));
+    EXPECT_EQ(robot_0, Evaluation::nearestRobot(team, Point(0, 0)));
 }
 
 TEST_F(TeamEvaluationTest, nearest_robot_zero_robots)
 {
     Team team = Team(Duration::fromMilliseconds(1000));
 
-    EXPECT_EQ(std::nullopt, Evaluation::nearest_robot(team, Point(0, 0)));
+    EXPECT_EQ(std::nullopt, Evaluation::nearestRobot(team, Point(0, 0)));
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Implemented the `getNumPassesToRobot` evaluation function that will be used in the `calculateEnemyThreat` functions for #477. This function turned out to be quite a doozy so I've put it in a separate PR.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Added unit tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
None (but will be part of #477)

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
