### PR TITLE
Ball in friendly/enemy corner

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/evaluation/ball.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/ball.cpp
@@ -16,13 +16,15 @@ namespace Evaluation
 
     bool ballInFriendlyCorner(const Field &field, const Ball &ball, double radius)
     {
-        return ball.position().isClose(field.friendlyCornerPos(), radius) ||
-               ball.position().isClose(field.friendlyCornerNeg(), radius);
+        return (ball.position().isClose(field.friendlyCornerPos(), radius) ||
+                ball.position().isClose(field.friendlyCornerNeg(), radius)) &&
+               field.pointInFieldLines(ball.position());
     }
 
     bool ballInEnemyCorner(const Field &field, const Ball &ball, double radius)
     {
-        return ball.position().isClose(field.enemyCornerPos(), radius) ||
-               ball.position().isClose(field.enemyCornerNeg(), radius);
+        return (ball.position().isClose(field.enemyCornerPos(), radius) ||
+                ball.position().isClose(field.enemyCornerNeg(), radius)) &&
+               field.pointInFieldLines(ball.position());
     }
 }  // namespace Evaluation

--- a/src/thunderbots/software/ai/hl/stp/evaluation/ball.cpp
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/ball.cpp
@@ -13,4 +13,16 @@ namespace Evaluation
     {
         return ball.position().x() >= field.centerPoint().x();
     }
+
+    bool ballInFriendlyCorner(const Field &field, const Ball &ball, double radius)
+    {
+        return ball.position().isClose(field.friendlyCornerPos(), radius) ||
+               ball.position().isClose(field.friendlyCornerNeg(), radius);
+    }
+
+    bool ballInEnemyCorner(const Field &field, const Ball &ball, double radius)
+    {
+        return ball.position().isClose(field.enemyCornerPos(), radius) ||
+               ball.position().isClose(field.enemyCornerNeg(), radius);
+    }
 }  // namespace Evaluation

--- a/src/thunderbots/software/ai/hl/stp/evaluation/ball.h
+++ b/src/thunderbots/software/ai/hl/stp/evaluation/ball.h
@@ -20,4 +20,26 @@ namespace Evaluation
      * @return true if the ball is in the enemy's half of the field, and false otherwise
      */
     bool ballInEnemyHalf(const Field &field, const Ball &ball);
+
+    /**
+     * Returns true if the ball is in withing the provided radius in one of the friendly
+     * corner.
+     *
+     * @param field The field
+     * @param ball The ball
+     * @param the radius from the corner, to decide whether or not the ball is in the
+     * field.
+     */
+    bool ballInFriendlyCorner(const Field &field, const Ball &ball, double radius);
+
+    /**
+     * Returns true if the ball is in withing the provided radius in one of the enemy
+     * corner.
+     *
+     * @param field The field
+     * @param ball The ball
+     * @param the radius from the corner, to decide whether or not the ball is in the
+     * field.
+     */
+    bool ballInEnemyCorner(const Field &field, const Ball &ball, double radius);
 }  // namespace Evaluation

--- a/src/thunderbots/software/ai/world/field.cpp
+++ b/src/thunderbots/software/ai/world/field.cpp
@@ -178,7 +178,7 @@ bool Field::pointInEnemyDefenseArea(const Point p) const
     return enemyDefenseArea().containsPoint(p);
 }
 
-bool Field::pointInFieldLines(const Point &p)
+bool Field::pointInFieldLines(const Point &p) const
 {
     return fieldLines().containsPoint(p);
 }

--- a/src/thunderbots/software/ai/world/field.h
+++ b/src/thunderbots/software/ai/world/field.h
@@ -256,7 +256,7 @@ class Field
      *
      * @return true if p is within the field lines of the field, false otherwise
      */
