### PR TITLE
Store Ball History

### DIFF
--- a/src/thunderbots/software/ai/world/ball.cpp
+++ b/src/thunderbots/software/ai/world/ball.cpp
@@ -1,8 +1,12 @@
 #include "ball.h"
 
-Ball::Ball(Point position, Vector velocity, const Timestamp &timestamp)
-    : position_(position), velocity_(velocity), last_update_timestamp(timestamp)
+Ball::Ball(Point position, Vector velocity, const Timestamp &timestamp,
+           unsigned int history_duration)
+    : positions_(history_duration),
+      velocities_(history_duration),
+      last_update_timestamps(history_duration)
 {
+    addStateToBallHistory(position, velocity, timestamp);
 }
 
 void Ball::updateState(const Ball &new_ball_data)
@@ -14,26 +18,24 @@ void Ball::updateState(const Ball &new_ball_data)
 void Ball::updateState(const Point &new_position, const Vector &new_velocity,
                        const Timestamp &timestamp)
 {
-    if (timestamp < last_update_timestamp)
+    if (timestamp < lastUpdateTimestamp())
     {
         throw std::invalid_argument(
             "Error: State of ball is updating times from the past");
     }
 
-    position_             = new_position;
-    velocity_             = new_velocity;
-    last_update_timestamp = timestamp;
+    addStateToBallHistory(new_position, new_velocity, timestamp);
 }
 
 void Ball::updateStateToPredictedState(const Timestamp &timestamp)
 {
-    if (timestamp < last_update_timestamp)
+    if (timestamp < lastUpdateTimestamp())
     {
         throw std::invalid_argument(
             "Error: Predicted state is updating times from the past");
     }
 
-    auto duration_in_future = timestamp - last_update_timestamp;
+    auto duration_in_future = timestamp - lastUpdateTimestamp();
     Point new_position      = estimatePositionAtFutureTime(duration_in_future);
     Point new_velocity      = estimateVelocityAtFutureTime(duration_in_future);
 
@@ -42,12 +44,12 @@ void Ball::updateStateToPredictedState(const Timestamp &timestamp)
 
 Timestamp Ball::lastUpdateTimestamp() const
 {
-    return last_update_timestamp;
+    return last_update_timestamps.front();
 }
 
 Point Ball::position() const
 {
-    return position_;
+    return positions_.front();
 }
 
 Point Ball::estimatePositionAtFutureTime(const Duration &duration_in_future) const
@@ -62,12 +64,12 @@ Point Ball::estimatePositionAtFutureTime(const Duration &duration_in_future) con
     // real-world behavior. Position prediction should be improved as outlined in
     // https://github.com/UBC-Thunderbots/Software/issues/47
     double seconds_in_future = duration_in_future.getSeconds();
-    return position_ + (velocity_.norm(seconds_in_future * velocity_.len()));
+    return position() + (velocity().norm(seconds_in_future * velocity().len()));
 }
 
 Vector Ball::velocity() const
 {
-    return velocity_;
+    return velocities_.front();
 }
 
 Vector Ball::estimateVelocityAtFutureTime(const Duration &duration_in_future) const
@@ -82,12 +84,47 @@ Vector Ball::estimateVelocityAtFutureTime(const Duration &duration_in_future) co
     // does not necessarily reflect real-world behavior. Velocity prediction should be
     // improved as outlined in https://github.com/UBC-Thunderbots/Software/issues/47
     double seconds_in_future = duration_in_future.getSeconds();
-    return velocity_ * exp(-0.1 * seconds_in_future);
+    return velocity() * exp(-0.1 * seconds_in_future);
+}
+
+std::vector<Point> Ball::getPreviousPositions()
+{
+    std::vector<Point> retval{};
+    for (Point p : positions_)
+        retval.push_back(p);
+
+    return retval;
+}
+
+std::vector<Vector> Ball::getPreviousVelocities()
+{
+    std::vector<Vector> retval{};
+    for (Vector v : velocities_)
+        retval.push_back(v);
+
+    return retval;
+}
+
+std::vector<Timestamp> Ball::getPreviousTimestamps()
+{
+    std::vector<Timestamp> retval{};
+    for (Timestamp t : last_update_timestamps)
+        retval.push_back(t);
+
+    return retval;
+}
+
+void Ball::addStateToBallHistory(const Point &position, const Vector &velocity,
+                                 const Timestamp &timestamp)
+{
+    positions_.push_front(position);
+    velocities_.push_front(velocity);
+    last_update_timestamps.push_front(timestamp);
 }
 
 bool Ball::operator==(const Ball &other) const
 {
-    return this->position_ == other.position_ && this->velocity_ == other.velocity_;
+    return this->position() == other.position() && this->velocity() == other.velocity();
 }
 
 bool Ball::operator!=(const Ball &other) const

