### PR TITLE
Pass Generator Improvements

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<Intent> CherryPickTactic::calculateNextIntent(
     intent_coroutine::push_type& yield)
 {
     MoveAction move_action                     = MoveAction();
-    auto best_pass_and_score = pass_generator.getBestPassSoFar();
+    auto best_pass_and_score                   = pass_generator.getBestPassSoFar();
     do
     {
         pass_generator.setWorld(world);
@@ -47,7 +47,8 @@ std::unique_ptr<Intent> CherryPickTactic::calculateNextIntent(
         if (best_pass_and_score)
         {
             yield(move_action.updateStateAndGetNextIntent(
-                *robot, best_pass_and_score->first.receiverPoint(), best_pass_and_score->first.receiverOrientation(), 0));
+                *robot, best_pass_and_score->first.receiverPoint(),
+                best_pass_and_score->first.receiverOrientation(), 0));
         }
     } while (!move_action.done());
 }

--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -9,7 +9,7 @@
 
 CherryPickTactic::CherryPickTactic(const World& world, const Rectangle& target_region,
                                    bool loop_forever)
-    : pass_generator(0.0, world, world.ball().position()),
+    : pass_generator(world, world.ball().position()),
       world(world),
       target_region(target_region),
       Tactic(loop_forever)

--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -7,10 +7,12 @@
 #include "ai/hl/stp/action/move_action.h"
 #include "geom/util.h"
 
-CherryPickTactic::CherryPickTactic(const World &world,
-                                   const Rectangle &target_region,
+CherryPickTactic::CherryPickTactic(const World& world, const Rectangle& target_region,
                                    bool loop_forever)
-    : pass_generator(0.0, world, world.ball().position()), world(world), target_region(target_region), Tactic(loop_forever)
+    : pass_generator(0.0, world, world.ball().position()),
+      world(world),
+      target_region(target_region),
+      Tactic(loop_forever)
 {
     pass_generator.setTargetRegion(target_region);
 }

--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -37,17 +37,17 @@ std::unique_ptr<Intent> CherryPickTactic::calculateNextIntent(
     intent_coroutine::push_type& yield)
 {
     MoveAction move_action                     = MoveAction();
-    std::optional<AI::Passing::Pass> best_pass = pass_generator.getBestPassSoFar();
+    auto best_pass_and_score = pass_generator.getBestPassSoFar();
     do
     {
         pass_generator.setWorld(world);
         // Move the robot to be the best possible receiver for the best pass we can
         // find (within the target region)
-        best_pass = pass_generator.getBestPassSoFar();
-        if (best_pass)
+        best_pass_and_score = pass_generator.getBestPassSoFar();
+        if (best_pass_and_score)
         {
             yield(move_action.updateStateAndGetNextIntent(
-                *robot, best_pass->receiverPoint(), best_pass->receiverOrientation(), 0));
+                *robot, best_pass_and_score->first.receiverPoint(), best_pass_and_score->first.receiverOrientation(), 0));
         }
-    } while (!move_action.done() && best_pass);
+    } while (!move_action.done());
 }

--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -7,8 +7,10 @@
 #include "ai/hl/stp/action/move_action.h"
 #include "geom/util.h"
 
-CherryPickTactic::CherryPickTactic(const Rectangle& target_region, bool loop_forever)
-    : pass_generator(0.0), target_region(target_region), Tactic(loop_forever)
+CherryPickTactic::CherryPickTactic(const World &world,
+                                   const Rectangle &target_region,
+                                   bool loop_forever)
+    : pass_generator(0.0, world, world.ball().position()), world(world), target_region(target_region), Tactic(loop_forever)
 {
     pass_generator.setTargetRegion(target_region);
 }

--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.h
@@ -21,8 +21,7 @@ class CherryPickTactic : public Tactic
     /**
      * Creates a new CherryPickTactic
      */
-    explicit CherryPickTactic(const World &world,
-                              const Rectangle &target_region,
+    explicit CherryPickTactic(const World& world, const Rectangle& target_region,
                               bool loop_forever);
 
     std::string getName() const override;

--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.h
@@ -21,7 +21,9 @@ class CherryPickTactic : public Tactic
     /**
      * Creates a new CherryPickTactic
      */
-    explicit CherryPickTactic(const Rectangle& target_region, bool loop_forever);
+    explicit CherryPickTactic(const World &world,
+                              const Rectangle &target_region,
+                              bool loop_forever);
 
     std::string getName() const override;
 

--- a/src/thunderbots/software/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/ai/passing/pass_generator.cpp
@@ -47,7 +47,8 @@ void PassGenerator::setPasserPoint(Point passer_point)
     this->passer_point = passer_point;
 }
 
