### PR TITLE
Add SIGINT handler to radio_communication

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -36,8 +36,8 @@ double CherryPickTactic::calculateRobotCost(const Robot& robot, const World& wor
 std::unique_ptr<Intent> CherryPickTactic::calculateNextIntent(
     intent_coroutine::push_type& yield)
 {
-    MoveAction move_action                     = MoveAction();
-    auto best_pass_and_score                   = pass_generator.getBestPassSoFar();
+    MoveAction move_action   = MoveAction();
+    auto best_pass_and_score = pass_generator.getBestPassSoFar();
     do
     {
         pass_generator.setWorld(world);

--- a/src/thunderbots/software/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/ai/passing/pass_generator.cpp
@@ -241,10 +241,14 @@ void PassGenerator::pruneAndReplacePasses()
             return passes;
         });
 
-    // Replace the least promising passes
-    passes_to_optimize.erase(
-        passes_to_optimize.begin() + getNumPassesToKeepAfterPruning(),
-        passes_to_optimize.end());
+    // Replace the least promising passes with newly generated passes
+    if (num_passes_to_keep_after_pruning.value() < num_passes_to_optimize.value() &&
+        num_passes_to_keep_after_pruning.value() < passes_to_optimize.size())
+    {
+        passes_to_optimize.erase(
+            passes_to_optimize.begin() + num_passes_to_keep_after_pruning.value(),
+            passes_to_optimize.end());
+    }
 
     // Generate new passes to replace the ones we just removed
     int num_new_passes = getNumPassesToOptimize() - passes_to_optimize.size();

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -1,9 +1,10 @@
-#include <csignal>
 #include <ros/ros.h>
 #include <ros/time.h>
 #include <thunderbots_msgs/Primitive.h>
 #include <thunderbots_msgs/PrimitiveArray.h>
 #include <thunderbots_msgs/World.h>
+
+#include <csignal>
 
 #include "ai/primitive/primitive.h"
 #include "ai/primitive/primitive_factory.h"
@@ -67,7 +68,7 @@ void signalHandler(int signum)
 {
     LOG(DEBUG) << "Ctrl-C signal caught" << std::endl;
 
-    // Destroys backend, allowing everything libusb-related to 
+    // Destroys backend, allowing everything libusb-related to
     // exit gracefully.
     backend_ptr.reset();
 }

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -1,3 +1,4 @@
+#include <csignal>
 #include <ros/ros.h>
 #include <ros/time.h>
 #include <thunderbots_msgs/Primitive.h>
@@ -62,11 +63,23 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
     backend_ptr->send_vision_packet();
 }
 
+void signalHandler(int signum)
+{
+    LOG(DEBUG) << "Ctrl-C signal caught" << std::endl;
+
+    // Destroys backend, allowing everything libusb-related to 
+    // exit gracefully.
+    backend_ptr.reset();
+}
+
 int main(int argc, char** argv)
 {
     // Init ROS node
     ros::init(argc, argv, "radio_communication");
     ros::NodeHandle node_handle;
+
+    // Register signal handler (has to be after ros::init)
+    signal(SIGINT, signalHandler);
 
     // Init backend
     backend_ptr = std::make_unique<MRFBackend>(node_handle);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Very often, sending SIGINT (Ctrl-C) to AI after roslaunch will hang at radio_communication before SIGTERM is sent. This usually has the effect of crashing the dongle, requiring replugging it into the computer.

A signal handler was added to main.cpp of the radio_communication node to explicitly destroy MRFBackend (and therefore anything libusb-related) for a more graceful exit.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Manually killed, verified termination process doesn't hang at radio_communication and dongle remains alive.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

N/A

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
