### PR TITLE
Added Functions To Visualizer For Drawing Points/Rectangles/World And Made It Threadsafe

### DIFF
--- a/src/thunderbots/software/ai/main.cpp
+++ b/src/thunderbots/software/ai/main.cpp
@@ -42,6 +42,8 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr &msg)
     }
     primitive_publisher.publish(primitive_array_message);
 
+    // On every tick, send the layer messages
+    Util::CanvasMessenger::getInstance()->publishAndClearLayers();
 
     count++;
 }
@@ -69,20 +71,6 @@ int main(int argc, char **argv)
     // Initialize Dynamic Parameters
     auto update_subscribers =
         Util::DynamicParameters::initUpdateSubscriptions(node_handle);
-
-    while (true){
-        auto painter = Util::CanvasMessenger::getInstance();
-        painter->drawRectangle(Util::CanvasMessenger::Layer::STATIC_FEATURES,
-                               Rectangle({3,1}, {-1,-1}),
-                               Angle::zero(),
-                               {0, 255, 0, 0}
-                               std::this_thread::sleep_for()
-        );
-
-        // On every tick, send the layer messages
-        Util::CanvasMessenger::getInstance()->publishAndClearLayers();
-
-    }
 
     // Services any ROS calls in a separate thread "behind the scenes". Does not return
     // until the node is shutdown

--- a/src/thunderbots/software/ai/main.cpp
+++ b/src/thunderbots/software/ai/main.cpp
@@ -42,8 +42,12 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr &msg)
     }
     primitive_publisher.publish(primitive_array_message);
 
+    // Draw the world
+    std::shared_ptr<Util::CanvasMessenger> canvas_messenger = Util::CanvasMessenger::getInstance();
+    canvas_messenger->drawWorld(world);
+
     // On every tick, send the layer messages
-    Util::CanvasMessenger::getInstance()->publishAndClearLayers();
+    canvas_messenger->publishAndClearAllLayers();
 
     count++;
 }

--- a/src/thunderbots/software/ai/main.cpp
+++ b/src/thunderbots/software/ai/main.cpp
@@ -43,7 +43,8 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr &msg)
     primitive_publisher.publish(primitive_array_message);
 
     // Draw the world
-    std::shared_ptr<Util::CanvasMessenger> canvas_messenger = Util::CanvasMessenger::getInstance();
+    std::shared_ptr<Util::CanvasMessenger> canvas_messenger =
+        Util::CanvasMessenger::getInstance();
     canvas_messenger->drawWorld(world);
 
     // On every tick, send the layer messages

--- a/src/thunderbots/software/ai/main.cpp
+++ b/src/thunderbots/software/ai/main.cpp
@@ -42,8 +42,6 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr &msg)
     }
     primitive_publisher.publish(primitive_array_message);
 
-    // On every tick, send the layer messages
-    Util::CanvasMessenger::getInstance()->publishAndClearLayers();
 
     count++;
 }
@@ -71,6 +69,20 @@ int main(int argc, char **argv)
     // Initialize Dynamic Parameters
     auto update_subscribers =
         Util::DynamicParameters::initUpdateSubscriptions(node_handle);
+
+    while (true){
+        auto painter = Util::CanvasMessenger::getInstance();
+        painter->drawRectangle(Util::CanvasMessenger::Layer::STATIC_FEATURES,
+                               Rectangle({3,1}, {-1,-1}),
+                               Angle::zero(),
+                               {0, 255, 0, 0}
+                               std::this_thread::sleep_for()
+        );
+
+        // On every tick, send the layer messages
+        Util::CanvasMessenger::getInstance()->publishAndClearLayers();
+
+    }
 
     // Services any ROS calls in a separate thread "behind the scenes". Does not return
     // until the node is shutdown

--- a/src/thunderbots/software/launch/ai.launch
+++ b/src/thunderbots/software/launch/ai.launch
@@ -9,8 +9,10 @@
     </node>
 
     <!-- Launch the ai logic node -->
+    <!--
     <node name="ai_logic" pkg="thunderbots" type="ai_logic" output="screen">
     </node>
+    -->
 
     <!-- Launch the dynamic parameters node -->
     <node name="parameters" pkg="thunderbots" type="parameters" output="screen"/>

--- a/src/thunderbots/software/launch/ai.launch
+++ b/src/thunderbots/software/launch/ai.launch
@@ -9,10 +9,8 @@
     </node>
 
     <!-- Launch the ai logic node -->
-    <!--
     <node name="ai_logic" pkg="thunderbots" type="ai_logic" output="screen">
     </node>
-    -->
 
     <!-- Launch the dynamic parameters node -->
     <node name="parameters" pkg="thunderbots" type="parameters" output="screen"/>

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
@@ -2,138 +2,201 @@
 
 #include "util/constants.h"
 
-namespace Util
+using namespace Util;
+
+std::shared_ptr<CanvasMessenger> CanvasMessenger::getInstance()
 {
-    std::shared_ptr<CanvasMessenger> CanvasMessenger::getInstance()
+    static std::shared_ptr<CanvasMessenger> canvas_messenger(new CanvasMessenger);
+    return canvas_messenger;
+}
+
+void CanvasMessenger::initializePublisher(ros::NodeHandle node_handle)
+{
+    this->publisher = node_handle.advertise<thunderbots_msgs::CanvasLayer>(
+        Util::Constants::VISUALIZER_DRAW_LAYER_TOPIC, BUFFER_SIZE);
+}
+
+void CanvasMessenger::publishAndClearLayers()
+{
+    // Take ownership of the layers for the duration of this function
+    std::lock_guard<std::mutex> best_known_pass_lock(layers_lock);
+
+    // Limit rate of the message publishing
+    // Get the time right now
+    const std::chrono::time_point<std::chrono::system_clock> now =
+        std::chrono::system_clock::now();
+    const int64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                   now - time_last_published)
+                                   .count();
+    const double elapsed_ms = elapsed_ns / 1.0e6;
+
+    // Do not do anything if the time passed hasn't been
+    // long enough
+    if (elapsed_ms < DESIRED_PERIOD_MS)
+        return;
+
+    // Send a payload per layer of messages
+    for (const auto& layer_pair : this->layers_map)
     {
-        static std::shared_ptr<CanvasMessenger> canvas_messenger(new CanvasMessenger);
-        return canvas_messenger;
+        // First is the layer number
+        const uint8_t layer_number = layer_pair.first;
+
+        // Second is the vector that contains the sprites
+        const std::vector<Sprite>& sprites = layer_pair.second;
+
+        // Only send the non-empty layers
+//            if (!layer_pair.second.empty())
+//            {
+            this->publishPayload(layer_number, sprites);
+//            }
     }
 
