### PR TITLE
Coroutine Fixes

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -1,17 +1,10 @@
 # This project name must match the name of the package defined in package.xml
 project(thunderbots)
 
-## Build in "Release" (with lots of compiler optimizations) by default
-#if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-##    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
-#    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Debug")
-#endif()
-
-# Force the build to DebugA
-# TODO: THIS IS A TEMPORARY FIX TO SUPPRESS THE MEMORY ISSUES FOUND IN
-# https://github.com/UBC-Thunderbots/Software/issues/584
-# This should be set back to the commented-out code above once the issue if fixed
-set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Debug")
+# Build in "Release" (with lots of compiler optimizations) by default
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
 
 # For external editor code completion (Visual Studio Code, Vim, etc.)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/src/thunderbots/software/ai/hl/stp/action/action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/action.cpp
@@ -9,43 +9,39 @@ Action::Action()
 
 bool Action::done() const
 {
+    // The action is done if the coroutine evaluates to false, which means execution
+    // has "dropped out" the bottom of the function and there is no more work to do
     return !static_cast<bool>(intent_sequence);
 }
 
 std::unique_ptr<Intent> Action::getNextIntent()
 {
-    std::unique_ptr<Intent> next_intent = {};
+    std::unique_ptr<Intent> next_intent = nullptr;
     if (!robot)
     {
         LOG(WARNING)
             << "Requesting the next Intent for an Action without a Robot assigned"
             << std::endl;
     }
-    // Default to returning a null pointer if the coroutine "iterator" is done, as this
-    // means that the calculateNextIntent function has completed and therefore the
-    // Action is done
-    else if (intent_sequence)
+    else if (intent_sequence())
     {
-        // Get the next intent from the coroutine
+        // Extract the result from the coroutine. This will be whatever value was
+        // yielded by the calculateNextIntent function
         next_intent = intent_sequence.get();
-
-        // Continue to run the coroutine (basically setting up for the next time this
-        // function is called)
-        intent_sequence();
     }
 
     return next_intent;
 }
 
-std::unique_ptr<Intent> Action::calculateNextIntentWrapper(
-    IntentCoroutine::push_type &yield)
+void Action::calculateNextIntentWrapper(IntentCoroutine::push_type &yield)
 {
     // Yield a null pointer the very first time the function is called. This value will
     // never be seen/used by the rest of the system.
     yield(std::unique_ptr<Intent>{});
 
     // Anytime after the first function call, the calculateNextIntent function will be
-    // used to perform the real logic. Note that we need to "yield" up at each level of
-    // of the coroutine
-    yield(calculateNextIntent(yield));
+    // used to perform the real logic. The calculateNextIntent function will yield its
+    // values to the top of the coroutine stack, where they will be retrieved by
+    // getNextIntent, so we do not need to yield or return the result of this function
+    calculateNextIntent(yield);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/action.cpp
@@ -23,6 +23,7 @@ std::unique_ptr<Intent> Action::getNextIntent()
             << "Requesting the next Intent for an Action without a Robot assigned"
             << std::endl;
     }
+    // Run the coroutine and check its status to see if it has any more work to do.
     else if (intent_sequence())
     {
         // Extract the result from the coroutine. This will be whatever value was

--- a/src/thunderbots/software/ai/hl/stp/action/action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/action.h
@@ -57,7 +57,10 @@ class Action
      * This function exists because when the coroutine (intent_sequence) is first
      * constructed the coroutine is called/entered. This would normally cause the
      * calculateNextIntentWrapper to be run once and potentially return incorrect results
-     * due to default constructed values.
+     * due to default constructed values. Calling the calculateNextIntent function this
+     * early also results in virtual function errors because this early in object
+     * construction, the concrete implementation of this Action doesn't exist yet so
+     * we would actually be trying to call the virtual function, which doesn't work.
      *
      * This wrapper function will yield a null pointer the first time it's called and
      * otherwise use the calculateNextIntent function. This first "null" value will never
@@ -68,13 +71,12 @@ class Action
      *
      * @param yield The coroutine push_type for the Action
      *
-     * @return A unique pointer to the next Intent that should be run for the Action.
+     * @yield A unique pointer to the next Intent that should be run for the Action.
      * If the Action is done, an empty/null unique pointer is returned. The very first
      * time this function is called, a null pointer will be returned (this does not
      * signify the Action is done).
      */
-    std::unique_ptr<Intent> calculateNextIntentWrapper(
-        IntentCoroutine::push_type &yield);
+    void calculateNextIntentWrapper(IntentCoroutine::push_type &yield);
 
     /**
      * Calculates the next Intent for the Action. If the Action is done
@@ -83,9 +85,8 @@ class Action
      *
      * @param yield The coroutine push_type for the Action
      *
-     * @return A unique pointer to the next Intent that should be run for the Action.
+     * @yield A unique pointer to the next Intent that should be run for the Action.
      * If the Action is done, an empty/null unique pointer is returned.
      */
-    virtual std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type &yield) = 0;
+    virtual void calculateNextIntent(IntentCoroutine::push_type &yield) = 0;
 };

--- a/src/thunderbots/software/ai/hl/stp/action/action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/action.h
@@ -8,7 +8,7 @@
 
 // We typedef the coroutine return type to make it shorter, more descriptive,
 // and easier to work with
