### PR TITLE
Properly Remove Expired Robots In Network Input

### DIFF
--- a/src/thunderbots/software/ai/world/team.cpp
+++ b/src/thunderbots/software/ai/world/team.cpp
@@ -158,6 +158,19 @@ void Team::clearAllRobots()
     team_robots.clear();
 }
 
+std::optional<Timestamp> Team::lastUpdateTimestamp() const
+{
+    std::optional<Timestamp> most_recent_timestamp = std::nullopt;
+    for (Robot& robot : getAllRobots())
+    {
+        if (!most_recent_timestamp || robot.lastUpdateTimestamp() > most_recent_timestamp)
+        {
+            most_recent_timestamp = robot.lastUpdateTimestamp();
+        }
+    }
+    return most_recent_timestamp;
+}
+
 bool Team::operator==(const Team& other) const
 {
     return this->getAllRobots() == other.getAllRobots() &&

--- a/src/thunderbots/software/ai/world/team.h
+++ b/src/thunderbots/software/ai/world/team.h
@@ -169,6 +169,14 @@ class Team
     void clearAllRobots();
 
     /**
+     * Returns the timestamp of the most recently updated robot on this team
+     *
+     * @return the timestamp of the most recently updated robot on this team, or
+     *         std::nullopt if this team is empty
+     */
+    std::optional<Timestamp> lastUpdateTimestamp() const;
+
+    /**
      * Defines the equality operator for a Team. Teams are equal if their robots are equal
      * and have the same robot assigned as the goalie
      *

--- a/src/thunderbots/software/network_input/filter/robot_filter.cpp
+++ b/src/thunderbots/software/network_input/filter/robot_filter.cpp
@@ -1,7 +1,17 @@
 #include "network_input/filter/robot_filter.h"
 
-RobotFilter::RobotFilter(Robot robot, Duration expiry_buffer_duration)
-    : current_robot_state(robot), expiry_buffer_duration(expiry_buffer_duration)
+RobotFilter::RobotFilter(Robot current_robot_state, Duration expiry_buffer_duration)
+    : current_robot_state(current_robot_state),
+      expiry_buffer_duration(expiry_buffer_duration)
+{
+}
+
+RobotFilter::RobotFilter(SSLRobotDetection current_robot_state,
+                         Duration expiry_buffer_duration)
+    : current_robot_state(current_robot_state.id, current_robot_state.position,
+                          Vector(0, 0), current_robot_state.orientation,
+                          AngularVelocity::zero(), current_robot_state.timestamp),
+      expiry_buffer_duration(expiry_buffer_duration)
 {
 }
 

--- a/src/thunderbots/software/network_input/filter/robot_filter.h
+++ b/src/thunderbots/software/network_input/filter/robot_filter.h
@@ -47,6 +47,8 @@ class RobotFilter
      * from the field if data about the robot is not received before that time
      */
     explicit RobotFilter(Robot current_robot_state, Duration expiry_buffer_duration);
+    explicit RobotFilter(SSLRobotDetection current_robot_state,
+                         Duration expiry_buffer_duration);
 
     /**
      * Updates the filter given a new set of data, and returns the most up to date

--- a/src/thunderbots/software/network_input/filter/robot_team_filter.h
+++ b/src/thunderbots/software/network_input/filter/robot_team_filter.h
@@ -24,4 +24,9 @@ class RobotTeamFilter
      */
     Team getFilteredData(const Team& current_team_state,
                          const std::vector<SSLRobotDetection>& new_robot_detections);
+
+
+    // A map used to store a separate robot filter for each robot on this team, so
+    // each robot can be filtered and handled separately
+    std::map<int, RobotFilter> robot_filters;
 };

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -7,7 +7,7 @@
 #include "util/parameter/dynamic_parameters.h"
 #include "util/ros_messages.h"
 
-NetworkClient::NetworkClient(ros::NodeHandle& node_handle) : backend(), io_service()
+NetworkClient::NetworkClient(ros::NodeHandle& node_handle) : backend(), io_service(), initial_packet_count(0), last_valid_t_capture(9999999)
 {
     // Set up publishers
     world_publisher = node_handle.advertise<thunderbots_msgs::World>(
@@ -21,7 +21,7 @@ NetworkClient::NetworkClient(ros::NodeHandle& node_handle) : backend(), io_servi
         ssl_vision_client = std::make_unique<SSLVisionClient>(
             io_service, Util::Constants::SSL_VISION_MULTICAST_ADDRESS,
             Util::Constants::SSL_VISION_MULTICAST_PORT,
-            boost::bind(&NetworkClient::filterAndPublishVisionData, this, _1));
+            boost::bind(&NetworkClient::filterAndPublishVisionDataWrapper, this, _1));
     }
     catch (const boost::exception& ex)
     {
@@ -66,6 +66,28 @@ NetworkClient::~NetworkClient()
     io_service_thread.join();
 }
 
