### PR TITLE
Added Autokick And Dribble Flags To Move(Action|Intent|Primitive)

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
@@ -2,21 +2,24 @@
 
 #include "ai/intent/move_intent.h"
 
-MoveAction::MoveAction(double close_to_dest_threshold)
-    : Action(), close_to_dest_threshold(close_to_dest_threshold)
+MoveAction::MoveAction(double close_to_dest_threshold, bool loop_forever)
+    : Action(),
+      close_to_dest_threshold(close_to_dest_threshold),
+      loop_forever(loop_forever)
 {
 }
 
-std::unique_ptr<Intent> MoveAction::updateStateAndGetNextIntent(const Robot& robot,
-                                                                Point destination,
-                                                                Angle final_orientation,
-                                                                double final_speed)
+std::unique_ptr<Intent> MoveAction::updateStateAndGetNextIntent(
+    const Robot& robot, Point destination, Angle final_orientation, double final_speed,
+    bool enable_dribbler, bool enable_autokick)
 {
     // Update the parameters stored by this Action
     this->robot             = robot;
     this->destination       = destination;
     this->final_orientation = final_orientation;
     this->final_speed       = final_speed;
+    this->enable_dribbler   = enable_dribbler;
+    this->enable_autokick   = enable_autokick;
 
     return getNextIntent();
 }
@@ -32,6 +35,8 @@ std::unique_ptr<Intent> MoveAction::calculateNextIntent(
     do
     {
         yield(std::make_unique<MoveIntent>(robot->id(), destination, final_orientation,
-                                           final_speed, 0));
-    } while ((robot->position() - destination).len() > close_to_dest_threshold);
+                                           final_speed, 0, enable_dribbler,
+                                           enable_autokick));
+    } while (loop_forever ||
+             (robot->position() - destination).len() > close_to_dest_threshold);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.h
@@ -12,13 +12,17 @@ class MoveAction : public Action
     // camera and positioning noise
     static constexpr double ROBOT_CLOSE_TO_DEST_THRESHOLD = 0.02;
 
+    // TODO: Test new param here
     /**
      * Creates a new MoveAction
      *
      * @param close_to_dest_threshold How far from the destination the robot must be
      * before the action is considered done
+     * @param loop_forever Continue yielding new Move Intents, even after we have reached
+     *                     our goal
      */
-    explicit MoveAction(double close_to_dest_threshold = ROBOT_CLOSE_TO_DEST_THRESHOLD);
+    explicit MoveAction(double close_to_dest_threshold = ROBOT_CLOSE_TO_DEST_THRESHOLD,
+                        bool loop_forever              = false);
 
     /**
      * Returns the next Intent this MoveAction wants to run, given the parameters.
@@ -29,14 +33,17 @@ class MoveAction : public Action
      * @param final_orientation The final orientation the robot should have at
      * the destination
      * @param final_speed The final speed the robot should have at the destination
+     * @param enable_dribbler Whether or not to enable the dribbler
+     * @param enable_autokick This will enable the "break-beam" on the robot, that will
+     *                        trigger the kicker to fire as soon as the ball is in front
+     *                        of it
      *
      * @return A unique pointer to the Intent the MoveAction wants to run. If the
      * MoveAction is done, returns an empty/null pointer
      */
-    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot,
-                                                        Point destination,
-                                                        Angle final_orientation,
-                                                        double final_speed);
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(
+        const Robot& robot, Point destination, Angle final_orientation,
+        double final_speed, bool enable_dribbler = false, bool enable_autokick = false);
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
@@ -46,5 +53,9 @@ class MoveAction : public Action
     Point destination;
     Angle final_orientation;
     double final_speed;
+    bool enable_dribbler;
+    bool enable_autokick;
+
     double close_to_dest_threshold;
+    bool loop_forever;
 };

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.h
@@ -12,7 +12,6 @@ class MoveAction : public Action
     // camera and positioning noise
     static constexpr double ROBOT_CLOSE_TO_DEST_THRESHOLD = 0.02;
 