-typedef boost::coroutines2::coroutine<std::unique_ptr<Intent>> intent_coroutine;
+typedef boost::coroutines2::coroutine<std::unique_ptr<Intent>> IntentCoroutine;
 
 /**
  * The Action class is the lowest level of abstraction in our STP architecture.
@@ -46,7 +46,7 @@ class Action
     std::unique_ptr<Intent> getNextIntent();
 
     // The coroutine that sequentially returns the Intents the Action wants to run
-    intent_coroutine::pull_type intent_sequence;
+    IntentCoroutine::pull_type intent_sequence;
     // The robot performing this Action
     std::optional<Robot> robot;
 
@@ -74,7 +74,7 @@ class Action
      * signify the Action is done).
      */
     std::unique_ptr<Intent> calculateNextIntentWrapper(
-        intent_coroutine::push_type &yield);
+        IntentCoroutine::push_type &yield);
 
     /**
      * Calculates the next Intent for the Action. If the Action is done
@@ -87,5 +87,5 @@ class Action
      * If the Action is done, an empty/null unique pointer is returned.
      */
     virtual std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type &yield) = 0;
+        IntentCoroutine::push_type &yield) = 0;
 };

--- a/src/thunderbots/software/ai/hl/stp/action/action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/action.h
@@ -69,12 +69,12 @@ class Action
      * returned. This effectively "shields" the logic from any errors caused by default
      * values during construction.
      *
-     * @param yield The coroutine push_type for the Action
+     * This function yields a unique pointer to the next Intent that should be run for the
+     * Action. If the Action is done, an empty/null unique pointer is returned. The very
+     * first time this function is called, a null pointer will be returned (this does not
+     * signify the Action is done). This yield happens in place of a return.
      *
-     * @yield A unique pointer to the next Intent that should be run for the Action.
-     * If the Action is done, an empty/null unique pointer is returned. The very first
-     * time this function is called, a null pointer will be returned (this does not
-     * signify the Action is done).
+     * @param yield The coroutine push_type for the Action
      */
     void calculateNextIntentWrapper(IntentCoroutine::push_type &yield);
 
@@ -83,10 +83,11 @@ class Action
      * (ie. it has achieved its objective and has no more Intents to return),
      * an empty/null unique pointer is returned.
      *
-     * @param yield The coroutine push_type for the Action
+     * This function yields a unique pointer to the next Intent that should be run for the
+     * Action. If the Action is done, an empty/null unique pointer is returned. This yield
+     * happens in place of a return
      *
-     * @yield A unique pointer to the next Intent that should be run for the Action.
-     * If the Action is done, an empty/null unique pointer is returned.
+     * @param yield The coroutine push_type for the Action
      */
     virtual void calculateNextIntent(IntentCoroutine::push_type &yield) = 0;
 };

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
@@ -30,7 +30,7 @@ std::unique_ptr<Intent> ChipAction::updateStateAndGetNextIntent(
 }
 
 std::unique_ptr<Intent> ChipAction::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    IntentCoroutine::push_type& yield)
 {
     // How large the triangle is that defines the region where the robot is
     // behind the ball and ready to chip.

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
@@ -29,8 +29,7 @@ std::unique_ptr<Intent> ChipAction::updateStateAndGetNextIntent(
     return getNextIntent();
 }
 
-std::unique_ptr<Intent> ChipAction::calculateNextIntent(
-    IntentCoroutine::push_type& yield)
+void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     // How large the triangle is that defines the region where the robot is
     // behind the ball and ready to chip.

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.h
@@ -52,7 +52,7 @@ class ChipAction : public Action
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point chip_origin;

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.h
@@ -51,8 +51,7 @@ class ChipAction : public Action
                                                         double chip_distance_meters);
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point chip_origin;

--- a/src/thunderbots/software/ai/hl/stp/action/dribble_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/dribble_action.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<Intent> DribbleAction::updateStateAndGetNextIntent(
 }
 
 std::unique_ptr<Intent> DribbleAction::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    IntentCoroutine::push_type& yield)
 {
     // We use a do-while loop so that we return the Intent at least once. If the robot was
     // already moving somewhere else, but was told to run the DribbleAction to a

--- a/src/thunderbots/software/ai/hl/stp/action/dribble_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/dribble_action.cpp
@@ -24,8 +24,7 @@ std::unique_ptr<Intent> DribbleAction::updateStateAndGetNextIntent(
     return getNextIntent();
 }
 
-std::unique_ptr<Intent> DribbleAction::calculateNextIntent(
-    IntentCoroutine::push_type& yield)
+void DribbleAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     // We use a do-while loop so that we return the Intent at least once. If the robot was
     // already moving somewhere else, but was told to run the DribbleAction to a

--- a/src/thunderbots/software/ai/hl/stp/action/dribble_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/dribble_action.h
@@ -46,7 +46,7 @@ class DribbleAction : public Action
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point destination;

--- a/src/thunderbots/software/ai/hl/stp/action/dribble_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/dribble_action.h
@@ -45,8 +45,7 @@ class DribbleAction : public Action
                                                         bool small_kick_allowed);
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point destination;

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(
 }
 
 std::unique_ptr<Intent> KickAction::calculateNextIntent(
-    intent_coroutine::push_type &yield)
+    IntentCoroutine::push_type &yield)
 {
     // How large the triangle is that defines the region where the robot is
     // behind the ball and ready to kick.

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -33,8 +33,7 @@ std::unique_ptr<Intent> KickAction::updateStateAndGetNextIntent(
     return getNextIntent();
 }
 
-std::unique_ptr<Intent> KickAction::calculateNextIntent(
-    IntentCoroutine::push_type &yield)
+void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
 {
     // How large the triangle is that defines the region where the robot is
     // behind the ball and ready to kick.

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -50,8 +50,7 @@ class KickAction : public Action
         double kick_speed_meters_per_second);
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type &yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type &yield) override;
 
     // Action parameters
     Ball ball;

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -51,7 +51,7 @@ class KickAction : public Action
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type &yield) override;
+        IntentCoroutine::push_type &yield) override;
 
     // Action parameters
     Ball ball;

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
@@ -24,8 +24,7 @@ std::unique_ptr<Intent> MoveAction::updateStateAndGetNextIntent(
     return getNextIntent();
 }
 