+void NetworkClient::filterAndPublishVisionDataWrapper(SSL_WrapperPacket packet) {
+    // We analyze the first 60 packets we receive to find the "real" starting time.
+    // The real starting time is the smaller value of the ones we receive
+    if(initial_packet_count < 60) {
+        initial_packet_count++;
+        if(packet.has_detection() && packet.detection().t_capture() < last_valid_t_capture) {
+            last_valid_t_capture = packet.detection().t_capture();
+        }
+    }else{
+        // We pass all packets without a detection to the logic (since they are likely
+        // geometry packet). Packets with detection timestamps are compared to the last
+        // valid timestamp to make sure they are close enough before the data is passed
+        // along. This ensures we ignore any of the garbage packets grsim sends that
+        // are thousands of seconds in the future.
+        if(!packet.has_detection()) {
+            filterAndPublishVisionData(packet);
+        }else if(packet.detection().t_capture() - last_valid_t_capture < 100){
+            last_valid_t_capture = packet.detection().t_capture();
+            filterAndPublishVisionData(packet);
+        }
+    }
+}
 
 void NetworkClient::filterAndPublishVisionData(SSL_WrapperPacket packet)
 {

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -7,7 +7,8 @@
 #include "util/parameter/dynamic_parameters.h"
 #include "util/ros_messages.h"
 
-NetworkClient::NetworkClient(ros::NodeHandle& node_handle) : backend(), io_service(), initial_packet_count(0), last_valid_t_capture(9999999)
+NetworkClient::NetworkClient(ros::NodeHandle& node_handle)
+    : backend(), io_service(), initial_packet_count(0), last_valid_t_capture(9999999)
 {
     // Set up publishers
     world_publisher = node_handle.advertise<thunderbots_msgs::World>(
@@ -66,23 +67,32 @@ NetworkClient::~NetworkClient()
     io_service_thread.join();
 }
 
-void NetworkClient::filterAndPublishVisionDataWrapper(SSL_WrapperPacket packet) {
+void NetworkClient::filterAndPublishVisionDataWrapper(SSL_WrapperPacket packet)
+{
     // We analyze the first 60 packets we receive to find the "real" starting time.
     // The real starting time is the smaller value of the ones we receive
-    if(initial_packet_count < 60) {
+    if (initial_packet_count < 60)
+    {
         initial_packet_count++;
-        if(packet.has_detection() && packet.detection().t_capture() < last_valid_t_capture) {
+        if (packet.has_detection() &&
+            packet.detection().t_capture() < last_valid_t_capture)
+        {
             last_valid_t_capture = packet.detection().t_capture();
         }
-    }else{
+    }
+    else
+    {
         // We pass all packets without a detection to the logic (since they are likely
         // geometry packet). Packets with detection timestamps are compared to the last
         // valid timestamp to make sure they are close enough before the data is passed
         // along. This ensures we ignore any of the garbage packets grsim sends that
         // are thousands of seconds in the future.
-        if(!packet.has_detection()) {
+        if (!packet.has_detection())
+        {
             filterAndPublishVisionData(packet);
-        }else if(packet.detection().t_capture() - last_valid_t_capture < 100){
+        }
+        else if (packet.detection().t_capture() - last_valid_t_capture < 100)
+        {
             last_valid_t_capture = packet.detection().t_capture();
             filterAndPublishVisionData(packet);
         }

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -120,6 +120,7 @@ void NetworkClient::filterAndPublishVisionData(SSL_WrapperPacket packet)
                 ret.first->second = detection;
             }
         }
+
         // Create a vector of the latest detection data for each camera
         std::vector<SSL_DetectionFrame> latest_detections;
         for (auto it = latest_detection_data.begin(); it != latest_detection_data.end();

--- a/src/thunderbots/software/network_input/networking/network_client.h
+++ b/src/thunderbots/software/network_input/networking/network_client.h
@@ -43,7 +43,6 @@ class NetworkClient
     NetworkClient(const NetworkClient&)            = delete;
 
    private:
-
     // TODO: Remove this wrapper function once we move to a better simulator
     // https://github.com/UBC-Thunderbots/Software/issues/609
     /**

--- a/src/thunderbots/software/network_input/networking/network_client.h
+++ b/src/thunderbots/software/network_input/networking/network_client.h
@@ -43,6 +43,19 @@ class NetworkClient
     NetworkClient(const NetworkClient&)            = delete;
 
    private:
+
+    // TODO: Remove this wrapper function once we move to a better simulator
+    // https://github.com/UBC-Thunderbots/Software/issues/609
+    /**
+     * A wrapper function for the filterAndPublishVisionData function. This wrapper is
+     * responsible for ignoring any bad packets we get from grSim, because grSim
+     * sends garbage packets from very far in the future that causes issues if they
+     * get through to our filters and logic.
+     *
+     * @param packet The vision packet
+     */
+    void filterAndPublishVisionDataWrapper(SSL_WrapperPacket packet);
+
     /**
      * Filters and publishes the new vision data
      *
@@ -90,4 +103,12 @@ class NetworkClient
     // The thread running the io_service in the background. This thread will run for the
     // entire lifetime of the class
     std::thread io_service_thread;
+
+    // Both these values are used for the filterAndPublishVisionDataWrapper function
+    // and should be removed when the function is removed
+    // The t_capture of the latest SSL_WrapperPacket we received with a valid timestamp
+    double last_valid_t_capture;
+    // How many packets to analyze to find the true starting time of the vision system
+    // before passing the packets on to the actual logic
+    int initial_packet_count;
 };


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Properly removed expired robots using the latest timestamp out of all received camera images. 

Still needs some tweaks from @MathewMacDougall.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Ran `network_input` and it published correct worlds from grsim.

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
NA
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification
NA
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
