### PR TITLE
Combined navigator tests

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -846,11 +846,14 @@ if (CATKIN_ENABLE_TESTING)
             test/ai/navigator/placeholder_navigator/placeholder_navigator.cpp
             test/test_util/test_util.cpp
             test/ai/navigator/obstacle/obstacle.cpp
+            test/ai/navigator/trespass/trespass.cpp
+            test/ai/navigator/path_planner/straight_line_path_planner.cpp
             util/parameter/dynamic_parameter_utils.cpp
             util/parameter/dynamic_parameters.cpp
             util/time/duration.cpp
             util/time/time.cpp
             util/time/timestamp.cpp
+            util/math_functions.cpp
             geom/angle.h
             geom/point.h
             geom/polygon.h
@@ -860,6 +863,8 @@ if (CATKIN_ENABLE_TESTING)
             ../shared/constants.h
             ai/navigator/obstacle/obstacle.cpp
             ai/navigator/obstacle/obstacle.h
+            ai/navigator/trespass.cpp
+            ai/navigator/path_planner/straight_line_path_planner.cpp
             )
     target_link_libraries(navigator_test
             ${catkin_LIBRARIES}
@@ -874,27 +879,6 @@ if (CATKIN_ENABLE_TESTING)
     target_link_libraries(polygon_test
             ${catkin_LIBRARIES}
             ${G3LOG})
-
-
-    catkin_add_gtest(straight_line_path_planner_test
-            test/ai/navigator/path_planner/straight_line_path_planner.cpp
-            ai/navigator/path_planner/straight_line_path_planner.cpp
-            )
-    target_link_libraries(straight_line_path_planner_test
-            ${catkin_LIBRARIES}
-            ${G3LOG}
-            )
-
-    catkin_add_gtest(trespass_test
-            test/ai/navigator/trespass/trespass.cpp
-            ai/navigator/trespass.cpp
-            util/math_functions.cpp
-            )
-    target_link_libraries(straight_line_path_planner_test
-            ${catkin_LIBRARIES}
-            ${G3LOG}
-            )
-
 endif()
 
 ##### ROSTests / Integration Tests #####

--- a/src/thunderbots/software/test/ai/navigator/path_planner/straight_line_path_planner.cpp
+++ b/src/thunderbots/software/test/ai/navigator/path_planner/straight_line_path_planner.cpp
@@ -16,10 +16,3 @@ TEST(TestStraightLinePathPlanner, test_straight_line_path_planner)
     EXPECT_EQ(path_points[0], start);
     EXPECT_EQ(path_points[1], dest);
 }
-
-int main(int argc, char** argv)
-{
-    std::cout << argv[0] << std::endl;
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/src/thunderbots/software/test/ai/navigator/trespass/trespass.cpp
+++ b/src/thunderbots/software/test/ai/navigator/trespass/trespass.cpp
@@ -45,10 +45,3 @@ TEST(TrespassTest, calcLinearTrespassScore_rectangle_test)
     // Test point at two-thirds the width of the rectangle and one tenth the height.
     EXPECT_EQ(Navigator::Trespass::calcLinearTrespassScore(rect, two_thirds), 2.0 / 3.0);
 }
-
-int main(int argc, char **argv)
-{
-    std::cout << argv[0] << std::endl;
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Combined the "trespass" and "straight line planner" tests with the navigator tests.

Specifically, this was to fix an issue with `pthread` when building the `trespass` test. For some reason, building that executable would fail with the following error, **but only when run locally**. The issue was not reproducible in CI builds.

```
/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): In function `testing::internal::UnitTestImpl::~UnitTestImpl()':
(.text+0xccb9): undefined reference to `pthread_getspecific'
(.text+0xccd2): undefined reference to `pthread_key_delete'
(.text+0xcdca): undefined reference to `pthread_getspecific'
(.text+0xcde3): undefined reference to `pthread_key_delete'
/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): In function `testing::internal::UnitTestImpl::UnitTestImpl(testing::UnitTest*)':
(.text+0x10e02): undefined reference to `pthread_key_create'
(.text+0x10f71): undefined reference to `pthread_key_create'
/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): In function `testing::UnitTest::PushGTestTrace(testing::internal::TraceInfo const&)':
(.text+0x14b92): undefined reference to `pthread_getspecific'
(.text+0x14c8b): undefined reference to `pthread_setspecific'
/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): In function `testing::internal::UnitTestImpl::GetTestPartResultReporterForCurrentThread()':
(.text+0x1c1f4): undefined reference to `pthread_getspecific'
(.text+0x1c27a): undefined reference to `pthread_setspecific'
/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): In function `testing::internal::UnitTestImpl::SetTestPartResultReporterForCurrentThread(testing::TestPartResultReporterInterface*)':
(.text+0x1ed59): undefined reference to `pthread_getspecific'
(.text+0x1ede1): undefined reference to `pthread_setspecific'
/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): In function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::~ThreadLocal()':
(.text._ZN7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEED2Ev[_ZN7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEED5Ev]+0x20): undefined reference to `pthread_getspecific'
(.text._ZN7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEED2Ev[_ZN7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEED5Ev]+0x35): undefined reference to `pthread_key_delete'
/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): In function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::~ThreadLocal()':
(.text._ZN7testing8internal11ThreadLocalISt6vectorINS0_9TraceInfoESaIS3_EEED2Ev[_ZN7testing8internal11ThreadLocalISt6vectorINS0_9TraceInfoESaIS3_EEED5Ev]+0x20): undefined reference to `pthread_getspecific'
(.text._ZN7testing8internal11ThreadLocalISt6vectorINS0_9TraceInfoESaIS3_EEED2Ev[_ZN7testing8internal11ThreadLocalISt6vectorINS0_9TraceInfoESaIS3_EEED5Ev]+0x35): undefined reference to `pthread_key_delete'
/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): In function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::GetOrCreateValue() const':
(.text._ZNK7testing8internal11ThreadLocalISt6vectorINS0_9TraceInfoESaIS3_EEE16GetOrCreateValueEv[_ZNK7testing8internal11ThreadLocalISt6vectorINS0_9TraceInfoESaIS3_EEE16GetOrCreateValueEv]+0x20): undefined reference to `pthread_getspecific'
(.text._ZNK7testing8internal11ThreadLocalISt6vectorINS0_9TraceInfoESaIS3_EEE16GetOrCreateValueEv[_ZNK7testing8internal11ThreadLocalISt6vectorINS0_9TraceInfoESaIS3_EEE16GetOrCreateValueEv]+0xaa): undefined reference to `pthread_setspecific'
collect2: error: ld returned 1 exit status
thunderbots/software/CMakeFiles/trespass_test.dir/build.make:147: recipe for target '/home/mathew/programming/Software/devel/lib/thunderbots/trespass_test' failed
make[3]: *** [/home/mathew/programming/Software/devel/lib/thunderbots/trespass_test] Error 1
CMakeFiles/Makefile2:1943: recipe for target 'thunderbots/software/CMakeFiles/trespass_test.dir/all' failed
make[2]: *** [thunderbots/software/CMakeFiles/trespass_test.dir/all] Error 2
```

After some investigation, the code itself didn't seem to be causing it, but changing the build fixed the problem.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Tests build and pass locally now

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
None

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
