### PR TITLE
Stop Action

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -746,7 +746,8 @@ if (CATKIN_ENABLE_TESTING)
             ai/intent/chip_intent.cpp
             ai/intent/direct_velocity_intent.cpp
             ai/intent/direct_wheels_intent.cpp
-            ai/intent/dribble_intent.cpp ai/intent/intent.cpp
+            ai/intent/dribble_intent.cpp
+            ai/intent/intent.cpp
             ai/intent/kick_intent.cpp
             ai/intent/move_intent.cpp
             ai/intent/movespin_intent.cpp

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -560,6 +560,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/hl/stp/action/move_action.cpp
             ai/hl/stp/action/movespin_action.cpp
             ai/hl/stp/action/pivot_action.cpp
+            ai/hl/stp/action/stop_action.cpp
             ai/intent/intent.cpp
             ai/intent/chip_intent.cpp
             ai/intent/dribble_intent.cpp
@@ -567,13 +568,17 @@ if (CATKIN_ENABLE_TESTING)
             ai/intent/move_intent.cpp
             ai/intent/movespin_intent.cpp
             ai/intent/pivot_intent.cpp
-            ai/primitive/primitive.cpp
-            ai/primitive/chip_primitive.cpp
-            ai/primitive/dribble_primitive.cpp
-            ai/primitive/kick_primitive.cpp
+            ai/intent/stop_intent.cpp
+            ai/intent/kick_intent.cpp
+            ai/intent/chip_intent.cpp
             ai/primitive/move_primitive.cpp
             ai/primitive/movespin_primitive.cpp
             ai/primitive/pivot_primitive.cpp
+            ai/primitive/kick_primitive.cpp
+            ai/primitive/chip_primitive.cpp
+            ai/primitive/stop_primitive.cpp
+            ai/primitive/primitive.cpp
+            ai/primitive/dribble_primitive.cpp
             ai/world/robot.cpp
             ai/world/ball.cpp
             test/ai/hl/stp/action/main.cpp
@@ -585,6 +590,7 @@ if (CATKIN_ENABLE_TESTING)
             test/ai/hl/stp/action/move_action.cpp
             test/ai/hl/stp/action/movespin_action.cpp
             test/ai/hl/stp/action/pivot_action.cpp
+            test/ai/hl/stp/action/stop_action.cpp
             geom/polygon.cpp
             geom/util.cpp
             util/logger/custom_g3log_sinks.h
@@ -740,8 +746,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/intent/chip_intent.cpp
             ai/intent/direct_velocity_intent.cpp
             ai/intent/direct_wheels_intent.cpp
-            ai/intent/dribble_intent.cpp
-            ai/intent/intent.cpp
+            ai/intent/dribble_intent.cpp ai/intent/intent.cpp
             ai/intent/kick_intent.cpp
             ai/intent/move_intent.cpp
             ai/intent/movespin_intent.cpp

--- a/src/thunderbots/software/ai/hl/stp/action/stop_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/stop_action.cpp
@@ -1,0 +1,27 @@
+#include "ai/hl/stp/action/stop_action.h"
+
+#include "ai/intent/stop_intent.h"
+#include "geom/angle.h"
+#include "geom/util.h"
+#include "shared/constants.h"
+
+StopAction::StopAction() : Action() {}
+
+std::unique_ptr<Intent> StopAction::updateStateAndGetNextIntent(const Robot& robot,
+                                                                bool coast)
+{
+    // update the parameters stored by this action
+    this->robot = robot;
+    this->coast = coast;
+
+    return getNextIntent();
+}
+
+std::unique_ptr<Intent> StopAction::calculateNextIntent(
+    intent_coroutine::push_type& yield)
+{
+    do
+    {
+        yield(std::make_unique<StopIntent>(robot->id(), coast, 0));
+    } while (true);
+}

--- a/src/thunderbots/software/ai/hl/stp/action/stop_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/stop_action.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "ai/hl/stp/action/action.h"
+#include "geom/angle.h"
+#include "geom/point.h"
+
+/**
+ * The StopAction makes the robot stop with the option to coast
+ */
+class StopAction : public Action
+{
+   public:
+    /**
+     * Creates a new StopAction
+     */
+    explicit StopAction();
+
+    /**
+     * Returns the next Intent this StopAction wants to run, given the parameters.
+     *
+     * @param robot the robot that should stop
+     * @param coast coasts if true, false will bring the robot to an abrupt stop
+     *
+     * @return A unique pointer to the Intent the StopAction wants to run.
+     *
+     */
+    std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot, bool coast);
+
+   private:
+    std::unique_ptr<Intent> calculateNextIntent(
+        intent_coroutine::push_type& yield) override;
+
+    // Action parameters
+    double coast;
+};

--- a/src/thunderbots/software/test/ai/hl/stp/action/stop_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/stop_action.cpp
@@ -1,0 +1,54 @@
+#include "ai/hl/stp/action/stop_action.h"
+
+#include <gtest/gtest.h>
+
+#include "ai/intent/stop_intent.h"
+
+
+// StopAction should be yeilding stop_intents without coast
+TEST(StopAction, stop_action_with_coast)
+{
+    Robot robot       = Robot(0, Point(10, 10), Vector(), Angle::zero(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    StopAction action = StopAction();
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, false);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    try
+    {
+        StopIntent stop_intent = dynamic_cast<StopIntent &>(*intent_ptr);
+        EXPECT_EQ(0, stop_intent.getRobotId());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "StopIntent was not returned by the StopAction!";
+    }
+}
+
+// StopAction should be yeilding stop_intents with coast
+TEST(StopAction, stop_action_coast)
+{
+    Robot robot       = Robot(0, Point(10, 10), Vector(), Angle::zero(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    StopAction action = StopAction();
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, true);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    try
+    {
+        StopIntent stop_intent = dynamic_cast<StopIntent &>(*intent_ptr);
+        EXPECT_EQ(0, stop_intent.getRobotId());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "StopIntent was not returned by the StopAction!";
+    }
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Stop action to return stop intent
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
unit tests, ran in grsim and robots didn't move. Didn't get a chance to field test as my mac is acting up
### Resolved Issues

Resolves #430 

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

N/A
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
