### PR TITLE
Implemented Passer Tactic

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -601,16 +601,20 @@ if (CATKIN_ENABLE_TESTING)
     catkin_add_gtest(tactic_test
             ai/evaluation/pass.cpp
             ai/hl/stp/action/action.cpp
+            ai/hl/stp/action/kick_action.cpp
             ai/hl/stp/action/move_action.cpp
             ai/hl/stp/tactic/block_shot_path_tactic.cpp
             ai/hl/stp/tactic/cherry_pick_tactic.cpp
             ai/hl/stp/tactic/move_tactic.cpp
+            ai/hl/stp/tactic/passer_tactic.cpp
             ai/hl/stp/tactic/tactic.cpp
             ai/intent/intent.cpp
+            ai/intent/kick_intent.cpp
             ai/intent/move_intent.cpp
             ai/passing/evaluation.cpp
             ai/passing/pass.cpp
             ai/passing/pass_generator.cpp
+            ai/primitive/kick_primitive.cpp
             ai/primitive/move_primitive.cpp
             ai/primitive/primitive.cpp
             ai/world/ball.cpp
@@ -619,11 +623,13 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/robot.cpp
             ai/world/team.cpp
             ai/world/world.cpp
+            geom/polygon.cpp
             geom/util.cpp
             test/ai/hl/stp/tactic/block_shot_path_tactic.cpp
             test/ai/hl/stp/tactic/cherry_pick_tactic.cpp
             test/ai/hl/stp/tactic/main.cpp
             test/ai/hl/stp/tactic/move_tactic.cpp
+            test/ai/hl/stp/tactic/passer_tactic.cpp
             test/ai/hl/stp/tactic/tactic.cpp
             test/ai/hl/stp/test_tactics/move_test_tactic.cpp
             test/test_util/test_util.cpp

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -1,0 +1,45 @@
+#include "ai/hl/stp/tactic/passer_tactic.h"
+#include "ai/hl/stp/action/kick_action.h"
+
+#include "geom/util.h"
+#include "shared/constants.h"
+#include "util/logger/init.h"
+
+using namespace AI::Passing;
+
+PasserTactic::PasserTactic(Pass pass, bool loop_forever)
+    : pass(std::move(pass)), Tactic(loop_forever)
+{
+}
+
+std::string PasserTactic::getName() const
+{
+    return "Passer Tactic";
+}
+
+void PasserTactic::updateParams(const Pass& updated_pass)
+{
+    this->pass = updated_pass;
+}
+
+double PasserTactic::calculateRobotCost(const Robot& robot, const World& world)
+{
+    // Prefer robots closer to the pass start position
+    // We normalize with the total field length so that robots that are within the field
+    // have a cost less than 1
+    double cost = (robot.position() - pass.passerPoint()).len() / world.field().totalLength();
+    return std::clamp<double>(cost, 0, 1);
+}
+
+std::unique_ptr<Intent> PasserTactic::calculateNextIntent(
+    intent_coroutine::push_type& yield)
+{
+    KickAction kick_action = KickAction();
+    do
+    {
+        // We want the robot to move to the starting position for the shot and also
+        // rotate to the correct orientation to face the shot
+        yield(kick_action.updateStateAndGetNextIntent(*robot, pass.passerPoint(),
+                                                      pass.passerOrientation(), pass.speed()));
+    } while (!kick_action.done());
+}

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -2,8 +2,8 @@
  * Implementation of the PasserTactic
  */
 #include "ai/hl/stp/tactic/passer_tactic.h"
-#include "ai/hl/stp/action/kick_action.h"
 
+#include "ai/hl/stp/action/kick_action.h"
 #include "geom/util.h"
 #include "shared/constants.h"
 #include "util/logger/init.h"
@@ -30,7 +30,8 @@ double PasserTactic::calculateRobotCost(const Robot& robot, const World& world)
     // Prefer robots closer to the pass start position
     // We normalize with the total field length so that robots that are within the field
     // have a cost less than 1
-    double cost = (robot.position() - pass.passerPoint()).len() / world.field().totalLength();
+    double cost =
+        (robot.position() - pass.passerPoint()).len() / world.field().totalLength();
     return std::clamp<double>(cost, 0, 1);
 }
 