-    void CanvasMessenger::initializePublisher(ros::NodeHandle node_handle)
+    // Clear shapes in layers of current frame/tick
+    this->clearLayers();
+
+    // Update last published time
+    time_last_published = now;
+}
+
+void CanvasMessenger::publishPayload(uint8_t layer,
+                                     std::vector<Sprite> sprites)
+{
+    std::vector<uint8_t> payload;
+
+    // Add the layer number at the begining of the binary message
+    payload.insert(payload.end(), layer);
+
+    // Convert each sprite into a binary message
+    for (Sprite& sprite : sprites)
     {
-        this->publisher = node_handle.advertise<thunderbots_msgs::CanvasLayer>(
-            Util::Constants::VISUALIZER_DRAW_LAYER_TOPIC, BUFFER_SIZE);
+        std::vector<uint8_t> sprite_payload = sprite.serialize();
+        payload.insert(payload.end(), sprite_payload.begin(), sprite_payload.end());
     }
 
-    void CanvasMessenger::publishAndClearLayers()
+    // Create a new layer message, add the binary data
+    thunderbots_msgs::CanvasLayer new_layer;
+    new_layer.data = payload;
+
+    // and publish
+    this->publisher.publish(new_layer);
+}
+
+void CanvasMessenger::clearLayers()
+{
+    // Clears all sprite vector in all the layers
+    for (auto& layer : this->layers_map)
     {
-        // Limit rate of the message publishing
-        // Get the time right now
-        const std::chrono::time_point<std::chrono::system_clock> now =
-            std::chrono::system_clock::now();
-        const int64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                       now - time_last_published)
-                                       .count();
-        const double elapsed_ms = elapsed_ns / 1.0e6;
+        layer.second.clear();
+//            Util::CanvasMessenger::getInstance()->drawPoint(Point(), 0.5, 255, 0, 0);
+    }
+}
 
-        // Do not do anything if the time passed hasn't been
-        // long enough
-        if (elapsed_ms < DESIRED_PERIOD_MS)
-            return;
 
-        // Send a payload per layer of messages
-        for (const std::pair<uint8_t, std::vector<Sprite>>& layer_pair : this->layers_map)
-        {
-            // First is the layer number
-            const uint8_t layer_number = layer_pair.first;
+void CanvasMessenger::drawSprite(Layer layer, Sprite sprite)
+{
+    // We simply add the sprite to the specified layer
+    this->addSpriteToLayer(layer, sprite);
+}
 
-            // Second is the vector that contains the sprites
-            const std::vector<Sprite>& sprites = layer_pair.second;
+void CanvasMessenger::addSpriteToLayer(Layer layer, Sprite &sprite)
+{
+    // Take ownership of the layers for the duration of this function
+    std::lock_guard<std::mutex> best_known_pass_lock(layers_lock);
 
-            // Only send the non-empty layers
-            if (!layer_pair.second.empty())
-            {
-                this->publishPayload(layer_number, sprites);
-            }
-        }
-
-        // Clear shapes in layers of current frame/tick
-        this->clearLayers();
-
-        // Update last published time
-        time_last_published = now;
+    // We look if the layer exists
+    if (this->layers_map.find(layer) == this->layers_map.end())
+    {
+        // If not, we initialize new key to empty vector pair
+        this->layers_map[layer];
     }
 
-    void CanvasMessenger::publishPayload(uint8_t layer,
-                                         const std::vector<Sprite>& sprites)
-    {
-        std::vector<uint8_t> payload;
+    // and add the sprite to the layer vector
+    this->layers_map[layer].emplace_back(sprite);
+}
 
-        // Add the layer number at the begining of the binary message
-        payload.insert(payload.end(), layer);
+void CanvasMessenger::drawRectangle(Layer layer, Rectangle rectangle, Angle orientation, Color color) {
+    Sprite rectangle_sprite(0, rectangle.centre(), orientation, rectangle.width(), rectangle.height(), color);
 
-        // Convert each sprite into a binary message
-        for (const Sprite& sprite : sprites)
-        {
-            payload.insert(payload.end(), sprite.texture);
+    drawSprite(layer, rectangle_sprite);
+}
 
-            // These are all 16 bits, we need to split them
-            Int16OrTwoInt8 x;
-            x.base = sprite.x;
-            payload.insert(payload.end(), x.result[1]);
-            payload.insert(payload.end(), x.result[0]);
+//void CanvasMessenger::drawPoint(Point p, double radius, int r, int g, int b,
+//                                int opacity) {
+//    Sprite sprite;
+//
+//    sprite.x = std::round(p.x() * PIXELS_PER_METER - (radius*PIXELS_PER_METER/2));
+//    sprite.y =  std::round(-p.y() * PIXELS_PER_METER - (radius*PIXELS_PER_METER/2));
+//
+//    sprite.width = radius * PIXELS_PER_METER;
+//    sprite.height = radius * PIXELS_PER_METER;
+//
+////        sprite.red = r;
+////        sprite.green = g;
+////        sprite.blue = b;
+////        sprite.opacity = opacity;
+//
+//    // 1 is a circle
+//    sprite.texture = 0;
+//
+//    drawSprite(1, sprite);
+//}
 
-            Int16OrTwoInt8 y;
-            y.base = sprite.y;
-            payload.insert(payload.end(), y.result[1]);
-            payload.insert(payload.end(), y.result[0]);
+//void CanvasMessenger::drawField(const Field &field) {
+//    Sprite field_sprite;
+//    field_sprite.width = field.length() * PIXELS_PER_METER;
+//    field_sprite.height = field.width() * PIXELS_PER_METER;
+//    field_sprite.x = std::round(-field.length() * PIXELS_PER_METER/2);
+//    field_sprite.y = std::round(-field.width() * PIXELS_PER_METER/2);
+//
+//    drawSprite(0, field_sprite);
+//}
 
-            Int16OrTwoInt8 width;
-            width.base = sprite.width;
-            payload.insert(payload.end(), width.result[1]);
-            payload.insert(payload.end(), width.result[0]);
 
-            Int16OrTwoInt8 height;
-            height.base = sprite.height;
-            payload.insert(payload.end(), height.result[1]);
-            payload.insert(payload.end(), height.result[0]);
 
-            Int16OrTwoInt8 rotation;
-            rotation.base = sprite.rotation;
-            payload.insert(payload.end(), rotation.result[1]);
-            payload.insert(payload.end(), rotation.result[0]);
 
-            payload.insert(payload.end(), sprite.opacity);
-            payload.insert(payload.end(), sprite.red);
-            payload.insert(payload.end(), sprite.green);
-            payload.insert(payload.end(), sprite.blue);
-        }
 
-        // Create a new layer message, add the binary data
-        thunderbots_msgs::CanvasLayer new_layer;
-        new_layer.data = payload;
 
-        // and publish
-        this->publisher.publish(new_layer);
-    }
 
