### PR TITLE
Configure MRF Dongle Config (channel) from roslaunch cmdline

### DIFF
--- a/src/thunderbots/software/launch/ai_mrf.launch
+++ b/src/thunderbots/software/launch/ai_mrf.launch
@@ -1,10 +1,12 @@
 <launch>
 
+    <!-- Configuration of the radio; default is 0-->
+    <arg name="mrf_config" default="0"/>
+
     <!-- Run all the shared AI nodes -->
     <include file="$(find thunderbots)/launch/ai.launch" />
 
     <!-- Launch the radio_communication node -->
-    <node name="radio_communication" pkg="thunderbots" type="radio_communication" output="screen">
-    </node>
+    <node name="radio_communication" pkg="thunderbots" type="radio_communication" output="screen" args="$(arg mrf_config)"/>
 
 </launch>

--- a/src/thunderbots/software/launch/ai_mrf.launch
+++ b/src/thunderbots/software/launch/ai_mrf.launch
@@ -1,6 +1,6 @@
 <launch>
 
-    <!-- Configuration of the radio; default is 0-->
+    <!-- Configuration of the radio; default is 0 -->
     <arg name="mrf_config" default="0"/>
 
     <!-- Run all the shared AI nodes -->

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -26,6 +26,9 @@ namespace
 
     // The MRFBackend instance that connects to the dongle
     std::unique_ptr<MRFBackend> backend_ptr;
+
+    // Index of argv that contains the mrf_config parameter
+    constexpr int MRF_CONFIG_ARGV_INDEX = 1;
 }  // namespace
 
 // Callbacks
@@ -82,7 +85,8 @@ int main(int argc, char** argv)
     // Register signal handler (has to be after ros::init)
     signal(SIGINT, signalHandler);
 
-    // Init backend
+    // Set radio configuration from cmdline, init backend
+    node_handle.setParam(Util::Constants::MRF_CONFIG_PARAM, argv[MRF_CONFIG_ARGV_INDEX]);
     backend_ptr = std::make_unique<MRFBackend>(node_handle);
 
     // Create subscribers to topics we care about

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv)
     signal(SIGINT, signalHandler);
 
     // Set radio configuration from cmdline, init backend
-    int config = std::stoi(argv[MRF_CONFIG_ARGV_INDEX], nullptr, 0);
+    int config  = std::stoi(argv[MRF_CONFIG_ARGV_INDEX], nullptr, 0);
     backend_ptr = std::make_unique<MRFBackend>(config, node_handle);
 
     // Create subscribers to topics we care about

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -86,8 +86,8 @@ int main(int argc, char** argv)
     signal(SIGINT, signalHandler);
 
     // Set radio configuration from cmdline, init backend
