### PR TITLE
Tweaked Kick Action And Added A Proper Termination Condition For Passer Tactic

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -565,6 +565,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/primitive/chip_primitive.cpp
             ai/primitive/primitive.cpp
             ai/world/robot.cpp
+            ai/world/ball.cpp
             test/ai/hl/stp/action/main.cpp
             test/ai/hl/stp/test_actions/move_test_action.cpp
             test/ai/hl/stp/action/action.cpp

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -117,11 +117,5 @@ std::unique_ptr<Intent> KickAction::calculateNextIntent(
                                                kick_speed_meters_per_second, 0));
         }
 
-        Vector ball_to_robot = robot->position() - ball.position();
-
-        ball_robot_angle =
-            ball.velocity().orientation().minDiff(ball_to_robot.orientation());
-
-        // Stop once the ball is travelling away from us with a non-zero velocity
-    } while (ball_robot_angle.toDegrees() < 90 || ball.velocity().len() < 0.5);
+    } while (true);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(
 }
 
 std::unique_ptr<Intent> KickAction::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    intent_coroutine::push_type &yield)
 {
     // How large the triangle is that defines the region where the robot is
     // behind the ball and ready to kick.

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -70,11 +70,6 @@ std::unique_ptr<Intent> KickAction::calculateNextIntent(
     //                             V
     //                     direction of kick
 
-    // The angle between the ball velocity vector and the vector formed by drawing
-    // a line from the ball to the robot. This lets us figure out if the ball is
-    // travelling towards the robot
-    Angle ball_robot_angle;
-
     do
     {
         // A vector in the direction opposite the kick (behind the ball)

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -1,5 +1,6 @@
-#include <ai/world/ball.h>
 #include "ai/hl/stp/action/kick_action.h"
+
+#include <ai/world/ball.h>
 
 #include "ai/intent/kick_intent.h"
 #include "ai/intent/move_intent.h"
@@ -7,20 +8,24 @@
 #include "geom/util.h"
 #include "shared/constants.h"
 
-KickAction::KickAction() : Action(), ball({0,0}, {0,0}, Timestamp::fromSeconds(0)) {}
+KickAction::KickAction() : Action(), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0)) {}
 
-std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(const Robot &robot, const Ball &ball, Point kick_origin, Point kick_target, double kick_speed_meters_per_second)
+std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(
+    const Robot &robot, const Ball &ball, Point kick_origin, Point kick_target,
+    double kick_speed_meters_per_second)
 {
     return updateStateAndGetNextIntent(robot, ball, kick_origin,
                                        (kick_target - kick_origin).orientation(),
                                        kick_speed_meters_per_second);
 }
 
-std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(const Robot &robot, const Ball &ball, Point kick_origin, Angle kick_direction, double kick_speed_meters_per_second)
+std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(
+    const Robot &robot, const Ball &ball, Point kick_origin, Angle kick_direction,
+    double kick_speed_meters_per_second)
 {
     // Update the parameters stored by this Action
     this->robot                        = robot;
-    this->ball = ball;
+    this->ball                         = ball;
     this->kick_origin                  = kick_origin;
     this->kick_direction               = kick_direction;
     this->kick_speed_meters_per_second = kick_speed_meters_per_second;
@@ -99,7 +104,7 @@ std::unique_ptr<Intent> KickAction::calculateNextIntent(
         Point point_behind_ball =
             kick_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT_METERS * 1 +
                                            size_of_region_behind_ball / 2);
-//
+        //
         // If we're not in position to kick, move into position
         if (!robot_behind_ball)
         {
@@ -114,7 +119,8 @@ std::unique_ptr<Intent> KickAction::calculateNextIntent(
 
         Vector ball_to_robot = robot->position() - ball.position();
 
-        ball_robot_angle = ball.velocity().orientation().minDiff(ball_to_robot.orientation());
+        ball_robot_angle =
+            ball.velocity().orientation().minDiff(ball_to_robot.orientation());
 
         // Stop once the ball is travelling away from us with a non-zero velocity
     } while (ball_robot_angle.toDegrees() < 90 || ball.velocity().len() < 0.5);

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -8,9 +8,6 @@
 /**
  * The KickAction makes the robot take a kick from the given location in the given
  * direction, with the given power.
- *
- * The KickAction will be done when the ball is travelling away from the robot at a
- * non-zero velocity.
  */
 class KickAction : public Action
 {

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -28,9 +28,7 @@ class KickAction : public Action
      * @return A unique pointer to the Intent the KickAction wants to run. If the
      * KickAction is done, returns an empty/null pointer
      */
-    std::unique_ptr<Intent> updateStateAndGetNextIntent(
-        const Robot& robot, Point kick_origin, Angle kick_direction,
-        double kick_speed_meters_per_second);
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot &robot, const Ball &ball, Point kick_origin, Angle kick_direction, double kick_speed_meters_per_second);
 
     /**
      * Returns the next Intent this KickAction wants to run, given the parameters.
@@ -44,9 +42,7 @@ class KickAction : public Action
      * @return A unique pointer to the Intent the KickAction wants to run. If the
      * KickAction is done, returns an empty/null pointer
      */
-    std::unique_ptr<Intent> updateStateAndGetNextIntent(
-        const Robot& robot, Point kick_origin, Point kick_target,
-        double kick_speed_meters_per_second);
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot &robot, const Ball &ball, Point kick_origin, Point kick_target, double kick_speed_meters_per_second);
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -1,12 +1,16 @@
 #pragma once
 
 #include "ai/hl/stp/action/action.h"
+#include "ai/world/ball.h"
 #include "geom/angle.h"
 #include "geom/point.h"
 
 /**
  * The KickAction makes the robot take a kick from the given location in the given
- * direction, with the given power
+ * direction, with the given power.
+ *
+ * The KickAction will be done when the ball is travelling away from the robot at a
+ * non-zero velocity.
  */
 class KickAction : public Action
 {
@@ -49,6 +53,7 @@ class KickAction : public Action
         intent_coroutine::push_type& yield) override;
 
     // Action parameters
+    Ball ball;
     Point kick_origin;
     Angle kick_direction;
     double kick_speed_meters_per_second;

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -32,7 +32,9 @@ class KickAction : public Action
      * @return A unique pointer to the Intent the KickAction wants to run. If the
      * KickAction is done, returns an empty/null pointer
      */
-    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot &robot, const Ball &ball, Point kick_origin, Angle kick_direction, double kick_speed_meters_per_second);
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(
+        const Robot &robot, const Ball &ball, Point kick_origin, Angle kick_direction,
+        double kick_speed_meters_per_second);
 
     /**
      * Returns the next Intent this KickAction wants to run, given the parameters.
@@ -46,7 +48,9 @@ class KickAction : public Action
      * @return A unique pointer to the Intent the KickAction wants to run. If the
      * KickAction is done, returns an empty/null pointer
      */
-    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot &robot, const Ball &ball, Point kick_origin, Point kick_target, double kick_speed_meters_per_second);
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(
+        const Robot &robot, const Ball &ball, Point kick_origin, Point kick_target,
+        double kick_speed_meters_per_second);
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -51,7 +51,7 @@ class KickAction : public Action
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        intent_coroutine::push_type &yield) override;
 
     // Action parameters
     Ball ball;

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -11,8 +11,9 @@
 
 using namespace AI::Passing;
 