-    // TODO: Test new param here
     /**
      * Creates a new MoveAction
      *

--- a/src/thunderbots/software/ai/intent/move_intent.cpp
+++ b/src/thunderbots/software/ai/intent/move_intent.cpp
@@ -5,8 +5,11 @@
 const std::string MoveIntent::INTENT_NAME = "Move Intent";
 
 MoveIntent::MoveIntent(unsigned int robot_id, const Point &dest, const Angle &final_angle,
-                       double final_speed, unsigned int priority)
-    : MovePrimitive(robot_id, dest, final_angle, final_speed), Intent(priority)
+                       double final_speed, unsigned int priority, bool enable_dribbler,
+                       bool enable_autokick)
+    : MovePrimitive(robot_id, dest, final_angle, final_speed, enable_dribbler,
+                    enable_autokick),
+      Intent(priority)
 {
 }
 

--- a/src/thunderbots/software/ai/intent/move_intent.h
+++ b/src/thunderbots/software/ai/intent/move_intent.h
@@ -19,10 +19,15 @@ class MoveIntent : public Intent, public MovePrimitive
      * destination
      * @param priority The priority of this Intent. A larger number indicates a higher
      * priority
+     * @param enable_dribbler Whether or not to enable the dribbler
+     * @param enable_autokick This will enable the "break-beam" on the robot, that will
+     *                        trigger the kicker to fire as soon as the ball is in front
+     *                        of it
      */
     explicit MoveIntent(unsigned int robot_id, const Point& dest,
                         const Angle& final_angle, double final_speed,
-                        unsigned int priority);
+                        unsigned int priority, bool enable_dribbler = false,
+                        bool enable_autokick = false);
 
     std::string getIntentName(void) const override;
 

--- a/src/thunderbots/software/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/move_primitive.cpp
@@ -5,8 +5,14 @@
 const std::string MovePrimitive::PRIMITIVE_NAME = "Move Primitive";
 
 MovePrimitive::MovePrimitive(unsigned int robot_id, const Point &dest,
-                             const Angle &final_angle, double final_speed)
-    : robot_id(robot_id), dest(dest), final_angle(final_angle), final_speed(final_speed)
+                             const Angle &final_angle, double final_speed,
+                             bool enable_dribbler, bool enable_autokick)
+    : robot_id(robot_id),
+      dest(dest),
+      final_angle(final_angle),
+      final_speed(final_speed),
+      enable_dribbler(enable_dribbler),
+      enable_autokick(enable_autokick)
 {
 }
 
@@ -20,6 +26,8 @@ MovePrimitive::MovePrimitive(const thunderbots_msgs::Primitive &primitive_msg)
     dest          = Point(dest_x, dest_y);
     final_angle   = Angle::ofRadians(primitive_msg.parameters.at(2));
     final_speed   = primitive_msg.parameters.at(3);
+    enable_dribbler = (bool)primitive_msg.parameters.at(4);
+    enable_autokick = (bool)primitive_msg.parameters.at(5);
 }
 
 
@@ -48,10 +56,24 @@ double MovePrimitive::getFinalSpeed() const
     return final_speed;
 }
 
+bool MovePrimitive::getAutoKickEnabled() const
+{
+    return enable_autokick;
+}
+
+bool MovePrimitive::getDribblerEnabled() const
+{
+    return enable_dribbler;
+}
+
 std::vector<double> MovePrimitive::getParameters() const
 {
-    std::vector<double> parameters = {dest.x(), dest.y(), final_angle.toRadians(),
-                                      final_speed};
+    std::vector<double> parameters = {dest.x(),
+                                      dest.y(),
+                                      final_angle.toRadians(),
+                                      final_speed,
+                                      (double)enable_dribbler,
+                                      (double)enable_autokick};
 
     return parameters;
 }