-    node_handle.setParam(Util::Constants::MRF_CONFIG_PARAM, argv[MRF_CONFIG_ARGV_INDEX]);
-    backend_ptr = std::make_unique<MRFBackend>(node_handle);
+    int config = std::stoi(argv[MRF_CONFIG_ARGV_INDEX], nullptr, 0);
+    backend_ptr = std::make_unique<MRFBackend>(config, node_handle);
 
     // Create subscribers to topics we care about
     ros::Subscriber prim_array_sub = node_handle.subscribe(

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -1,4 +1,9 @@
 #include "dongle.h"
+#include "messages.h"
+#include "radio_communication/visitor/mrf_primitive_visitor.h"
+#include "util/constants.h"
+#include "util/logger/init.h"
+
 
 #include <sigc++/bind.h>
 #include <sigc++/functors/mem_fun.h>
@@ -15,10 +20,6 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
-
-#include "messages.h"
-#include "radio_communication/visitor/mrf_primitive_visitor.h"
-#include "util/logger/init.h"
 
 namespace
 {
@@ -117,7 +118,7 @@ MRFDongle::MRFDongle(Annunciator &annunciator)
             ros::NodeHandle nh;
             std::string config_string;
 
-            if (nh.getParam("mrf_config", config_string))
+            if (nh.getParam(Util::Constants::MRF_CONFIG_PARAM, config_string))
             {
                 int i = std::stoi(config_string, nullptr, 0);
                 if (i < 0 || static_cast<std::size_t>(i) >=
@@ -129,7 +130,6 @@ MRFDongle::MRFDongle(Annunciator &annunciator)
                 config = static_cast<unsigned int>(i);
             }
         }
-        std::cout << "MRF CONFIG is " << config << std::endl;
 
         channel_ = DEFAULT_CONFIGS[config].channel;
         {

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -31,7 +31,8 @@ namespace
 
     // Different configs for the dongle, to allow for communication over
     // different PANs and/or channels
-    const RadioConfig DEFAULT_CONFIGS[4] = {
+    constexpr int NUM_DEFAULT_CONFIGS = 4;
+    const RadioConfig DEFAULT_CONFIGS[NUM_DEFAULT_CONFIGS] = {
         {25U, 250, 0x1846U},
         {25U, 250, 0x1847U},
         {25U, 250, 0x1848U},
@@ -113,20 +114,23 @@ MRFDongle::MRFDongle(Annunciator &annunciator)
     {
         unsigned int config = 0U;
         {
-            const char *config_string = std::getenv("MRF_CONFIG");
-            if (config_string)
+            // const char *config_string = std::getenv("MRF_CONFIG");
+            ros::NodeHandle nh;
+            std::string config_string;
+            if (nh.getParam("mrf_config", config_string))
             {
                 int i = std::stoi(config_string, nullptr, 0);
                 if (i < 0 || static_cast<std::size_t>(i) >=
                                  sizeof(DEFAULT_CONFIGS) / sizeof(*DEFAULT_CONFIGS))
                 {
                     throw std::out_of_range(
-                        "Config index must be between 0 and number of configs "
-                        "- 1.");
+                        "Config index must be between 0 and " + std::to_string(NUM_DEFAULT_CONFIGS - 1));
                 }
                 config = static_cast<unsigned int>(i);
             }
         }
+        std::cout << "MRF CONFIG is " << config << std::endl;
+
         channel_ = DEFAULT_CONFIGS[config].channel;
         {
             const char *channel_string = std::getenv("MRF_CHANNEL");

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -113,7 +113,7 @@ MRFDongle::MRFDongle(unsigned int config, Annunciator &annunciator)
     device.set_interface_alt_setting(radio_interface, configuration_altsetting);
     {
         if (config < 0 || static_cast<std::size_t>(config) >=
-                            sizeof(DEFAULT_CONFIGS) / sizeof(*DEFAULT_CONFIGS))
+                              sizeof(DEFAULT_CONFIGS) / sizeof(*DEFAULT_CONFIGS))
         {
             throw std::out_of_range("Config index must be between 0 and " +
                                     std::to_string(NUM_DEFAULT_CONFIGS - 1));

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -1,9 +1,4 @@
 #include "dongle.h"
-#include "messages.h"
-#include "radio_communication/visitor/mrf_primitive_visitor.h"
-#include "util/constants.h"
-#include "util/logger/init.h"
-
 
 #include <sigc++/bind.h>
 #include <sigc++/functors/mem_fun.h>
@@ -20,6 +15,11 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+
+#include "messages.h"
+#include "radio_communication/visitor/mrf_primitive_visitor.h"
+#include "util/constants.h"
+#include "util/logger/init.h"
 
 namespace
 {

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -31,7 +31,7 @@ namespace
 
     // Different configs for the dongle, to allow for communication over
     // different PANs and/or channels
-    constexpr int NUM_DEFAULT_CONFIGS = 4;
+    constexpr int NUM_DEFAULT_CONFIGS                      = 4;
     const RadioConfig DEFAULT_CONFIGS[NUM_DEFAULT_CONFIGS] = {
         {25U, 250, 0x1846U},
         {25U, 250, 0x1847U},
@@ -114,17 +114,17 @@ MRFDongle::MRFDongle(Annunciator &annunciator)
     {
         unsigned int config = 0U;
         {
-            // const char *config_string = std::getenv("MRF_CONFIG");
             ros::NodeHandle nh;
             std::string config_string;
+
             if (nh.getParam("mrf_config", config_string))
             {
                 int i = std::stoi(config_string, nullptr, 0);
                 if (i < 0 || static_cast<std::size_t>(i) >=
                                  sizeof(DEFAULT_CONFIGS) / sizeof(*DEFAULT_CONFIGS))
                 {
-                    throw std::out_of_range(
-                        "Config index must be between 0 and " + std::to_string(NUM_DEFAULT_CONFIGS - 1));
+                    throw std::out_of_range("Config index must be between 0 and " +
+                                            std::to_string(NUM_DEFAULT_CONFIGS - 1));
                 }
                 config = static_cast<unsigned int>(i);
             }

--- a/src/thunderbots/software/radio_communication/mrf/dongle.h
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.h
@@ -43,6 +43,8 @@ class MRFDongle final
    public:
     /**
      * Constructs a new MRFDongle.
+     *
+     * @param annunciator annunciator to publish robot statuses
      */
     explicit MRFDongle(Annunciator &annunciator);
 
@@ -62,9 +64,9 @@ class MRFDongle final
     /**
      * Sends a camera packet over radio to all robots, including vision coordinates of
      * all robots and the ball.
-     * @param robots
-     * @param ball
-     * @param timestamp
+     * @param robots vector of tuples of {robot ID, robot location, robot orientation}
+     * @param ball ball location
+     * @param timestamp timestamp in seconds when this data was received
      */
     void send_camera_packet(std::vector<std::tuple<uint8_t, Point, Angle>> robots,
                             Point ball, uint64_t timestamp);

--- a/src/thunderbots/software/radio_communication/mrf/dongle.h
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.h
@@ -44,9 +44,10 @@ class MRFDongle final
     /**
      * Constructs a new MRFDongle.
      *
+     * @param config MRF configuration to start dongle in
      * @param annunciator annunciator to publish robot statuses
      */
-    explicit MRFDongle(Annunciator &annunciator);
+    explicit MRFDongle(unsigned int config, Annunciator &annunciator);
 
     /**
      * Destroys an MRFDongle.

--- a/src/thunderbots/software/radio_communication/mrf_backend.cpp
+++ b/src/thunderbots/software/radio_communication/mrf_backend.cpp
@@ -4,9 +4,9 @@
 
 #include "util/logger/init.h"
 
-MRFBackend::MRFBackend(ros::NodeHandle &node_handle)
+MRFBackend::MRFBackend(unsigned int config, ros::NodeHandle &node_handle)
     : annunciator(Annunciator(node_handle)),
-      dongle(MRFDongle(annunciator)),
+      dongle(MRFDongle(config, annunciator)),
       ball(Ball(Point(0, 0), Vector(0, 0), Timestamp::fromSeconds(1)))
 {
 }

--- a/src/thunderbots/software/radio_communication/mrf_backend.h
+++ b/src/thunderbots/software/radio_communication/mrf_backend.h
@@ -16,9 +16,10 @@ class MRFBackend
      * Creates a new MRFBackend.
      * Automatically connects to the dongle upon initialization.
      *
+     * @param config MRF configuration to start dongle in
      * @param node_handle the ROS NodeHandle of the radio_communication node
      */
-    explicit MRFBackend(ros::NodeHandle& node_handle);
+    explicit MRFBackend(unsigned int config, ros::NodeHandle& node_handle);
 
     ~MRFBackend();
 

--- a/src/thunderbots/software/util/constants.h
+++ b/src/thunderbots/software/util/constants.h
@@ -50,5 +50,8 @@ namespace Util
         // How many milliseconds a robot must not be seen in vision before it is
         // considered as "gone" and no longer reported.
         static const unsigned int ROBOT_DEBOUNCE_DURATION_MILLISECONDS = 200;
+
+        // Parameter name for MRF configuration
+        static const std::string MRF_CONFIG_PARAM = "mrf_config";
     }  // namespace Constants
 }  // namespace Util

--- a/src/thunderbots/software/util/constants.h
+++ b/src/thunderbots/software/util/constants.h
@@ -50,8 +50,5 @@ namespace Util
         // How many milliseconds a robot must not be seen in vision before it is
         // considered as "gone" and no longer reported.
         static const unsigned int ROBOT_DEBOUNCE_DURATION_MILLISECONDS = 200;
-
-        // Parameter name for MRF configuration
-        static const std::string MRF_CONFIG_PARAM = "mrf_config";
     }  // namespace Constants
 }  // namespace Util


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Allowed dongle config to be configured from the command line, used when changing channels. Because of how dongle was structured out, I found it easiest if the arg was published to the param server and then retrieved within the `MRFDongle` class, not sure if this is fine with you guys.

Usage: `roslaunch thunderbots ai_mrf.launch mrf_config:=0` (0 is the default)
### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Tested with physical robot, via robot status.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
