### PR TITLE
Added calcBinaryTrespass(Rectangle, Point) function

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -24,7 +24,7 @@ std::string PasserTactic::getName() const
 void PasserTactic::updateParams(const Pass& updated_pass,
                                 const Timestamp& updated_curr_time)
 {
-    this->pass = updated_pass;
+    this->pass      = updated_pass;
     this->curr_time = updated_curr_time;
 }
 

--- a/src/thunderbots/software/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/move_primitive.cpp
@@ -20,12 +20,12 @@ MovePrimitive::MovePrimitive(const thunderbots_msgs::Primitive &primitive_msg)
 {
     validatePrimitiveMessage(primitive_msg, getPrimitiveName());
 
-    robot_id      = primitive_msg.robot_id;
-    double dest_x = primitive_msg.parameters.at(0);
-    double dest_y = primitive_msg.parameters.at(1);
-    dest          = Point(dest_x, dest_y);
-    final_angle   = Angle::ofRadians(primitive_msg.parameters.at(2));
-    final_speed   = primitive_msg.parameters.at(3);
+    robot_id        = primitive_msg.robot_id;
+    double dest_x   = primitive_msg.parameters.at(0);
+    double dest_y   = primitive_msg.parameters.at(1);
+    dest            = Point(dest_x, dest_y);
+    final_angle     = Angle::ofRadians(primitive_msg.parameters.at(2));
+    final_speed     = primitive_msg.parameters.at(3);
     enable_dribbler = static_cast<bool>(primitive_msg.parameters.at(4));
     enable_autokick = static_cast<bool>(primitive_msg.parameters.at(5));
 }

--- a/src/thunderbots/software/geom/util.cpp
+++ b/src/thunderbots/software/geom/util.cpp
@@ -1061,3 +1061,12 @@ double getPointsVariance(const std::vector<Point> &points)
     sum /= static_cast<double>(points.size());
     return sqrt(sum);
 }
+
+int calcBinaryTrespassScore( const Rectangle &rectangle, const Point &point) {
+
+    if( rectangle.containsPoint(point)) {
+        return 1;
+    } else {
+        return 0;
+    }
+}

--- a/src/thunderbots/software/geom/util.cpp
+++ b/src/thunderbots/software/geom/util.cpp
@@ -1062,11 +1062,14 @@ double getPointsVariance(const std::vector<Point> &points)
     return sqrt(sum);
 }
 
-int calcBinaryTrespassScore( const Rectangle &rectangle, const Point &point) {
-
-    if( rectangle.containsPoint(point)) {
+int calcBinaryTrespassScore(const Rectangle &rectangle, const Point &point)
+{
+    if (rectangle.containsPoint(point))
+    {
         return 1;
-    } else {
+    }
+    else
+    {
         return 0;
     }
 }

--- a/src/thunderbots/software/geom/util.h
+++ b/src/thunderbots/software/geom/util.h
@@ -509,3 +509,13 @@ Point getPointsMean(const std::vector<Point> &points);
  * @return the variance of the list of points
  */
 double getPointsVariance(const std::vector<Point> &points);
+
+/**
+ * Returns the binary trespass score of a point and rectangle
+ *
+ * @param point The point to check for trespassing
+ * @param rectangle The rectangle to check for trespassing by the Point parameter
+ * @return 1 if the point exists within the rectangle, or on the boundry of the rectangle
+ *         0 if the point exists outside of the rectangle
+ */
+int calcBinaryTrespassScore(const Rectangle &rectangle, const Point &point);

--- a/src/thunderbots/software/test/geom/util.cpp
+++ b/src/thunderbots/software/test/geom/util.cpp
@@ -1055,37 +1055,38 @@ TEST(GeomUtilTest, test_ray_segment_overlapping_passes_through_seg_start_and_end
 // Test to see if the 1 is returned when the point exists within the rectangle
 TEST(GeomUtilTest, test_binary_trespass_point_is_trespassing_in_rectangle)
 {
-    Rectangle rectangle = Rectangle( Point(-1,-1), Point(1,1));
+    Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
 
-    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(0,0)));
-    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(0.5,0.5)));
-    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-0.5,-0.5)));
-    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(0.5,-0.5)));
-    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-0.5,0.5)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(0, 0)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(0.5, 0.5)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-0.5, -0.5)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(0.5, -0.5)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-0.5, 0.5)));
 }
 