-std::unique_ptr<Intent> MoveAction::calculateNextIntent(
-    IntentCoroutine::push_type& yield)
+void MoveAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     // We use a do-while loop so that we return the Intent at least once. If the robot was
     // already moving somewhere else, but was told to run the MoveAction to a destination

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<Intent> MoveAction::updateStateAndGetNextIntent(
 }
 
 std::unique_ptr<Intent> MoveAction::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    IntentCoroutine::push_type& yield)
 {
     // We use a do-while loop so that we return the Intent at least once. If the robot was
     // already moving somewhere else, but was told to run the MoveAction to a destination

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.h
@@ -46,7 +46,7 @@ class MoveAction : public Action
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point destination;

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.h
@@ -45,8 +45,7 @@ class MoveAction : public Action
         double final_speed, bool enable_dribbler = false, bool enable_autokick = false);
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point destination;

--- a/src/thunderbots/software/ai/hl/stp/action/movespin_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/movespin_action.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<Intent> MoveSpinAction::updateStateAndGetNextIntent(
 }
 
 std::unique_ptr<Intent> MoveSpinAction::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    IntentCoroutine::push_type& yield)
 {
     // We use a do-while loop so that we return the Intent at least once. If the robot was
     // already moving somewhere else, but was told to run the MoveSpinAction to a

--- a/src/thunderbots/software/ai/hl/stp/action/movespin_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/movespin_action.cpp
@@ -18,8 +18,7 @@ std::unique_ptr<Intent> MoveSpinAction::updateStateAndGetNextIntent(
     return getNextIntent();
 }
 
-std::unique_ptr<Intent> MoveSpinAction::calculateNextIntent(
-    IntentCoroutine::push_type& yield)
+void MoveSpinAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     // We use a do-while loop so that we return the Intent at least once. If the robot was
     // already moving somewhere else, but was told to run the MoveSpinAction to a

--- a/src/thunderbots/software/ai/hl/stp/action/movespin_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/movespin_action.h
@@ -41,8 +41,7 @@ class MoveSpinAction : public Action
                                                         AngularVelocity angular_velocity);
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point destination;

--- a/src/thunderbots/software/ai/hl/stp/action/movespin_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/movespin_action.h
@@ -42,7 +42,7 @@ class MoveSpinAction : public Action
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point destination;

--- a/src/thunderbots/software/ai/hl/stp/action/pivot_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/pivot_action.cpp
@@ -22,8 +22,7 @@ std::unique_ptr<Intent> PivotAction::updateStateAndGetNextIntent(const Robot& ro
     return getNextIntent();
 }
 
-std::unique_ptr<Intent> PivotAction::calculateNextIntent(
-    IntentCoroutine::push_type& yield)
+void PivotAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     do
     {

--- a/src/thunderbots/software/ai/hl/stp/action/pivot_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/pivot_action.cpp
@@ -23,7 +23,7 @@ std::unique_ptr<Intent> PivotAction::updateStateAndGetNextIntent(const Robot& ro
 }
 
 std::unique_ptr<Intent> PivotAction::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    IntentCoroutine::push_type& yield)
 {
     do
     {

--- a/src/thunderbots/software/ai/hl/stp/action/pivot_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/pivot_action.h
@@ -34,7 +34,7 @@ class PivotAction : public Action
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point pivot_point;

--- a/src/thunderbots/software/ai/hl/stp/action/pivot_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/pivot_action.h
@@ -33,8 +33,7 @@ class PivotAction : public Action
                                                         double pivot_radius);
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point pivot_point;

--- a/src/thunderbots/software/ai/hl/stp/play/example_play.cpp
+++ b/src/thunderbots/software/ai/hl/stp/play/example_play.cpp
@@ -20,7 +20,7 @@ bool ExamplePlay::invariantHolds(const World &world) const
     return true;
 }
 
-void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
+void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield)
 {
     // Create MoveTactics that will loop forever
     auto move_tactic_1 = std::make_shared<MoveTactic>(true);

--- a/src/thunderbots/software/ai/hl/stp/play/example_play.cpp
+++ b/src/thunderbots/software/ai/hl/stp/play/example_play.cpp
@@ -20,8 +20,7 @@ bool ExamplePlay::invariantHolds(const World &world) const
     return true;
 }
 
-std::vector<std::shared_ptr<Tactic>> ExamplePlay::getNextTactics(
-    TacticCoroutine::push_type &yield, const World &world)
+void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
 {
     // Create MoveTactics that will loop forever
     auto move_tactic_1 = std::make_shared<MoveTactic>(true);

--- a/src/thunderbots/software/ai/hl/stp/play/example_play.h
+++ b/src/thunderbots/software/ai/hl/stp/play/example_play.h
@@ -18,6 +18,5 @@ class ExamplePlay : public Play
 
     bool invariantHolds(const World &world) const override;
 
-    std::vector<std::shared_ptr<Tactic>> getNextTactics(TacticCoroutine::push_type &yield,
-                                                        const World &world) override;
+    void getNextTactics(TacticCoroutine::push_type &yield, const World &world) override;
 };

