### PR TITLE
Fix empty layer bug

### DIFF
--- a/src/corner_kick/src/containers/Canvas/layer.ts
+++ b/src/corner_kick/src/containers/Canvas/layer.ts
@@ -77,7 +77,12 @@ export class Layer {
 
         // Add/remove allocated sprites in layer if needed
         const currSpriteCount = this.layerObject.children.length;
-        if (incomingSpriteCount > currSpriteCount) {
+        if (incomingSpriteCount === 0) {
+            // Special case, simply unallocate all sprites
+            const oldSprites = this.layerObject.children as PIXI.Sprite[];
+            this.spritePool.unallocate(oldSprites);
+            this.layerObject.removeChildren();
+        } else if (incomingSpriteCount > currSpriteCount) {
             // We allocated what we are missing
             const newSprites = this.spritePool.allocate(
                 incomingSpriteCount - currSpriteCount,


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

This PR fixes a bug that occured when the visualizer received an empty layer (a layer with no sprites). This caused a bug in the graphics library as it didn't know what to draw. A special case to handle empty layer messages was added to address this edge case.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Tested using a scenario provided by @garethellis0 

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [X] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [X] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [X] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