-void PassGenerator::setPasserRobotId(unsigned int robot_id) {
+void PassGenerator::setPasserRobotId(unsigned int robot_id)
+{
     // Take ownershp of the passer robot id for the duration of this function
     std::lock_guard<std::mutex> passer_robot_id_lock(passer_robot_id_mutex);
 

--- a/src/thunderbots/software/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/ai/passing/pass_generator.cpp
@@ -6,13 +6,16 @@
 #include "ai/passing/evaluation.h"
 #include "pass_generator.h"
 
+#include "util/canvas_messenger/canvas_messenger.h"
 
 using namespace AI::Passing;
 using namespace Util::DynamicParameters::AI::Passing;
 
-PassGenerator::PassGenerator(double min_reasonable_pass_quality)
+PassGenerator::PassGenerator(double min_reasonable_pass_quality, const World& world, const Point& passer_point)
     : min_reasonable_pass_quality(min_reasonable_pass_quality),
+      updated_world(world),
       optimizer(optimizer_param_weights),
+      passer_point(passer_point),
       best_known_pass(std::nullopt),
       target_region(std::nullopt),
       random_num_gen(random_device()),
@@ -30,11 +33,11 @@ PassGenerator::PassGenerator(double min_reasonable_pass_quality)
 
 void PassGenerator::setWorld(World world)
 {
-    // Take ownership of the world for the duration of this function
-    std::lock_guard<std::mutex> world_lock(world_mutex);
+    // Take ownership of the updated world for the duration of this function
+    std::lock_guard<std::mutex> updated_world_lock(updated_world_mutex);
 
     // Update the world
-    this->world = std::move(world);
+    this->updated_world = std::move(world);
 }
 
 void PassGenerator::setPasserPoint(Point passer_point)
@@ -44,11 +47,6 @@ void PassGenerator::setPasserPoint(Point passer_point)
 
     // Update the passer point
     this->passer_point = passer_point;
-
-    // Replace all the passes we're currently trying to optimize, as they are probably
-    // not going to converge to this new passer point if they've already been converging
-    // to another passer point for a while
-    passes_to_optimize = generatePasses(num_passes_to_optimize.value());
 }
 
 std::optional<Pass> PassGenerator::getBestPassSoFar()
@@ -90,9 +88,17 @@ void PassGenerator::continuouslyGeneratePasses()
     in_destructor_mutex.lock();
     while (!in_destructor)
     {
+
         // Give up ownership of the in_destructor flag now that we're done the
         // conditional check
         in_destructor_mutex.unlock();
+
+        // Copy over the updated world
+        world_mutex.lock();
+        updated_world_mutex.lock();
+        world = updated_world;
+        updated_world_mutex.unlock();
+        world_mutex.unlock();
 
         optimizePasses();
         pruneAndReplacePasses();
@@ -114,14 +120,10 @@ void PassGenerator::optimizePasses()
     // that we're optimizing
     const auto objective_function =
         [this](std::array<double, NUM_PARAMS_TO_OPTIMIZE> pass_array) {
-            try
-            {
+            try{
                 Pass pass = convertArrayToPass(pass_array);
                 return ratePass(pass);
-            }
-            catch (std::invalid_argument& e)
-            {
-                // If the pass was invalid, just rate it as poorly as possible
+            } catch (std::invalid_argument& e){
                 return 0.0;
             }
         };
@@ -173,20 +175,18 @@ void PassGenerator::pruneAndReplacePasses()
         });
 
     // Replace the least promising passes with newly generated passes
-    if (num_passes_to_keep_after_pruning.value() < num_passes_to_optimize.value())
+    if (num_passes_to_keep_after_pruning.value() < num_passes_to_optimize.value() && num_passes_to_keep_after_pruning.value() < passes_to_optimize.size())
     {
-        // Remove the worst paths
-        if (num_passes_to_keep_after_pruning.value() < passes_to_optimize.size())
-        {
             passes_to_optimize.erase(
                 passes_to_optimize.begin() + num_passes_to_keep_after_pruning.value(),
                 passes_to_optimize.end());
-        }
+    }
 
-        // Generate new passes to replace the ones we just removed
+    // Generate new passes to replace the ones we just removed
+    int num_new_passes = num_passes_to_optimize.value() - passes_to_optimize.size();
+    if (num_new_passes > 0){
         std::vector<Pass> new_passes =
-            generatePasses(num_passes_to_optimize.value() - passes_to_optimize.size());
-
+                generatePasses(num_new_passes);
         // Append our newly generated passes to replace the passes we just removed
         passes_to_optimize.insert(passes_to_optimize.end(), new_passes.begin(),
                                   new_passes.end());
@@ -219,7 +219,15 @@ double PassGenerator::ratePass(Pass pass)
     std::lock_guard<std::mutex> world_lock(world_mutex);
     std::lock_guard<std::mutex> target_region_lock(target_region_mutex);
 
-    return ::ratePass(world, pass, target_region);
+    double rating = 0;
+    try {
+        rating = ::ratePass(world, pass, target_region);
+    } catch (std::invalid_argument& e){
+        // If the pass is invalid, just rate it as poorly as possible
+        rating = 0;
+    }
+
+    return rating;
 }
 
 std::vector<Pass> PassGenerator::generatePasses(unsigned long num_passes_to_gen)
@@ -227,10 +235,10 @@ std::vector<Pass> PassGenerator::generatePasses(unsigned long num_passes_to_gen)
     // Take ownership of world for the duration of this function
     std::lock_guard<std::mutex> world_lock(world_mutex);
 
-    std::uniform_real_distribution x_distribution(-world.field().width() / 2,
-                                                  world.field().width() / 2);
-    std::uniform_real_distribution y_distribution(-world.field().length() / 2,
+    std::uniform_real_distribution x_distribution(-world.field().length() / 2,
                                                   world.field().length() / 2);
+    std::uniform_real_distribution y_distribution(-world.field().width() / 2,
+                                                  world.field().width() / 2);
     // TODO (Issue #423): We should use the timestamp from the world instead of the ball
     double curr_time = world.ball().lastUpdateTimestamp().getSeconds();
     double min_start_time_offset =
@@ -291,6 +299,9 @@ bool PassGenerator::passesEqual(AI::Passing::Pass pass1, AI::Passing::Pass pass2
 std::array<double, PassGenerator::NUM_PARAMS_TO_OPTIMIZE>
 PassGenerator::convertPassToArray(Pass pass)
 {
+    // Take ownership of the world for the duration of this function
+    std::lock_guard<std::mutex> world_lock(world_mutex);
+
     return {pass.receiverPoint().x(), pass.receiverPoint().y(), pass.speed(),
             pass.startTime().getSeconds()};
 }
@@ -298,12 +309,13 @@ PassGenerator::convertPassToArray(Pass pass)
 Pass PassGenerator::convertArrayToPass(
     std::array<double, PassGenerator::NUM_PARAMS_TO_OPTIMIZE> array)
 {
-    // Take ownership of the passer_point for the duration of this function
+    // Take ownership of the passer_point and world for the duration of this function
     std::lock_guard<std::mutex> passer_point_lock(passer_point_mutex);
+    std::lock_guard<std::mutex> world_lock(world_mutex);
 
     // Clamp the time to be >= 0, otherwise the TimeStamp will throw an exception
-    double clamped_time = std::max(0.0, array.at(3));
+    double time_offset_seconds = std::max(0.0, array.at(3));
 
     return Pass(passer_point, Point(array.at(0), array.at(1)), array.at(2),
-                Timestamp::fromSeconds(clamped_time));
+                Timestamp::fromSeconds(time_offset_seconds));
 }

--- a/src/thunderbots/software/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/ai/passing/pass_generator.cpp
@@ -10,9 +10,8 @@
 using namespace AI::Passing;
 using namespace Util::DynamicParameters::AI::Passing;
 
-PassGenerator::PassGenerator(double min_reasonable_pass_quality, const World& world,
-                             const Point& passer_point)
-    : min_reasonable_pass_quality(min_reasonable_pass_quality),
+PassGenerator::PassGenerator(const World &world, const Point &passer_point)
+    :
       updated_world(world),
       optimizer(optimizer_param_weights),
       passer_point(passer_point),
@@ -205,8 +204,7 @@ void PassGenerator::saveBestPass()
     std::sort(
         passes_to_optimize.begin(), passes_to_optimize.end(),
         [this](auto pass1, auto pass2) { return comparePassQuality(pass1, pass2); });
-    if (!passes_to_optimize.empty() &&
-        ratePass(passes_to_optimize[0]) >= min_reasonable_pass_quality)
+    if (!passes_to_optimize.empty())
     {
         best_known_pass = std::optional(passes_to_optimize[0]);
     }

--- a/src/thunderbots/software/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/ai/passing/pass_generator.cpp
@@ -48,12 +48,16 @@ void PassGenerator::setPasserPoint(Point passer_point)
     this->passer_point = passer_point;
 }
 
-std::optional<Pass> PassGenerator::getBestPassSoFar()
+std::optional<std::pair<Pass, double>> PassGenerator::getBestPassSoFar()
 {
     // Take ownership of the best_known_pass for the duration of this function
     std::lock_guard<std::mutex> best_known_pass_lock(best_known_pass_mutex);
 
-    return best_known_pass;
+    if (best_known_pass){
+        Pass pass = *best_known_pass;
+        return std::make_pair<Pass, double>(std::move(pass), ratePass(pass));
+    }
+    return std::nullopt;
 }
 
 void PassGenerator::setTargetRegion(std::optional<Rectangle> area)

--- a/src/thunderbots/software/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/ai/passing/pass_generator.cpp
@@ -10,9 +10,8 @@
 using namespace AI::Passing;
 using namespace Util::DynamicParameters::AI::Passing;
 
-PassGenerator::PassGenerator(const World &world, const Point &passer_point)
-    :
-      updated_world(world),
+PassGenerator::PassGenerator(const World& world, const Point& passer_point)
+    : updated_world(world),
       optimizer(optimizer_param_weights),
       passer_point(passer_point),
       best_known_pass(std::nullopt),
@@ -53,7 +52,8 @@ std::optional<std::pair<Pass, double>> PassGenerator::getBestPassSoFar()
     // Take ownership of the best_known_pass for the duration of this function
     std::lock_guard<std::mutex> best_known_pass_lock(best_known_pass_mutex);
 
-    if (best_known_pass){
+    if (best_known_pass)
+    {
         Pass pass = *best_known_pass;
         return std::make_pair<Pass, double>(std::move(pass), ratePass(pass));
     }

--- a/src/thunderbots/software/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/ai/passing/pass_generator.cpp
@@ -5,13 +5,13 @@
 
 #include "ai/passing/evaluation.h"
 #include "pass_generator.h"
-
 #include "util/canvas_messenger/canvas_messenger.h"
 
 using namespace AI::Passing;
 using namespace Util::DynamicParameters::AI::Passing;
 
-PassGenerator::PassGenerator(double min_reasonable_pass_quality, const World& world, const Point& passer_point)
+PassGenerator::PassGenerator(double min_reasonable_pass_quality, const World& world,
+                             const Point& passer_point)
     : min_reasonable_pass_quality(min_reasonable_pass_quality),
       updated_world(world),
       optimizer(optimizer_param_weights),
@@ -88,7 +88,6 @@ void PassGenerator::continuouslyGeneratePasses()
     in_destructor_mutex.lock();
     while (!in_destructor)
     {
-
         // Give up ownership of the in_destructor flag now that we're done the
         // conditional check
         in_destructor_mutex.unlock();
@@ -120,10 +119,13 @@ void PassGenerator::optimizePasses()
     // that we're optimizing
     const auto objective_function =
         [this](std::array<double, NUM_PARAMS_TO_OPTIMIZE> pass_array) {
-            try{
+            try
+            {
                 Pass pass = convertArrayToPass(pass_array);
                 return ratePass(pass);
-            } catch (std::invalid_argument& e){
+            }
+            catch (std::invalid_argument& e)
+            {
                 return 0.0;
             }
         };
@@ -175,7 +177,8 @@ void PassGenerator::pruneAndReplacePasses()
         });
 
     // Replace the least promising passes with newly generated passes
-    if (num_passes_to_keep_after_pruning.value() < num_passes_to_optimize.value() && num_passes_to_keep_after_pruning.value() < passes_to_optimize.size())
+    if (num_passes_to_keep_after_pruning.value() < num_passes_to_optimize.value() &&
+        num_passes_to_keep_after_pruning.value() < passes_to_optimize.size())
     {
             passes_to_optimize.erase(
                 passes_to_optimize.begin() + num_passes_to_keep_after_pruning.value(),
@@ -184,9 +187,9 @@ void PassGenerator::pruneAndReplacePasses()
 
     // Generate new passes to replace the ones we just removed
     int num_new_passes = num_passes_to_optimize.value() - passes_to_optimize.size();
-    if (num_new_passes > 0){
-        std::vector<Pass> new_passes =
-                generatePasses(num_new_passes);
+    if (num_new_passes > 0)
+    {
+        std::vector<Pass> new_passes = generatePasses(num_new_passes);
         // Append our newly generated passes to replace the passes we just removed
         passes_to_optimize.insert(passes_to_optimize.end(), new_passes.begin(),
                                   new_passes.end());
@@ -220,9 +223,12 @@ double PassGenerator::ratePass(Pass pass)
     std::lock_guard<std::mutex> target_region_lock(target_region_mutex);
 
     double rating = 0;
-    try {
+    try
+    {
         rating = ::ratePass(world, pass, target_region);
-    } catch (std::invalid_argument& e){
+    }
+    catch (std::invalid_argument& e)
+    {
         // If the pass is invalid, just rate it as poorly as possible
         rating = 0;
     }

--- a/src/thunderbots/software/ai/passing/pass_generator.h
+++ b/src/thunderbots/software/ai/passing/pass_generator.h
@@ -49,14 +49,10 @@ namespace AI::Passing
         /**
          * Create a PassGenerator with given parameters
          *
-         * @param min_reasonable_pass_quality A value in [0,1] representing the minimum
-         *                                    quality for a pass to be considered
-         *                                    "reasonable", with higher being better
          * @param world The world we're passing int
          * @param passer_point The point we're passing from
          */
-        explicit PassGenerator(double min_reasonable_pass_quality, const World& world,
-                               const Point& passer_point);
+        explicit PassGenerator(const World &world, const Point &passer_point);
 
         /**
          * Updates the world
@@ -205,9 +201,6 @@ namespace AI::Passing
         // This constant is used to prevent division by 0 in our implementation of Adam
         // (gradient descent)
         static constexpr double eps = 1e-8;
-
-        // The minimum pass quality that we would consider a "reasonable" pass
-        double min_reasonable_pass_quality;
 
         // The thread running the pass optimization/pruning/re-generation in the
         // background. This thread will run for the entire lifetime of the class

--- a/src/thunderbots/software/ai/passing/pass_generator.h
+++ b/src/thunderbots/software/ai/passing/pass_generator.h
@@ -52,8 +52,10 @@ namespace AI::Passing
          * @param min_reasonable_pass_quality A value in [0,1] representing the minimum
          *                                    quality for a pass to be considered
          *                                    "reasonable", with higher being better
+         * @param world The world we're passing int
+         * @param passer_point The point we're passing from
          */
-        explicit PassGenerator(double min_reasonable_pass_quality);
+        explicit PassGenerator(double min_reasonable_pass_quality, const World& world, const Point& passer_point);
 
         /**
          * Updates the world
@@ -64,8 +66,6 @@ namespace AI::Passing
 
         /**
          * Updates the point that we are passing from
-         *
-         * WARNING: This will clear all passes currently being optimized
          *
          * @param passer_point the point we are passing from
          */
@@ -108,8 +108,8 @@ namespace AI::Passing
         // Weights used to normalize the parameters that we pass to GradientDescent
         // (see the GradientDescent documentation for details)
         static constexpr double PASS_SPACE_WEIGHT                          = 0.01;
-        static constexpr double PASS_TIME_WEIGHT                           = 1;
-        static constexpr double PASS_SPEED_WEIGHT                          = 1;
+        static constexpr double PASS_TIME_WEIGHT                           = 0.1;
+        static constexpr double PASS_SPEED_WEIGHT                          = 0.1;
         std::array<double, NUM_PARAMS_TO_OPTIMIZE> optimizer_param_weights = {
             PASS_SPACE_WEIGHT, PASS_SPACE_WEIGHT, PASS_TIME_WEIGHT, PASS_SPEED_WEIGHT};
 
@@ -144,7 +144,7 @@ namespace AI::Passing
          *         form: {receiver_point.x, receiver_point.y, pass_speed_m_per_s
          *                pass_start_time}
          */
-        static std::array<double, NUM_PARAMS_TO_OPTIMIZE> convertPassToArray(Pass pass);
+        std::array<double, NUM_PARAMS_TO_OPTIMIZE> convertPassToArray(Pass pass);
 
         /**
          * Convert a given array to a Pass
@@ -223,8 +223,16 @@ namespace AI::Passing
         // The mutex for the world
         std::mutex world_mutex;
 
-        // The most recent world we know about
+        // This world is what is used in the optimization loop
         World world;
+
+        // The mutex for the updated world
+        std::mutex updated_world_mutex;
+
+        // This world is the most recently updated one. We use this variable to "buffer"
+        // the most recently updated world so that the world stays the same for the
+        // entirety of each optimization loop, which makes things easier to reason about
+        World updated_world;
 
         // The mutex for the passer_point
         std::mutex passer_point_mutex;

--- a/src/thunderbots/software/ai/passing/pass_generator.h
+++ b/src/thunderbots/software/ai/passing/pass_generator.h
@@ -85,10 +85,10 @@ namespace AI::Passing
          * Gradient descent must be allowed to run for some number of iterations before
          * this can be used to get a reasonable value.
          *
-         * @return The best currently known pass, or `std::nullopt` if there is no
-         *         reasonable pass
+         * @return The best currently known pass and the rating of that pass (in [0-1)
+         *         or `std::nullopt` if there is no reasonable pass,
          */
-        std::optional<Pass> getBestPassSoFar();
+        std::optional<std::pair<Pass, double>> getBestPassSoFar();
 
         /**
          * Destructs this PassGenerator

--- a/src/thunderbots/software/ai/passing/pass_generator.h
+++ b/src/thunderbots/software/ai/passing/pass_generator.h
@@ -52,7 +52,7 @@ namespace AI::Passing
          * @param world The world we're passing int
          * @param passer_point The point we're passing from
          */
-        explicit PassGenerator(const World &world, const Point &passer_point);
+        explicit PassGenerator(const World& world, const Point& passer_point);
 
         /**
          * Updates the world

--- a/src/thunderbots/software/ai/passing/pass_generator.h
+++ b/src/thunderbots/software/ai/passing/pass_generator.h
@@ -69,6 +69,16 @@ namespace AI::Passing
         void setPasserPoint(Point passer_point);
 
         /**
+         * Set the id of the robot performing the pass.
+         *
+         * This id will be used so we ignore the passer when determining where to
+         * pass to
+         *
+         * @param robot_id The id of the robot performing the pass
+         */
+        void setPasserRobotId(unsigned int robot_id);
+
+        /**
          * Set the target region that we would like to pass to
          *
          * @param area An optional that may contain the area to pass to. If the
@@ -233,6 +243,12 @@ namespace AI::Passing
 
         // The point we are passing from
         Point passer_point;
+
+        // The mutex for the passer robot ID
+        std::mutex passer_robot_id_mutex;
+
+        // The id of the robot that is performing the pass. We want to ignore this robot
+        unsigned int passer_robot_id;
 
         // The mutex for the target region
         std::mutex target_region_mutex;

--- a/src/thunderbots/software/ai/passing/pass_generator.h
+++ b/src/thunderbots/software/ai/passing/pass_generator.h
@@ -55,7 +55,8 @@ namespace AI::Passing
          * @param world The world we're passing int
          * @param passer_point The point we're passing from
          */
-        explicit PassGenerator(double min_reasonable_pass_quality, const World& world, const Point& passer_point);
+        explicit PassGenerator(double min_reasonable_pass_quality, const World& world,
+                               const Point& passer_point);
 
         /**
          * Updates the world

--- a/src/thunderbots/software/ai/world/team.cpp
+++ b/src/thunderbots/software/ai/world/team.cpp
@@ -78,7 +78,8 @@ void Team::removeExpiredRobots(const Timestamp& timestamp)
     }
 }
 
-void Team::removeRobotWithId(unsigned int robot_id) {
+void Team::removeRobotWithId(unsigned int robot_id)
+{
     team_robots.erase(robot_id);
 }
 

--- a/src/thunderbots/software/ai/world/team.cpp
+++ b/src/thunderbots/software/ai/world/team.cpp
@@ -78,6 +78,10 @@ void Team::removeExpiredRobots(const Timestamp& timestamp)
     }
 }
 
+void Team::removeRobotWithId(unsigned int robot_id) {
+    team_robots.erase(robot_id);
+}
+
 void Team::assignGoalie(unsigned int new_goalie_id)
 {
     if (getRobotById(new_goalie_id))

--- a/src/thunderbots/software/ai/world/team.h
+++ b/src/thunderbots/software/ai/world/team.h
@@ -76,6 +76,15 @@ class Team
     void removeExpiredRobots(const Timestamp& timestamp);
 
     /**
+     * Remove the robot with the given ID from the team
+     *
+     * If there is no robot with the given id on the team, does nothing
+     *
+     * @param robot_id The id of the robot to remove
+     */
+    void removeRobotWithId(unsigned int robot_id);
+
+    /**
      * Assigns the goalie for this team, making it the robot with the newly given id.
      * A robot with the given id must already exist on the team.
      *

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -38,15 +38,21 @@ TEST_F(PassGeneratorTest, check_pass_converges)
     });
     world.updateFriendlyTeamState(friendly_team);
     Team enemy_team(Duration::fromSeconds(10));
-    enemy_team.updateRobots({Robot(4, {0.5, 4}, {-0.5, 0}, Angle::zero(),
-                                   AngularVelocity::zero(), Timestamp::fromSeconds(0))});
+    enemy_team.updateRobots({
+                                    Robot(0, {1, 3.7}, {-0.5, 0}, Angle::zero(),
+                                          AngularVelocity::zero(), Timestamp::fromSeconds(0)),
+                                    Robot(1, {-2, 4.0}, {-0.5, 0}, Angle::zero(),
+                                    AngularVelocity::zero(), Timestamp::fromSeconds(0)),
+                                    Robot(2, {3, -2}, {-0.5, 0}, Angle::zero(),
+                                    AngularVelocity::zero(), Timestamp::fromSeconds(0)),
+        Robot(3, {-2.5, 4}, {-0.5, 0}, Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0))
+    });
     world.updateEnemyTeamState(enemy_team);
 
     pass_generator->setWorld(world);
 
-    std::this_thread::sleep_for(1s);
-
-    // Wait until the pass stops improving or 1 minute, whichever comes first
+    // Wait until the pass stops improving or 30 seconds, whichever comes first
     int seconds_so_far = 0;
     double curr_score = 0;
     double prev_score = 0;
@@ -58,9 +64,9 @@ TEST_F(PassGeneratorTest, check_pass_converges)
         if (curr_pass_and_score){
             curr_score = curr_pass_and_score->second;
         }
-    } while((abs(curr_score - prev_score) > 0.001 || curr_score < 0.2) && seconds_so_far < 60);
+    } while((abs(curr_score - prev_score) > 0.001 || curr_score < 0.2) && seconds_so_far < 30);
 
-    ASSERT_LE(seconds_so_far, 60) << "Pass generator did not converge after running for a minute";
+    ASSERT_LE(seconds_so_far, 60) << "Pass generator did not converge after running for 30 seconds";
 
     // Find what pass we converged to
     auto converged_pass_and_score = pass_generator->getBestPassSoFar();

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -86,7 +86,7 @@ TEST_F(PassGeneratorTest, check_pass_converges)
     pass_generator->setWorld(world);
 
     // Wait until the pass stops improving or 30 seconds, whichever comes first
-    waitForConvergence(pass_generator, 0.001, 30);
+    waitForConvergence(pass_generator, 0.00001, 30);
 
     // Find what pass we converged to
     auto converged_pass_and_score = pass_generator->getBestPassSoFar();

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -44,8 +44,21 @@ TEST_F(PassGeneratorTest, check_pass_converges)
 
     pass_generator->setWorld(world);
 
+    // Wait until the pass stops improving or 1 minute, whichever comes first
+    int seconds_so_far = 0;
+    double curr_score = 0;
+    double prev_score = 0;
+    do {
+        prev_score = curr_score;
+        std::this_thread::sleep_for(1s);
+        seconds_so_far++;
+        auto curr_pass_and_score = pass_generator->getBestPassSoFar();
+        if (curr_pass_and_score){
+            curr_score = curr_pass_and_score->second;
+        }
+    } while((curr_score - prev_score > 0.01 || curr_score < 0.1) && seconds_so_far < 60);
 
-    std::this_thread::sleep_for(15s);
+    ASSERT_TRUE(seconds_so_far < 60) << "Pass generator did not converge after running for a minute";
 
     // Find what pass we converged to
     auto converged_pass_and_score = pass_generator->getBestPassSoFar();

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -73,9 +73,9 @@ TEST_F(PassGeneratorTest, check_pass_converges)
     });
     world.updateFriendlyTeamState(friendly_team);
     Team enemy_team(Duration::fromSeconds(10));
-    enemy_team.updateRobots({Robot(0, {1, 3.7}, {-0.5, 0}, Angle::zero(),
+    enemy_team.updateRobots({Robot(0, {0.5, 0.5}, {-0.5, 0}, Angle::zero(),
                                    AngularVelocity::zero(), Timestamp::fromSeconds(0)),
-                             Robot(1, {-2, 4.0}, {-0.5, 0}, Angle::zero(),
+                             Robot(1, {-2, -2}, {-0.5, 0}, Angle::zero(),
                                    AngularVelocity::zero(), Timestamp::fromSeconds(0)),
                              Robot(2, {3, -2}, {-0.5, 0}, Angle::zero(),
                                    AngularVelocity::zero(), Timestamp::fromSeconds(0)),
@@ -101,6 +101,8 @@ TEST_F(PassGeneratorTest, check_pass_converges)
         ASSERT_TRUE(pass_and_score);
 
         auto [pass, score] = *pass_and_score;
+
+        std::cout << converged_pass << std::endl;
 
         EXPECT_EQ(pass.passerPoint(), converged_pass.passerPoint());
         EXPECT_LE((converged_pass.receiverPoint() - pass.receiverPoint()).len(), 0.2);

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -32,3 +32,41 @@ class PassGeneratorTest : public testing::Test
     std::shared_ptr<PassGenerator> pass_generator;
 };
 
+TEST_F(PassGeneratorTest, check_pass_converges){
+    // Test that the pass converges to a stable pass when there are a a random
+    // scattering of friendly and enemy robots around the field
+    Team friendly_team(Duration::fromSeconds(10));
+    friendly_team.updateRobots({
+        Robot(0, {0, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                   Timestamp::fromSeconds(0)),
+                                       Robot(0, {2, 2}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+                                       Timestamp::fromSeconds(0)),
+        Robot(0, {-3, 1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+              Timestamp::fromSeconds(0)),
+        Robot(0, {-1, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+              Timestamp::fromSeconds(0)),
+        Robot(0, {0.2, 0.5}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+              Timestamp::fromSeconds(0))
+            });
+    world.updateFriendlyTeamState(friendly_team);
+    Team enemy_team(Duration::fromSeconds(10));
+    enemy_team.updateRobots({
+                                       Robot(0, {1, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                                             Timestamp::fromSeconds(0)),
+                                       Robot(0, {2, 1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+                                             Timestamp::fromSeconds(0)),
+                                       Robot(0, {3, 2}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+                                             Timestamp::fromSeconds(0)),
+                                       Robot(0, {4, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+                                             Timestamp::fromSeconds(0)),
+                                       Robot(0, {0.5, 4}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+                                             Timestamp::fromSeconds(0))
+                               });
+    world.updateFriendlyTeamState(enemy_team);
+
+    pass_generator->setWorld(world);
+
+    std::this_thread::sleep_for(5);
+}
+
+

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -33,13 +33,12 @@ TEST_F(PassGeneratorTest, check_pass_converges)
 
     Team friendly_team(Duration::fromSeconds(10));
     friendly_team.updateRobots({
-         Robot(3, {-1, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
-               Timestamp::fromSeconds(0)),
+        Robot(3, {-1, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+              Timestamp::fromSeconds(0)),
     });
     world.updateFriendlyTeamState(friendly_team);
     Team enemy_team(Duration::fromSeconds(10));
-    enemy_team.updateRobots({
-                             Robot(4, {0.5, 4}, {-0.5, 0}, Angle::zero(),
+    enemy_team.updateRobots({Robot(4, {0.5, 4}, {-0.5, 0}, Angle::zero(),
                                    AngularVelocity::zero(), Timestamp::fromSeconds(0))});
     world.updateEnemyTeamState(enemy_team);
 
@@ -63,12 +62,8 @@ TEST_F(PassGeneratorTest, check_pass_converges)
         auto [pass, score] = *pass_and_score;
 
         EXPECT_EQ(pass.passerPoint(), converged_pass.passerPoint());
-        EXPECT_LE(
-            (converged_pass.receiverPoint() - pass.receiverPoint()).len(),
-            0.2);
+        EXPECT_LE((converged_pass.receiverPoint() - pass.receiverPoint()).len(), 0.2);
         EXPECT_LE(abs(converged_pass.speed() - pass.speed()), 0.2);
-        EXPECT_LE(abs((converged_pass.startTime() - pass.startTime())
-                          .getSeconds()),
-                  0.2);
+        EXPECT_LE(abs((converged_pass.startTime() - pass.startTime()).getSeconds()), 0.2);
     }
 }

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -103,6 +103,7 @@ TEST_F(PassGeneratorTest, check_pass_converges)
         auto [pass, score] = *pass_and_score;
 
         std::cout << converged_pass << std::endl;
+        std::cout << pass << std::endl;
 
         EXPECT_EQ(pass.passerPoint(), converged_pass.passerPoint());
         EXPECT_LE((converged_pass.receiverPoint() - pass.receiverPoint()).len(), 0.2);

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -20,7 +20,7 @@ class PassGeneratorTest : public testing::Test
     {
         world = ::Test::TestUtil::createBlankTestingWorld();
         world.updateFieldGeometry(::Test::TestUtil::createSSLDivBField());
-        pass_generator = std::make_shared<PassGenerator>(0.05, world);
+        pass_generator = std::make_shared<PassGenerator>(0.05, world, Point(1, 0));
     }
 
     World world;

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -49,6 +49,8 @@ class PassGeneratorTest : public testing::Test
             if (curr_pass_and_score)
             {
                 curr_score = curr_pass_and_score->second;
+                std::cout << curr_score << std::endl;
+                std::cout << curr_pass_and_score->first << std::endl;
             }
         } while ((abs(curr_score - prev_score) > 0.001 || curr_score < 0.2) &&
                  seconds_so_far < max_num_seconds);
@@ -106,8 +108,8 @@ TEST_F(PassGeneratorTest, check_pass_converges)
         std::cout << pass << std::endl;
 
         EXPECT_EQ(pass.passerPoint(), converged_pass.passerPoint());
-        EXPECT_LE((converged_pass.receiverPoint() - pass.receiverPoint()).len(), 0.2);
-        EXPECT_LE(abs(converged_pass.speed() - pass.speed()), 0.2);
+        EXPECT_LE((converged_pass.receiverPoint() - pass.receiverPoint()).len(), 0.3);
+        EXPECT_LE(abs(converged_pass.speed() - pass.speed()), 0.3);
         EXPECT_LE(abs((converged_pass.startTime() - pass.startTime()).getSeconds()), 0.2);
     }
 }

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -57,7 +57,7 @@ TEST_F(PassGeneratorTest, check_pass_converges)
 
     pass_generator->setWorld(world);
 
-    std::this_thread::sleep_for(5s);
+    std::this_thread::sleep_for(10s);
 
     // Find what pass we converged to
     auto converged_pass_opt = pass_generator->getBestPassSoFar();

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -15,12 +15,40 @@ using namespace std::chrono_literals;
 class PassGeneratorTest : public testing::Test
 {
    protected:
-   protected:
     virtual void SetUp()
     {
         world = ::Test::TestUtil::createBlankTestingWorld();
         world.updateFieldGeometry(::Test::TestUtil::createSSLDivBField());
         pass_generator = std::make_shared<PassGenerator>(world, Point(1, 0));
+    }
+
+    /**
+     * Wait for the pass generator to converge to a pass
+     *
+     * If the pass generator does not converge within `max_num_seconds`, this will
+     * cause the test to fail
+     *
+     * @param pass_generator Modified in-place
+     * @param max_score_diff The maximum absolute difference between the scores of two
+     *                       consecutive optimized passes before this function returns
+     * @param max_num_seconds The maximum number of seconds that the pass optimizer
+     *                        can run for before this function returns
+     */
+    static void waitForConvergence(std::shared_ptr<PassGenerator> pass_generator, double max_score_diff, int max_num_seconds){
+        int seconds_so_far = 0;
+        double curr_score = 0;
+        double prev_score = 0;
+        do {
+            prev_score = curr_score;
+            std::this_thread::sleep_for(1s);
+            seconds_so_far++;
+            auto curr_pass_and_score = pass_generator->getBestPassSoFar();
+            if (curr_pass_and_score){
+                curr_score = curr_pass_and_score->second;
+            }
+        } while((abs(curr_score - prev_score) > 0.001 || curr_score < 0.2) && seconds_so_far < max_num_seconds);
+
+        ASSERT_LE(seconds_so_far, max_num_seconds) << "Pass generator did not converge after running for " << max_num_seconds << " seconds";
     }
 
     World world;
@@ -53,20 +81,7 @@ TEST_F(PassGeneratorTest, check_pass_converges)
     pass_generator->setWorld(world);
 
     // Wait until the pass stops improving or 30 seconds, whichever comes first
-    int seconds_so_far = 0;
-    double curr_score = 0;
-    double prev_score = 0;
-    do {
-        prev_score = curr_score;
-        std::this_thread::sleep_for(1s);
-        seconds_so_far++;
-        auto curr_pass_and_score = pass_generator->getBestPassSoFar();
-        if (curr_pass_and_score){
-            curr_score = curr_pass_and_score->second;
-        }
-    } while((abs(curr_score - prev_score) > 0.001 || curr_score < 0.2) && seconds_so_far < 30);
-
-    ASSERT_LE(seconds_so_far, 60) << "Pass generator did not converge after running for 30 seconds";
+    waitForConvergence(pass_generator, 0.001, 30);
 
     // Find what pass we converged to
     auto converged_pass_and_score = pass_generator->getBestPassSoFar();
@@ -87,4 +102,51 @@ TEST_F(PassGeneratorTest, check_pass_converges)
         EXPECT_LE(abs(converged_pass.speed() - pass.speed()), 0.2);
         EXPECT_LE(abs((converged_pass.startTime() - pass.startTime()).getSeconds()), 0.2);
     }
+}
+
+TEST_F(PassGeneratorTest, check_passer_robot_is_ignored)
+{
+    // Test that the pass generator does not converge to use the robot set as the passer
+
+    world.updateBallState(Ball({2,0.5}, {0,0}, Timestamp::fromSeconds(0)));
+    pass_generator->setPasserPoint({2,0.5});
+
+    Team friendly_team(Duration::fromSeconds(10));
+
+    // This would be the ideal robot to pass to
+    Robot robot_0 = Robot(0, {0, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                                             Timestamp::fromSeconds(0));
+    // This is a reasonable robot to pass to, but not the ideal
+    Robot robot_1 = Robot(1, {2, -1}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                                             Timestamp::fromSeconds(0));
+    friendly_team.updateRobots({
+        robot_0, robot_1
+                               });
+    world.updateFriendlyTeamState(friendly_team);
+    Team enemy_team(Duration::fromSeconds(10));
+    // We put a few enemies in to force the pass generator to make a decision,
+    // otherwise most of the field would be a valid point to pass to
+    enemy_team.updateRobots({
+                                    Robot(0, {3, 3}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                                          Timestamp::fromSeconds(0)),
+                                    Robot(1, {-3, -3}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                                          Timestamp::fromSeconds(0)),
+    });
+    world.updateEnemyTeamState(enemy_team);
+
+    pass_generator->setWorld(world);
+    pass_generator->setPasserRobotId(0);
+
+    // Wait until the pass stops improving or 30 seconds, whichever comes first
+    waitForConvergence(pass_generator, 0.0001, 30);
+
+    // Find what pass we converged to
+    auto converged_pass_and_score = pass_generator->getBestPassSoFar();
+    ASSERT_TRUE(converged_pass_and_score);
+    auto [converged_pass, converged_score] = *converged_pass_and_score;
+
+    // We expect to have converged to a point near robot 1. The tolerance is fairly
+    // generous here because the enemies on the field can "force" the point slightly
+    // away from the chosen receiver robot
+    EXPECT_LE((converged_pass.receiverPoint() - robot_1.position()).len(), 0.5);
 }

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -49,8 +49,6 @@ class PassGeneratorTest : public testing::Test
             if (curr_pass_and_score)
             {
                 curr_score = curr_pass_and_score->second;
-                std::cout << curr_score << std::endl;
-                std::cout << curr_pass_and_score->first << std::endl;
             }
         } while ((abs(curr_score - prev_score) > 0.001 || curr_score < 0.2) &&
                  seconds_so_far < max_num_seconds);
@@ -103,9 +101,6 @@ TEST_F(PassGeneratorTest, check_pass_converges)
         ASSERT_TRUE(pass_and_score);
 
         auto [pass, score] = *pass_and_score;
-
-        std::cout << converged_pass << std::endl;
-        std::cout << pass << std::endl;
 
         EXPECT_EQ(pass.passerPoint(), converged_pass.passerPoint());
         EXPECT_LE((converged_pass.receiverPoint() - pass.receiverPoint()).len(), 0.3);

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -27,34 +27,32 @@ class PassGeneratorTest : public testing::Test
     std::shared_ptr<PassGenerator> pass_generator;
 };
 
-TEST_F(PassGeneratorTest, check_pass_converges){
+TEST_F(PassGeneratorTest, check_pass_converges)
+{
     // Test that the pass converges to a stable pass when there is a somewhat random
     // scattering of friendly and enemy robots around the field
     Team friendly_team(Duration::fromSeconds(10));
-    friendly_team.updateRobots({
-           Robot(1, {2, 2}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
-           Timestamp::fromSeconds(0)),
-        Robot(2, {-3, 1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
-              Timestamp::fromSeconds(0)),
-        Robot(3, {-1, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
-              Timestamp::fromSeconds(0)),
-        Robot(4, {0.2, 0.5}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
-              Timestamp::fromSeconds(0))
-            });
+    friendly_team.updateRobots(
+        {Robot(1, {2, 2}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+               Timestamp::fromSeconds(0)),
+         Robot(2, {-3, 1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+               Timestamp::fromSeconds(0)),
+         Robot(3, {-1, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+               Timestamp::fromSeconds(0)),
+         Robot(4, {0.2, 0.5}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+               Timestamp::fromSeconds(0))});
     world.updateFriendlyTeamState(friendly_team);
     Team enemy_team(Duration::fromSeconds(10));
-    enemy_team.updateRobots({
-                                       Robot(0, {1, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
-                                             Timestamp::fromSeconds(0)),
-                                       Robot(1, {2, 1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
-                                             Timestamp::fromSeconds(0)),
-                                       Robot(2, {3, 2}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
-                                             Timestamp::fromSeconds(0)),
-                                       Robot(3, {4, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
-                                             Timestamp::fromSeconds(0)),
-                                       Robot(4, {0.5, 4}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
-                                             Timestamp::fromSeconds(0))
-                               });
+    enemy_team.updateRobots({Robot(0, {1, 0}, {0, 0}, Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0)),
+                             Robot(1, {2, 1}, {-0.5, 0}, Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0)),
+                             Robot(2, {3, 2}, {-0.5, 0}, Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0)),
+                             Robot(3, {4, -1}, {-0.5, 0}, Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0)),
+                             Robot(4, {0.5, 4}, {-0.5, 0}, Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0))});
     world.updateEnemyTeamState(enemy_team);
 
     pass_generator->setWorld(world);
@@ -66,16 +64,19 @@ TEST_F(PassGeneratorTest, check_pass_converges){
     ASSERT_TRUE(converged_pass_opt);
 
     // Check that we keep converging to the same pass
-    for (int i = 0; i < 7; i++){
+    for (int i = 0; i < 7; i++)
+    {
         std::this_thread::sleep_for(0.5s);
         auto new_pass_opt = pass_generator->getBestPassSoFar();
         ASSERT_TRUE(new_pass_opt);
 
         EXPECT_EQ(converged_pass_opt->passerPoint(), new_pass_opt->passerPoint());
-        EXPECT_LE((converged_pass_opt->receiverPoint() - new_pass_opt->receiverPoint()).len(), 0.2);
+        EXPECT_LE(
+            (converged_pass_opt->receiverPoint() - new_pass_opt->receiverPoint()).len(),
+            0.2);
         EXPECT_LE(converged_pass_opt->speed() - new_pass_opt->speed(), 0.2);
-        EXPECT_LE(abs((converged_pass_opt->startTime() - new_pass_opt->startTime()).getSeconds()), 0.2);
+        EXPECT_LE(abs((converged_pass_opt->startTime() - new_pass_opt->startTime())
+                          .getSeconds()),
+                  0.2);
     }
 }
-
-

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -20,8 +20,7 @@ class PassGeneratorTest : public testing::Test
     {
         world = ::Test::TestUtil::createBlankTestingWorld();
         world.updateFieldGeometry(::Test::TestUtil::createSSLDivBField());
-        pass_generator = std::make_shared<PassGenerator>(0.05);
-        pass_generator->setWorld(world);
+        pass_generator = std::make_shared<PassGenerator>(0.05, world);
     }
 
     World world;

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -34,21 +34,28 @@ class PassGeneratorTest : public testing::Test
      * @param max_num_seconds The maximum number of seconds that the pass optimizer
      *                        can run for before this function returns
      */
-    static void waitForConvergence(std::shared_ptr<PassGenerator> pass_generator, double max_score_diff, int max_num_seconds){
+    static void waitForConvergence(std::shared_ptr<PassGenerator> pass_generator,
+                                   double max_score_diff, int max_num_seconds)
+    {
         int seconds_so_far = 0;
-        double curr_score = 0;
-        double prev_score = 0;
-        do {
+        double curr_score  = 0;
+        double prev_score  = 0;
+        do
+        {
             prev_score = curr_score;
             std::this_thread::sleep_for(1s);
             seconds_so_far++;
             auto curr_pass_and_score = pass_generator->getBestPassSoFar();
-            if (curr_pass_and_score){
+            if (curr_pass_and_score)
+            {
                 curr_score = curr_pass_and_score->second;
             }
-        } while((abs(curr_score - prev_score) > 0.001 || curr_score < 0.2) && seconds_so_far < max_num_seconds);
+        } while ((abs(curr_score - prev_score) > 0.001 || curr_score < 0.2) &&
+                 seconds_so_far < max_num_seconds);
 
-        ASSERT_LE(seconds_so_far, max_num_seconds) << "Pass generator did not converge after running for " << max_num_seconds << " seconds";
+        ASSERT_LE(seconds_so_far, max_num_seconds)
+            << "Pass generator did not converge after running for " << max_num_seconds
+            << " seconds";
     }
 
     World world;
@@ -66,16 +73,14 @@ TEST_F(PassGeneratorTest, check_pass_converges)
     });
     world.updateFriendlyTeamState(friendly_team);
     Team enemy_team(Duration::fromSeconds(10));
-    enemy_team.updateRobots({
-                                    Robot(0, {1, 3.7}, {-0.5, 0}, Angle::zero(),
-                                          AngularVelocity::zero(), Timestamp::fromSeconds(0)),
-                                    Robot(1, {-2, 4.0}, {-0.5, 0}, Angle::zero(),
-                                    AngularVelocity::zero(), Timestamp::fromSeconds(0)),
-                                    Robot(2, {3, -2}, {-0.5, 0}, Angle::zero(),
-                                    AngularVelocity::zero(), Timestamp::fromSeconds(0)),
-        Robot(3, {-2.5, 4}, {-0.5, 0}, Angle::zero(),
-                                   AngularVelocity::zero(), Timestamp::fromSeconds(0))
-    });
+    enemy_team.updateRobots({Robot(0, {1, 3.7}, {-0.5, 0}, Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0)),
+                             Robot(1, {-2, 4.0}, {-0.5, 0}, Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0)),
+                             Robot(2, {3, -2}, {-0.5, 0}, Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0)),
+                             Robot(3, {-2.5, 4}, {-0.5, 0}, Angle::zero(),
+                                   AngularVelocity::zero(), Timestamp::fromSeconds(0))});
     world.updateEnemyTeamState(enemy_team);
 
     pass_generator->setWorld(world);
@@ -108,29 +113,27 @@ TEST_F(PassGeneratorTest, check_passer_robot_is_ignored)
 {
     // Test that the pass generator does not converge to use the robot set as the passer
 
-    world.updateBallState(Ball({2,0.5}, {0,0}, Timestamp::fromSeconds(0)));
-    pass_generator->setPasserPoint({2,0.5});
+    world.updateBallState(Ball({2, 0.5}, {0, 0}, Timestamp::fromSeconds(0)));
+    pass_generator->setPasserPoint({2, 0.5});
 
     Team friendly_team(Duration::fromSeconds(10));
 
     // This would be the ideal robot to pass to
     Robot robot_0 = Robot(0, {0, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
-                                             Timestamp::fromSeconds(0));
+                          Timestamp::fromSeconds(0));
     // This is a reasonable robot to pass to, but not the ideal
     Robot robot_1 = Robot(1, {2, -1}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
-                                             Timestamp::fromSeconds(0));
-    friendly_team.updateRobots({
-        robot_0, robot_1
-                               });
+                          Timestamp::fromSeconds(0));
+    friendly_team.updateRobots({robot_0, robot_1});
     world.updateFriendlyTeamState(friendly_team);
     Team enemy_team(Duration::fromSeconds(10));
     // We put a few enemies in to force the pass generator to make a decision,
     // otherwise most of the field would be a valid point to pass to
     enemy_team.updateRobots({
-                                    Robot(0, {3, 3}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
-                                          Timestamp::fromSeconds(0)),
-                                    Robot(1, {-3, -3}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
-                                          Timestamp::fromSeconds(0)),
+        Robot(0, {3, 3}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+              Timestamp::fromSeconds(0)),
+        Robot(1, {-3, -3}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+              Timestamp::fromSeconds(0)),
     });
     world.updateEnemyTeamState(enemy_team);
 

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -44,6 +44,8 @@ TEST_F(PassGeneratorTest, check_pass_converges)
 
     pass_generator->setWorld(world);
 
+    std::this_thread::sleep_for(1s);
+
     // Wait until the pass stops improving or 1 minute, whichever comes first
     int seconds_so_far = 0;
     double curr_score = 0;
@@ -56,9 +58,9 @@ TEST_F(PassGeneratorTest, check_pass_converges)
         if (curr_pass_and_score){
             curr_score = curr_pass_and_score->second;
         }
-    } while((curr_score - prev_score > 0.01 || curr_score < 0.1) && seconds_so_far < 60);
+    } while((abs(curr_score - prev_score) > 0.001 || curr_score < 0.2) && seconds_so_far < 60);
 
-    ASSERT_TRUE(seconds_so_far < 60) << "Pass generator did not converge after running for a minute";
+    ASSERT_LE(seconds_so_far, 60) << "Pass generator did not converge after running for a minute";
 
     // Find what pass we converged to
     auto converged_pass_and_score = pass_generator->getBestPassSoFar();

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -10,6 +10,7 @@
 #include "test/test_util/test_util.h"
 
 using namespace AI::Passing;
+using namespace std::chrono_literals;
 
 class PassGeneratorTest : public testing::Test
 {
@@ -18,13 +19,8 @@ class PassGeneratorTest : public testing::Test
     virtual void SetUp()
     {
         world = ::Test::TestUtil::createBlankTestingWorld();
-        Team friendly_team(Duration::fromSeconds(10));
-        friendly_team.updateRobots(
-            {Robot(0, {0, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
-                   Timestamp::fromSeconds(0))});
-        world.updateFriendlyTeamState(friendly_team);
         world.updateFieldGeometry(::Test::TestUtil::createSSLDivBField());
-        pass_generator = std::make_shared<PassGenerator>(0.0);
+        pass_generator = std::make_shared<PassGenerator>(0.05);
         pass_generator->setWorld(world);
     }
 
@@ -33,19 +29,17 @@ class PassGeneratorTest : public testing::Test
 };
 
 TEST_F(PassGeneratorTest, check_pass_converges){
-    // Test that the pass converges to a stable pass when there are a a random
+    // Test that the pass converges to a stable pass when there is a somewhat random
     // scattering of friendly and enemy robots around the field
     Team friendly_team(Duration::fromSeconds(10));
     friendly_team.updateRobots({
-        Robot(0, {0, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
-                   Timestamp::fromSeconds(0)),
-                                       Robot(0, {2, 2}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
-                                       Timestamp::fromSeconds(0)),
-        Robot(0, {-3, 1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+           Robot(1, {2, 2}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+           Timestamp::fromSeconds(0)),
+        Robot(2, {-3, 1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
               Timestamp::fromSeconds(0)),
-        Robot(0, {-1, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+        Robot(3, {-1, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
               Timestamp::fromSeconds(0)),
-        Robot(0, {0.2, 0.5}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+        Robot(4, {0.2, 0.5}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
               Timestamp::fromSeconds(0))
             });
     world.updateFriendlyTeamState(friendly_team);
@@ -53,20 +47,36 @@ TEST_F(PassGeneratorTest, check_pass_converges){
     enemy_team.updateRobots({
                                        Robot(0, {1, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
                                              Timestamp::fromSeconds(0)),
-                                       Robot(0, {2, 1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+                                       Robot(1, {2, 1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
                                              Timestamp::fromSeconds(0)),
-                                       Robot(0, {3, 2}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+                                       Robot(2, {3, 2}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
                                              Timestamp::fromSeconds(0)),
-                                       Robot(0, {4, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+                                       Robot(3, {4, -1}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
                                              Timestamp::fromSeconds(0)),
-                                       Robot(0, {0.5, 4}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
+                                       Robot(4, {0.5, 4}, {-0.5, 0}, Angle::zero(), AngularVelocity::zero(),
                                              Timestamp::fromSeconds(0))
                                });
-    world.updateFriendlyTeamState(enemy_team);
+    world.updateEnemyTeamState(enemy_team);
 
     pass_generator->setWorld(world);
 
-    std::this_thread::sleep_for(5);
+    std::this_thread::sleep_for(5s);
+
+    // Find what pass we converged to
+    auto converged_pass_opt = pass_generator->getBestPassSoFar();
+    ASSERT_TRUE(converged_pass_opt);
+
+    // Check that we keep converging to the same pass
+    for (int i = 0; i < 7; i++){
+        std::this_thread::sleep_for(0.5s);
+        auto new_pass_opt = pass_generator->getBestPassSoFar();
+        ASSERT_TRUE(new_pass_opt);
+
+        EXPECT_EQ(converged_pass_opt->passerPoint(), new_pass_opt->passerPoint());
+        EXPECT_LE((converged_pass_opt->receiverPoint() - new_pass_opt->receiverPoint()).len(), 0.2);
+        EXPECT_LE(converged_pass_opt->speed() - new_pass_opt->speed(), 0.2);
+        EXPECT_LE(abs((converged_pass_opt->startTime() - new_pass_opt->startTime()).getSeconds()), 0.2);
+    }
 }
 
 

--- a/src/thunderbots/software/test/ai/world/team.cpp
+++ b/src/thunderbots/software/test/ai/world/team.cpp
@@ -249,16 +249,15 @@ TEST_F(TeamTest, remove_expired_robots_in_future_so_1_robot_expires_1_robot_does
     EXPECT_EQ(robot_1, team.getRobotById(1));
 }
 
-TEST_F(TeamTest, removeRobotWithId_robot_with_id_on_team){
-    Team team = Team(Duration::fromMilliseconds(2000));
+TEST_F(TeamTest, removeRobotWithId_robot_with_id_on_team)
+{
+    Team team     = Team(Duration::fromMilliseconds(2000));
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
 
     Robot robot_1 = Robot(1, Point(3, -1), Vector(), Angle::zero(),
                           AngularVelocity::zero(), one_second_future);
-    team.updateRobots({
-        robot_0, robot_1
-    });
+    team.updateRobots({robot_0, robot_1});
 
     team.removeRobotWithId(0);
 
@@ -266,16 +265,15 @@ TEST_F(TeamTest, removeRobotWithId_robot_with_id_on_team){
     EXPECT_EQ(std::vector<Robot>{robot_1}, team.getAllRobots());
 }
 
-TEST_F(TeamTest, removeRobotWithId_robot_with_id_not_on_team){
-    Team team = Team(Duration::fromMilliseconds(2000));
+TEST_F(TeamTest, removeRobotWithId_robot_with_id_not_on_team)
+{
+    Team team     = Team(Duration::fromMilliseconds(2000));
     Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
                           AngularVelocity::threeQuarter(), current_time);
 
     Robot robot_1 = Robot(1, Point(3, -1), Vector(), Angle::zero(),
                           AngularVelocity::zero(), one_second_future);
-    team.updateRobots({
-                              robot_0, robot_1
-                      });
+    team.updateRobots({robot_0, robot_1});
 
     team.removeRobotWithId(2);
 
@@ -284,7 +282,7 @@ TEST_F(TeamTest, removeRobotWithId_robot_with_id_not_on_team){
 }
 
 
-    TEST_F(TeamTest, clear_all_robots)
+TEST_F(TeamTest, clear_all_robots)
 {
     Team team = Team(Duration::fromMilliseconds(1000));
 

--- a/src/thunderbots/software/test/ai/world/team.cpp
+++ b/src/thunderbots/software/test/ai/world/team.cpp
@@ -249,7 +249,42 @@ TEST_F(TeamTest, remove_expired_robots_in_future_so_1_robot_expires_1_robot_does
     EXPECT_EQ(robot_1, team.getRobotById(1));
 }
 
-TEST_F(TeamTest, clear_all_robots)
+TEST_F(TeamTest, removeRobotWithId_robot_with_id_on_team){
+    Team team = Team(Duration::fromMilliseconds(2000));
+    Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
+                          AngularVelocity::threeQuarter(), current_time);
+
+    Robot robot_1 = Robot(1, Point(3, -1), Vector(), Angle::zero(),
+                          AngularVelocity::zero(), one_second_future);
+    team.updateRobots({
+        robot_0, robot_1
+    });
+
+    team.removeRobotWithId(0);
+
+    EXPECT_EQ(1, team.getAllRobots().size());
+    EXPECT_EQ(std::vector<Robot>{robot_1}, team.getAllRobots());
+}
+
+TEST_F(TeamTest, removeRobotWithId_robot_with_id_not_on_team){
+    Team team = Team(Duration::fromMilliseconds(2000));
+    Robot robot_0 = Robot(0, Point(0, 1), Vector(-1, -2), Angle::half(),
+                          AngularVelocity::threeQuarter(), current_time);
+
+    Robot robot_1 = Robot(1, Point(3, -1), Vector(), Angle::zero(),
+                          AngularVelocity::zero(), one_second_future);
+    team.updateRobots({
+                              robot_0, robot_1
+                      });
+
+    team.removeRobotWithId(2);
+
+    EXPECT_EQ(2, team.getAllRobots().size());
+    EXPECT_EQ(std::vector<Robot>({robot_0, robot_1}), team.getAllRobots());
+}
+
+
+    TEST_F(TeamTest, clear_all_robots)
 {
     Team team = Team(Duration::fromMilliseconds(1000));
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
- returned pair of pass and score instead of just pass
- removed pass score cutoff, callers can enforce it themselves
- made the pass generator convergence test more robust so it should always pass in CI
- added the functionality to the `PassGenerator` to set the passer robot id, so that we don't converge to a pass that is the passer robot passing to itself
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
NA
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