@@ -42,7 +43,7 @@ std::unique_ptr<Intent> PasserTactic::calculateNextIntent(
     {
         // We want the robot to move to the starting position for the shot and also
         // rotate to the correct orientation to face the shot
-        yield(kick_action.updateStateAndGetNextIntent(*robot, pass.passerPoint(),
-                                                      pass.passerOrientation(), pass.speed()));
+        yield(kick_action.updateStateAndGetNextIntent(
+            *robot, pass.passerPoint(), pass.passerOrientation(), pass.speed()));
     } while (!kick_action.done());
 }

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -1,3 +1,6 @@
+/**
+ * Implementation of the PasserTactic
+ */
 #include "ai/hl/stp/tactic/passer_tactic.h"
 #include "ai/hl/stp/action/kick_action.h"
 

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "ai/hl/stp/tactic/tactic.h"
+#include "ai/passing/pass.h"
+
+/**
+ * This tactic is for a robot performing a pass. It should be used in conjunction with
+ * the `ReceiverTactic` in order to complete the pass.
+ *
+ * Note that this tactic does not take into account the time the pass should occur at,
+ * it simply tries to move to the best position to take the pass as fast as possible
+ */
+class PasserTactic : public Tactic
+{
+   public:
+    /**
+     * Creates a new PasserTactic
+     *
+     * @param pass The pass this tactic should try to execute
+     * @param loop_forever Whether or not this Tactic should never complete. If true, the
+     * tactic will be restarted every time it completes
+     */
+    explicit PasserTactic(AI::Passing::Pass pass, bool loop_forever);
+
+    std::string getName() const override;
+
+    /**
+     * Updates the parameters for this PasserTactic.
+     *
+     * @param pass The pass to perform
+     */
+    void updateParams(const AI::Passing::Pass& updated_pass);
+
+    /**
+     * Calculates the cost of assigning the given robot to this Tactic. Prefers robots
+     * closer to the block destination
+     *
+     * @param robot The robot to evaluate the cost for
+     * @param world The state of the world with which to perform the evaluation
+     * @return A cost in the range [0,1] indicating the cost of assigning the given robot
+     * to this tactic. Lower cost values indicate a more preferred robot.
+     */
+    double calculateRobotCost(const Robot& robot, const World& world) override;
+
+   private:
+    std::unique_ptr<Intent> calculateNextIntent(
+        intent_coroutine::push_type& yield) override;
+
+    // Tactic parameters
+    // The pass this tactic is executing
+    AI::Passing::Pass pass;
+};

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
@@ -1,3 +1,6 @@
+/**
+ * Interface of the PasserTactic
+ */
 #pragma once
 
 #include "ai/hl/stp/tactic/tactic.h"

--- a/src/thunderbots/software/ai/passing/pass.cpp
+++ b/src/thunderbots/software/ai/passing/pass.cpp
@@ -31,6 +31,12 @@ Angle Pass::receiverOrientation() const
     return (passerPoint() - receiverPoint()).orientation();
 }
 