--- a/src/thunderbots/software/ai/hl/stp/play/example_play.h
+++ b/src/thunderbots/software/ai/hl/stp/play/example_play.h
@@ -18,5 +18,5 @@ class ExamplePlay : public Play
 
     bool invariantHolds(const World &world) const override;
 
-    void getNextTactics(TacticCoroutine::push_type &yield, const World &world) override;
+    void getNextTactics(TacticCoroutine::push_type &yield) override;
 };

--- a/src/thunderbots/software/ai/hl/stp/play/play.cpp
+++ b/src/thunderbots/software/ai/hl/stp/play/play.cpp
@@ -16,6 +16,7 @@ std::optional<std::vector<std::shared_ptr<Tactic>>> Play::getTactics(const World
     // the getNextTactics function. This is easier than directly passing the World data
     // into the coroutine
     this->world = world;
+    // Run the coroutine and check its status to see if it has any more work to do.
     if (tactic_sequence())
     {
         // Extract the result from the coroutine. This will be whatever value was
@@ -45,5 +46,5 @@ void Play::getNextTacticsWrapper(TacticCoroutine::push_type &yield)
     // comes from when implementing Plays. The World is passed as a reference, so when
     // the world member variable is updated the implemented Plays will have access
     // to the updated world as well.
-    getNextTactics(yield, this->world);
+    getNextTactics(yield);
 }

--- a/src/thunderbots/software/ai/hl/stp/play/play.cpp
+++ b/src/thunderbots/software/ai/hl/stp/play/play.cpp
@@ -16,10 +16,10 @@ std::optional<std::vector<std::shared_ptr<Tactic>>> Play::getTactics(const World
     // the getNextTactics function. This is easier than directly passing the World data
     // into the coroutine
     this->world = world;
-    if (tactic_sequence)
+    if (tactic_sequence())
     {
-        // Calculate and return the next Intent
-        tactic_sequence();
+        // Extract the result from the coroutine. This will be whatever value was
+        // yielded by the getNextTactics function
         auto next_tactics = tactic_sequence.get();
         return std::make_optional(next_tactics);
     }
@@ -29,17 +29,21 @@ std::optional<std::vector<std::shared_ptr<Tactic>>> Play::getTactics(const World
     return std::nullopt;
 }
 
-std::vector<std::shared_ptr<Tactic>> Play::getNextTacticsWrapper(
-    TacticCoroutine::push_type &yield)
+void Play::getNextTacticsWrapper(TacticCoroutine::push_type &yield)
 {
     // Yield an empty vector the very first time the function is called. This value will
     // never be seen/used by the rest of the system.
     yield({});
 
     // Anytime after the first function call, the getNextTactics function will be
-    // used to perform the real logic.
+    // used to perform the real logic. The calculateNextIntent function will yield its
+    // values to the top of the coroutine stack, where they will be retrieved by
+    // getNextIntent, so we do not need to yield or return the result of this function
+    //
     // The getNextTactics function is given the World as a parameter rather than using
     // the member variable since it's more explicit and obvious where the World
-    // comes from when implementing Plays
-    return getNextTactics(yield, this->world);
+    // comes from when implementing Plays. The World is passed as a reference, so when
+    // the world member variable is updated the implemented Plays will have access
+    // to the updated world as well.
+    getNextTactics(yield, this->world);
 }

--- a/src/thunderbots/software/ai/hl/stp/play/play.h
+++ b/src/thunderbots/software/ai/hl/stp/play/play.h
@@ -111,11 +111,10 @@ class Play
      *
      * @param yield The coroutine push_type for the Play
      *
-     * @return A list of shared_ptrs to the Tactics the Play wants to run at this time, in
+     * @yield A list of shared_ptrs to the Tactics the Play wants to run at this time, in
      * order of priority
      */
-    std::vector<std::shared_ptr<Tactic>> getNextTacticsWrapper(
-        TacticCoroutine::push_type& yield);
+    void getNextTacticsWrapper(TacticCoroutine::push_type& yield);
 
     /**
      * Returns a list of shared_ptrs to the Tactics the Play wants to run at this time, in
@@ -124,11 +123,11 @@ class Play
      * @param yield The coroutine push_type for the Play
      * @param world The current state of the World
      *
-     * @return A list of shared_ptrs to the Tactics the Play wants to run at this time, in
+     * @yield A list of shared_ptrs to the Tactics the Play wants to run at this time, in
      * order of priority
      */
-    virtual std::vector<std::shared_ptr<Tactic>> getNextTactics(
-        TacticCoroutine::push_type& yield, const World& world) = 0;
+    virtual void getNextTactics(TacticCoroutine::push_type& yield,
+                                const World& world) = 0;
 
     // The coroutine that sequentially returns the Tactics the Play wants to run
     TacticCoroutine::pull_type tactic_sequence;

--- a/src/thunderbots/software/ai/hl/stp/play/play.h
+++ b/src/thunderbots/software/ai/hl/stp/play/play.h
@@ -93,6 +93,10 @@ class Play
 
     virtual ~Play() = default;
 
+   protected:
+    // The Play's knowledge of the most up-to-date World
+    World world;
+
    private:
     /**
      * A wrapper function for the getNextTactics function.
@@ -109,10 +113,10 @@ class Play
      * returned. This effectively "shields" the logic from any errors caused by default
      * values during construction.
      *
-     * @param yield The coroutine push_type for the Play
+     * This function yields a list of shared_ptrs to the Tactics the Play wants to run at
+     * this time, in order of priority. This yield happens in place of a return.
      *
-     * @yield A list of shared_ptrs to the Tactics the Play wants to run at this time, in
-     * order of priority
+     * @param yield The coroutine push_type for the Play
      */
     void getNextTacticsWrapper(TacticCoroutine::push_type& yield);
 
@@ -120,17 +124,13 @@ class Play
      * Returns a list of shared_ptrs to the Tactics the Play wants to run at this time, in
      * order of priority
      *
-     * @param yield The coroutine push_type for the Play
-     * @param world The current state of the World
+     * This function yields a list of shared_ptrs to the Tactics the Play wants to run at
+     * this time, in order of priority. This yield happens in place of a return.
      *
-     * @yield A list of shared_ptrs to the Tactics the Play wants to run at this time, in
-     * order of priority
+     * @param yield The coroutine push_type for the Play
      */
-    virtual void getNextTactics(TacticCoroutine::push_type& yield,
-                                const World& world) = 0;
+    virtual void getNextTactics(TacticCoroutine::push_type& yield) = 0;
 
     // The coroutine that sequentially returns the Tactics the Play wants to run
     TacticCoroutine::pull_type tactic_sequence;
-    // The Play's knowledge of the most up-to-date World
-    World world;
 };

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
@@ -43,8 +43,7 @@ Point BlockShotPathTactic::getBlockPosition()
     return block_position;
 }
 
