### PR TITLE
Add SIGINT handler to radio_communication

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -36,8 +36,8 @@ double CherryPickTactic::calculateRobotCost(const Robot& robot, const World& wor
 std::unique_ptr<Intent> CherryPickTactic::calculateNextIntent(
     intent_coroutine::push_type& yield)
 {
-    MoveAction move_action                     = MoveAction();
-    auto best_pass_and_score                   = pass_generator.getBestPassSoFar();
+    MoveAction move_action   = MoveAction();
+    auto best_pass_and_score = pass_generator.getBestPassSoFar();
     do
     {
         pass_generator.setWorld(world);

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -4,6 +4,8 @@
 #include <thunderbots_msgs/PrimitiveArray.h>
 #include <thunderbots_msgs/World.h>
 
+#include <csignal>
+
 #include "ai/primitive/primitive.h"
 #include "ai/primitive/primitive_factory.h"
 #include "geom/point.h"
@@ -62,11 +64,23 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
     backend_ptr->send_vision_packet();
 }
 
+void signalHandler(int signum)
+{
+    LOG(DEBUG) << "Ctrl-C signal caught" << std::endl;
+
+    // Destroys backend, allowing everything libusb-related to
+    // exit gracefully.
+    backend_ptr.reset();
+}
+
 int main(int argc, char** argv)
 {
     // Init ROS node
     ros::init(argc, argv, "radio_communication");
     ros::NodeHandle node_handle;
+
+    // Register signal handler (has to be after ros::init)
+    signal(SIGINT, signalHandler);
 
     // Init backend
     backend_ptr = std::make_unique<MRFBackend>(node_handle);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Redo of #588, see that for more info

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