@@ -70,7 +92,9 @@ bool MovePrimitive::operator==(const MovePrimitive &other) const
 {
     return this->robot_id == other.robot_id && this->dest == other.dest &&
            this->final_angle == other.final_angle &&
-           this->final_speed == other.final_speed;
+           this->final_speed == other.final_speed &&
+           this->enable_dribbler == other.enable_dribbler &&
+           this->enable_autokick == other.enable_autokick;
 }
 
 bool MovePrimitive::operator!=(const MovePrimitive &other) const

--- a/src/thunderbots/software/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/move_primitive.cpp
@@ -56,7 +56,7 @@ double MovePrimitive::getFinalSpeed() const
     return final_speed;
 }
 
-bool MovePrimitive::getAutoKickEnabled() const
+bool MovePrimitive::isAutoKickEnabled() const
 {
     return enable_autokick;
 }

--- a/src/thunderbots/software/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/move_primitive.cpp
@@ -26,8 +26,8 @@ MovePrimitive::MovePrimitive(const thunderbots_msgs::Primitive &primitive_msg)
     dest          = Point(dest_x, dest_y);
     final_angle   = Angle::ofRadians(primitive_msg.parameters.at(2));
     final_speed   = primitive_msg.parameters.at(3);
-    enable_dribbler = (bool)primitive_msg.parameters.at(4);
-    enable_autokick = (bool)primitive_msg.parameters.at(5);
+    enable_dribbler = static_cast<bool>(primitive_msg.parameters.at(4));
+    enable_autokick = static_cast<bool>(primitive_msg.parameters.at(5));
 }
 
 
@@ -61,7 +61,7 @@ bool MovePrimitive::isAutoKickEnabled() const
     return enable_autokick;
 }
 
-bool MovePrimitive::getDribblerEnabled() const
+bool MovePrimitive::isDribblerEnabled() const
 {
     return enable_dribbler;
 }

--- a/src/thunderbots/software/ai/primitive/move_primitive.h
+++ b/src/thunderbots/software/ai/primitive/move_primitive.h
@@ -74,7 +74,6 @@ class MovePrimitive : public Primitive
      */
     double getFinalSpeed() const;
 
-    // TODO: Test me!
     /**
      * Gets whether or not auto-kick should be enabled while moving
      *
@@ -82,7 +81,6 @@ class MovePrimitive : public Primitive
      */
     bool getAutoKickEnabled() const;
 
-    // TODO: Test me!
     /**
      * Gets whether or not the dribbler should be enabled while moving
      *

--- a/src/thunderbots/software/ai/primitive/move_primitive.h
+++ b/src/thunderbots/software/ai/primitive/move_primitive.h
@@ -24,9 +24,14 @@ class MovePrimitive : public Primitive
      * of the movement
      * @param final_speed The final speed the Robot should have when it reaches
      * its destination at the end of the movement
+     * @param enable_dribbler Whether or not to enable the dribbler
+     * @param enable_autokick This will enable the "break-beam" on the robot, that will
+     *                        trigger the kicker to fire as soon as the ball is in front
+     *                        of it
      */
     explicit MovePrimitive(unsigned int robot_id, const Point &dest,
-                           const Angle &final_angle, double final_speed);
+                           const Angle &final_angle, double final_speed,
+                           bool enable_dribbler = false, bool enable_autokick = false);
 
     /**
      * Creates a new Move Primitive from a Primitive message
@@ -34,6 +39,7 @@ class MovePrimitive : public Primitive
      * @param primitive_msg The message from which to create the Move Primitive
      */
     explicit MovePrimitive(const thunderbots_msgs::Primitive &primitive_msg);
+
     /**
      * Gets the primitive name
      *
@@ -68,11 +74,27 @@ class MovePrimitive : public Primitive
      */
     double getFinalSpeed() const;
 