+Angle Pass::passerOrientation() const
+{
+    return (receiverPoint() - passerPoint()).orientation();
+}
+
+
 Point Pass::passerPoint() const
 {
     return passer_point;

--- a/src/thunderbots/software/ai/passing/pass.h
+++ b/src/thunderbots/software/ai/passing/pass.h
@@ -47,6 +47,13 @@ namespace AI::Passing
         Angle receiverOrientation() const;
 
         /**
+         * Gets the angle the passer should be facing to perform the pass
+         *
+         * @return The angle the passer should be facing to perform the pass
+         */
+        Angle passerOrientation() const;
+
+        /**
          * Gets the value of the passer point
          *
          * @return The value of the passer point

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/passer_tactic.cpp
@@ -1,0 +1,98 @@
+#include "ai/hl/stp/tactic/passer_tactic.h"
+#include "ai/intent/kick_intent.h"
+#include "ai/intent/move_intent.h"
+
+#include <gtest/gtest.h>
+
+#include "test/test_util/test_util.h"
+
+using namespace AI::Passing;
+
+TEST(PasserTacticTest, passer_already_at_pass_start_position_but_oriented_incorrectly){
+    // Robot is sitting at origin facing towards enemy goal
+    Robot robot = Robot(13, Point(0, 0), Vector(), Angle::zero(),
+                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+
+    // We want to pass from the origin to 1 meter in the -y direction
+    Pass pass({0,0}, {0,-1}, 2.29, Timestamp::fromSeconds(0));
+    PasserTactic tactic(pass, false);
+
+    tactic.updateRobot(robot);
+
+    // In this case we should be moving into position to kick the ball, since we're
+    // in front of it and need to get behind it
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*tactic.getNextIntent());
+    EXPECT_EQ(13, move_intent.getRobotId());
+    EXPECT_NEAR(0, move_intent.getDestination().x(), 1e-5);
+    EXPECT_LE(0, move_intent.getDestination().y());
+    EXPECT_GE(0.5, move_intent.getDestination().y());
+    EXPECT_EQ(-90, move_intent.getFinalAngle().toDegrees());
+    EXPECT_EQ(0, move_intent.getFinalSpeed());
+}
+
+TEST(PasserTacticTest, passer_oriented_correctly_but_not_at_pass_start_position){
+    // Robot is sitting at {1,2} facing towards -y
+    Robot robot = Robot(13, Point(1, 2), Vector(), Angle::ofDegrees(-90),
+                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+
+    // We want to pass from the origin to 1 meter in the -y direction
+    Pass pass({0,0}, {0,-1}, 2.29, Timestamp::fromSeconds(0));
+    PasserTactic tactic(pass, false);
+
+    tactic.updateRobot(robot);
+
+    // In this case we should be moving into position to kick the ball, since we're
+    // in front of it and need to get behind it
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*tactic.getNextIntent());
+    EXPECT_EQ(13, move_intent.getRobotId());
+    EXPECT_NEAR(0, move_intent.getDestination().x(), 1e-5);
+    EXPECT_LE(0, move_intent.getDestination().y());
+    EXPECT_GE(0.5, move_intent.getDestination().y());
+    EXPECT_EQ(-90, move_intent.getFinalAngle().toDegrees());
+    EXPECT_EQ(0, move_intent.getFinalSpeed());
+}
+
+TEST(PasserTacticTest, passer_oriented_incorrectly_and_close_to_start_position_but_in_front_of_pass){
+    // Robot is sitting at {-0.3,0.2} facing towards -y
+    Robot robot = Robot(13, Point(-0.3, 0.2), Vector(), Angle::ofDegrees(-90),
+                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+
+    // We want to pass from the origin to 1 meter in the -y direction. This means the
+    // robot needs to move around the ball to get toa point where it can kick
+    Pass pass({0,0}, {0,-1}, 2.29, Timestamp::fromSeconds(0));
+    PasserTactic tactic(pass, false);
+
+    tactic.updateRobot(robot);
+
+    // In this case we should be moving into position to kick the ball, since we're
+    // in front of it and need to get behind it
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*tactic.getNextIntent());
+    EXPECT_EQ(13, move_intent.getRobotId());
+    EXPECT_NEAR(0, move_intent.getDestination().x(), 1e-5);
+    EXPECT_LE(0, move_intent.getDestination().y());
+    EXPECT_GE(0.5, move_intent.getDestination().y());
+    EXPECT_EQ(-90, move_intent.getFinalAngle().toDegrees());
+    EXPECT_EQ(0, move_intent.getFinalSpeed());
+}
+
+TEST(PasserTacticTest, passer_in_position_to_kick){
+    // Robot is sitting just behind where we want to pass from, in the perfect
+    // position to just move forward a bit and take the kick
+    Robot robot = Robot(13, Point(0, 0.3), Vector(), Angle::ofDegrees(-90),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+
+    // We want to pass from the origin to 1 meter in the -y direction
+    Pass pass({0,0}, {0,-1}, 2.29, Timestamp::fromSeconds(0));
+    PasserTactic tactic(pass, false);
+
+    tactic.updateRobot(robot);
+
+    // Should yield one move intent and then stop
+    KickIntent kick_intent = dynamic_cast<KickIntent &>(*tactic.getNextIntent());
+    EXPECT_EQ(13, kick_intent.getRobotId());
+    EXPECT_EQ(-90, kick_intent.getKickDirection().toDegrees());
+    EXPECT_EQ(Point(0,0), kick_intent.getKickOrigin());
+    EXPECT_EQ(2.29, kick_intent.getKickSpeed());
+
+
+}

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/passer_tactic.cpp
@@ -1,3 +1,6 @@
+/**
+ * Tests for the Passer Tactic
+ */
 #include "ai/hl/stp/tactic/passer_tactic.h"
 #include "ai/intent/kick_intent.h"
 #include "ai/intent/move_intent.h"

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/passer_tactic.cpp
@@ -2,22 +2,23 @@
  * Tests for the Passer Tactic
  */
 #include "ai/hl/stp/tactic/passer_tactic.h"
-#include "ai/intent/kick_intent.h"
-#include "ai/intent/move_intent.h"
 
 #include <gtest/gtest.h>
 
+#include "ai/intent/kick_intent.h"
+#include "ai/intent/move_intent.h"
 #include "test/test_util/test_util.h"
 
 using namespace AI::Passing;
 
-TEST(PasserTacticTest, passer_already_at_pass_start_position_but_oriented_incorrectly){
+TEST(PasserTacticTest, passer_already_at_pass_start_position_but_oriented_incorrectly)
+{
     // Robot is sitting at origin facing towards enemy goal
-    Robot robot = Robot(13, Point(0, 0), Vector(), Angle::zero(),
-                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot robot = Robot(13, Point(0, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction
-    Pass pass({0,0}, {0,-1}, 2.29, Timestamp::fromSeconds(0));
+    Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(0));
     PasserTactic tactic(pass, false);
 
     tactic.updateRobot(robot);
@@ -33,13 +34,14 @@ TEST(PasserTacticTest, passer_already_at_pass_start_position_but_oriented_incorr
     EXPECT_EQ(0, move_intent.getFinalSpeed());
 }
 
-TEST(PasserTacticTest, passer_oriented_correctly_but_not_at_pass_start_position){
+TEST(PasserTacticTest, passer_oriented_correctly_but_not_at_pass_start_position)
+{
     // Robot is sitting at {1,2} facing towards -y
     Robot robot = Robot(13, Point(1, 2), Vector(), Angle::ofDegrees(-90),
-                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction
-    Pass pass({0,0}, {0,-1}, 2.29, Timestamp::fromSeconds(0));
+    Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(0));
     PasserTactic tactic(pass, false);
 
     tactic.updateRobot(robot);
@@ -55,14 +57,16 @@ TEST(PasserTacticTest, passer_oriented_correctly_but_not_at_pass_start_position)
     EXPECT_EQ(0, move_intent.getFinalSpeed());
 }
 
-TEST(PasserTacticTest, passer_oriented_incorrectly_and_close_to_start_position_but_in_front_of_pass){
+TEST(PasserTacticTest,
+     passer_oriented_incorrectly_and_close_to_start_position_but_in_front_of_pass)
+{
     // Robot is sitting at {-0.3,0.2} facing towards -y
     Robot robot = Robot(13, Point(-0.3, 0.2), Vector(), Angle::ofDegrees(-90),
-                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction. This means the
     // robot needs to move around the ball to get toa point where it can kick
-    Pass pass({0,0}, {0,-1}, 2.29, Timestamp::fromSeconds(0));
+    Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(0));
     PasserTactic tactic(pass, false);
 
     tactic.updateRobot(robot);
@@ -78,14 +82,15 @@ TEST(PasserTacticTest, passer_oriented_incorrectly_and_close_to_start_position_b
     EXPECT_EQ(0, move_intent.getFinalSpeed());
 }
 
-TEST(PasserTacticTest, passer_in_position_to_kick){
+TEST(PasserTacticTest, passer_in_position_to_kick)
+{
     // Robot is sitting just behind where we want to pass from, in the perfect
     // position to just move forward a bit and take the kick
     Robot robot = Robot(13, Point(0, 0.3), Vector(), Angle::ofDegrees(-90),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction
-    Pass pass({0,0}, {0,-1}, 2.29, Timestamp::fromSeconds(0));
+    Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(0));
     PasserTactic tactic(pass, false);
 
     tactic.updateRobot(robot);
@@ -94,8 +99,6 @@ TEST(PasserTacticTest, passer_in_position_to_kick){
     KickIntent kick_intent = dynamic_cast<KickIntent &>(*tactic.getNextIntent());
     EXPECT_EQ(13, kick_intent.getRobotId());
     EXPECT_EQ(-90, kick_intent.getKickDirection().toDegrees());
-    EXPECT_EQ(Point(0,0), kick_intent.getKickOrigin());
+    EXPECT_EQ(Point(0, 0), kick_intent.getKickOrigin());
     EXPECT_EQ(2.29, kick_intent.getKickSpeed());
-
-
 }

--- a/src/thunderbots/software/test/ai/passing/pass.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass.cpp
@@ -26,35 +26,66 @@ TEST(PassTest, simple_getters)
     EXPECT_EQ(Timestamp::fromSeconds(10), p.startTime());
 }
 
-TEST(PassTest, getRecieverOrientation_passer_at_center_and_receiver_on_neg_x_axis)
+TEST(PassTest, receiverOrientation_passer_at_center_and_receiver_on_neg_x_axis)
 {
     Pass p({0, 0}, {-1, 0}, 1, Timestamp::fromSeconds(10));
     EXPECT_DOUBLE_EQ(0, p.receiverOrientation().mod(Angle::full()).toDegrees());
 }
 
-TEST(PassTest, getRecieverOrientation_passer_at_center_and_receiver_on_neg_y_axis)
+TEST(PassTest, receiverOrientation_passer_at_center_and_receiver_on_neg_y_axis)
 {
     Pass p({0, 0}, {0, -1}, 1, Timestamp::fromSeconds(10));
     EXPECT_DOUBLE_EQ(90, p.receiverOrientation().mod(Angle::full()).toDegrees());
 }
 
-TEST(PassTest, getRecieverOrientation_passer_at_center_and_receiver_on_pos_x_axis)
+TEST(PassTest, receiverOrientation_passer_at_center_and_receiver_on_pos_x_axis)
 {
     Pass p({0, 0}, {1, 0}, 1, Timestamp::fromSeconds(10));
     EXPECT_DOUBLE_EQ(180, p.receiverOrientation().mod(Angle::full()).toDegrees());
 }
 
-TEST(PassTest, getRecieverOrientation_passer_at_center_and_receiver_on_pos_y_axis)
+TEST(PassTest, receiverOrientation_passer_at_center_and_receiver_on_pos_y_axis)
 {
     Pass p({0, 0}, {0, 1}, 1, Timestamp::fromSeconds(10));
     EXPECT_DOUBLE_EQ(-90, p.receiverOrientation().mod(Angle::full()).toDegrees());
 }
 
-TEST(PassTest, getRecieverOrientation_passer_diagonal_to_receiver)
+TEST(PassTest, receiverOrientation_passer_diagonal_to_receiver)
 {
     Pass p({1, -1}, {4, 1}, 1, Timestamp::fromSeconds(10));
     EXPECT_DOUBLE_EQ(-180 + atan(2.0 / 3.0) * 180 / M_PI,
                      p.receiverOrientation().mod(Angle::full()).toDegrees());
+}
+
+TEST(PassTest, passerOrientation_receiver_at_center_and_passer_on_neg_x_axis)
+{
+    Pass p({-1, 0}, {0, 0}, 1, Timestamp::fromSeconds(10));
+    EXPECT_DOUBLE_EQ(0, p.passerOrientation().mod(Angle::full()).toDegrees());
+}
+
+TEST(PassTest, passerOrientation_receiver_at_center_and_passer_on_neg_y_axis)
+{
+    Pass p({0, -1}, {0, 0}, 1, Timestamp::fromSeconds(10));
+    EXPECT_DOUBLE_EQ(90, p.passerOrientation().mod(Angle::full()).toDegrees());
+}
+
+TEST(PassTest, passerOrientation_receiver_at_center_and_passer_on_pos_x_axis)
+{
+    Pass p({1, 0}, {0, 0}, 1, Timestamp::fromSeconds(10));
+    EXPECT_DOUBLE_EQ(180, p.passerOrientation().mod(Angle::full()).toDegrees());
+}
+
+TEST(PassTest, passerOrientation_receiver_at_center_and_passer_on_pos_y_axis)
+{
+    Pass p({0, 1}, {0, 0}, 1, Timestamp::fromSeconds(10));
+    EXPECT_DOUBLE_EQ(-90, p.passerOrientation().mod(Angle::full()).toDegrees());
+}
+
+TEST(PassTest, passerOrientation_passer_diagonal_to_receiver)
+{
+    Pass p({4, 1}, {1, -1}, 1, Timestamp::fromSeconds(10));
+    EXPECT_DOUBLE_EQ(-180 + atan(2.0 / 3.0) * 180 / M_PI,
+                     p.passerOrientation().mod(Angle::full()).toDegrees());
 }
 
 TEST(PassTest, stream_operator)


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Added `PasserTactic` and associated tests. Also added a utility function to the `Pass` class to support.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Partly resolves #373
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification
NA
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