-std::unique_ptr<Intent> BlockShotPathTactic::calculateNextIntent(
-    IntentCoroutine::push_type& yield)
+void BlockShotPathTactic::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     MoveAction move_action = MoveAction();
     do

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.cpp
@@ -44,7 +44,7 @@ Point BlockShotPathTactic::getBlockPosition()
 }
 
 std::unique_ptr<Intent> BlockShotPathTactic::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    IntentCoroutine::push_type& yield)
 {
     MoveAction move_action = MoveAction();
     do

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.h
@@ -48,7 +48,7 @@ class BlockShotPathTactic : public Tactic
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     /**
      * Calculates the location to move to in order to block the shot.

--- a/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/block_shot_path_tactic.h
@@ -47,8 +47,7 @@ class BlockShotPathTactic : public Tactic
     double calculateRobotCost(const Robot& robot, const World& world) override;
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     /**
      * Calculates the location to move to in order to block the shot.

--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -34,7 +34,7 @@ double CherryPickTactic::calculateRobotCost(const Robot& robot, const World& wor
 }
 
 std::unique_ptr<Intent> CherryPickTactic::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    IntentCoroutine::push_type& yield)
 {
     MoveAction move_action   = MoveAction();
     auto best_pass_and_score = pass_generator.getBestPassSoFar();

--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -33,8 +33,7 @@ double CherryPickTactic::calculateRobotCost(const Robot& robot, const World& wor
     return dist(robot.position(), target_region);
 }
 
-std::unique_ptr<Intent> CherryPickTactic::calculateNextIntent(
-    IntentCoroutine::push_type& yield)
+void CherryPickTactic::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     MoveAction move_action   = MoveAction();
     auto best_pass_and_score = pass_generator.getBestPassSoFar();

--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.h
@@ -47,7 +47,7 @@ class CherryPickTactic : public Tactic
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     // The region in which we want to position the cherry picking robot
     Rectangle target_region;

--- a/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/cherry_pick_tactic.h
@@ -46,8 +46,7 @@ class CherryPickTactic : public Tactic
     double calculateRobotCost(const Robot& robot, const World& world) override;
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // The region in which we want to position the cherry picking robot
     Rectangle target_region;

--- a/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.cpp
@@ -27,8 +27,7 @@ double MoveTactic::calculateRobotCost(const Robot &robot, const World &world)
     return std::clamp<double>(cost, 0, 1);
 }
 
-std::unique_ptr<Intent> MoveTactic::calculateNextIntent(
-    IntentCoroutine::push_type &yield)
+void MoveTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
 {
     MoveAction move_action = MoveAction();
     do

--- a/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.cpp
@@ -28,7 +28,7 @@ double MoveTactic::calculateRobotCost(const Robot &robot, const World &world)
 }
 
 std::unique_ptr<Intent> MoveTactic::calculateNextIntent(
-    intent_coroutine::push_type &yield)
+    IntentCoroutine::push_type &yield)
 {
     MoveAction move_action = MoveAction();
     do

--- a/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.h
@@ -43,7 +43,7 @@ class MoveTactic : public Tactic
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     // Tactic parameters
     // The point the robot is trying to move to

--- a/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/move_tactic.h
@@ -42,8 +42,7 @@ class MoveTactic : public Tactic
     double calculateRobotCost(const Robot& robot, const World& world) override;
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Tactic parameters
     // The point the robot is trying to move to

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -37,8 +37,7 @@ double PasserTactic::calculateRobotCost(const Robot& robot, const World& world)
     return std::clamp<double>(cost, 0, 1);
 }
 
-std::unique_ptr<Intent> PasserTactic::calculateNextIntent(
-    IntentCoroutine::push_type& yield)
+void PasserTactic::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     MoveAction move_action = MoveAction(MoveAction::ROBOT_CLOSE_TO_DEST_THRESHOLD, true);
     // Move to a position just behind the ball (in the direction of the pass)

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -38,7 +38,7 @@ double PasserTactic::calculateRobotCost(const Robot& robot, const World& world)
 }
 
 std::unique_ptr<Intent> PasserTactic::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    IntentCoroutine::push_type& yield)
 {
     MoveAction move_action = MoveAction(MoveAction::ROBOT_CLOSE_TO_DEST_THRESHOLD, true);
     // Move to a position just behind the ball (in the direction of the pass)

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
@@ -49,7 +49,7 @@ class PasserTactic : public Tactic
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     // Tactic parameters
     AI::Passing::Pass pass;

--- a/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/passer_tactic.h
@@ -48,8 +48,7 @@ class PasserTactic : public Tactic
     double calculateRobotCost(const Robot& robot, const World& world) override;
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Tactic parameters
     AI::Passing::Pass pass;

--- a/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -50,8 +50,7 @@ double ReceiverTactic::calculateRobotCost(const Robot& robot, const World& world
     return std::clamp<double>(cost, 0, 1);
 }
 
-std::unique_ptr<Intent> ReceiverTactic::calculateNextIntent(
-    IntentCoroutine::push_type& yield)
+void ReceiverTactic::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     MoveAction move_action = MoveAction(MoveAction::ROBOT_CLOSE_TO_DEST_THRESHOLD, true);
 

--- a/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -51,7 +51,7 @@ double ReceiverTactic::calculateRobotCost(const Robot& robot, const World& world
 }
 
 std::unique_ptr<Intent> ReceiverTactic::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    IntentCoroutine::push_type& yield)
 {
     MoveAction move_action = MoveAction(MoveAction::ROBOT_CLOSE_TO_DEST_THRESHOLD, true);
 

--- a/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.h
@@ -77,8 +77,7 @@ class ReceiverTactic : public Tactic
     // enemy goal with
     static constexpr Angle MAX_DEFLECTION_FOR_ONE_TOUCH_SHOT = Angle::ofDegrees(90);
 
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     /**
      * Finds a feasible shot for the robot, if any.

--- a/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.h
@@ -78,7 +78,7 @@ class ReceiverTactic : public Tactic
     static constexpr Angle MAX_DEFLECTION_FOR_ONE_TOUCH_SHOT = Angle::ofDegrees(90);
 
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     /**
      * Finds a feasible shot for the robot, if any.

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
@@ -34,6 +34,10 @@ std::unique_ptr<Intent> Tactic::getNextIntent()
     }
     else
     {
+        // We call the getNextIntentHelper before checking if we should loop forever
+        // so we can catch the tactic right when it's done. Since we do not want to return
+        // any nullptrs while a tactic is looping forever, we need to perform this
+        // check after running the logic and immediately restarting.
         next_intent = getNextIntentHelper();
         if (done_ && loop_forever)
         {
@@ -63,8 +67,7 @@ void Tactic::calculateNextIntentWrapper(IntentCoroutine::push_type &yield)
 std::unique_ptr<Intent> Tactic::getNextIntentHelper()
 {
     std::unique_ptr<Intent> next_intent = nullptr;
-    // Check if the coroutine "iterator" has any more work to do. Only run the coroutine
-    // if there is work to be done otherwise the coroutine library will fail on an assert.
+    // Run the coroutine and check its status to see if it has any more work to do.
     if (intent_sequence())
     {
         // Extract the result from the coroutine. This will be whatever value was

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
@@ -121,13 +121,12 @@ class Tactic
      *
      * @param yield The coroutine push_type for the Tactic
      *
-     * @return A unique pointer to the next Intent that should be run for the Tactic.
+     * @yield A unique pointer to the next Intent that should be run for the Tactic.
      * If the Tactic is done, an empty/null unique pointer is returned. The very first
      * time this function is called, a null pointer will be returned (this does not
      * signify the Tactic is done).
      */
-    std::unique_ptr<Intent> calculateNextIntentWrapper(
-        IntentCoroutine::push_type &yield);
+    void calculateNextIntentWrapper(IntentCoroutine::push_type &yield);
 
     /**
      * Calculates the next Intent for the Tactic. If the Tactic is done
@@ -136,11 +135,10 @@ class Tactic
      *
      * @param yield The coroutine push_type for the Tactic
      *
-     * @return A unique pointer to the next Intent that should be run for the Tactic.
+     * @yield A unique pointer to the next Intent that should be run for the Tactic.
      * If the Tactic is done, a nullptr is returned.
      */
-    virtual std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type &yield) = 0;
+    virtual void calculateNextIntent(IntentCoroutine::push_type &yield) = 0;
 
     /**
      * A helper function that runs the intent_sequence coroutine and returns the result

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
@@ -119,12 +119,12 @@ class Tactic
      * returned. This effectively "shields" the logic from any errors caused by default
      * values during construction.
      *
-     * @param yield The coroutine push_type for the Tactic
+     * This function yields a unique pointer to the next Intent that should be run for the
+     * Tactic. If the Tactic is done, an empty/null unique pointer is returned. The very
+     * first time this function is called, a null pointer will be returned (this does not
+     * signify the Tactic is done). This yield happens in place of a return.
      *
-     * @yield A unique pointer to the next Intent that should be run for the Tactic.
-     * If the Tactic is done, an empty/null unique pointer is returned. The very first
-     * time this function is called, a null pointer will be returned (this does not
-     * signify the Tactic is done).
+     * @param yield The coroutine push_type for the Tactic
      */
     void calculateNextIntentWrapper(IntentCoroutine::push_type &yield);
 
