### PR TITLE
Fix += and -= Operators for Point

### DIFF
--- a/src/thunderbots/software/geom/point.h
+++ b/src/thunderbots/software/geom/point.h
@@ -463,7 +463,7 @@ inline constexpr Point operator+(const Point &p, const Point &q)
 
 inline Point &operator+=(Point &p, const Point &q)
 {
-    p.set(q.x(), q.y());
+    p.set(p.x() + q.x(), p.y() + q.y());
     return p;
 }
 
@@ -479,7 +479,7 @@ inline constexpr Point operator-(const Point &p, const Point &q)
 
 inline Point &operator-=(Point &p, const Point &q)
 {
-    p.set(q.x(), q.y());
+    p.set(p.x() - q.x(), p.y() - q.y());
     return p;
 }
 

--- a/src/thunderbots/software/test/geom/point.cpp
+++ b/src/thunderbots/software/test/geom/point.cpp
@@ -7,6 +7,26 @@ TEST(AngleTest, accesors)
     EXPECT_DOUBLE_EQ(0, Point().x());
 }
 
+TEST(PlusEqualOperatorTest, plus_equal_operator_test)
+{
+    Point p = Point(1, 2);
+    Point q = Point(3, 4);
+
+    p += q;
+
+    EXPECT_EQ(Point(4, 6), p);
+}
+
+TEST(MinusEqualOperatorTest, minus_equal_operator_test)
+{
+    Point p = Point(4, 6);
+    Point q = Point(3, 4);
+
+    p -= q;
+    
+    EXPECT_EQ(Point(1, 2), p);
+}
+
 int main(int argc, char **argv)
 {
     std::cout << argv[0] << std::endl;

--- a/src/thunderbots/software/test/geom/point.cpp
+++ b/src/thunderbots/software/test/geom/point.cpp
@@ -23,7 +23,7 @@ TEST(MinusEqualOperatorTest, minus_equal_operator_test)
     Point q = Point(3, 4);
 
     p -= q;
-    
+
     EXPECT_EQ(Point(1, 2), p);
 }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
For `Point`, the `+=` and `-=` operators were not working as intended (confirmed through unit testing) because currently it sets the original point equal to the point to be added/subtracted instead of adding/subtracting *then* setting equal.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit testing are done for both `+=` and `-=` and passes.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #340 
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