-    void CanvasMessenger::clearLayers()
-    {
-        // Clears all sprite vector in all the layers
-        for (auto& layer : this->layers_map)
-        {
-            layer.second.clear();
-        }
-    }
+Point CanvasMessenger::Sprite::getTopLeftCorner() {
+    return _center + Vector(_width, _height).rotate(_orientation);
+}
 
-    void CanvasMessenger::drawSprite(uint8_t layer, Sprite sprite)
-    {
-        // We simply add the sprite to the specified layer
-        this->addSpriteToLayer(layer, sprite);
-    }
 
-    void CanvasMessenger::addSpriteToLayer(uint8_t layer, Sprite& sprite)
-    {
-        // We look if the layer exists
-        if (this->layers_map.find(layer) == this->layers_map.end())
-        {
-            // If not, we initialize new key to empty vector pair
-            this->layers_map[layer];
-        }
+std::vector<uint8_t> CanvasMessenger::Sprite::serialize() {
+    std::vector<uint8_t> payload;
 
-        // and add the sprite to the layer vector
-        this->layers_map[layer].emplace_back(sprite);
-    }
+    Point top_left_corner = getTopLeftCorner();
 
-}  // namespace Util
+    // These are all 16 bits, we need to split them
+    Int16OrTwoInt8 x;
+    x.base = top_left_corner.x();
+    payload.insert(payload.end(), x.result[1]);
+    payload.insert(payload.end(), x.result[0]);
+
+    Int16OrTwoInt8 y;
+    y.base = top_left_corner.y();
+    payload.insert(payload.end(), y.result[1]);
+    payload.insert(payload.end(), y.result[0]);
+
+    Int16OrTwoInt8 width;
+    width.base = _width;
+    payload.insert(payload.end(), width.result[1]);
+    payload.insert(payload.end(), width.result[0]);
+
+    Int16OrTwoInt8 height;
+    height.base = _height;
+    payload.insert(payload.end(), height.result[1]);
+    payload.insert(payload.end(), height.result[0]);
+
+    Int16OrTwoInt8 orientation;
+    orientation.base = _orientation.toDegrees();
+    payload.insert(payload.end(), orientation.result[1]);
+    payload.insert(payload.end(), orientation.result[0]);
+
+    payload.insert(payload.end(), _color.a);
+    payload.insert(payload.end(), _color.r);
+    payload.insert(payload.end(), _color.g);
+    payload.insert(payload.end(), _color.b);
+
+    return payload;
+}

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
@@ -1,5 +1,6 @@
-#include <firmware/main/shared_util/constants.h>
 #include "canvas_messenger.h"
+
+#include <firmware/main/shared_util/constants.h>
 
 #include "util/constants.h"
 
@@ -129,21 +130,22 @@ void CanvasMessenger::drawRectangle(Layer layer, Rectangle rectangle, Angle orie
     drawSprite(layer, rectangle_sprite);
 }
 
-void CanvasMessenger::drawLine(Layer layer, Point p1, Point p2, double thickness, Color color)
+void CanvasMessenger::drawLine(Layer layer, Point p1, Point p2, double thickness,
+                               Color color)
 {
     // Since we're just repurposing the Rectangle sprite as a line, we need to figure
     // out where its center is
-    Point line_center = (p2 + p1)/2;
+    Point line_center      = (p2 + p1) / 2;
     Angle line_orientation = (p2 - p1).orientation();
-    double line_length = (p2 - p1).len();
+    double line_length     = (p2 - p1).len();
 
-    Sprite rectangle_sprite(0, line_center, line_orientation, line_length,
-                            thickness, color);
+    Sprite rectangle_sprite(0, line_center, line_orientation, line_length, thickness,
+                            color);
 
     drawSprite(layer, rectangle_sprite);
 }
 
