### PR TITLE
Receiver Tactic Tweaks

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -56,13 +56,26 @@ std::unique_ptr<Intent> ReceiverTactic::calculateNextIntent(
     MoveAction move_action = MoveAction(MoveAction::ROBOT_CLOSE_TO_DEST_THRESHOLD, true);
 
     // Setup for the pass. We want to use any free time before the pass starts putting
-    // ourself in the best position possible to take the pass
-    while (ball.lastUpdateTimestamp() < pass.startTime())
+    // ourselves in the best position possible to take the pass
+    // We wait for the ball to start moving at least a bit to make sure the passer
+    // has actually started the pass
+    while (ball.lastUpdateTimestamp() < pass.startTime() || ball.velocity().len() < 0.5)
     {
+        // If there is a feasible shot we can take, we want to wait for the pass at the
+        // halfway point between the angle required to receive the ball and the angle
+        // for a one-time shot
+        std::optional<std::pair<Point, Angle>> shot = findFeasibleShot();
+        Angle desired_angle                         = pass.receiverOrientation();
+        if (shot)
+        {
+            auto [target_position, _] = *shot;
+            Angle shot_angle = (target_position - robot->position()).orientation();
+            desired_angle    = (shot_angle + pass.receiverOrientation()) / 2;
+        }
         // We want the robot to move to the receiving position for the shot and also
         // rotate to the correct orientation to face where the pass is coming from
         yield(move_action.updateStateAndGetNextIntent(*robot, pass.receiverPoint(),
-                                                      pass.receiverOrientation(), 0));
+                                                      desired_angle, 0));
     }
 
     // Check if we can shoot on the enemy goal from the receiver position
@@ -91,12 +104,12 @@ std::unique_ptr<Intent> ReceiverTactic::calculateNextIntent(
         net_percent_open = best_shot_opt->second.toDegrees() / goal_angle.toDegrees();
     }
 
-    // If we have a shot with a sufficiently large enough opening, and the deflection
-    // angle that is reasonable, we should one-touch kick the ball towards the enemy net
-    if (best_shot_opt && net_percent_open > MIN_SHOT_NET_PERCENT_OPEN &&
-        abs_angle_between_pass_and_shot_vectors < MAX_DEFLECTION_FOR_ONE_TOUCH_SHOT)
+
+    std::optional<std::pair<Point, Angle>> best_shot = findFeasibleShot();
+
+    if (best_shot)
     {
-        auto [best_shot_target, _] = *best_shot_opt;
+        auto [best_shot_target, _] = *best_shot;
 
         // The angle between the ball velocity and a vector from the ball to the robot
         Vector ball_velocity = ball.velocity();
@@ -124,8 +137,7 @@ std::unique_ptr<Intent> ReceiverTactic::calculateNextIntent(
             // rather then the center of the robot
             Point ideal_position = closest_ball_pos - ideal_orientation_vec.norm(
                                                           DIST_TO_FRONT_OF_ROBOT_METERS +
-                                                          BALL_MAX_RADIUS_METERS);
-
+                                                          BALL_MAX_RADIUS_METERS * 1.5);
 
             yield(move_action.updateStateAndGetNextIntent(
                 *robot, ideal_position, ideal_orientation, 0, false, true));
@@ -176,4 +188,42 @@ Angle ReceiverTactic::getOneTimeShotDirection(const Ray& shot, const Ball& ball)
         shot_offset = -shot_offset;
     }
     return shot_dir + shot_offset;
+}
+
+std::optional<std::pair<Point, Angle>> ReceiverTactic::findFeasibleShot()
+{
+    // Check if we can shoot on the enemy goal from the receiver position
+    std::optional<std::pair<Point, Angle>> best_shot_opt =
+        calcBestShotOnEnemyGoal(field, friendly_team, enemy_team, *robot);
+
+    // Vector from the ball to the robot
+    Vector robot_to_ball = ball.position() - robot->position();
+
+    // The angle the robot will have to deflect the ball to shoot
+    Angle abs_angle_between_pass_and_shot_vectors;
+    // The percentage of open net the robot would shoot on
+    double net_percent_open;
+    if (best_shot_opt)
+    {
+        Vector robot_to_shot_target = best_shot_opt->first - robot->position();
+        abs_angle_between_pass_and_shot_vectors =
+            (robot_to_ball.orientation() - robot_to_shot_target.orientation())
+                .angleMod()
+                .abs();
+
+        Angle goal_angle =
+            acuteVertexAngle(field.friendlyGoalpostPos(), robot->position(),
+                             field.friendlyGoalpostNeg())
+                .abs();
+        net_percent_open = best_shot_opt->second.toDegrees() / goal_angle.toDegrees();
+    }
+
+    // If we have a shot with a sufficiently large enough opening, and the deflection
+    // angle that is reasonable, we should one-touch kick the ball towards the enemy net
+    if (best_shot_opt && net_percent_open > MIN_SHOT_NET_PERCENT_OPEN &&
+        abs_angle_between_pass_and_shot_vectors < MAX_DEFLECTION_FOR_ONE_TOUCH_SHOT)
+    {
+        return best_shot_opt;
+    }
+    return std::nullopt;
 }

--- a/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.h
@@ -81,7 +81,10 @@ class ReceiverTactic : public Tactic
         intent_coroutine::push_type& yield) override;
 
     /**
-     * Finds a feasible shot for the robot, if any
+     * Finds a feasible shot for the robot, if any.
+     *
+     * A feasible shot is one where the robot does not have to rotate to much to
+     * take the shot, and there is a sufficient percentage of the net open for the shot.
      *
      * @return A pair of a Point to shoot at and the open angle the shot could
      *         go through, or std::nullopt if there is no feasible shot

--- a/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.h
@@ -25,8 +25,8 @@ class ReceiverTactic : public Tactic
      * @param enemy_team The enemy team
      * @param pass The pass this tactic should try to receive
      * @param ball The ball being passed
-     * @param loop_forever Whether or not this Tactic should never complete. If true, the
-     * tactic will be restarted every time it completes
+     * @param loop_forever Whether or not this Tactic should never complete. If true,
+     *                     the tactic will be restarted every time it completes
      */
     explicit ReceiverTactic(const Field& field, const Team& friendly_team,
                             const Team& enemy_team, const AI::Passing::Pass pass,
@@ -79,6 +79,14 @@ class ReceiverTactic : public Tactic
 
     std::unique_ptr<Intent> calculateNextIntent(
         intent_coroutine::push_type& yield) override;
+
+    /**
+     * Finds a feasible shot for the robot, if any
+     *
+     * @return A pair of a Point to shoot at and the open angle the shot could
+     *         go through, or std::nullopt if there is no feasible shot
+     */
+    std::optional<std::pair<Point, Angle>> findFeasibleShot();
 
     // The field the pass is occuring on
     Field field;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
updated the receiver tactic with a few tweaks that we made from field testing:
- if there is an open shot, we wait at the average of the orientation  required to receive the ball directly and the orientation required to shoot
- pulled some duplicated code out into a function `findFeasibleShot`

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
NA
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