-PasserTactic::PasserTactic(Pass pass, const Timestamp& curr_time, bool loop_forever)
-    : pass(std::move(pass)), curr_time(curr_time), Tactic(loop_forever)
+PasserTactic::PasserTactic(AI::Passing::Pass pass, const Ball &ball,
+                           bool loop_forever)
+    : pass(std::move(pass)), ball(ball), Tactic(loop_forever)
 {
 }
 
@@ -21,11 +22,11 @@ std::string PasserTactic::getName() const
     return "Passer Tactic";
 }
 
-void PasserTactic::updateParams(const Pass& updated_pass,
-                                const Timestamp& updated_curr_time)
+void PasserTactic::updateParams(const Pass &updated_pass,
+                                const Ball &updated_ball)
 {
     this->pass      = updated_pass;
-    this->curr_time = updated_curr_time;
+    this->ball = updated_ball;
 }
 
 double PasserTactic::calculateRobotCost(const Robot& robot, const World& world)
@@ -44,7 +45,7 @@ std::unique_ptr<Intent> PasserTactic::calculateNextIntent(
     MoveAction move_action = MoveAction(MoveAction::ROBOT_CLOSE_TO_DEST_THRESHOLD, true);
     // Move to a position just behind the ball (in the direction of the pass)
     // until it's time to perform the pass
-    while (curr_time < pass.startTime())
+    while (ball.lastUpdateTimestamp() < pass.startTime())
     {
         // We want to wait just behind where the pass is supposed to start, so that the
         // ball is *almost* touching the kicker
@@ -58,11 +59,10 @@ std::unique_ptr<Intent> PasserTactic::calculateNextIntent(
     }
 
     KickAction kick_action = KickAction();
-    do
-    {
+    while (!kick_action.done()){
         // We want the robot to move to the starting position for the shot and also
         // rotate to the correct orientation to face the shot
         yield(kick_action.updateStateAndGetNextIntent(
-            *robot, pass.passerPoint(), pass.passerOrientation(), pass.speed()));
-    } while (!kick_action.done());
+            *robot, ball, pass.passerPoint(), pass.passerOrientation(), pass.speed()));
+    }
 }

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -23,8 +23,8 @@ std::string PasserTactic::getName() const
 
 void PasserTactic::updateParams(const Pass& updated_pass, const Ball& updated_ball)
 {
-    this->pass      = updated_pass;
-    this->ball      = updated_ball;
+    this->pass = updated_pass;
+    this->ball = updated_ball;
 }
 
 double PasserTactic::calculateRobotCost(const Robot& robot, const World& world)

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -11,8 +11,7 @@
 
 using namespace AI::Passing;
 
