### PR TITLE
Made coroutine logic more explicit and fixed bugs with null contexts

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/action/action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/action.cpp
@@ -23,12 +23,21 @@ std::unique_ptr<Intent> Action::getNextIntent()
             << "Requesting the next Intent for an Action without a Robot assigned"
             << std::endl;
     }
-    // Run the coroutine and check its status to see if it has any more work to do.
-    else if (intent_sequence())
+    // Check the coroutine status to see if it has any more work to do.
+    else if (intent_sequence)
     {
-        // Extract the result from the coroutine. This will be whatever value was
-        // yielded by the calculateNextIntent function
-        next_intent = intent_sequence.get();
+        // Run the coroutine. This will call the bound calculateNextIntent function
+        intent_sequence();
+
+        // Check if the coroutine is still valid before getting the result. This makes
+        // sure we don't try get the result after "running out the bottom" of the
+        // coroutine function
+        if (intent_sequence)
+        {
+            // Extract the result from the coroutine. This will be whatever value was
+            // yielded by the calculateNextIntent function
+            next_intent = intent_sequence.get();
+        }
     }
 
     return next_intent;

--- a/src/thunderbots/software/ai/hl/stp/play/play.cpp
+++ b/src/thunderbots/software/ai/hl/stp/play/play.cpp
@@ -16,13 +16,22 @@ std::optional<std::vector<std::shared_ptr<Tactic>>> Play::getTactics(const World
     // the getNextTactics function. This is easier than directly passing the World data
     // into the coroutine
     this->world = world;
-    // Run the coroutine and check its status to see if it has any more work to do.
-    if (tactic_sequence())
+    // Check the coroutine status to see if it has any more work to do.
+    if (tactic_sequence)
     {
-        // Extract the result from the coroutine. This will be whatever value was
-        // yielded by the getNextTactics function
-        auto next_tactics = tactic_sequence.get();
-        return std::make_optional(next_tactics);
+        // Run the coroutine. This will call the bound getNextTactics function
+        tactic_sequence();
+
+        // Check if the coroutine is still valid before getting the result. This makes
+        // sure we don't try get the result after "running out the bottom" of the
+        // coroutine function
+        if (tactic_sequence)
+        {
+            // Extract the result from the coroutine. This will be whatever value was
+            // yielded by the getNextTactics function
+            auto next_tactics = tactic_sequence.get();
+            return std::make_optional(next_tactics);
+        }
     }
     // If the coroutine "iterator" is done, the getNextTactics function has completed
     // and has no more work to do. Therefore, the Play is done so wereturn an empty

--- a/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/tactic.cpp
@@ -67,12 +67,21 @@ void Tactic::calculateNextIntentWrapper(IntentCoroutine::push_type &yield)
 std::unique_ptr<Intent> Tactic::getNextIntentHelper()
 {
     std::unique_ptr<Intent> next_intent = nullptr;
-    // Run the coroutine and check its status to see if it has any more work to do.
-    if (intent_sequence())
+    // Check the coroutine status to see if it has any more work to do.
+    if (intent_sequence)
     {
-        // Extract the result from the coroutine. This will be whatever value was
-        // yielded by the calculateNextIntent function
-        next_intent = intent_sequence.get();
+        // Run the coroutine. This will call the bound calculateNextIntent function
+        intent_sequence();
+
+        // Check if the coroutine is still valid before getting the result. This makes
+        // sure we don't try get the result after "running out the bottom" of the
+        // coroutine function
+        if (intent_sequence)
+        {
+            // Extract the result from the coroutine. This will be whatever value was
+            // yielded by the calculateNextIntent function
+            next_intent = intent_sequence.get();
+        }
     }
 
     // The Tactic is considered done once the next_intent becomes a nullptr. This could


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Made coroutine logic more explicit. This also fixes bugs with null coroutine contexts when running plays.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
