### PR TITLE
Added calcBestShotOnFriendlyGoal functions and tests

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/evaluation/calc_best_shot.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/calc_best_shot.cpp
@@ -46,7 +46,7 @@ namespace Evaluation
             best_shot = calcBestShotOnGoal(world.field().enemyGoalpostNeg(),
                                            world.field().enemyGoalpostPos(), point,
                                            obstacles, radius);
-            // If not shot is found, at least set the target to the goal
+            // If no shot is found, at least set the target to the goal
             if (best_shot.second == Angle::zero())
             {
                 best_shot.first = world.field().enemyGoal();

--- a/src/thunderbots/software/ai/hl/stp/evaluation/calc_best_shot.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/calc_best_shot.cpp
@@ -4,79 +4,102 @@
 
 namespace Evaluation
 {
-    std::pair<Point, Angle> calcBestShotOnEnemyGoal(const Field &f,
-                                                    const std::vector<Point> &obstacles,
-                                                    const Point &p, double radius)
+    std::pair<Point, Angle> calcBestShotOnGoal(const Point &goal_post_neg,
+                                               const Point &goal_post_pos, const Point &p,
+                                               const std::vector<Point> &obstacles,
+                                               double radius)
     {
-        // Calculate the location of goalpost then use angleSweepCircle function to get
-        // the pair
-        const Point p1 = f.enemyGoalpostNeg();
-        const Point p2 = f.enemyGoalpostPos();
-        return angleSweepCircles(p, p1, p2, obstacles, radius);
+        // Use angleSweepCircle function to get the pair
+        return angleSweepCircles(p, goal_post_neg, goal_post_pos, obstacles, radius);
     }
 
-    std::vector<std::pair<Point, Angle>> calcBestShotOnEnemyGoalAll(
-        const Field &f, const std::vector<Point> &obstacles, const Point &p,
-        double radius)
-    {
-        const Point p1 = f.enemyGoalpostNeg();
-        const Point p2 = f.enemyGoalpostPos();
-        return angleSweepCirclesAll(p, p1, p2, obstacles, radius);
-    }
-
-    std::pair<Point, Angle> calcBestShotOnEnemyGoal(const World &world,
-                                                    const Point &point, double radius)
+    std::pair<Point, Angle> calcBestShotOnGoal(const World &world, const Point &point,
+                                               double radius,
+                                               const std::vector<Robot> &robots_to_ignore,
+                                               bool shoot_on_enemy_goal)
     {
         std::vector<Point> obstacles;
-        const Team &enemy    = world.enemyTeam();
-        const Team &friendly = world.friendlyTeam();
-        obstacles.reserve(enemy.numRobots() + friendly.numRobots());
-        // create a vector of points for all the robots except the shooting one
-        for (const Robot &i : enemy.getAllRobots())
+        for (const Robot &enemy_robot : world.enemyTeam().getAllRobots())
         {
-            obstacles.emplace_back(i.position());
-        }
-        for (const Robot &fpl : friendly.getAllRobots())
-        {
-            if (fpl.position() == point)
+            // Only add the robot to the obstacles if it is not ignored
+            if (std::count(robots_to_ignore.begin(), robots_to_ignore.end(),
+                           enemy_robot) == 0)
             {
-                continue;
+                obstacles.emplace_back(enemy_robot.position());
             }
-            obstacles.emplace_back(fpl.position());
         }
-        std::pair<Point, Angle> best_shot =
-            calcBestShotOnEnemyGoal(world.field(), obstacles, point, radius);
-        // if there is no good shot at least make the
-        // target within the goal area
-        if (best_shot.second == Angle::zero())
+        for (const Robot &friendly_robot : world.friendlyTeam().getAllRobots())
         {
-            Point temp      = world.field().enemyGoal();
-            best_shot.first = temp;
+            // Only add the robot to the obstacles if it is not ignored
+            if (std::count(robots_to_ignore.begin(), robots_to_ignore.end(),
+                           friendly_robot) == 0)
+            {
+                obstacles.emplace_back(friendly_robot.position());
+            }
         }
+
+        std::pair<Point, Angle> best_shot;
+
+        // Calculate the best_shot based on what goal we're shooting at
+        if (shoot_on_enemy_goal)
+        {
+            best_shot = calcBestShotOnGoal(world.field().enemyGoalpostNeg(),
+                                           world.field().enemyGoalpostPos(), point,
+                                           obstacles, radius);
+            // If not shot is found, at least set the target to the goal
+            if (best_shot.second == Angle::zero())
+            {
+                best_shot.first = world.field().enemyGoal();
+            }
+        }
+        else
+        {
+            best_shot = calcBestShotOnGoal(world.field().friendlyGoalpostPos(),
+                                           world.field().friendlyGoalpostNeg(), point,
+                                           obstacles, radius);
+            // If not shot is found, at least set the target to the goal
+            if (best_shot.second == Angle::zero())
+            {
+                best_shot.first = world.field().friendlyGoal();
+            }
+        }
+
         return best_shot;
     }
 
-    std::vector<std::pair<Point, Angle>> calcBestShotOnEnemyGoalAll(const World &world,
-                                                                    const Point &point,
-                                                                    double radius)
+    std::pair<Point, Angle> calcBestShotOnEnemyGoal(
+        const World &world, const Robot &robot, double radius,
+        const std::vector<Robot> &robots_to_ignore)
     {
-        std::vector<Point> obstacles;
-        const Team &enemy    = world.enemyTeam();
-        const Team &friendly = world.friendlyTeam();
-        obstacles.reserve(enemy.numRobots() + friendly.numRobots());
-        for (const Robot &i : enemy.getAllRobots())
-        {
-            obstacles.push_back(i.position());
-        }
-        for (const Robot &fpl : friendly.getAllRobots())
-        {
-            if (fpl.position() == point)
-            {
-                continue;
-            }
-            obstacles.push_back(fpl.position());
-        }
-        return calcBestShotOnEnemyGoalAll(world.field(), obstacles, point, radius);
+        std::vector<Robot> all_robots_to_ignore = robots_to_ignore;
+        // Ignore the robot shooting the ball
+        all_robots_to_ignore.emplace_back(robot);
+        return calcBestShotOnEnemyGoal(world, robot.position(), radius,
+                                       all_robots_to_ignore);
     }
 
+    std::pair<Point, Angle> calcBestShotOnEnemyGoal(
+        const World &world, const Point &shot_origin, double radius,
+        const std::vector<Robot> &robots_to_ignore)
+    {
+        return calcBestShotOnGoal(world, shot_origin, radius, robots_to_ignore, true);
+    }
+
+    std::pair<Point, Angle> calcBestShotOnFriendlyGoal(
+        const World &world, const Robot &robot, double radius,
+        const std::vector<Robot> &robots_to_ignore)
+    {
+        std::vector<Robot> all_robots_to_ignore = robots_to_ignore;
+        // Ignore the robot shooting the ball
+        all_robots_to_ignore.emplace_back(robot);
+        return calcBestShotOnFriendlyGoal(world, robot.position(), radius,
+                                          all_robots_to_ignore);
+    }
+
+    std::pair<Point, Angle> calcBestShotOnFriendlyGoal(
+        const World &world, const Point &shot_origin, double radius,
+        const std::vector<Robot> &robots_to_ignore)
+    {
+        return calcBestShotOnGoal(world, shot_origin, radius, robots_to_ignore, false);
+    }
 }  // namespace Evaluation

--- a/src/thunderbots/software/ai/hl/stp/evaluation/calc_best_shot.h
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/calc_best_shot.h
@@ -1,5 +1,4 @@
-#ifndef PROJECT_CALC_BEST_SHOT_H
-#define PROJECT_CALC_BEST_SHOT_H
+#pragma once
 
 #include "ai/world/field.h"
 #include "ai/world/robot.h"
@@ -9,82 +8,133 @@
 namespace Evaluation
 {
     /**
-     * Finds the length of the largest continuous interval (angle-wise) of the
-     * goal that can be seen from a point.
+     * Finds the best shot on the given goal, and returns the best target to shoot at and
+     * the largest open angle interval for the shot (this is the total angle between the
+     * obstacles on either side of the shot vector).
      *
-     * @param f-field is needed to calculate the location of the goalposts based on field
-     * length and goal width
+     * @param goal_post_neg The goal post of the net with the negative y-coordinate
+     * @param goal_post_posThe goal post of the net with the positive y-coordinate
+     * @param p The point that the shot will be taken from
+     * @param obstacles The locations of any obstacles on the field that may obstruct the
+     * shot. These are treated as circular obstacles, and are usually used to represent
+     * robots on the field.
+     * @param radius The radius of the given obstacles
      *
-     * @param obstacles-obstacles is a list of all the obstacles in the way between the
-     * point and the net
-     *
-     * @param p-the point that the shot is being calculated from
-     *
-     * @param radius-the radius of all obstacles
-     *
-     * @return the point and the score (angle),
-     * where the score will be 0 if the point is invalid.
+     * @return the best target to shoot at and the largest open angle interval for the
+     * shot (this is the total angle between the obstacles on either side of the shot
+     * vector). If no shot is possible, the returned angle will be 0
      */
-    std::pair<Point, Angle> calcBestShotOnEnemyGoal(const Field &f,
-                                                    const std::vector<Point> &obstacles,
-                                                    const Point &p, double radius);
+    std::pair<Point, Angle> calcBestShotOnGoal(const Point &goal_post_neg,
+                                               const Point &goal_post_pos, const Point &p,
+                                               const std::vector<Point> &obstacles,
+                                               double radius);
 
     /**
-     * Finds the length of the all continuous interval (angle-wise) of the
-     * goal that can be seen from a point.
+     * Finds the best shot on the specified goal, and returns the best target to shoot at
+     * and the largest open angle interval for the shot (this is the total angle between
+     * the obstacles on either side of the shot vector).
      *
-     * @param f-field is needed to calculate the location of the goalposts based on field
-     * length and goal width
+     * This function will treat all robots on the field as obstacles, except for the
+     * robots_to_ignore
      *
-     * @param obstacles-obstacles is a list of all the obstacles in the way between the
-     * point and the net
+     * @param world The world state
+     * @param point The point that the shot will be taken from
+     * @param radius The radius for the robot obstacles
+     * @param robots_to_ignore The robots to ignore
+     * @param shoot_at_enemy_goal Whether or not the shot is at the enemy goal. If true,
+     * the shot will be treated as a shot at the enemy goal, and if false, the shot will
+     * be treated as a shot at the friendly goal
      *
-     * @param p-the point that the shot is being calculated from
-     *
-     * @param radius-the radius of all obstacles
-     *
-     * @return a set of points and the corresponding score (angle),
-     * where the score will be 0 if the point is invalid.
+     * @return the best target to shoot at and the largest open angle interval for the
+     * shot (this is the total angle between the obstacles on either side of the shot
+     * vector).
      */
-    std::vector<std::pair<Point, Angle>> calcBestShotOnEnemyGoalAll(
-        const Field &f, const std::vector<Point> &obstacles, const Point &p,
-        double radius);
+    std::pair<Point, Angle> calcBestShotOnGoal(const World &world, const Point &point,
+                                               double radius,
+                                               const std::vector<Robot> &robots_to_ignore,
+                                               bool shoot_at_enemy_goal);
 
     /**
-     * Finds the length of the largest continuous interval (angle-wise) of the
-     * goal that can be seen from a point.
-     * To add imaginary threats or obstacles, please use the above calc_best_shot.
+     * Finds the best shot on the enemy goal, and returns the best target to shoot at and
+     * the largest open angle interval for the shot (this is the total angle between the
+     * obstacles on either side of the shot vector).
      *
-     * @param world-world with field information
+     * This function will treat all robot on the field as obstacles, except for the robot
+     * taking the shot and the robots_to_ignore
      *
-     * @param point-robot that the shot is being calculated from
+     * @param world The world state
+     * @param robot The robot taking the shot
+     * @param radius The radius for the robot obstacles
+     * @param robots_to_ignore The robots to ignore
      *
-     * @param radius-the radius of all obstacles
-     *
-     * @return the point as and the score (angle),
-     * where the score will be 0 if the point is invalid.
+     * @return the best target to shoot at and the largest open angle interval for the
+     * shot (this is the total angle between the obstacles on either side of the shot
+     * vector).
      */
-    std::pair<Point, Angle> calcBestShotOnEnemyGoal(const World &world,
-                                                    const Point &point, double radius);
-
+    std::pair<Point, Angle> calcBestShotOnEnemyGoal(
+        const World &world, const Robot &robot, double radius,
+        const std::vector<Robot> &robots_to_ignore = {});
 
     /**
-     * Finds the list of length of the largest continuous interval (angle-wise) of the
-     * goal that can be seen from a point.
-     * To add imaginary threats or obstacles, please use the above calc_best_shot_all.
+     * Finds the best shot on the enemy goal, and returns the best target to shoot at and
+     * the largest open angle interval for the shot (this is the total angle between the
+     * obstacles on either side of the shot vector).
      *
-     * @param world-world with field information
+     * This function will treat all robot on the field as obstacles, except for the
+     * robots_to_ignore
      *
-     * @param point-robot that the shot is being calculated from
+     * @param world The world state
+     * @param shot_origin The point the shot is being taken from
+     * @param radius The radius for the robot obstacles
+     * @param robots_to_ignore The robots to ignore
      *
-     * @@param radius-the radius of all obstacles
-     *
-     * @return the point as and the score (angle),
-     * where the score will be 0 if the point is invalid.
+     * @return the best target to shoot at and the largest open angle interval for the
+     * shot (this is the total angle between the obstacles on either side of the shot
+     * vector).
      */
-    std::vector<std::pair<Point, Angle>> calcBestShotOnEnemyGoalAll(const World &world,
-                                                                    const Point &point,
-                                                                    double radius);
+    std::pair<Point, Angle> calcBestShotOnEnemyGoal(
+        const World &world, const Point &shot_origin, double radius,
+        const std::vector<Robot> &robots_to_ignore = {});
 
+    /**
+     * Finds the best shot on the friendly goal, and returns the best target to shoot at
+     * and the largest open angle interval for the shot (this is the total angle between
+     * the obstacles on either side of the shot vector).
+     *
+     * This function will treat all robot on the field as obstacles, except for the robot
+     * taking the shot and the robots_to_ignore
+     *
+     * @param world The world state
+     * @param robot The robot taking the shot
+     * @param radius The radius for the robot obstacles
+     * @param robots_to_ignore The robots to ignore
+     *
+     * @return the best target to shoot at and the largest open angle interval for the
+     * shot (this is the total angle between the obstacles on either side of the shot
+     * vector).
+     */
+    std::pair<Point, Angle> calcBestShotOnFriendlyGoal(
+        const World &world, const Robot &robot, double radius,
+        const std::vector<Robot> &robots_to_ignore = {});
+
+    /**
+     * Finds the best shot on the friendly goal, and returns the best target to shoot at
+     * and the largest open angle interval for the shot (this is the total angle between
+     * the obstacles on either side of the shot vector).
+     *
+     * This function will treat all robot on the field as obstacles, except for the
+     * robots_to_ignore
+     *
+     * @param world The world state
+     * @param shot_origin The point the shot is being taken from
+     * @param radius The radius for the robot obstacles
+     * @param robots_to_ignore The robots to ignore
+     *
+     * @return the best target to shoot at and the largest open angle interval for the
+     * shot (this is the total angle between the obstacles on either side of the shot
+     * vector).
+     */
+    std::pair<Point, Angle> calcBestShotOnFriendlyGoal(
+        const World &world, const Point &shot_origin, double radius,
+        const std::vector<Robot> &robots_to_ignore = {});
 }  // namespace Evaluation
-#endif

--- a/src/thunderbots/software/ai/hl/stp/evaluation/calc_best_shot.h
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/calc_best_shot.h
@@ -13,7 +13,7 @@ namespace Evaluation
      * obstacles on either side of the shot vector).
      *
      * @param goal_post_neg The goal post of the net with the negative y-coordinate
-     * @param goal_post_posThe goal post of the net with the positive y-coordinate
+     * @param goal_post_pos The goal post of the net with the positive y-coordinate
      * @param p The point that the shot will be taken from
      * @param obstacles The locations of any obstacles on the field that may obstruct the
      * shot. These are treated as circular obstacles, and are usually used to represent


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Added `calcBestShotOnFriendlyGoal` evaluation functions and restructured the `calcBestShot` functions a bit to more easily support both teams. Also removed the `calcBestShotAll` versions because YAGNI.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests added

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
None

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
A fair amount of stuff was changed or moved so it adds up to just over 500 lines

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