-// Test to see if the 1 is returned when the point exists on the boundries of the rectangle
+// Test to see if the 1 is returned when the point exists on the boundries of the
+// rectangle
 TEST(GeomUtilTest, test_binary_trespass_point_is_on_rectangle_boundry)
 {
-    Rectangle rectangle = Rectangle( Point(-1,-1), Point(1,1));
+    Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
 
-    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-1,-1)));
-    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(1,1)));
-    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-1,1)));
-    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(1,-1)));
-    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-1,0.5)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-1, -1)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(1, 1)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-1, 1)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(1, -1)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-1, 0.5)));
 }
 
 // Test to see if the 0 is returned when the point exists outside of the rectangle
 TEST(GeomUtilTest, test_binary_trespass_point_is_outside_rectangle)
 {
-    Rectangle rectangle = Rectangle( Point(-1,-1), Point(1,1));
+    Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
 
-    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(-1,-2)));
-    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(2,1)));
-    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(-1,3)));
-    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(5,-0.2)));
-    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(-4,5)));
+    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(-1, -2)));
+    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(2, 1)));
+    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(-1, 3)));
+    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(5, -0.2)));
+    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(-4, 5)));
 }
 
 int main(int argc, char **argv)

--- a/src/thunderbots/software/test/geom/util.cpp
+++ b/src/thunderbots/software/test/geom/util.cpp
@@ -1051,6 +1051,43 @@ TEST(GeomUtilTest, test_ray_segment_overlapping_passes_through_seg_start_and_end
     EXPECT_EQ(intersection2.value(), segment.getEnd());
 }
 
+
+// Test to see if the 1 is returned when the point exists within the rectangle
+TEST(GeomUtilTest, test_binary_trespass_point_is_trespassing_in_rectangle)
+{
+    Rectangle rectangle = Rectangle( Point(-1,-1), Point(1,1));
+
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(0,0)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(0.5,0.5)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-0.5,-0.5)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(0.5,-0.5)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-0.5,0.5)));
+}
+
+// Test to see if the 1 is returned when the point exists on the boundries of the rectangle
+TEST(GeomUtilTest, test_binary_trespass_point_is_on_rectangle_boundry)
+{
+    Rectangle rectangle = Rectangle( Point(-1,-1), Point(1,1));
+
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-1,-1)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(1,1)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-1,1)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(1,-1)));
+    EXPECT_EQ(1, calcBinaryTrespassScore(rectangle, Point(-1,0.5)));
+}
+
+// Test to see if the 0 is returned when the point exists outside of the rectangle
+TEST(GeomUtilTest, test_binary_trespass_point_is_outside_rectangle)
+{
+    Rectangle rectangle = Rectangle( Point(-1,-1), Point(1,1));
+
+    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(-1,-2)));
+    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(2,1)));
+    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(-1,3)));
+    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(5,-0.2)));
+    EXPECT_EQ(0, calcBinaryTrespassScore(rectangle, Point(-4,5)));
+}
+
 int main(int argc, char **argv)
 {
     std::cout << argv[0] << std::endl;


### PR DESCRIPTION

### Description

Added calcBinaryTrespass(Rectangle, Point) function to geom/util.cpp/h

Just a wrapper for Rectangle.contains(Point), but is one of the issues.


### Testing Done

Unit tests for:
-Inside the rectangle cases
-On the border of rectangle cases
-Outside the rectangle cases

### Resolved Issues
Issue #534 

### Review Checklist
- [X] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [X] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [X] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.