-void CanvasMessenger::drawPoint(Layer layer, const Point &p, double radius, Color color)
+void CanvasMessenger::drawPoint(Layer layer, const Point& p, double radius, Color color)
 {
     Sprite circle_sprite(
         // NOTE: Currently this uses texture ID zero, which is a rectangle, but
@@ -152,39 +154,51 @@ void CanvasMessenger::drawPoint(Layer layer, const Point &p, double radius, Colo
     drawSprite(layer, circle_sprite);
 }
 
-void CanvasMessenger::drawWorld(const World &world) {
+void CanvasMessenger::drawWorld(const World& world)
+{
     drawBall(world.ball());
     drawField(world.field());
     drawTeam(world.friendlyTeam(), FRIENDLY_TEAM_COLOR);
     drawTeam(world.enemyTeam(), ENEMY_TEAM_COLOR);
 }
 
-void CanvasMessenger::drawBall(const Ball &ball) {
-    drawPoint(Layer::ROBOTS_AND_BALL, ball.position(), BALL_MAX_RADIUS_METERS*2, BALL_COLOR);
+void CanvasMessenger::drawBall(const Ball& ball)
+{
+    drawPoint(Layer::ROBOTS_AND_BALL, ball.position(), BALL_MAX_RADIUS_METERS * 2,
+              BALL_COLOR);
 }
 
-void CanvasMessenger::drawField(Field field) {
+void CanvasMessenger::drawField(Field field)
+{
     // Draw the base of the field
-    drawRectangle(Layer::STATIC_FEATURES, Rectangle(field.enemyCornerNeg(), field.friendlyCornerPos()), Angle::zero(), FIELD_COLOR);
+    drawRectangle(Layer::STATIC_FEATURES,
+                  Rectangle(field.enemyCornerNeg(), field.friendlyCornerPos()),
+                  Angle::zero(), FIELD_COLOR);
 
     // Draw the defense areas
-    drawRectangle(Layer::STATIC_FEATURES, field.enemyDefenseArea(), Angle::zero(), DEFENSE_AREA_COLOR);
-    drawRectangle(Layer::STATIC_FEATURES, field.friendlyDefenseArea(), Angle::zero(), DEFENSE_AREA_COLOR);
+    drawRectangle(Layer::STATIC_FEATURES, field.enemyDefenseArea(), Angle::zero(),
+                  DEFENSE_AREA_COLOR);
+    drawRectangle(Layer::STATIC_FEATURES, field.friendlyDefenseArea(), Angle::zero(),
+                  DEFENSE_AREA_COLOR);
 
     // Draw the center line
-    drawLine(Layer::STATIC_FEATURES, {0, -field.width()/2}, {0, field.width()/2}, 0.05, FIELD_LINE_COLOR);
+    drawLine(Layer::STATIC_FEATURES, {0, -field.width() / 2}, {0, field.width() / 2},
+             0.05, FIELD_LINE_COLOR);
 }
 
-void CanvasMessenger::drawTeam(const Team &team, CanvasMessenger::Color color) {
-    for (const Robot& robot : team.getAllRobots()){
+void CanvasMessenger::drawTeam(const Team& team, CanvasMessenger::Color color)
+{
+    for (const Robot& robot : team.getAllRobots())
+    {
         drawRobot(robot, color);
     }
 }
 
-void CanvasMessenger::drawRobot(Robot robot, CanvasMessenger::Color color) {
-    Rectangle robot_rectangle(robot.position() + Vector(ROBOT_MAX_RADIUS_METERS, ROBOT_MAX_RADIUS_METERS),
-            robot.position() + Vector(-ROBOT_MAX_RADIUS_METERS, -ROBOT_MAX_RADIUS_METERS)
-            );
+void CanvasMessenger::drawRobot(Robot robot, CanvasMessenger::Color color)
+{
+    Rectangle robot_rectangle(
+        robot.position() + Vector(ROBOT_MAX_RADIUS_METERS, ROBOT_MAX_RADIUS_METERS),
+        robot.position() + Vector(-ROBOT_MAX_RADIUS_METERS, -ROBOT_MAX_RADIUS_METERS));
     drawRectangle(Layer::ROBOTS_AND_BALL, robot_rectangle, robot.orientation(), color);
 }
 

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
@@ -126,7 +126,8 @@ void CanvasMessenger::drawRectangle(Layer layer, Rectangle rectangle, Angle orie
 
 void CanvasMessenger::drawPoint(Layer layer, Point p, double radius, Color color) {
     Sprite circle_sprite(
-            // TODO: Change to texture id 1 once circles are properly implemented
+            // NOTE: Currently this uses texture ID zero, which is a rectangle, but
+            // eventually we should use a proper circle texture
             0, p, Angle::zero(), radius*2, radius*2, color
             );
     drawSprite(layer, circle_sprite);

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
@@ -164,8 +164,7 @@ void CanvasMessenger::drawWorld(const World& world)
 
 void CanvasMessenger::drawBall(const Ball& ball)
 {
-    drawPoint(Layer::BALL, ball.position(), BALL_MAX_RADIUS_METERS * 2,
-              BALL_COLOR);
+    drawPoint(Layer::BALL, ball.position(), BALL_MAX_RADIUS_METERS * 2, BALL_COLOR);
 }
 
 void CanvasMessenger::drawField(Field field)

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
@@ -1,3 +1,4 @@
+#include <firmware/main/shared_util/constants.h>
 #include "canvas_messenger.h"
 
 #include "util/constants.h"
@@ -128,13 +129,63 @@ void CanvasMessenger::drawRectangle(Layer layer, Rectangle rectangle, Angle orie
     drawSprite(layer, rectangle_sprite);
 }
 
-void CanvasMessenger::drawPoint(Layer layer, Point p, double radius, Color color)
+void CanvasMessenger::drawLine(Layer layer, Point p1, Point p2, double thickness, Color color)
+{
+    // Since we're just repurposing the Rectangle sprite as a line, we need to figure
+    // out where its center is
+    Point line_center = (p2 + p1)/2;
+    Angle line_orientation = (p2 - p1).orientation();
+    double line_length = (p2 - p1).len();
+
+    Sprite rectangle_sprite(0, line_center, line_orientation, line_length,
+                            thickness, color);
+
+    drawSprite(layer, rectangle_sprite);
+}
+
+void CanvasMessenger::drawPoint(Layer layer, const Point &p, double radius, Color color)
 {
     Sprite circle_sprite(
         // NOTE: Currently this uses texture ID zero, which is a rectangle, but
         // eventually we should use a proper circle texture
         0, p, Angle::zero(), radius * 2, radius * 2, color);
     drawSprite(layer, circle_sprite);
+}
+
+void CanvasMessenger::drawWorld(const World &world) {
+    drawBall(world.ball());
+    drawField(world.field());
+    drawTeam(world.friendlyTeam(), FRIENDLY_TEAM_COLOR);
+    drawTeam(world.enemyTeam(), ENEMY_TEAM_COLOR);
+}
+
+void CanvasMessenger::drawBall(const Ball &ball) {
+    drawPoint(Layer::ROBOTS_AND_BALL, ball.position(), BALL_MAX_RADIUS_METERS*2, BALL_COLOR);
+}
+
+void CanvasMessenger::drawField(Field field) {
+    // Draw the base of the field
+    drawRectangle(Layer::STATIC_FEATURES, Rectangle(field.enemyCornerNeg(), field.friendlyCornerPos()), Angle::zero(), FIELD_COLOR);
+
+    // Draw the defense areas
+    drawRectangle(Layer::STATIC_FEATURES, field.enemyDefenseArea(), Angle::zero(), DEFENSE_AREA_COLOR);
+    drawRectangle(Layer::STATIC_FEATURES, field.friendlyDefenseArea(), Angle::zero(), DEFENSE_AREA_COLOR);
+
+    // Draw the center line
+    drawLine(Layer::STATIC_FEATURES, {0, -field.width()/2}, {0, field.width()/2}, 0.05, FIELD_LINE_COLOR);
+}
+
+void CanvasMessenger::drawTeam(const Team &team, CanvasMessenger::Color color) {
+    for (const Robot& robot : team.getAllRobots()){
+        drawRobot(robot, color);
+    }
+}
+
+void CanvasMessenger::drawRobot(Robot robot, CanvasMessenger::Color color) {
+    Rectangle robot_rectangle(robot.position() + Vector(ROBOT_MAX_RADIUS_METERS, ROBOT_MAX_RADIUS_METERS),
+            robot.position() + Vector(-ROBOT_MAX_RADIUS_METERS, -ROBOT_MAX_RADIUS_METERS)
+            );
+    drawRectangle(Layer::ROBOTS_AND_BALL, robot_rectangle, robot.orientation(), color);
 }
 
 Point CanvasMessenger::Sprite::getTopLeftCorner()

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
@@ -164,7 +164,7 @@ void CanvasMessenger::drawWorld(const World& world)
 
 void CanvasMessenger::drawBall(const Ball& ball)
 {
-    drawPoint(Layer::ROBOTS_AND_BALL, ball.position(), BALL_MAX_RADIUS_METERS * 2,
+    drawPoint(Layer::BALL, ball.position(), BALL_MAX_RADIUS_METERS * 2,
               BALL_COLOR);
 }
 
@@ -202,7 +202,7 @@ void CanvasMessenger::drawRobot(Robot robot, CanvasMessenger::Color color)
     Rectangle robot_rectangle(
         robot.position() + Vector(ROBOT_MAX_RADIUS_METERS, ROBOT_MAX_RADIUS_METERS),
         robot.position() + Vector(-ROBOT_MAX_RADIUS_METERS, -ROBOT_MAX_RADIUS_METERS));
-    drawRectangle(Layer::ROBOTS_AND_BALL, robot_rectangle, robot.orientation(), color);
+    drawRectangle(Layer::ROBOTS, robot_rectangle, robot.orientation(), color);
 }
 
 Point CanvasMessenger::Sprite::getTopLeftCorner()

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
@@ -184,6 +184,9 @@ void CanvasMessenger::drawField(Field field)
     // Draw the center line
     drawLine(Layer::STATIC_FEATURES, {0, -field.width() / 2}, {0, field.width() / 2},
              0.05, FIELD_LINE_COLOR);
+
+    // Draw a marker for the origin
+    drawLine(Layer::STATIC_FEATURES, {-0.1, 0}, {0.1, 0}, 0.05, FIELD_LINE_COLOR);
 }
 
 void CanvasMessenger::drawTeam(const Team& team, CanvasMessenger::Color color)

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.cpp
@@ -25,9 +25,9 @@ void CanvasMessenger::publishAndClearAllLayers()
     // Get the time right now
     const std::chrono::time_point<std::chrono::system_clock> now =
         std::chrono::system_clock::now();
-    const int64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                   now - time_last_published)
-                                   .count();
+    const int64_t elapsed_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(now - time_last_published)
+            .count();
     const double elapsed_ms = elapsed_ns / 1.0e6;
 
     // Do not do anything if the time passed hasn't been
@@ -54,8 +54,7 @@ void CanvasMessenger::publishAndClearAllLayers()
     time_last_published = now;
 }
 
-void CanvasMessenger::publishPayload(uint8_t layer,
-                                     std::vector<Sprite> sprites)
+void CanvasMessenger::publishPayload(uint8_t layer, std::vector<Sprite> sprites)
 {
     std::vector<uint8_t> payload;
 
@@ -86,11 +85,13 @@ void CanvasMessenger::clearAllLayers()
     }
 }
 
-void CanvasMessenger::clearLayer(Layer layer){
+void CanvasMessenger::clearLayer(Layer layer)
+{
     // Take ownership of the layers for the duration of this function
     std::lock_guard<std::mutex> best_known_pass_lock(layers_map_lock);
 
-    if (layers_map.find(layer) != layers_map.end()){
+    if (layers_map.find(layer) != layers_map.end())
+    {
         layers_map[layer] = {};
     }
 }
@@ -101,7 +102,7 @@ void CanvasMessenger::drawSprite(Layer layer, Sprite sprite)
     this->addSpriteToLayer(layer, sprite);
 }
 
-void CanvasMessenger::addSpriteToLayer(Layer layer, Sprite &sprite)
+void CanvasMessenger::addSpriteToLayer(Layer layer, Sprite& sprite)
 {
     // Take ownership of the layers for the duration of this function
     std::lock_guard<std::mutex> best_known_pass_lock(layers_map_lock);
@@ -117,27 +118,32 @@ void CanvasMessenger::addSpriteToLayer(Layer layer, Sprite &sprite)
     this->layers_map[layer].emplace_back(sprite);
 }
 
-void CanvasMessenger::drawRectangle(Layer layer, Rectangle rectangle, Angle orientation, Color color) {
+void CanvasMessenger::drawRectangle(Layer layer, Rectangle rectangle, Angle orientation,
+                                    Color color)
+{
     // We switch the width and height here because they're switched in the visualizer
-    Sprite rectangle_sprite(0, rectangle.centre(), orientation, rectangle.width(), rectangle.height(), color);
+    Sprite rectangle_sprite(0, rectangle.centre(), orientation, rectangle.width(),
+                            rectangle.height(), color);
 
     drawSprite(layer, rectangle_sprite);
 }
 
-void CanvasMessenger::drawPoint(Layer layer, Point p, double radius, Color color) {
+void CanvasMessenger::drawPoint(Layer layer, Point p, double radius, Color color)
+{
     Sprite circle_sprite(
-            // NOTE: Currently this uses texture ID zero, which is a rectangle, but
-            // eventually we should use a proper circle texture
-            0, p, Angle::zero(), radius*2, radius*2, color
-            );
+        // NOTE: Currently this uses texture ID zero, which is a rectangle, but
+        // eventually we should use a proper circle texture
+        0, p, Angle::zero(), radius * 2, radius * 2, color);
     drawSprite(layer, circle_sprite);
 }
 
-Point CanvasMessenger::Sprite::getTopLeftCorner() {
-    return _center + Vector(-_width/2, _height/2);
+Point CanvasMessenger::Sprite::getTopLeftCorner()
+{
+    return _center + Vector(-_width / 2, _height / 2);
 }
 
-std::vector<uint8_t> CanvasMessenger::Sprite::serialize(int size_scaling_factor) {
+std::vector<uint8_t> CanvasMessenger::Sprite::serialize(int size_scaling_factor)
+{
     std::vector<uint8_t> payload;
 
     payload.emplace_back(_texture);

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
@@ -50,11 +50,9 @@ namespace Util
             uint8_t a;
         };
 
-        // TODO: Update this comment
         /**
          * Sprite is a struct that contains all the information
-         * necessary to create a sprite. The default constructor
-         * creates a 100x100 white rectangle sprite.
+         * necessary to create a sprite.
          */
         class Sprite {
         public:
@@ -96,7 +94,6 @@ namespace Util
             std::vector<uint8_t> serialize(int size_scaling_factor);
 
         private:
-            // TODO: Comment these
             uint8_t _texture;
             Point _center;
             double _width;
@@ -143,12 +140,6 @@ namespace Util
          * @param radius The radius to draw the point with
          */
         void drawPoint(Layer layer, Point p, double radius, Color color);
-
-        /**
-         * Draw the given field
-         * @param field
-         */
-        void drawField(const Field& field);
 
        private:
 

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
@@ -39,7 +39,8 @@ namespace Util
         enum class Layer
         {
             STATIC_FEATURES,
-            ROBOTS_AND_BALL
+            ROBOTS,
+            BALL,
         };
 
         struct Color

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
@@ -14,14 +14,13 @@
 #include <chrono>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
-#include <mutex>
-
-#include "thunderbots_msgs/CanvasLayer.h"
-#include "util/constants.h"
 
 #include "ai/world/field.h"
+#include "thunderbots_msgs/CanvasLayer.h"
+#include "util/constants.h"
 
 namespace Util
 {
@@ -34,12 +33,14 @@ namespace Util
     class CanvasMessenger
     {
        public:
-        enum class Layer{
+        enum class Layer
+        {
             STATIC_FEATURES,
             ROBOTS_AND_BALL
         };
 
-        struct Color {
+        struct Color
+        {
             // Red value of the color
             uint8_t r;
             // Green value of the color
@@ -54,8 +55,9 @@ namespace Util
          * Sprite is a struct that contains all the information
          * necessary to create a sprite.
          */
-        class Sprite {
-        public:
+        class Sprite
+        {
+           public:
             // delete the default constructor
             Sprite() = delete;
 
@@ -65,24 +67,29 @@ namespace Util
              *        what sprite this is (circle, rectangle, robot, etc.)
              * @param center The center of the sprite
              * @param orientation The orientation of the sprite
-             * @param width The width of the sprite (in meters, will be translated to pixels)
-             * @param height The height of the sprite (in meters, will be translated to pixels)
+             * @param width The width of the sprite (in meters, will be translated to
+             * pixels)
+             * @param height The height of the sprite (in meters, will be translated to
+             * pixels)
              * @param color The color of the sprite
              */
-            Sprite(uint8_t texture, const Point& center, const Angle& orientation, double width, double height, Color color)
-                    : _texture(texture),
-                      _center(center),
-                      _orientation(orientation),
-                      _color(color),
-                      _width(width),
-                      _height(height){}
+            Sprite(uint8_t texture, const Point& center, const Angle& orientation,
+                   double width, double height, Color color)
+                : _texture(texture),
+                  _center(center),
+                  _orientation(orientation),
+                  _color(color),
+                  _width(width),
+                  _height(height)
+            {
+            }
 
-                      /**
-                       * Get the top left corner of the sprite
-                       *
-                       * @return the top left corner of the sprite
-                       */
-                      Point getTopLeftCorner();
+            /**
+             * Get the top left corner of the sprite
+             *
+             * @return the top left corner of the sprite
+             */
+            Point getTopLeftCorner();
 
             /**
              * Get the serialized form of this sprite
@@ -93,7 +100,7 @@ namespace Util
              */
             std::vector<uint8_t> serialize(int size_scaling_factor);
 
-        private:
+           private:
             uint8_t _texture;
             Point _center;
             double _width;
@@ -130,7 +137,8 @@ namespace Util
          * @param rectangle The rectangle to draw (units are in meters)
          * @param color The color the rectangle should be
          */
-        void drawRectangle(Layer layer, Rectangle rectangle, Angle orientation, Color color);
+        void drawRectangle(Layer layer, Rectangle rectangle, Angle orientation,
+                           Color color);
 
         /**
          * Draw a point at a given location with a given radius
@@ -142,7 +150,6 @@ namespace Util
         void drawPoint(Layer layer, Point p, double radius, Color color);
 
        private:
-
         /**
          * Union used to convert a int16_t into two uint8_t
          */
@@ -166,7 +173,7 @@ namespace Util
          * @param layer: The layer which the sprite is to be added to
          * @param sprite: The sprite data
          */
-        void addSpriteToLayer(Layer layer, Sprite &sprite);
+        void addSpriteToLayer(Layer layer, Sprite& sprite);
 
         /**
          * Draw a sprite onto a specific layer.

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
@@ -25,7 +25,12 @@
 
 namespace Util
 {
-
+    /**
+     * This class provides an interface for drawing on the "Canvas" area of the visualizer
+     *
+     * All public methods are (and must be) thread safe, so please be careful when
+     * exposing more public functionality
+     */
     class CanvasMessenger
     {
        public:
@@ -70,7 +75,9 @@ namespace Util
                     : _texture(texture),
                       _center(center),
                       _orientation(orientation),
-                      _color(color){}
+                      _color(color),
+                      _width(width),
+                      _height(height){}
 
                       /**
                        * Get the top left corner of the sprite
@@ -86,7 +93,7 @@ namespace Util
              *
              * @return the serialized form of this sprite
              */
-            std::vector<uint8_t> serialize();
+            std::vector<uint8_t> serialize(int size_scaling_factor);
 
         private:
             // TODO: Comment these
@@ -111,12 +118,13 @@ namespace Util
          * Uses ROS publishers to publish sprite data for each layer and
          * then clears all layer data.
          */
-        void publishAndClearLayers();
+        void publishAndClearAllLayers();
 
         /**
-         * Clears all sprite data for all layers
+         * Clear the given layer
+         * @param layer The layer to clear
          */
-        void clearLayers();
+        void clearLayer(Layer layer);
 
         /**
          * Draw a rectangle on the given layer
@@ -134,7 +142,7 @@ namespace Util
          * // TODO: Units for the radius???
          * @param radius The radius to draw the point with
          */
-        void drawPoint(Point p, double radius, int r, int g, int b, int opacity);
+        void drawPoint(Layer layer, Point p, double radius, Color color);
 
         /**
          * Draw the given field
@@ -177,6 +185,10 @@ namespace Util
          */
         void drawSprite(Layer layer, Sprite sprite);
 
+        /**
+         * Clears all sprite data for all layers
+         */
+        void clearAllLayers();
 
         // layer to sprite data map
         std::map<Layer, std::vector<Sprite>> layers_map;
@@ -193,6 +205,6 @@ namespace Util
         std::chrono::time_point<std::chrono::system_clock> time_last_published;
 
         // The mutex for the layers
-        std::mutex layers_lock;
+        std::mutex layers_map_lock;
     };
 }  // namespace Util

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
@@ -16,49 +16,88 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include "thunderbots_msgs/CanvasLayer.h"
 #include "util/constants.h"
 
+#include "ai/world/field.h"
+
 namespace Util
 {
+
     class CanvasMessenger
     {
        public:
+        enum class Layer{
+            STATIC_FEATURES,
+            ROBOTS_AND_BALL
+        };
+
+        struct Color {
+            // Red value of the color
+            uint8_t r;
+            // Green value of the color
+            uint8_t g;
+            // Blue value of the color
+            uint8_t b;
+            // Alpha (transparency) value of the color
+            uint8_t a;
+        };
+
+        // TODO: Update this comment
         /**
          * Sprite is a struct that contains all the information
          * necessary to create a sprite. The default constructor
          * creates a 100x100 white rectangle sprite.
          */
-        typedef struct Sprite
-        {
-            Sprite()
-                : texture(0),
-                  x(0.0),
-                  y(0.0),
-                  width(100.0),
-                  height(100.0),
-                  rotation(0.0),
-                  opacity(255),
-                  red(255),
-                  green(255),
-                  blue(255)
-            {
-            }
+        class Sprite {
+        public:
+            // delete the default constructor
+            Sprite() = delete;
 
-            uint8_t texture;
-            int16_t x;
-            int16_t y;
-            int16_t width;
-            int16_t height;
-            int16_t rotation;
-            uint8_t opacity;
-            uint8_t red;
-            uint8_t green;
-            uint8_t blue;
-        } Sprite;
+            /**
+             * Create a Sprite
+             * @param texture The texture id. On the visualizer side this will determine
+             *        what sprite this is (circle, rectangle, robot, etc.)
+             * @param center The center of the sprite
+             * @param orientation The orientation of the sprite
+             * @param width The width of the sprite (in meters, will be translated to pixels)
+             * @param height The height of the sprite (in meters, will be translated to pixels)
+             * @param color The color of the sprite
+             */
+            Sprite(uint8_t texture, const Point& center, const Angle& orientation, double width, double height, Color color)
+                    : _texture(texture),
+                      _center(center),
+                      _orientation(orientation),
+                      _color(color){}
 
-       public:
+                      /**
+                       * Get the top left corner of the sprite
+                       *
+                       * @return the top left corner of the sprite
+                       */
+                      Point getTopLeftCorner();
+
+            /**
+             * Get the serialized form of this sprite
+             *
+             * This is the form that is streamed over to the web interface
+             *
+             * @return the serialized form of this sprite
+             */
+            std::vector<uint8_t> serialize();
+
+        private:
+            // TODO: Comment these
+            uint8_t _texture;
+            Point _center;
+            double _width;
+            double _height;
+            Angle _orientation;
+            Color _color;
+        };
+
         /**
          * Getter of the singleton object.
          *
@@ -80,14 +119,31 @@ namespace Util
         void clearLayers();
 
         /**
-         * Draw a sprite onto a specific layer.
+         * Draw a rectangle on the given layer
          *
-         * @param layer: The layer number this shape is being drawn to
-         * @param sprite: the sprite data to draw
+         * @param layer The layer to draw the rectangle on
+         * @param rectangle The rectangle to draw (units are in meters)
+         * @param color The color the rectangle should be
          */
-        void drawSprite(uint8_t layer, Sprite sprite);
+        void drawRectangle(Layer layer, Rectangle rectangle, Angle orientation, Color color);
+
+        /**
+         * Draw a point at a given location with a given radius
+         *
+         * @param p The point to draw
+         * // TODO: Units for the radius???
+         * @param radius The radius to draw the point with
+         */
+        void drawPoint(Point p, double radius, int r, int g, int b, int opacity);
+
+        /**
+         * Draw the given field
+         * @param field
+         */
+        void drawField(const Field& field);
 
        private:
+
         /**
          * Union used to convert a int16_t into two uint8_t
          */
@@ -96,24 +152,34 @@ namespace Util
             uint8_t result[2];
         };
 
-       private:
+        // The number of pixels per meter
+        static const int PIXELS_PER_METER = 100;
+
         /**
          * Constructor; initializes an empty layers map then populates it
          */
         explicit CanvasMessenger() : layers_map(), publisher() {}
 
-        void publishPayload(uint8_t layer, const std::vector<Sprite>& shapes);
+        void publishPayload(uint8_t layer, std::vector<Sprite> shapes);
 
         /**
          * Add sprite to layer
          * @param layer: The layer which the sprite is to be added to
-         * @param sprite_data: The sprite data
+         * @param sprite: The sprite data
          */
-        void addSpriteToLayer(uint8_t layer, Sprite& sprite_data);
+        void addSpriteToLayer(Layer layer, Sprite &sprite);
 
-       private:
+        /**
+         * Draw a sprite onto a specific layer.
+         *
+         * @param layer: The layer number this shape is being drawn to
+         * @param sprite: the sprite data to draw
+         */
+        void drawSprite(Layer layer, Sprite sprite);
+
+
         // layer to sprite data map
-        std::map<uint8_t, std::vector<Sprite>> layers_map;
+        std::map<Layer, std::vector<Sprite>> layers_map;
         ros::Publisher publisher;
 
         // Period in nanoseconds
@@ -125,5 +191,8 @@ namespace Util
 
         // Time point
         std::chrono::time_point<std::chrono::system_clock> time_last_published;
+
+        // The mutex for the layers
+        std::mutex layers_lock;
     };
 }  // namespace Util

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
@@ -19,6 +19,9 @@
 #include <vector>
 
 #include "ai/world/field.h"
+#include "ai/world/world.h"
+#include "ai/world/ball.h"
+#include "ai/world/robot.h"
 #include "thunderbots_msgs/CanvasLayer.h"
 #include "util/constants.h"
 
@@ -141,13 +144,62 @@ namespace Util
                            Color color);
 
         /**
+         * Draw a straight line from p1 to p2
+         *
+         * @param layer The layer to draw the line on
+         * @param p1 The start point of the line
+         * @param p2 The end point of the line
+         * @param thickness The thickness of the line (units are in meters)
+         * @param color The color of the line
+         */
+        void drawLine(Layer layer, Point p1, Point p2, double thickness, Color color);
+
+        /**
          * Draw a point at a given location with a given radius
          *
          * @param p The point to draw
-         * // TODO: Units for the radius???
          * @param radius The radius to draw the point with
          */
-        void drawPoint(Layer layer, Point p, double radius, Color color);
+        void drawPoint(Layer layer, const Point &p, double radius, Color color);
+
+        /**
+         * Draw the given World
+         *
+         * This will draw all parts of the world over multiple layers
+         *
+         * @param world The world to draw
+         */
+        void drawWorld(const World &world);
+
+        /**
+         * Draw the given ball
+         *
+         * @param ball The ball to draw
+         */
+        void drawBall(const Ball &ball);
+
+        /**
+         * Draw the given field
+         *
+         * @param field The field to draw
+         */
+        void drawField(Field field);
+
+        /**
+         * Draw the given team
+         *
+         * @param team The team to draw
+         * @param color The color to draw the team with
+         */
+        void drawTeam(const Team &team, Color color);
+
+        /**
+         * Draw the given robot
+         *
+         * @param robot The robot to draw
+         * @param color The color of the robot
+         */
+        void drawRobot(Robot robot, Color color);
 
        private:
         /**
@@ -160,6 +212,14 @@ namespace Util
 
         // The number of pixels per meter
         static const int PIXELS_PER_METER = 100;
+
+        // Colors
+        static constexpr Color FIELD_COLOR  = {0, 153, 0, 255};
+        static constexpr Color DEFENSE_AREA_COLOR = {242, 242, 242, 255};
+        static constexpr Color FIELD_LINE_COLOR = {242, 242, 242, 255};
+        static constexpr Color BALL_COLOR = {255, 153, 0, 255};
+        static constexpr Color FRIENDLY_TEAM_COLOR = {230, 230, 0, 255};
+        static constexpr Color ENEMY_TEAM_COLOR = {0, 230, 230, 255};
 
         /**
          * Constructor; initializes an empty layers map then populates it

--- a/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
+++ b/src/thunderbots/software/util/canvas_messenger/canvas_messenger.h
@@ -18,10 +18,10 @@
 #include <string>
 #include <vector>
 
-#include "ai/world/field.h"
-#include "ai/world/world.h"
 #include "ai/world/ball.h"
+#include "ai/world/field.h"
 #include "ai/world/robot.h"
+#include "ai/world/world.h"
 #include "thunderbots_msgs/CanvasLayer.h"
 #include "util/constants.h"
 
@@ -76,7 +76,7 @@ namespace Util
              * pixels)
              * @param color The color of the sprite
              */
-            Sprite(uint8_t texture, const Point& center, const Angle& orientation,
+            Sprite(uint8_t texture, const Point &center, const Angle &orientation,
                    double width, double height, Color color)
                 : _texture(texture),
                   _center(center),
@@ -214,12 +214,12 @@ namespace Util
         static const int PIXELS_PER_METER = 100;
 
         // Colors
-        static constexpr Color FIELD_COLOR  = {0, 153, 0, 255};
-        static constexpr Color DEFENSE_AREA_COLOR = {242, 242, 242, 255};
-        static constexpr Color FIELD_LINE_COLOR = {242, 242, 242, 255};
-        static constexpr Color BALL_COLOR = {255, 153, 0, 255};
+        static constexpr Color FIELD_COLOR         = {0, 153, 0, 255};
+        static constexpr Color DEFENSE_AREA_COLOR  = {242, 242, 242, 255};
+        static constexpr Color FIELD_LINE_COLOR    = {242, 242, 242, 255};
+        static constexpr Color BALL_COLOR          = {255, 153, 0, 255};
         static constexpr Color FRIENDLY_TEAM_COLOR = {230, 230, 0, 255};
-        static constexpr Color ENEMY_TEAM_COLOR = {0, 230, 230, 255};
+        static constexpr Color ENEMY_TEAM_COLOR    = {0, 230, 230, 255};
 
         /**
          * Constructor; initializes an empty layers map then populates it
@@ -233,7 +233,7 @@ namespace Util
          * @param layer: The layer which the sprite is to be added to
          * @param sprite: The sprite data
          */
-        void addSpriteToLayer(Layer layer, Sprite& sprite);
+        void addSpriteToLayer(Layer layer, Sprite &sprite);
 
         /**
          * Draw a sprite onto a specific layer.

--- a/src/thunderbots/software/util/constants.h
+++ b/src/thunderbots/software/util/constants.h
@@ -45,7 +45,7 @@ namespace Util
         static const unsigned int NUMBER_OF_SSL_VISION_CAMERAS = 4;
 
         // Canvas messenger message maximum publishing frequency
-        static const unsigned int DESIRED_CANVAS_MESSAGE_FREQ = 120;
+        static const unsigned int DESIRED_CANVAS_MESSAGE_FREQ = 60;
 
         // How many milliseconds a robot must not be seen in vision before it is
         // considered as "gone" and no longer reported.

--- a/src/thunderbots/software/util/constants.h
+++ b/src/thunderbots/software/util/constants.h
@@ -44,8 +44,8 @@ namespace Util
         // There are 4 cameras for SSL Division B
         static const unsigned int NUMBER_OF_SSL_VISION_CAMERAS = 4;
 
-        // Canvas messenger message publishing frequency
-        static const unsigned int DESIRED_CANVAS_MESSAGE_FREQ = 60;
+        // Canvas messenger message maximum publishing frequency
+        static const unsigned int DESIRED_CANVAS_MESSAGE_FREQ = 120;
 
         // How many milliseconds a robot must not be seen in vision before it is
         // considered as "gone" and no longer reported.


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
- added `drawRectangle`, `drawPoint`
- made `CanvasMessenger` threadsafe

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Just some testing on my local machine. Determinations about what is "correct" is largely determined on visualizer side.

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