-    bool pointInFieldLines(const Point &p);
+    bool pointInFieldLines(const Point &p) const;
 
     /**
      * Compares two fields for equality

--- a/src/thunderbots/software/test/ai/hl/stp/evaluation/ball.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/evaluation/ball.cpp
@@ -69,15 +69,23 @@ TEST(BallInEnemyHalfTest, ball_at_friendly_goal)
     EXPECT_FALSE(Evaluation::ballInEnemyHalf(field, ball));
 }
 
-class BallPositionsInFriendlyCorner : public ::testing::TestWithParam<Point>
+class BallPositionsInFriendlyCornerOffField : public ::testing::TestWithParam<Point>
 {
 };
 
-class BallPositionsNotInFriendlyCorner : public ::testing::TestWithParam<Point>
+class BallPositionsInFriendlyCornerOnField : public ::testing::TestWithParam<Point>
 {
 };
 
-TEST_P(BallPositionsInFriendlyCorner, in_corner_test)
+class BallPositionsInEnemyCornerOnField : public ::testing::TestWithParam<Point>
+{
+};
+
+class BallPositionsInEnemyCornerOffField : public ::testing::TestWithParam<Point>
+{
+};
+
+TEST_P(BallPositionsInFriendlyCornerOnField, in_corner_inside_field)
 {
     Field field = ::Test::TestUtil::createSSLDivBField();
     Ball ball   = Ball(GetParam(), Point(0, 0), Timestamp::fromMilliseconds(0));
@@ -89,11 +97,25 @@ TEST_P(BallPositionsInFriendlyCorner, in_corner_test)
     EXPECT_TRUE(Evaluation::ballInFriendlyCorner(field, ball, 1.0));
 }
 
-INSTANTIATE_TEST_CASE_P(Positions, BallPositionsInFriendlyCorner,
+INSTANTIATE_TEST_CASE_P(Positions, BallPositionsInFriendlyCornerOnField,
                         ::testing::Values(Point(-4.5, 3), Point(-4.5, -3), Point(-4.0, 3),
                                           Point(-4.0, -3)));
 
-TEST_P(BallPositionsNotInFriendlyCorner, out_of_corner_test)
+TEST_P(BallPositionsInFriendlyCornerOffField, in_corner_outside_field)
+{
+    Field field = ::Test::TestUtil::createSSLDivBField();
+    Ball ball   = Ball(GetParam(), Point(0, 0), Timestamp::fromMilliseconds(0));
+
+    EXPECT_FALSE(Evaluation::ballInFriendlyCorner(field, ball, 1.0));
+    EXPECT_FALSE(Evaluation::ballInEnemyCorner(field, ball, 1.0));
+}
+
+INSTANTIATE_TEST_CASE_P(Positions, BallPositionsInFriendlyCornerOffField,
+                        ::testing::Values(Point(-4.6, 3), Point(-4.6, -3), Point(-5.0, 3),
+                                          Point(-5.0, -3), Point(-4.5, -3.1),
+                                          Point(-4.0, -3.1)));
+
+TEST_P(BallPositionsInEnemyCornerOnField, in_corner_inside_field)
 {
     Field field = ::Test::TestUtil::createSSLDivBField();
     Ball ball   = Ball(GetParam(), Point(0, 0), Timestamp::fromMilliseconds(0));
@@ -105,6 +127,20 @@ TEST_P(BallPositionsNotInFriendlyCorner, out_of_corner_test)
     EXPECT_FALSE(Evaluation::ballInFriendlyCorner(field, ball, 1.0));
 }
 
-INSTANTIATE_TEST_CASE_P(Positions, BallPositionsNotInFriendlyCorner,
+INSTANTIATE_TEST_CASE_P(Positions, BallPositionsInEnemyCornerOnField,
                         ::testing::Values(Point(4.5, 3), Point(4.5, -3), Point(4.0, 3),
                                           Point(4.0, -3)));
+
+TEST_P(BallPositionsInEnemyCornerOffField, in_corner_outside_field)
+{
+    Field field = ::Test::TestUtil::createSSLDivBField();
+    Ball ball   = Ball(GetParam(), Point(0, 0), Timestamp::fromMilliseconds(0));
+
+    EXPECT_FALSE(Evaluation::ballInEnemyCorner(field, ball, 1.0));
+    EXPECT_FALSE(Evaluation::ballInFriendlyCorner(field, ball, 1.0));
+}
+
+INSTANTIATE_TEST_CASE_P(Positions, BallPositionsInEnemyCornerOffField,
+                        ::testing::Values(Point(4.6, 3), Point(4.6, -3), Point(5.0, 3),
+                                          Point(5.0, -3), Point(4.5, -3.1),
+                                          Point(4.0, -3.1)));

--- a/src/thunderbots/software/test/ai/hl/stp/evaluation/ball.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/evaluation/ball.cpp
@@ -68,3 +68,44 @@ TEST(BallInEnemyHalfTest, ball_at_friendly_goal)
 
     EXPECT_FALSE(Evaluation::ballInEnemyHalf(field, ball));
 }
+
+class BallPositionsInFriendlyCorner : public ::testing::TestWithParam<Point>
+{
+};
+
+class BallPositionsNotInFriendlyCorner : public ::testing::TestWithParam<Point>
+{
+};
+
+TEST_P(BallPositionsInFriendlyCorner, in_corner_test)
+{
+    Field field = ::Test::TestUtil::createSSLDivBField();
+    Ball ball   = Ball(GetParam(), Point(0, 0), Timestamp::fromMilliseconds(0));
+
+    EXPECT_TRUE(Evaluation::ballInEnemyCorner(field, ball, 2.0));
+    EXPECT_FALSE(Evaluation::ballInFriendlyCorner(field, ball, 2.0));
+
+    EXPECT_TRUE(Evaluation::ballInEnemyCorner(field, ball, 1.0));
+    EXPECT_FALSE(Evaluation::ballInFriendlyCorner(field, ball, 1.0));
+}
+
+INSTANTIATE_TEST_CASE_P(Positions, BallPositionsInFriendlyCorner,
+                        ::testing::Values(Point(-4.5, 3), Point(-4.5, -3), Point(-4.0, 3),
+                                          Point(-4.0, -3)));
+
+// Field field = Field(9.0, 6.0, 1.0, 2.0, 1.0, 0.3, 0.5);
+TEST_P(BallPositionsNotInFriendlyCorner, out_of_corner_test)
+{
+    Field field = ::Test::TestUtil::createSSLDivBField();
+    Ball ball   = Ball(GetParam(), Point(0, 0), Timestamp::fromMilliseconds(0));
+
+    EXPECT_TRUE(Evaluation::ballInEnemyCorner(field, ball, 2.0));
+    EXPECT_FALSE(Evaluation::ballInFriendlyCorner(field, ball, 2.0));
+
+    EXPECT_TRUE(Evaluation::ballInEnemyCorner(field, ball, 1.0));
+    EXPECT_FALSE(Evaluation::ballInFriendlyCorner(field, ball, 1.0));
+}
+
+INSTANTIATE_TEST_CASE_P(Positions, BallPositionsNotInFriendlyCorner,
+                        ::testing::Values(Point(4.5, 3), Point(4.5, -3), Point(4.0, 3),
+                                          Point(4.0, -3)));

--- a/src/thunderbots/software/test/ai/hl/stp/evaluation/ball.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/evaluation/ball.cpp
@@ -93,7 +93,6 @@ INSTANTIATE_TEST_CASE_P(Positions, BallPositionsInFriendlyCorner,
                         ::testing::Values(Point(-4.5, 3), Point(-4.5, -3), Point(-4.0, 3),
                                           Point(-4.0, -3)));
 
-// Field field = Field(9.0, 6.0, 1.0, 2.0, 1.0, 0.3, 0.5);
 TEST_P(BallPositionsNotInFriendlyCorner, out_of_corner_test)
 {
     Field field = ::Test::TestUtil::createSSLDivBField();

--- a/src/thunderbots/software/test/ai/hl/stp/evaluation/ball.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/evaluation/ball.cpp
@@ -82,11 +82,11 @@ TEST_P(BallPositionsInFriendlyCorner, in_corner_test)
     Field field = ::Test::TestUtil::createSSLDivBField();
     Ball ball   = Ball(GetParam(), Point(0, 0), Timestamp::fromMilliseconds(0));
 
-    EXPECT_TRUE(Evaluation::ballInEnemyCorner(field, ball, 2.0));
-    EXPECT_FALSE(Evaluation::ballInFriendlyCorner(field, ball, 2.0));
+    EXPECT_FALSE(Evaluation::ballInEnemyCorner(field, ball, 2.0));
+    EXPECT_TRUE(Evaluation::ballInFriendlyCorner(field, ball, 2.0));
 
-    EXPECT_TRUE(Evaluation::ballInEnemyCorner(field, ball, 1.0));
-    EXPECT_FALSE(Evaluation::ballInFriendlyCorner(field, ball, 1.0));
+    EXPECT_FALSE(Evaluation::ballInEnemyCorner(field, ball, 1.0));
+    EXPECT_TRUE(Evaluation::ballInFriendlyCorner(field, ball, 1.0));
 }
 
 INSTANTIATE_TEST_CASE_P(Positions, BallPositionsInFriendlyCorner,


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

Evaluation function to check if the ball is in the corner or not. (enemy/friendly)
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

Have two unit tests that verify basic functionality.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

#439 
#438 

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
