### PR TITLE
Disable camera by ID

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -138,6 +138,8 @@ file(GLOB_RECURSE NETWORK_INPUT_SRC LIST_DIRECTORIES false CONFIGURE_DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/ai/world/*.h
         ${CMAKE_CURRENT_SOURCE_DIR}/util/*.h
         ${CMAKE_CURRENT_SOURCE_DIR}/util/*.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/util/parameter/*.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/util/parameter/*.cpp
         )
 add_executable (network_input
         ${PROTO_SRCS}

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -86,32 +86,24 @@ void NetworkClient::filterAndPublishVisionData(SSL_WrapperPacket packet)
         switch (detection.camera_id())
         {
             case 0:
-                if (Util::DynamicParameters::cameras::ignore_camera_0.value())
-                {
-                    camera_disabled = true;
-                }
+                camera_disabled =
+                    Util::DynamicParameters::cameras::ignore_camera_0.value();
                 break;
             case 1:
-                if (Util::DynamicParameters::cameras::ignore_camera_1.value())
-                {
-                    camera_disabled = true;
-                }
+                camera_disabled =
+                    Util::DynamicParameters::cameras::ignore_camera_1.value();
                 break;
             case 2:
-                if (Util::DynamicParameters::cameras::ignore_camera_2.value())
-                {
-                    camera_disabled = true;
-                }
+                camera_disabled =
+                    Util::DynamicParameters::cameras::ignore_camera_2.value();
                 break;
             case 3:
-                if (Util::DynamicParameters::cameras::ignore_camera_3.value())
-                {
-                    camera_disabled = true;
-                }
+                camera_disabled =
+                    Util::DynamicParameters::cameras::ignore_camera_3.value();
                 break;
             default:
-                LOG(INFO) << "An unkown camera id was detected, disabled by default "
-                          << "id: " << detection.camera_id() << std::endl;
+                LOG(WARNING) << "An unkown camera id was detected, disabled by default "
+                             << "id: " << detection.camera_id() << std::endl;
                 camera_disabled = true;
                 break;
         }


### PR DESCRIPTION


<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR


### Description

<!--
    Give a high-level description of the changes in this PR
-->
The detection packets are ignored if the dynamic parameter is selected, for all 4 cameras

### Testing Done
Tested in grsim, no field testing was done.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
#101 
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification
N/A
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