@@ -133,10 +133,11 @@ class Tactic
      * (ie. it has achieved its objective and has no more Intents to return),
      * a nullptr is returned.
      *
-     * @param yield The coroutine push_type for the Tactic
+     * This function yields a unique pointer to the next Intent that should be run for the
+     * Tactic. If the Tactic is done, a nullptr is returned. This yield happens in place
+     * of a return
      *
-     * @yield A unique pointer to the next Intent that should be run for the Tactic.
-     * If the Tactic is done, a nullptr is returned.
+     * @param yield The coroutine push_type for the Tactic
      */
     virtual void calculateNextIntent(IntentCoroutine::push_type &yield) = 0;
 

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
@@ -153,7 +153,7 @@ class Tactic
     std::unique_ptr<Intent> getNextIntentHelper();
 
     // The coroutine that sequentially returns the Intents the Tactic wants to run
-    std::unique_ptr<IntentCoroutine::pull_type> intent_sequence;
+    IntentCoroutine::pull_type intent_sequence;
     // Whether or not this Tactic is done
     bool done_;
     // Whether or not this tactic should loop forever by restarting each time it is done

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.h
@@ -127,7 +127,7 @@ class Tactic
      * signify the Tactic is done).
      */
     std::unique_ptr<Intent> calculateNextIntentWrapper(
-        intent_coroutine::push_type &yield);
+        IntentCoroutine::push_type &yield);
 
     /**
      * Calculates the next Intent for the Tactic. If the Tactic is done
@@ -140,7 +140,7 @@ class Tactic
      * If the Tactic is done, a nullptr is returned.
      */
     virtual std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type &yield) = 0;