-PasserTactic::PasserTactic(AI::Passing::Pass pass, const Ball &ball,
-                           bool loop_forever)
+PasserTactic::PasserTactic(AI::Passing::Pass pass, const Ball& ball, bool loop_forever)
     : pass(std::move(pass)), ball(ball), Tactic(loop_forever)
 {
 }
@@ -22,11 +21,10 @@ std::string PasserTactic::getName() const
     return "Passer Tactic";
 }
 
-void PasserTactic::updateParams(const Pass &updated_pass,
-                                const Ball &updated_ball)
+void PasserTactic::updateParams(const Pass& updated_pass, const Ball& updated_ball)
 {
     this->pass      = updated_pass;
-    this->ball = updated_ball;
+    this->ball      = updated_ball;
 }
 
 double PasserTactic::calculateRobotCost(const Robot& robot, const World& world)
@@ -59,7 +57,8 @@ std::unique_ptr<Intent> PasserTactic::calculateNextIntent(
     }
 
     KickAction kick_action = KickAction();
-    while (!kick_action.done()){
+    while (!kick_action.done())
+    {
         // We want the robot to move to the starting position for the shot and also
         // rotate to the correct orientation to face the shot
         yield(kick_action.updateStateAndGetNextIntent(

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -56,12 +56,24 @@ std::unique_ptr<Intent> PasserTactic::calculateNextIntent(
                                                       pass.passerOrientation(), 0));
     }
 
+    // The angle between the ball velocity vector and a vector from the passer
+    // point to the receiver point
+    Angle ball_velocity_to_pass_orientation;
+
     KickAction kick_action = KickAction();
-    while (!kick_action.done())
+    do
     {
         // We want the robot to move to the starting position for the shot and also
         // rotate to the correct orientation to face the shot
         yield(kick_action.updateStateAndGetNextIntent(
             *robot, ball, pass.passerPoint(), pass.passerOrientation(), pass.speed()));
-    }
+
+        // We want to keep trying to kick until the ball is moving along the pass
+        // vector with sufficient velocity
+        Angle passer_to_receiver_angle =
+            (pass.receiverPoint() - pass.passerPoint()).orientation();
+        ball_velocity_to_pass_orientation =
+            ball.velocity().orientation().minDiff(passer_to_receiver_angle);
+    } while (ball_velocity_to_pass_orientation.abs() > Angle::ofDegrees(20) ||
+             ball.velocity().len() < 0.5);
 }

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
@@ -24,8 +24,7 @@ class PasserTactic : public Tactic
      * @param loop_forever Whether or not this Tactic should never complete. If true, the
      * tactic will be restarted every time it completes
      */
-    explicit PasserTactic(AI::Passing::Pass pass, const Ball &ball,
-                          bool loop_forever);
+    explicit PasserTactic(AI::Passing::Pass pass, const Ball& ball, bool loop_forever);
 
     std::string getName() const override;
 
@@ -35,8 +34,7 @@ class PasserTactic : public Tactic
      * @param pass The pass to perform
      * @param updated_ball The ball we're passing
      */
-    void updateParams(const AI::Passing::Pass &updated_pass,
-                      const Ball &updated_ball);
+    void updateParams(const AI::Passing::Pass& updated_pass, const Ball& updated_ball);
 
     /**
      * Calculates the cost of assigning the given robot to this Tactic. Prefers robots

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
@@ -20,11 +20,11 @@ class PasserTactic : public Tactic
      * Creates a new PasserTactic
      *
      * @param pass The pass this tactic should try to execute
-     * @param curr_time The current time
+     * @param ball The ball that we're trying to pass
      * @param loop_forever Whether or not this Tactic should never complete. If true, the
      * tactic will be restarted every time it completes
      */