+    // TODO: Test me!
+    /**
+     * Gets whether or not auto-kick should be enabled while moving
+     *
+     * @return whether or not auto-kick should be enabled while moving
+     */
+    bool getAutoKickEnabled() const;
+
+    // TODO: Test me!
+    /**
+     * Gets whether or not the dribbler should be enabled while moving
+     *
+     * @return whether or not the dribbler should be enabled while moving
+     */
+    bool getDribblerEnabled() const;
+
     /**
      * Returns the generic vector of parameters for this Primitive
      *
      * @return A vector of the form {dest.x(), dest.y(), final_angle.toRadians(),
-     *                               final_speed}
+     *                               final_speed, enable_dribbler, enable_autokick}
      */
     std::vector<double> getParameters() const override;
 
@@ -107,4 +129,6 @@ class MovePrimitive : public Primitive
     Point dest;
     Angle final_angle;
     double final_speed;
+    bool enable_dribbler;
+    bool enable_autokick;
 };

--- a/src/thunderbots/software/ai/primitive/move_primitive.h
+++ b/src/thunderbots/software/ai/primitive/move_primitive.h
@@ -79,14 +79,14 @@ class MovePrimitive : public Primitive
      *
      * @return whether or not auto-kick should be enabled while moving
      */
-    bool getAutoKickEnabled() const;
+    bool isAutoKickEnabled() const;
 
     /**
      * Gets whether or not the dribbler should be enabled while moving
      *
      * @return whether or not the dribbler should be enabled while moving
      */