+        IntentCoroutine::push_type &yield) = 0;
 
     /**
      * A helper function that runs the intent_sequence coroutine and returns the result
@@ -153,7 +153,7 @@ class Tactic
     std::unique_ptr<Intent> getNextIntentHelper();
 
     // The coroutine that sequentially returns the Intents the Tactic wants to run
-    std::unique_ptr<intent_coroutine::pull_type> intent_sequence;
+    std::unique_ptr<IntentCoroutine::pull_type> intent_sequence;
     // Whether or not this Tactic is done
     bool done_;
     // Whether or not this tactic should loop forever by restarting each time it is done

--- a/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.cpp
@@ -18,7 +18,7 @@ std::unique_ptr<Intent> MoveTestAction::updateStateAndGetNextIntent(const Robot&
 }
 
 std::unique_ptr<Intent> MoveTestAction::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+    IntentCoroutine::push_type& yield)
 {
     // We use a do-while loop so that we return the Intent at least once. If the robot was
     // already moving somewhere else, but was told to run the MoveTestAction to a

--- a/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.cpp
@@ -17,8 +17,7 @@ std::unique_ptr<Intent> MoveTestAction::updateStateAndGetNextIntent(const Robot&
     return getNextIntent();
 }
 
-std::unique_ptr<Intent> MoveTestAction::calculateNextIntent(
-    IntentCoroutine::push_type& yield)
+void MoveTestAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     // We use a do-while loop so that we return the Intent at least once. If the robot was
     // already moving somewhere else, but was told to run the MoveTestAction to a

--- a/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.h
@@ -35,7 +35,7 @@ class MoveTestAction : public Action
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point destination;

--- a/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_actions/move_test_action.h
@@ -34,8 +34,7 @@ class MoveTestAction : public Action
                                                         Point destination);
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Action parameters
     Point destination;

--- a/src/thunderbots/software/test/ai/hl/stp/test_plays/move_test_play.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_plays/move_test_play.cpp
@@ -20,7 +20,7 @@ bool MoveTestPlay::invariantHolds(const World &world) const
     return world.ball().position().x() >= 0;
 }
 
-void MoveTestPlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
+void MoveTestPlay::getNextTactics(TacticCoroutine::push_type &yield)
 {
     auto move_test_tactic_friendly_goal = std::make_shared<MoveTestTactic>();
     auto move_test_tactic_enemy_goal    = std::make_shared<MoveTestTactic>();

--- a/src/thunderbots/software/test/ai/hl/stp/test_plays/move_test_play.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_plays/move_test_play.cpp
@@ -20,8 +20,7 @@ bool MoveTestPlay::invariantHolds(const World &world) const
     return world.ball().position().x() >= 0;
 }
 
-std::vector<std::shared_ptr<Tactic>> MoveTestPlay::getNextTactics(
-    TacticCoroutine::push_type &yield, const World &world)
+void MoveTestPlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
 {
     auto move_test_tactic_friendly_goal = std::make_shared<MoveTestTactic>();
     auto move_test_tactic_enemy_goal    = std::make_shared<MoveTestTactic>();

--- a/src/thunderbots/software/test/ai/hl/stp/test_plays/move_test_play.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_plays/move_test_play.h
@@ -27,6 +27,5 @@ class MoveTestPlay : public Play
 
     bool invariantHolds(const World &world) const override;
 
-    std::vector<std::shared_ptr<Tactic>> getNextTactics(TacticCoroutine::push_type &yield,
-                                                        const World &world) override;
+    void getNextTactics(TacticCoroutine::push_type &yield, const World &world) override;
 };

--- a/src/thunderbots/software/test/ai/hl/stp/test_plays/move_test_play.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_plays/move_test_play.h
@@ -27,5 +27,5 @@ class MoveTestPlay : public Play
 
     bool invariantHolds(const World &world) const override;
 
-    void getNextTactics(TacticCoroutine::push_type &yield, const World &world) override;
+    void getNextTactics(TacticCoroutine::push_type &yield) override;
 };

--- a/src/thunderbots/software/test/ai/hl/stp/test_plays/stop_test_play.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_plays/stop_test_play.cpp
@@ -23,8 +23,7 @@ bool StopTestPlay::invariantHolds(const World &world) const
         world.ball().position());
 }
 
-std::vector<std::shared_ptr<Tactic>> StopTestPlay::getNextTactics(
-    TacticCoroutine::push_type &yield, const World &world)
+void StopTestPlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
 {
     auto stop_test_tactic_1 = std::make_shared<StopTestTactic>();
     auto stop_test_tactic_2 = std::make_shared<StopTestTactic>();

--- a/src/thunderbots/software/test/ai/hl/stp/test_plays/stop_test_play.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_plays/stop_test_play.cpp
@@ -23,7 +23,7 @@ bool StopTestPlay::invariantHolds(const World &world) const
         world.ball().position());
 }
 
-void StopTestPlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
+void StopTestPlay::getNextTactics(TacticCoroutine::push_type &yield)
 {
     auto stop_test_tactic_1 = std::make_shared<StopTestTactic>();
     auto stop_test_tactic_2 = std::make_shared<StopTestTactic>();

--- a/src/thunderbots/software/test/ai/hl/stp/test_plays/stop_test_play.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_plays/stop_test_play.h
@@ -26,6 +26,5 @@ class StopTestPlay : public Play
 
     bool invariantHolds(const World &world) const override;
 
-    std::vector<std::shared_ptr<Tactic>> getNextTactics(TacticCoroutine::push_type &yield,
-                                                        const World &world) override;
+    void getNextTactics(TacticCoroutine::push_type &yield, const World &world) override;
 };

--- a/src/thunderbots/software/test/ai/hl/stp/test_plays/stop_test_play.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_plays/stop_test_play.h
@@ -26,5 +26,5 @@ class StopTestPlay : public Play
 
     bool invariantHolds(const World &world) const override;
 
-    void getNextTactics(TacticCoroutine::push_type &yield, const World &world) override;
+    void getNextTactics(TacticCoroutine::push_type &yield) override;
 };

--- a/src/thunderbots/software/test/ai/hl/stp/test_tactics/move_test_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_tactics/move_test_tactic.cpp
@@ -26,8 +26,7 @@ double MoveTestTactic::calculateRobotCost(const Robot &robot, const World &world
     return std::clamp<double>(cost, 0, 1);
 }
 
-std::unique_ptr<Intent> MoveTestTactic::calculateNextIntent(
-    IntentCoroutine::push_type &yield)
+void MoveTestTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
 {
     do
     {

--- a/src/thunderbots/software/test/ai/hl/stp/test_tactics/move_test_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_tactics/move_test_tactic.cpp
@@ -27,7 +27,7 @@ double MoveTestTactic::calculateRobotCost(const Robot &robot, const World &world
 }
 
 std::unique_ptr<Intent> MoveTestTactic::calculateNextIntent(
-    intent_coroutine::push_type &yield)
+    IntentCoroutine::push_type &yield)
 {
     do
     {

--- a/src/thunderbots/software/test/ai/hl/stp/test_tactics/move_test_tactic.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_tactics/move_test_tactic.h
@@ -39,8 +39,7 @@ class MoveTestTactic : public Tactic
     double calculateRobotCost(const Robot& robot, const World& world) override;
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Tactic parameters
     // The point the robot is trying to move to

--- a/src/thunderbots/software/test/ai/hl/stp/test_tactics/move_test_tactic.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_tactics/move_test_tactic.h
@@ -40,7 +40,7 @@ class MoveTestTactic : public Tactic
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 
     // Tactic parameters
     // The point the robot is trying to move to

--- a/src/thunderbots/software/test/ai/hl/stp/test_tactics/stop_test_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_tactics/stop_test_tactic.cpp
@@ -20,7 +20,7 @@ double StopTestTactic::calculateRobotCost(const Robot &robot, const World &world
 }
 
 std::unique_ptr<Intent> StopTestTactic::calculateNextIntent(
-    intent_coroutine::push_type &yield)
+    IntentCoroutine::push_type &yield)
 {
     do
     {

--- a/src/thunderbots/software/test/ai/hl/stp/test_tactics/stop_test_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/test_tactics/stop_test_tactic.cpp
@@ -19,8 +19,7 @@ double StopTestTactic::calculateRobotCost(const Robot &robot, const World &world
     return 0.5;
 }
 
-std::unique_ptr<Intent> StopTestTactic::calculateNextIntent(
-    IntentCoroutine::push_type &yield)
+void StopTestTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
 {
     do
     {

--- a/src/thunderbots/software/test/ai/hl/stp/test_tactics/stop_test_tactic.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_tactics/stop_test_tactic.h
@@ -37,6 +37,5 @@ class StopTestTactic : public Tactic
     double calculateRobotCost(const Robot& robot, const World& world) override;
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        IntentCoroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 };

--- a/src/thunderbots/software/test/ai/hl/stp/test_tactics/stop_test_tactic.h
+++ b/src/thunderbots/software/test/ai/hl/stp/test_tactics/stop_test_tactic.h
@@ -38,5 +38,5 @@ class StopTestTactic : public Tactic
 
    private:
     std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+        IntentCoroutine::push_type& yield) override;
 };


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Misc fixes to coroutines
* The return type of coroutine functions is now `void`
* Coroutines now run before extracting their results
* Removed extra yield calls in the coroutine wrapper functions for Tactic and Action
* CMake now builds in Release by default

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests all pass

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