-    explicit PasserTactic(AI::Passing::Pass pass, const Timestamp& time,
+    explicit PasserTactic(AI::Passing::Pass pass, const Ball &ball,
                           bool loop_forever);
 
     std::string getName() const override;
@@ -33,10 +33,10 @@ class PasserTactic : public Tactic
      * Updates the parameters for this PasserTactic.
      *
      * @param pass The pass to perform
-     * @param updated_curr_time The current time
+     * @param updated_ball The ball we're passing
      */
-    void updateParams(const AI::Passing::Pass& updated_pass,
-                      const Timestamp& updated_curr_time);
+    void updateParams(const AI::Passing::Pass &updated_pass,
+                      const Ball &updated_ball);
 
     /**
      * Calculates the cost of assigning the given robot to this Tactic. Prefers robots
@@ -54,9 +54,6 @@ class PasserTactic : public Tactic
         intent_coroutine::push_type& yield) override;
 
     // Tactic parameters
-    // The pass this tactic is executing
     AI::Passing::Pass pass;
-
-    // The current time
-    Timestamp curr_time;
+    Ball ball;
 };

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
@@ -3,7 +3,7 @@
 #include "util/logger/init.h"
 
 Tactic::Tactic(bool loop_forever)
-    : intent_sequence(boost::bind(&Tactic::calculateNextIntentWrapper, this, _1)),
+    : intent_sequence(new intent_coroutine::pull_type([this](intent_coroutine::push_type &yield){ return this->calculateNextIntentWrapper(yield); })),
       done_(false),
       loop_forever(loop_forever)
 {
@@ -42,8 +42,9 @@ std::unique_ptr<Intent> Tactic::getNextIntent()
         // old one. This way, any callers of this function won't accidentally get a
         // nullptr returned for a single call (which could come from the "old" coroutine)
         // when this Tactic restarts
-        intent_sequence = intent_coroutine::pull_type(
-            boost::bind(&Tactic::calculateNextIntentWrapper, this, _1));
+        delete(intent_sequence);
+        intent_sequence = new intent_coroutine::pull_type(
+            [this](intent_coroutine::push_type &yield){ return this->calculateNextIntentWrapper(yield); });
         next_intent = getNextIntentHelper();
     }
 
@@ -67,13 +68,13 @@ std::unique_ptr<Intent> Tactic::getNextIntentHelper()
     std::unique_ptr<Intent> next_intent;
     // Check if the coroutine "iterator" has any more work to do. Only run the coroutine
     // if there is work to be done otherwise the coroutine library will fail on an assert.
-    if (intent_sequence)
+    if (*intent_sequence)
     {
         // Run the coroutine
-        intent_sequence();
+        (*intent_sequence)();
         // Get the result of running the coroutine, which is the next Intent the Tactic
         // wants to run
-        next_intent = intent_sequence.get();
+        next_intent = intent_sequence->get();
     }
 
     // The Tactic is considered done once the next_intent becomes a nullptr. This could

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
@@ -3,7 +3,7 @@
 #include "util/logger/init.h"
 
 Tactic::Tactic(bool loop_forever)
-    : intent_sequence(new intent_coroutine::pull_type([this](intent_coroutine::push_type &yield){ return this->calculateNextIntentWrapper(yield); })),
+    : intent_sequence(std::make_unique<intent_coroutine::pull_type>([this](intent_coroutine::push_type &yield){ return this->calculateNextIntentWrapper(yield); })),
       done_(false),
       loop_forever(loop_forever)
 {
@@ -42,8 +42,8 @@ std::unique_ptr<Intent> Tactic::getNextIntent()
         // old one. This way, any callers of this function won't accidentally get a
         // nullptr returned for a single call (which could come from the "old" coroutine)
         // when this Tactic restarts
-        delete(intent_sequence);
-        intent_sequence = new intent_coroutine::pull_type(
+        intent_sequence.reset();
+        intent_sequence = std::make_unique<intent_coroutine::pull_type>(
             [this](intent_coroutine::push_type &yield){ return this->calculateNextIntentWrapper(yield); });
         next_intent = getNextIntentHelper();
     }

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
@@ -3,7 +3,10 @@
 #include "util/logger/init.h"
 
 Tactic::Tactic(bool loop_forever)
-    : intent_sequence(std::make_unique<intent_coroutine::pull_type>([this](intent_coroutine::push_type &yield){ return this->calculateNextIntentWrapper(yield); })),
+    : intent_sequence(std::make_unique<intent_coroutine::pull_type>(
+          [this](intent_coroutine::push_type &yield) {
+              return this->calculateNextIntentWrapper(yield);
+          })),
       done_(false),
       loop_forever(loop_forever)
 {
@@ -44,7 +47,9 @@ std::unique_ptr<Intent> Tactic::getNextIntent()
         // when this Tactic restarts
         intent_sequence.reset();
         intent_sequence = std::make_unique<intent_coroutine::pull_type>(
-            [this](intent_coroutine::push_type &yield){ return this->calculateNextIntentWrapper(yield); });
+            [this](intent_coroutine::push_type &yield) {
+                return this->calculateNextIntentWrapper(yield);
+            });
         next_intent = getNextIntentHelper();
     }
 

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
@@ -153,7 +153,7 @@ class Tactic
     std::unique_ptr<Intent> getNextIntentHelper();
 
     // The coroutine that sequentially returns the Intents the Tactic wants to run
-    intent_coroutine::pull_type intent_sequence;
+    intent_coroutine::pull_type* intent_sequence;
     // Whether or not this Tactic is done
     bool done_;
     // Whether or not this tactic should loop forever by restarting each time it is done

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
@@ -153,7 +153,7 @@ class Tactic
     std::unique_ptr<Intent> getNextIntentHelper();
 
     // The coroutine that sequentially returns the Intents the Tactic wants to run
-    intent_coroutine::pull_type* intent_sequence;
+    std::unique_ptr<intent_coroutine::pull_type> intent_sequence;
     // Whether or not this Tactic is done
     bool done_;
     // Whether or not this tactic should loop forever by restarting each time it is done

--- a/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
@@ -12,7 +12,7 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
     KickAction action = KickAction();
 
     auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+            action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(0, 0), Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -31,7 +31,7 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_positive_y)
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(-2.5, 2.5),
                                                          Angle::ofDegrees(105), 5.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -51,7 +51,7 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_negative_y)
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-0.1, -0.4),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(-0.1, -0.4),
                                                          Angle::ofDegrees(255), 3.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -71,7 +71,7 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_negative_y)
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(0, 0),
                                                          Angle::ofDegrees(306), 5.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -92,7 +92,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y
     KickAction action = KickAction();
 
     auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+            action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(0, 0), Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -112,7 +112,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(-2.5, 2.5),
                                                          Angle::ofDegrees(105), 5.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -133,7 +133,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-1, -4),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(-1, -4),
                                                          Angle::ofDegrees(255), 3.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -154,7 +154,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(0, 0),
                                                          Angle::ofDegrees(306), 5.0);
 
     // Check an intent was returned (the pointer is not null)

--- a/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
@@ -7,12 +7,13 @@
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
 {
-    Robot robot       = Robot(0, Point(-0.5, 0), Vector(), Angle::zero(),
+    Robot robot       (0, Point(-0.5, 0), Vector(), Angle::zero(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr =
-            action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(0, 0), Angle::zero(), 5.0);
+            action.updateStateAndGetNextIntent(robot, ball, Point(0, 0), Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -27,11 +28,12 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_positive_y)
 {
-    Robot robot       = Robot(0, Point(-2.3, 2.1), Vector(), Angle::quarter(),
+    Robot robot(0, Point(-2.3, 2.1), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(-2.5, 2.5),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-2.5, 2.5),
                                                          Angle::ofDegrees(105), 5.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -47,11 +49,12 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_positive_y)
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_negative_y)
 {
-    Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
+    Robot robot(0, Point(0, 0), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(-0.1, -0.4),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-0.1, -0.4),
                                                          Angle::ofDegrees(255), 3.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -67,11 +70,12 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_negative_y)
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_negative_y)
 {
-    Robot robot       = Robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
+    Robot robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(0, 0),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
                                                          Angle::ofDegrees(306), 5.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -87,12 +91,13 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_negative_y)
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y)
 {
-    Robot robot       = Robot(0, Point(-1, 0.0), Vector(), Angle::zero(),
+    Robot robot(0, Point(-1, 0.0), Vector(), Angle::zero(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr =
-            action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(0, 0), Angle::zero(), 5.0);
+            action.updateStateAndGetNextIntent(robot, ball, Point(0, 0), Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -108,11 +113,12 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y)
 {
-    Robot robot       = Robot(0, Point(-2, 5), Vector(), Angle::quarter(),
+    Robot robot(0, Point(-2, 5), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(-2.5, 2.5),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-2.5, 2.5),
                                                          Angle::ofDegrees(105), 5.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -129,11 +135,12 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y)
 {
-    Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
+    Robot robot(0, Point(0, 0), Vector(), Angle::quarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(-1, -4),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-1, -4),
                                                          Angle::ofDegrees(255), 3.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -150,11 +157,12 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y)
 {
-    Robot robot       = Robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
+    Robot robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, <#initializer#>, Point(0, 0),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
                                                          Angle::ofDegrees(306), 5.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -167,4 +175,24 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y
     EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0.25), 0.1));
     EXPECT_EQ(Angle::ofDegrees(306), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+}
+
+TEST(KickActionTest, ball_travelling_away_from_robot){
+    // Test for the termination condition of the KickAction where the ball is travelling
+    // away from the robot
+    Robot robot(0, Point(1, 1), Vector(), Angle::threeQuarter(),
+                AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0.5,0.3}, {-1, -0.7}, Timestamp::fromSeconds(0));
+    KickAction action = KickAction();
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
+                                                         Angle::ofDegrees(306), 5.0);
+
+    // We expect to return one intent
+    EXPECT_TRUE(intent_ptr);
+
+    intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
+                                                         Angle::ofDegrees(306), 5.0);
+    // After returning one intent the action should be done, so we should return no more
+    EXPECT_FALSE(intent_ptr);
 }

--- a/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
@@ -19,11 +19,18 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
-    EXPECT_EQ(0, kick_intent.getRobotId());
-    EXPECT_EQ(Point(0, 0), kick_intent.getKickOrigin());
-    EXPECT_EQ(Angle::zero(), kick_intent.getKickDirection());
-    EXPECT_EQ(5.0, kick_intent.getKickSpeed());
+    try
+    {
+        KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
+        EXPECT_EQ(0, kick_intent.getRobotId());
+        EXPECT_EQ(Point(0, 0), kick_intent.getKickOrigin());
+        EXPECT_EQ(Angle::zero(), kick_intent.getKickDirection());
+        EXPECT_EQ(5.0, kick_intent.getKickSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Kick intent not returned by Kick Action!";
+    }
 }
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_positive_y)
@@ -40,11 +47,18 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_positive_y)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
-    EXPECT_EQ(0, kick_intent.getRobotId());
-    EXPECT_EQ(Point(-2.5, 2.5), kick_intent.getKickOrigin());
-    EXPECT_EQ(Angle::ofDegrees(105), kick_intent.getKickDirection());
-    EXPECT_EQ(5.0, kick_intent.getKickSpeed());
+    try
+    {
+        KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
+        EXPECT_EQ(0, kick_intent.getRobotId());
+        EXPECT_EQ(Point(-2.5, 2.5), kick_intent.getKickOrigin());
+        EXPECT_EQ(Angle::ofDegrees(105), kick_intent.getKickDirection());
+        EXPECT_EQ(5.0, kick_intent.getKickSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Kick intent not returned by Kick Action!";
+    }
 }
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_negative_y)
@@ -54,23 +68,30 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_negative_y)
     Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-0.1, -0.4),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-0.05, -0.2),
                                                          Angle::ofDegrees(255), 3.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
-    EXPECT_EQ(0, kick_intent.getRobotId());
-    EXPECT_EQ(Point(-0.1, -0.4), kick_intent.getKickOrigin());
-    EXPECT_EQ(Angle::ofDegrees(255), kick_intent.getKickDirection());
-    EXPECT_EQ(3.0, kick_intent.getKickSpeed());
+    try
+    {
+        KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
+        EXPECT_EQ(0, kick_intent.getRobotId());
+        EXPECT_EQ(Point(-0.05, -0.2), kick_intent.getKickOrigin());
+        EXPECT_EQ(Angle::ofDegrees(255), kick_intent.getKickDirection());
+        EXPECT_EQ(3.0, kick_intent.getKickSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Kick intent not returned by Kick Action!";
+    }
 }
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_negative_y)
 {
-    Robot robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
+    Robot robot(0, Point(-0.125, 0.25), Vector(), Angle::threeQuarter(),
                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
     Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
@@ -82,11 +103,18 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_negative_y)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
-    EXPECT_EQ(0, kick_intent.getRobotId());
-    EXPECT_EQ(Point(0, 0), kick_intent.getKickOrigin());
-    EXPECT_EQ(Angle::ofDegrees(306), kick_intent.getKickDirection());
-    EXPECT_EQ(5.0, kick_intent.getKickSpeed());
+    try
+    {
+        KickIntent kick_intent = dynamic_cast<KickIntent &>(*intent_ptr);
+        EXPECT_EQ(0, kick_intent.getRobotId());
+        EXPECT_EQ(Point(0, 0), kick_intent.getKickOrigin());
+        EXPECT_EQ(Angle::ofDegrees(306), kick_intent.getKickDirection());
+        EXPECT_EQ(5.0, kick_intent.getKickSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Kick intent not returned by Kick Action!";
+    }
 }
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y)
@@ -103,12 +131,19 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-    EXPECT_EQ(0, move_intent.getRobotId());
-    // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.28, 0), 0.1));
-    EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
-    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_EQ(0, move_intent.getRobotId());
+        // Check the MoveIntent is moving roughly behind the ball
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.28, 0), 0.1));
+        EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
+        EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Move intent not returned by Kick Action!";
+    }
 }
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y)
@@ -125,12 +160,19 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-    EXPECT_EQ(0, move_intent.getRobotId());
-    // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-2.45, 2.25), 0.1));
-    EXPECT_EQ(Angle::ofDegrees(105), move_intent.getFinalAngle());
-    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_EQ(0, move_intent.getRobotId());
+        // Check the MoveIntent is moving roughly behind the ball
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(-2.45, 2.25), 0.1));
+        EXPECT_EQ(Angle::ofDegrees(105), move_intent.getFinalAngle());
+        EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Move intent not returned by Kick Action!";
+    }
 }
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y)
@@ -147,12 +189,19 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-    EXPECT_EQ(0, move_intent.getRobotId());
-    // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.85, -3.75), 0.1));
-    EXPECT_EQ(Angle::ofDegrees(255), move_intent.getFinalAngle());
-    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_EQ(0, move_intent.getRobotId());
+        // Check the MoveIntent is moving roughly behind the ball
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.85, -3.75), 0.1));
+        EXPECT_EQ(Angle::ofDegrees(255), move_intent.getFinalAngle());
+        EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Move intent not returned by Kick Action!";
+    }
 }
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y)
@@ -169,10 +218,17 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-    EXPECT_EQ(0, move_intent.getRobotId());
-    // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0.25), 0.1));
-    EXPECT_EQ(Angle::ofDegrees(306), move_intent.getFinalAngle());
-    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_EQ(0, move_intent.getRobotId());
+        // Check the MoveIntent is moving roughly behind the ball
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0.25), 0.1));
+        EXPECT_EQ(Angle::ofDegrees(306), move_intent.getFinalAngle());
+        EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Move intent not returned by Kick Action!";
+    }
 }

--- a/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
@@ -176,24 +176,3 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y
     EXPECT_EQ(Angle::ofDegrees(306), move_intent.getFinalAngle());
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
-
-TEST(KickActionTest, ball_travelling_away_from_robot)
-{
-    // Test for the termination condition of the KickAction where the ball is travelling
-    // away from the robot
-    Robot robot(0, Point(1, 1), Vector(), Angle::threeQuarter(), AngularVelocity::zero(),
-                Timestamp::fromSeconds(0));
-    Ball ball({0.5, 0.3}, {-1, -0.7}, Timestamp::fromSeconds(0));
-    KickAction action = KickAction();
-
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
-                                                         Angle::ofDegrees(306), 5.0);
-
-    // We expect to return one intent
-    EXPECT_TRUE(intent_ptr);
-
-    intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
-                                                    Angle::ofDegrees(306), 5.0);
-    // After returning one intent the action should be done, so we should return no more
-    EXPECT_FALSE(intent_ptr);
-}

--- a/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
@@ -7,13 +7,13 @@
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
 {
-    Robot robot       (0, Point(-0.5, 0), Vector(), Angle::zero(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(-0.5, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr =
-            action.updateStateAndGetNextIntent(robot, ball, Point(0, 0), Angle::zero(), 5.0);
+        action.updateStateAndGetNextIntent(robot, ball, Point(0, 0), Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -28,9 +28,9 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_positive_y)
 {
-    Robot robot(0, Point(-2.3, 2.1), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(-2.3, 2.1), Vector(), Angle::quarter(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-2.5, 2.5),
@@ -49,9 +49,9 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_positive_y)
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_negative_y)
 {
-    Robot robot(0, Point(0, 0), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(0, 0), Vector(), Angle::quarter(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-0.1, -0.4),
@@ -71,8 +71,8 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_negative_y)
 TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_negative_y)
 {
     Robot robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
+                AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
@@ -91,13 +91,13 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_negative_y)
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y)
 {
-    Robot robot(0, Point(-1, 0.0), Vector(), Angle::zero(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(-1, 0.0), Vector(), Angle::zero(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr =
-            action.updateStateAndGetNextIntent(robot, ball, Point(0, 0), Angle::zero(), 5.0);
+        action.updateStateAndGetNextIntent(robot, ball, Point(0, 0), Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -113,9 +113,9 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y)
 {
-    Robot robot(0, Point(-2, 5), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(-2, 5), Vector(), Angle::quarter(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-2.5, 2.5),
@@ -135,9 +135,9 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y
 
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y)
 {
-    Robot robot(0, Point(0, 0), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(0, 0), Vector(), Angle::quarter(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-1, -4),
@@ -158,8 +158,8 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y
 TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y)
 {
     Robot robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, robot.position(), Timestamp::fromSeconds(0));
+                AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
@@ -177,12 +177,13 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y
     EXPECT_EQ(0.0, move_intent.getFinalSpeed());
 }
 
-TEST(KickActionTest, ball_travelling_away_from_robot){
+TEST(KickActionTest, ball_travelling_away_from_robot)
+{
     // Test for the termination condition of the KickAction where the ball is travelling
     // away from the robot
-    Robot robot(0, Point(1, 1), Vector(), Angle::threeQuarter(),
-                AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0.5,0.3}, {-1, -0.7}, Timestamp::fromSeconds(0));
+    Robot robot(0, Point(1, 1), Vector(), Angle::threeQuarter(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({0.5, 0.3}, {-1, -0.7}, Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
@@ -192,7 +193,7 @@ TEST(KickActionTest, ball_travelling_away_from_robot){
     EXPECT_TRUE(intent_ptr);
 
     intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
-                                                         Angle::ofDegrees(306), 5.0);
+                                                    Angle::ofDegrees(306), 5.0);
     // After returning one intent the action should be done, so we should return no more
     EXPECT_FALSE(intent_ptr);
 }

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/passer_tactic.cpp
@@ -18,7 +18,7 @@ TEST(PasserTacticTest,
     // Robot is sitting at origin facing towards enemy goal
     Robot robot = Robot(13, Point(0, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    Ball ball({0,0}, {0,0}, Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction
     Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(5));
@@ -46,7 +46,7 @@ TEST(PasserTacticTest,
     // Robot is sitting at {1,2} facing towards -y
     Robot robot = Robot(13, Point(1, 2), Vector(), Angle::ofDegrees(-90),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, {0,0}, Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction
     Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(5));
@@ -75,7 +75,7 @@ TEST(
     // Robot is sitting at {-0.3,0.2} facing towards -y
     Robot robot = Robot(13, Point(-0.3, 0.2), Vector(), Angle::ofDegrees(-90),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, {0,0}, Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction. This means the
     // robot needs to move around the ball to get toa point where it can kick
@@ -104,7 +104,7 @@ TEST(PasserTacticTest, passer_in_position_to_kick_pass_not_yet_started)
     // position to just move forward a bit and take the kick
     Robot robot = Robot(13, Point(0, 0.3), Vector(), Angle::ofDegrees(-90),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Ball ball({0,0}, {0,0}, Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction
     Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(5));
@@ -134,7 +134,7 @@ TEST(PasserTacticTest, passer_in_position_to_kick_pass_started)
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
     // Ball not moving initially
-    Ball ball({0,0}, {0,0}, Timestamp::fromSeconds(5));
+    Ball ball({0, 0}, {0, 0}, Timestamp::fromSeconds(5));
 
     // We want to pass from the origin to 1 meter in the -y direction
     Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(5));
@@ -150,7 +150,7 @@ TEST(PasserTacticTest, passer_in_position_to_kick_pass_started)
     EXPECT_EQ(2.29, kick_intent.getKickSpeed());
 
     // Ball starts moving as if we've kicked it
-    ball = Ball({0,0}, {0,-2}, Timestamp::fromSeconds(5.1));
+    ball = Ball({0, 0}, {0, -2}, Timestamp::fromSeconds(5.1));
     tactic.updateParams(pass, ball);
 
     // We need to try to get the next the intent to make the tactic finish

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/passer_tactic.cpp
@@ -18,10 +18,11 @@ TEST(PasserTacticTest,
     // Robot is sitting at origin facing towards enemy goal
     Robot robot = Robot(13, Point(0, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
+    Ball ball({0,0}, {0,0}, Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction
     Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(5));
-    PasserTactic tactic(pass, Timestamp::fromSeconds(0), false);
+    PasserTactic tactic(pass, ball, false);
 
     tactic.updateRobot(robot);
 
@@ -45,10 +46,11 @@ TEST(PasserTacticTest,
     // Robot is sitting at {1,2} facing towards -y
     Robot robot = Robot(13, Point(1, 2), Vector(), Angle::ofDegrees(-90),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, {0,0}, Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction
     Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(5));
-    PasserTactic tactic(pass, Timestamp::fromSeconds(0), false);
+    PasserTactic tactic(pass, ball, false);
 
     tactic.updateRobot(robot);
 
@@ -73,11 +75,12 @@ TEST(
     // Robot is sitting at {-0.3,0.2} facing towards -y
     Robot robot = Robot(13, Point(-0.3, 0.2), Vector(), Angle::ofDegrees(-90),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, {0,0}, Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction. This means the
     // robot needs to move around the ball to get toa point where it can kick
     Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(5));
-    PasserTactic tactic(pass, Timestamp::fromSeconds(0), false);
+    PasserTactic tactic(pass, ball, false);
 
     tactic.updateRobot(robot);
 
@@ -101,10 +104,11 @@ TEST(PasserTacticTest, passer_in_position_to_kick_pass_not_yet_started)
     // position to just move forward a bit and take the kick
     Robot robot = Robot(13, Point(0, 0.3), Vector(), Angle::ofDegrees(-90),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0,0}, {0,0}, Timestamp::fromSeconds(0));
 
     // We want to pass from the origin to 1 meter in the -y direction
     Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(5));
-    PasserTactic tactic(pass, Timestamp::fromSeconds(0), false);
+    PasserTactic tactic(pass, ball, false);
 
     tactic.updateRobot(robot);
 
@@ -129,15 +133,29 @@ TEST(PasserTacticTest, passer_in_position_to_kick_pass_started)
     Robot robot = Robot(13, Point(0, 0.3), Vector(), Angle::ofDegrees(-90),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
+    // Ball not moving initially
+    Ball ball({0,0}, {0,0}, Timestamp::fromSeconds(5));
+
     // We want to pass from the origin to 1 meter in the -y direction
     Pass pass({0, 0}, {0, -1}, 2.29, Timestamp::fromSeconds(5));
-    PasserTactic tactic(pass, Timestamp::fromSeconds(5.01), false);
+    PasserTactic tactic(pass, ball, false);
 
     tactic.updateRobot(robot);
 
+    // We should try to kick the ball
     KickIntent kick_intent = dynamic_cast<KickIntent &>(*tactic.getNextIntent());
     EXPECT_EQ(13, kick_intent.getRobotId());
     EXPECT_EQ(-90, kick_intent.getKickDirection().toDegrees());
     EXPECT_EQ(Point(0, 0), kick_intent.getKickOrigin());
     EXPECT_EQ(2.29, kick_intent.getKickSpeed());
+
+    // Ball starts moving as if we've kicked it
+    ball = Ball({0,0}, {0,-2}, Timestamp::fromSeconds(5.1));
+    tactic.updateParams(pass, ball);
+
+    // We need to try to get the next the intent to make the tactic finish
+    tactic.getNextIntent();
+
+    // The tactic should now be done
+    EXPECT_TRUE(tactic.done());
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
- tweaks to `KickAction` from testing
- added a termination condition to the `PasserTactic` for when the ball is moving along the pass
 
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