-    bool getDribblerEnabled() const;
+    bool isDribblerEnabled() const;
 
     /**
      * Returns the generic vector of parameters for this Primitive

--- a/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
+++ b/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
@@ -88,6 +88,7 @@ void MRFPrimitiveVisitor::visit(const KickPrimitive &kick_primitive)
     radio_prim->extra_bits = static_cast<uint8_t>(2 | 0);
 }
 
+// TODO: new extra bits here need to be tested!!
 void MRFPrimitiveVisitor::visit(const MovePrimitive &move_primitive)
 {
     radio_prim              = RadioPrimitive();
@@ -98,6 +99,8 @@ void MRFPrimitiveVisitor::visit(const MovePrimitive &move_primitive)
         move_primitive.getFinalAngle().toRadians() * CENTIRADIANS_PER_RADIAN,
         move_primitive.getFinalSpeed() * MILLIMETERS_PER_METER};
     radio_prim->extra_bits = 0;
+    radio_prim->extra_bits += move_primitive.getAutoKickEnabled() * 0x01;
+    radio_prim->extra_bits += move_primitive.getDribblerEnabled() * 0x02;
 }
 
 void MRFPrimitiveVisitor::visit(const MoveSpinPrimitive &movespin_primitive)

--- a/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
+++ b/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
@@ -88,7 +88,6 @@ void MRFPrimitiveVisitor::visit(const KickPrimitive &kick_primitive)
     radio_prim->extra_bits = static_cast<uint8_t>(2 | 0);
 }
 
-// TODO: new extra bits here need to be tested!!
 void MRFPrimitiveVisitor::visit(const MovePrimitive &move_primitive)
 {
     radio_prim              = RadioPrimitive();

--- a/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
+++ b/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
@@ -98,8 +98,8 @@ void MRFPrimitiveVisitor::visit(const MovePrimitive &move_primitive)
         move_primitive.getFinalAngle().toRadians() * CENTIRADIANS_PER_RADIAN,
         move_primitive.getFinalSpeed() * MILLIMETERS_PER_METER};
     radio_prim->extra_bits = 0;
-    radio_prim->extra_bits += move_primitive.getAutoKickEnabled() * 0x01;
-    radio_prim->extra_bits += move_primitive.getDribblerEnabled() * 0x02;
+    radio_prim->extra_bits |= move_primitive.isAutoKickEnabled() * 0x01;
+    radio_prim->extra_bits |= move_primitive.isDribblerEnabled() * 0x02;
 }
 
 void MRFPrimitiveVisitor::visit(const MoveSpinPrimitive &movespin_primitive)

--- a/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
@@ -4,6 +4,8 @@
 
 #include "ai/intent/move_intent.h"
 
+// TODO: Update these tests with new primitive parameters
+
 TEST(MoveActionTest, robot_far_from_destination)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),

--- a/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
@@ -4,8 +4,6 @@
 
 #include "ai/intent/move_intent.h"
 
-// TODO: Update these tests with new primitive parameters
-
 TEST(MoveActionTest, robot_far_from_destination)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
@@ -24,6 +22,8 @@ TEST(MoveActionTest, robot_far_from_destination)
     EXPECT_EQ(Point(1, 0), move_intent.getDestination());
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
+    EXPECT_FALSE(move_intent.getDribblerEnabled());
+    EXPECT_FALSE(move_intent.getAutoKickEnabled());
 }
 
 TEST(MoveActionTest, robot_at_destination)
@@ -60,4 +60,48 @@ TEST(MoveActionTest, test_action_does_not_prematurely_report_done)
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
+}
+
+TEST(MoveActionTest, robot_far_from_destination_autokick_turned_on)
+{
+    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+    MoveAction action = MoveAction(0.05);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(
+        robot, Point(1, 0), Angle::quarter(), 1.0, false, true);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    EXPECT_EQ(Point(1, 0), move_intent.getDestination());
+    EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
+    EXPECT_EQ(1.0, move_intent.getFinalSpeed());
+    EXPECT_FALSE(move_intent.getDribblerEnabled());
+    EXPECT_TRUE(move_intent.getAutoKickEnabled());
+}
+
+TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
+{
+    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+    MoveAction action = MoveAction(0.05);
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(
+        robot, Point(1, 0), Angle::quarter(), 1.0, true, false);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+    EXPECT_EQ(0, move_intent.getRobotId());
+    EXPECT_EQ(Point(1, 0), move_intent.getDestination());
+    EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
+    EXPECT_EQ(1.0, move_intent.getFinalSpeed());
+    EXPECT_TRUE(move_intent.getDribblerEnabled());
+    EXPECT_FALSE(move_intent.getAutoKickEnabled());
 }

--- a/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
@@ -22,8 +22,8 @@ TEST(MoveActionTest, robot_far_from_destination)
     EXPECT_EQ(Point(1, 0), move_intent.getDestination());
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
-    EXPECT_FALSE(move_intent.getDribblerEnabled());
-    EXPECT_FALSE(move_intent.getAutoKickEnabled());
+    EXPECT_FALSE(move_intent.isDribblerEnabled());
+    EXPECT_FALSE(move_intent.isAutoKickEnabled());
 }
 
 TEST(MoveActionTest, robot_at_destination)
@@ -80,8 +80,8 @@ TEST(MoveActionTest, robot_far_from_destination_autokick_turned_on)
     EXPECT_EQ(Point(1, 0), move_intent.getDestination());
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
-    EXPECT_FALSE(move_intent.getDribblerEnabled());
-    EXPECT_TRUE(move_intent.getAutoKickEnabled());
+    EXPECT_FALSE(move_intent.isDribblerEnabled());
+    EXPECT_TRUE(move_intent.isAutoKickEnabled());
 }
 
 TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
@@ -102,6 +102,6 @@ TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
     EXPECT_EQ(Point(1, 0), move_intent.getDestination());
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
-    EXPECT_TRUE(move_intent.getDribblerEnabled());
-    EXPECT_FALSE(move_intent.getAutoKickEnabled());
+    EXPECT_TRUE(move_intent.isDribblerEnabled());
+    EXPECT_FALSE(move_intent.isAutoKickEnabled());
 }

--- a/src/thunderbots/software/test/ai/intent/move_intent.cpp
+++ b/src/thunderbots/software/test/ai/intent/move_intent.cpp
@@ -7,6 +7,8 @@
 #include <gtest/gtest.h>
 #include <string.h>
 
+// TODO: Update these tests with new primitive parameters
+
 TEST(MoveIntentTest, intent_name_test)
 {
     MoveIntent move_intent = MoveIntent(0, Point(), Angle::zero(), 0, 0);

--- a/src/thunderbots/software/test/ai/intent/move_intent.cpp
+++ b/src/thunderbots/software/test/ai/intent/move_intent.cpp
@@ -7,8 +7,6 @@
 #include <gtest/gtest.h>
 #include <string.h>
 
-// TODO: Update these tests with new primitive parameters
-
 TEST(MoveIntentTest, intent_name_test)
 {
     MoveIntent move_intent = MoveIntent(0, Point(), Angle::zero(), 0, 0);

--- a/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
@@ -7,6 +7,8 @@
 #include <gtest/gtest.h>
 #include <string.h>
 
+// TODO: Update these tests with new primitive parameters
+
 TEST(MovePrimTest, primitive_name_test)
 {
     MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0);

--- a/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
@@ -26,22 +26,22 @@ TEST(MovePrimTest, get_robot_id_test)
 TEST(MovePrimTest, autokick_and_dribble_disabled_by_default)
 {
     MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0);
-    EXPECT_FALSE(move_prim.getAutoKickEnabled());
-    EXPECT_FALSE(move_prim.getDribblerEnabled());
+    EXPECT_FALSE(move_prim.isAutoKickEnabled());
+    EXPECT_FALSE(move_prim.isDribblerEnabled());
 }
 
 TEST(MovePrimTest, get_dribble_enabled)
 {
     MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, true, false);
-    EXPECT_TRUE(move_prim.getDribblerEnabled());
-    EXPECT_FALSE(move_prim.getAutoKickEnabled());
+    EXPECT_TRUE(move_prim.isDribblerEnabled());
+    EXPECT_FALSE(move_prim.isAutoKickEnabled());
 }
 
 TEST(MovePrimTest, get_autokick_enabled)
 {
     MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, false, true);
-    EXPECT_FALSE(move_prim.getDribblerEnabled());
-    EXPECT_TRUE(move_prim.getAutoKickEnabled());
+    EXPECT_FALSE(move_prim.isDribblerEnabled());
+    EXPECT_TRUE(move_prim.isAutoKickEnabled());
 }
 
 TEST(MovePrimTest, parameter_array_test)

--- a/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
@@ -7,8 +7,6 @@
 #include <gtest/gtest.h>
 #include <string.h>
 
-// TODO: Update these tests with new primitive parameters
-
 TEST(MovePrimTest, primitive_name_test)
 {
     MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0);
@@ -23,6 +21,27 @@ TEST(MovePrimTest, get_robot_id_test)
     MovePrimitive move_prim = MovePrimitive(robot_id, Point(), Angle(), 0.0);
 
     EXPECT_EQ(robot_id, move_prim.getRobotId());
+}
+
+TEST(MovePrimTest, autokick_and_dribble_disabled_by_default)
+{
+    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0);
+    EXPECT_FALSE(move_prim.getAutoKickEnabled());
+    EXPECT_FALSE(move_prim.getDribblerEnabled());
+}
+
+TEST(MovePrimTest, get_dribble_enabled)
+{
+    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, true, false);
+    EXPECT_TRUE(move_prim.getDribblerEnabled());
+    EXPECT_FALSE(move_prim.getAutoKickEnabled());
+}
+
+TEST(MovePrimTest, get_autokick_enabled)
+{
+    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, false, true);
+    EXPECT_FALSE(move_prim.getDribblerEnabled());
+    EXPECT_TRUE(move_prim.getAutoKickEnabled());
 }
 
 TEST(MovePrimTest, parameter_array_test)

--- a/src/thunderbots/software/test/radio_communication/visitor/mrf_primitive_visitor.cpp
+++ b/src/thunderbots/software/test/radio_communication/visitor/mrf_primitive_visitor.cpp
@@ -130,7 +130,7 @@ TEST(MRFPrimitiveVisitorTest, visit_kick_primitive)
     EXPECT_RADIO_PRIMITIVES_EQ(expected_radio_primitive, actual_radio_primitive);
 }
 
-TEST(MRFPrimitiveVisitorTest, visit_move_primitive)
+TEST(MRFPrimitiveVisitorTest, visit_move_primitive_autokick_and_dribble_off)
 {
     MovePrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33);
     RadioPrimitive expected_radio_primitive;
@@ -138,6 +138,51 @@ TEST(MRFPrimitiveVisitorTest, visit_move_primitive)
     expected_radio_primitive.param_array = {22 * 1000, 33.3 * 1000,
                                             Angle::half().toRadians() * 100, 2.33 * 1000};
     expected_radio_primitive.extra_bits  = 0;
+
+    MRFPrimitiveVisitor prim_visitor;
+    primitive.accept(prim_visitor);
+    RadioPrimitive actual_radio_primitive = prim_visitor.getSerializedRadioPacket();
+    EXPECT_RADIO_PRIMITIVES_EQ(expected_radio_primitive, actual_radio_primitive);
+}
+
+TEST(MRFPrimitiveVisitorTest, visit_move_primitive_autokick_enabled_dribble_off)
+{
+    MovePrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33, false, true);
+    RadioPrimitive expected_radio_primitive;
+    expected_radio_primitive.prim_type   = FirmwarePrimitiveType::MOVE;
+    expected_radio_primitive.param_array = {22 * 1000, 33.3 * 1000,
+                                            Angle::half().toRadians() * 100, 2.33 * 1000};
+    expected_radio_primitive.extra_bits  = 1;
+
+    MRFPrimitiveVisitor prim_visitor;
+    primitive.accept(prim_visitor);
+    RadioPrimitive actual_radio_primitive = prim_visitor.getSerializedRadioPacket();
+    EXPECT_RADIO_PRIMITIVES_EQ(expected_radio_primitive, actual_radio_primitive);
+}
+
+TEST(MRFPrimitiveVisitorTest, visit_move_primitive_dribble_enabled_autokick_off)
+{
+    MovePrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33, true, false);
+    RadioPrimitive expected_radio_primitive;
+    expected_radio_primitive.prim_type   = FirmwarePrimitiveType::MOVE;
+    expected_radio_primitive.param_array = {22 * 1000, 33.3 * 1000,
+                                            Angle::half().toRadians() * 100, 2.33 * 1000};
+    expected_radio_primitive.extra_bits  = 2;
+
+    MRFPrimitiveVisitor prim_visitor;
+    primitive.accept(prim_visitor);
+    RadioPrimitive actual_radio_primitive = prim_visitor.getSerializedRadioPacket();
+    EXPECT_RADIO_PRIMITIVES_EQ(expected_radio_primitive, actual_radio_primitive);
+}
+
+TEST(MRFPrimitiveVisitorTest, visit_move_primitive_autokick_and_dribble_enabled)
+{
+    MovePrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33, true, true);
+    RadioPrimitive expected_radio_primitive;
+    expected_radio_primitive.prim_type   = FirmwarePrimitiveType::MOVE;
+    expected_radio_primitive.param_array = {22 * 1000, 33.3 * 1000,
+                                            Angle::half().toRadians() * 100, 2.33 * 1000};
+    expected_radio_primitive.extra_bits  = 3;
 
     MRFPrimitiveVisitor prim_visitor;
     primitive.accept(prim_visitor);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Added a flags to enable autokick and dribbling to the `MoveIntent`, `MoveAction`, `MovePrimitive` and added associated changes to the `MrfPrimitiveVisitor`. Added associated tests.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests, tested on robots.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Part of #373
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification
NA
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