--- a/src/thunderbots/software/ai/world/robot.h
+++ b/src/thunderbots/software/ai/world/robot.h
@@ -24,6 +24,7 @@ class Robot
      * per second
      * @param timestamp The timestamp at which the robot was observed to be in the given
      * state
+     * @param history_duration The number of previous robot states that should be stored.
      */
     explicit Robot(unsigned int id, const Point &position, const Vector &velocity,
                    const Angle &orientation, const AngularVelocity &angular_velocity,
@@ -280,16 +281,16 @@ class Robot
     // All previous positions of the robot, with the most recent position at the front of
     // the queue, coordinates in meters
     boost::circular_buffer<Point> positions_;
-    // All previous velocities of the robot, with the most recent position at the front of
+    // All previous velocities of the robot, with the most recent velocity at the front of
     // the queue, in metres per second
     boost::circular_buffer<Vector> velocities_;
-    // All previous orientations of the robot, with the most recent position at the front
-    // of the queue, in radians
+    // All previous orientations of the robot, with the most recent orientation at the
+    // front of the queue, in radians
     boost::circular_buffer<Angle> orientations_;
-    // All previous angular velocities of the robot, with the most recent position at the
-    // front of the queue, in radians per second
+    // All previous angular velocities of the robot, with the most recent angular velocity
+    // at the front of the queue, in radians per second
     boost::circular_buffer<AngularVelocity> angularVelocities_;
     // All previous timestamps of when the robot was updated, with the most recent
-    // position at the front of the queue,
+    // timestamp at the front of the queue,
     boost::circular_buffer<Timestamp> last_update_timestamps;
 };

--- a/src/thunderbots/software/test/ai/world/ball.cpp
+++ b/src/thunderbots/software/test/ai/world/ball.cpp
@@ -258,3 +258,37 @@ TEST_F(BallTest, equality_operator_balls_with_different_timestamps)
 
     EXPECT_EQ(ball_0, ball_1);
 }
+
+TEST_F(BallTest, get_position_history)
+{
+    std::vector prevPositions = {Point(-1.3, 3), Point(-1.2, 3), Point(3, 1.2)};
+
+    Ball ball = Ball(Point(3, 1.2), Vector(2.2, -0.05), current_time);
+    ball.updateState(Point(-1.2, 3), Vector(2.2, -0.05), half_second_future);
+    ball.updateState(Point(-1.3, 3), Vector(2.3, -0.05), half_second_future);
+
+    EXPECT_EQ(prevPositions, ball.getPreviousPositions());
+}
+
+TEST_F(BallTest, get_velocity_history)
+{
+    std::vector prevVelocities = {Vector(2.3, -0.05), Vector(2.2, -0.05), Vector(-3, 1)};
+
+    Ball ball = Ball(Point(3, 1.2), Vector(-3, 1), current_time);
+    ball.updateState(Point(-1.2, 3), Vector(2.2, -0.05), half_second_future);
+    ball.updateState(Point(-1.3, 3), Vector(2.3, -0.05), half_second_future);
+
+    EXPECT_EQ(prevVelocities, ball.getPreviousVelocities());
+}
+
+TEST_F(BallTest, get_timestamp_history)
+{
+    std::vector prevAngularVelocities = {half_second_future, half_second_future,
+                                         current_time};
+
+    Ball ball = Ball(Point(3, 1.2), Vector(2.2, -0.05), current_time);
+    ball.updateState(Point(-1.2, 3), Vector(2.2, -0.05), half_second_future);
+    ball.updateState(Point(-1.3, 3), Vector(2.3, -0.05), half_second_future);
+
+    EXPECT_EQ(prevAngularVelocities, ball.getPreviousTimestamps());
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Store the history of ball states in circular buffers. This is very similar to #552.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #499 

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
