### PR TITLE
Added a Test For Corner Kick Scenario And Made RatePass Work For It

### DIFF
--- a/src/thunderbots/software/ai/passing/evaluation.cpp
+++ b/src/thunderbots/software/ai/passing/evaluation.cpp
@@ -188,13 +188,15 @@ double AI::Passing::calculateInterceptRisk(Robot enemy_robot, const Pass& pass)
     Duration ball_time_to_pass_receive_position = pass.estimatePassDuration();
 
     Duration time_until_pass = pass.startTime() - enemy_robot.lastUpdateTimestamp();
+    Duration enemy_reaction_time = Duration::fromSeconds(
+        Util::DynamicParameters::AI::Passing::enemy_reaction_time.value());
 
     double robot_ball_time_diff_at_closest_pass_point =
-        (enemy_robot_time_to_closest_pass_point -
+        ((enemy_robot_time_to_closest_pass_point + enemy_reaction_time) -
          (ball_time_to_closest_pass_point + time_until_pass))
             .getSeconds();
     double robot_ball_time_diff_at_pass_receive_point =
-        (enemy_robot_time_to_pass_receive_position -
+        ((enemy_robot_time_to_pass_receive_position + enemy_reaction_time) -
          (ball_time_to_pass_receive_position + time_until_pass))
             .getSeconds();
 

--- a/src/thunderbots/software/test/ai/passing/evaluation.cpp
+++ b/src/thunderbots/software/test/ai/passing/evaluation.cpp
@@ -71,7 +71,7 @@ TEST_F(PassingEvaluationTest, ratePass_enemy_directly_on_pass_trajectory)
 
     double pass_rating = ratePass(world, pass, std::nullopt, std::nullopt);
     EXPECT_GE(pass_rating, 0.0);
-    EXPECT_LE(pass_rating, 0.01);
+    EXPECT_LE(pass_rating, 0.02);
 }
 
 TEST_F(PassingEvaluationTest, ratePass_one_friendly_marked_and_one_friendly_free)
@@ -127,7 +127,7 @@ TEST_F(PassingEvaluationTest, ratePass_only_friendly_marked)
 
     double pass_rating = ratePass(world, pass, std::nullopt, std::nullopt);
     EXPECT_GE(pass_rating, 0.0);
-    EXPECT_LE(pass_rating, 0.01);
+    EXPECT_LE(pass_rating, 0.02);
 }
 
 TEST_F(PassingEvaluationTest, ratePass_cross_over_enemy_goal_defender_somewhat_near_pass)

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -1,5 +1,9 @@
 /**
  * This file contains unit tests for the GradientDescent class
+ *
+ * NOTE: A lot of the testing for the PassGenerator should be done in the `ratePass`
+ *       function, as the PassGenerator essentially just maximizes the value returned
+ *       by `ratePass`
  */
 
 #include "ai/passing/pass_generator.h"

--- a/src/thunderbots/software/test/ai/passing/pass_generator.cpp
+++ b/src/thunderbots/software/test/ai/passing/pass_generator.cpp
@@ -89,7 +89,7 @@ TEST_F(PassGeneratorTest, check_pass_converges)
     });
     world.updateFriendlyTeamState(friendly_team);
     Team enemy_team(Duration::fromSeconds(10));
-    enemy_team.updateRobots({Robot(0, {0.5, 0.5}, {-0.5, 0}, Angle::zero(),
+    enemy_team.updateRobots({Robot(0, {0, 0}, {-0.5, 0}, Angle::zero(),
                                    AngularVelocity::zero(), Timestamp::fromSeconds(0)),
                              Robot(1, {-2, -2}, {-0.5, 0}, Angle::zero(),
                                    AngularVelocity::zero(), Timestamp::fromSeconds(0)),

--- a/src/thunderbots/software/util/parameter/config/ai.yaml
+++ b/src/thunderbots/software/util/parameter/config/ai.yaml
@@ -61,8 +61,8 @@ AI:
       description: "The minimum pass speed (in m/s)"
     max_pass_speed_m_per_s:
       min: 0
-      max: 5
-      default: 4.0
+      max: 10
+      default: 5.0
       type: "double"
       description: "The maximum pass speed (in m/s)"
     min_time_offset_for_pass_seconds:
@@ -83,6 +83,14 @@ AI:
         Maximum time into the future at which the pass should occur. This gives the
         upper bound on the pass start time, relative to the current time. This is in
         seconds.
+    enemy_reaction_time:
+      min: 0
+      max: 3.0
+      default: 0.4
+      type: "double"
+      description: >-
+        How long we think the enemy will take to recognize we're passing and start
+        moving to intercept
     num_passes_to_optimize:
       min: 1
       max: 1000


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Added a test for one-time pass/shot in a corner kick scenario where the robot we're passing to is marked by an enemy

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit test.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
N/A
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
