### PR TITLE
Added Tolerance Parameter To getTimeToPositionForRobot

### DIFF
--- a/src/thunderbots/software/ai/evaluation/pass.cpp
+++ b/src/thunderbots/software/ai/evaluation/pass.cpp
@@ -44,7 +44,8 @@ Duration AI::Evaluation::getTimeToOrientationForRobot(const Robot& robot,
 
 Duration AI::Evaluation::getTimeToPositionForRobot(const Robot& robot, const Point& dest,
                                                    const double& max_velocity,
-                                                   const double& max_acceleration)
+                                                   const double& max_acceleration,
+                                                   const double& tolerance_meters)
 {
     // We assume a linear acceleration profile:
     // (1) velocity = MAX_ACCELERATION*time
@@ -59,7 +60,7 @@ Duration AI::Evaluation::getTimeToPositionForRobot(const Robot& robot, const Poi
     // We re-arrange (3) to get:
     // (6) displacement = time^2 * MAX_ACCELERATION/2
 
-    double dist = (robot.position() - dest).len();
+    double dist = std::max(0.0, (robot.position() - dest).len() - tolerance_meters);
 
     // Calculate the distance required to reach max possible velocity of the robot
     // using (5)

--- a/src/thunderbots/software/ai/evaluation/pass.h
+++ b/src/thunderbots/software/ai/evaluation/pass.h
@@ -35,12 +35,15 @@ namespace AI::Evaluation
      * @param dest The destination that the robot is going to
      * @param max_velocity The maximum linear velocity the robot can travel at (m/s)
      * @param max_acceleration The maximum acceleration of the robot (m/s^2)
+     * @param tolerance_meters The radius around the target at which we will be considered
+     *                         "at" the target.
      *
      * @return The minimum theoretical time it would take the robot to reach the dest
      * point
      */
     Duration getTimeToPositionForRobot(const Robot& robot, const Point& dest,
                                        const double& max_velocity,
-                                       const double& max_acceleration);
+                                       const double& max_acceleration,
+                                       const double& tolerance_meters = 0);
 
 }  // namespace AI::Evaluation

--- a/src/thunderbots/software/test/ai/evaluation/pass.cpp
+++ b/src/thunderbots/software/test/ai/evaluation/pass.cpp
@@ -85,3 +85,38 @@ TEST(PassingEvaluationTest, getTimeToPositionForRobot_reaches_max_velocity)
     EXPECT_EQ(Duration::fromSeconds(travel_time),
               getTimeToPositionForRobot(robot, dest, 2.0, 3.0));
 }
+
+TEST(PassingEvaluationTest, getTimeToPositionForRobot_reaches_max_velocity_with_tolerance)
+{
+    // Check that the robot reaches the dest in the at the expected time when
+    // it has enough time that it accelerates up to it's maximum velocity
+    // We set the distance here such that it the robot *should* always have time to
+    // get to the max velocity, unless our robots suddenly get *much* faster
+
+    // The point we're trying to move ot
+    Point target_location(0, 1);
+
+    // The first point within tolerance of the goal on the path of the robot
+    Point first_point_in_tolerance(0, 1.5);
+
+    Point robot_location(0, 40);
+
+    Robot robot(0, robot_location, Vector(0, 0), Angle::ofDegrees(0),
+                AngularVelocity::ofDegrees(0), Timestamp::fromSeconds(0));
+
+    double distance_to_dest = (robot_location - first_point_in_tolerance).len();
+
+    double acceleration_time = ROBOT_MAX_SPEED_METERS_PER_SECOND /
+                               ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED;
+    // x = v*t + 1/2*a*t^2, v = initial velocity = 0
+    double acceleration_distance = 0.5 *
+                                   ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED *
+                                   std::pow(acceleration_time, 2);
+    double time_at_max_vel = (distance_to_dest - 2 * acceleration_distance) /
+                             ROBOT_MAX_SPEED_METERS_PER_SECOND;
+
+    double travel_time = 2 * acceleration_time + time_at_max_vel;
+
+    EXPECT_EQ(Duration::fromSeconds(travel_time),
+              getTimeToPositionForRobot(robot, target_location, 2.0, 3.0, 0.5));
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Added a `tolerance` parameter to `getTimeToPositionForRobot`.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
NA
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
