### PR TITLE
Fixed segment contains point function (Vertical edge case)

### DIFF
--- a/src/thunderbots/software/geom/util.cpp
+++ b/src/thunderbots/software/geom/util.cpp
@@ -174,9 +174,11 @@ bool contains(const Segment &out, const Point &in)
 {
     if (collinear(in, out.getSegStart(), out.getEnd()))
     {
-        // If the segment and point are in a perfect vertical line, we must use Y coordinate centric logic
-        if( (in.x() - out.getEnd().x() == 0) && (out.getEnd().x() - out.getSegStart().x() == 0)) {
-
+        // If the segment and point are in a perfect vertical line, we must use Y
+        // coordinate centric logic
+        if ((in.x() - out.getEnd().x() == 0) &&
+            (out.getEnd().x() - out.getSegStart().x() == 0))
+        {
             // if collinear we only need to check one of the coordinates,
             // in this case we select Y because all X values are equal
             return (in.y() <= out.getSegStart().y() && in.y() >= out.getEnd().y()) ||

--- a/src/thunderbots/software/geom/util.cpp
+++ b/src/thunderbots/software/geom/util.cpp
@@ -144,7 +144,7 @@ double lensq(const Line &line)
     return std::numeric_limits<double>::infinity();
 }
 
-bool contains(const LegacyTriangle &out, const Vector &in)
+bool contains(const LegacyTriangle &out, const Point &in)
 {
     double angle = 0;
     for (int i = 0, j = 2; i < 3; j = i++)
@@ -160,7 +160,7 @@ bool contains(const LegacyTriangle &out, const Vector &in)
     return std::fabs(angle) > 6;
 }
 
-bool contains(const Circle &out, const Vector &in)
+bool contains(const Circle &out, const Point &in)
 {
     return distsq(out.getOrigin(), in) <= out.getRadius() * out.getRadius();
 }
@@ -170,12 +170,21 @@ bool contains(const Circle &out, const Segment &in)
     return dist(in, out.getOrigin()) < out.getRadius();
 }
 
-bool contains(const Segment &out, const Vector &in)
+bool contains(const Segment &out, const Point &in)
 {
     if (collinear(in, out.getSegStart(), out.getEnd()))
     {
+        // If the segment and point are in a perfect vertical line, we must use Y coordinate centric logic
+        if( (in.x() - out.getEnd().x() == 0) && (out.getEnd().x() - out.getSegStart().x() == 0)) {
+
+            // if collinear we only need to check one of the coordinates,
+            // in this case we select Y because all X values are equal
+            return (in.y() <= out.getSegStart().y() && in.y() >= out.getEnd().y()) ||
+                   (in.y() <= out.getEnd().y() && in.y() >= out.getSegStart().y());
+        }
+
         // if collinear we only need to check one of the coordinates,
-        // arbitrarily choose x
+        // choose x because we know there is variance in these values
         return (in.x() <= out.getSegStart().x() && in.x() >= out.getEnd().x()) ||
                (in.x() <= out.getEnd().x() && in.x() >= out.getSegStart().x());
     }
@@ -183,7 +192,7 @@ bool contains(const Segment &out, const Vector &in)
     return false;
 }
 
-bool contains(const Ray &out, const Vector &in)
+bool contains(const Ray &out, const Point &in)
 {
     Point point_in_ray_direction = out.getRayStart() + out.getDirection();
     if (collinear(in, out.getRayStart(), point_in_ray_direction) &&
@@ -194,7 +203,7 @@ bool contains(const Ray &out, const Vector &in)
     return false;
 }
 
-bool contains(const Rectangle &out, const Vector &in)
+bool contains(const Rectangle &out, const Point &in)
 {
     return out.containsPoint(in);
 }

--- a/src/thunderbots/software/geom/util.h
+++ b/src/thunderbots/software/geom/util.h
@@ -50,12 +50,12 @@ double proj_len(const Segment &first, const Vector &second);
  * inside the first parameter.
  */
 
-bool contains(const LegacyTriangle &out, const Vector &in);
-bool contains(const Circle &out, const Vector &in);
+bool contains(const LegacyTriangle &out, const Point &in);
+bool contains(const Circle &out, const Point &in);
 bool contains(const Circle &out, const Segment &in);
-bool contains(const Ray &out, const Vector &in);
-bool contains(const Segment &out, const Vector &in);
-bool contains(const Rectangle &out, const Vector &in);
+bool contains(const Ray &out, const Point &in);
+bool contains(const Segment &out, const Point &in);
+bool contains(const Rectangle &out, const Point &in);
 
 /*
  * The family of `intersects` functions determines whether there

--- a/src/thunderbots/software/test/geom/util.cpp
+++ b/src/thunderbots/software/test/geom/util.cpp
@@ -165,20 +165,20 @@ TEST(GeomUtilTest, test_contains_triangle_point)
     EXPECT_EQ(expected_val, calculated_val);
 }
 
-TEST(GeomUtilTest, test_segment_contains_point_no_x_deviation) {
+TEST(GeomUtilTest, test_segment_contains_point_no_x_deviation)
+{
+    Segment segment = Segment(Point(0, 0), Point(0, 1));
 
-    Segment segment = Segment( Point(0,0), Point(0,1));
-
-    Point point = Point(0,0.5);
+    Point point = Point(0, 0.5);
 
     EXPECT_EQ(contains(segment, point), true);
 }
 
-TEST(GeomUtilTest, test_segment_contains_point_no_y_deviation) {
+TEST(GeomUtilTest, test_segment_contains_point_no_y_deviation)
+{
+    Segment segment = Segment(Point(0, 0), Point(1, 0));
 
-    Segment segment = Segment( Point(0,0), Point(1,0));
-
-    Point point = Point(0.5,0);
+    Point point = Point(0.5, 0);
 
     EXPECT_EQ(contains(segment, point), true);
 }

--- a/src/thunderbots/software/test/geom/util.cpp
+++ b/src/thunderbots/software/test/geom/util.cpp
@@ -165,6 +165,24 @@ TEST(GeomUtilTest, test_contains_triangle_point)
     EXPECT_EQ(expected_val, calculated_val);
 }
 
+TEST(GeomUtilTest, test_segment_contains_point_no_x_deviation) {
+
+    Segment segment = Segment( Point(0,0), Point(0,1));
+
+    Point point = Point(0,0.5);
+
+    EXPECT_EQ(contains(segment, point), true);
+}
+
+TEST(GeomUtilTest, test_segment_contains_point_no_y_deviation) {
+
+    Segment segment = Segment( Point(0,0), Point(1,0));
+
+    Point point = Point(0.5,0);
+
+    EXPECT_EQ(contains(segment, point), true);
+}
+
 TEST(GeomUtilTest, test_collinear)
 {
     for (unsigned int i = 0; i < 10; ++i)


### PR DESCRIPTION
Current implementation of contain(Segment, Point) does not account for the edge case where the segment and point exist along the same perfectly vertical (y direction) line.

Additionally, I changed the parameter types from Vector to Point in all the contains() functions to represent the data type being used more appropriately.
### Testing Done

This PR contains the fix for this issue and 2 additional unit tests to check these edge cases.

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.