### PR TITLE
Add Stop Play

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -661,11 +661,14 @@ if (CATKIN_ENABLE_TESTING)
             ai/evaluation/pass.cpp
             ai/hl/stp/action/action.cpp
             ai/hl/stp/action/move_action.cpp
+            ai/hl/stp/action/stop_action.cpp
             ai/hl/stp/evaluation/calc_best_shot.cpp
             ai/hl/stp/play/example_play.cpp
+            ai/hl/stp/play/stop_play.cpp
             ai/hl/stp/play/play.cpp
             ai/hl/stp/play/play_factory.cpp
             ai/hl/stp/tactic/move_tactic.cpp
+            ai/hl/stp/tactic/stop_tactic.cpp
             ai/hl/stp/tactic/tactic.cpp
             ai/intent/intent.cpp
             ai/intent/move_intent.cpp
@@ -684,6 +687,7 @@ if (CATKIN_ENABLE_TESTING)
             ai/world/world.cpp
             geom/util.cpp
             test/ai/hl/stp/play/example_play.cpp
+            test/ai/hl/stp/play/stop_play.cpp
             test/ai/hl/stp/play/main.cpp
             test/ai/hl/stp/play/play_factory.cpp
             test/ai/hl/stp/test_plays/move_test_play.cpp

--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -605,21 +605,25 @@ if (CATKIN_ENABLE_TESTING)
             ai/hl/stp/action/action.cpp
             ai/hl/stp/action/kick_action.cpp
             ai/hl/stp/action/move_action.cpp
+            ai/hl/stp/action/stop_action.cpp
             ai/hl/stp/evaluation/calc_best_shot.cpp
             ai/hl/stp/tactic/block_shot_path_tactic.cpp
             ai/hl/stp/tactic/cherry_pick_tactic.cpp
             ai/hl/stp/tactic/move_tactic.cpp
             ai/hl/stp/tactic/passer_tactic.cpp
             ai/hl/stp/tactic/receiver_tactic.cpp
+            ai/hl/stp/tactic/stop_tactic.cpp
             ai/hl/stp/tactic/tactic.cpp
             ai/intent/intent.cpp
             ai/intent/kick_intent.cpp
             ai/intent/move_intent.cpp
+            ai/intent/stop_intent.cpp
             ai/passing/evaluation.cpp
             ai/passing/pass.cpp
             ai/passing/pass_generator.cpp
             ai/primitive/kick_primitive.cpp
             ai/primitive/move_primitive.cpp
+            ai/primitive/stop_primitive.cpp
             ai/primitive/primitive.cpp
             ai/world/ball.cpp
             ai/world/field.cpp
@@ -635,6 +639,7 @@ if (CATKIN_ENABLE_TESTING)
             test/ai/hl/stp/tactic/move_tactic.cpp
             test/ai/hl/stp/tactic/passer_tactic.cpp
             test/ai/hl/stp/tactic/receiver_tactic.cpp
+            test/ai/hl/stp/tactic/stop_tactic.cpp
             test/ai/hl/stp/tactic/tactic.cpp
             test/ai/hl/stp/test_tactics/move_test_tactic.cpp
             test/test_util/test_util.cpp

--- a/src/thunderbots/software/ai/hl/stp/action/stop_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/stop_action.cpp
@@ -1,27 +1,25 @@
 #include "ai/hl/stp/action/stop_action.h"
 
 #include "ai/intent/stop_intent.h"
-#include "geom/angle.h"
-#include "geom/util.h"
-#include "shared/constants.h"
 
-StopAction::StopAction() : Action() {}
-
-std::unique_ptr<Intent> StopAction::updateStateAndGetNextIntent(const Robot& robot,
-                                                                bool coast)
+StopAction::StopAction(double stopped_speed_threshold, bool loop_forever)
+        : Action(), stopped_speed_threshold(stopped_speed_threshold), loop_forever(loop_forever)
 {
-    // update the parameters stored by this action
+}
+
+std::unique_ptr<Intent> StopAction::updateStateAndGetNextIntent(const Robot& robot, bool coast)
+{
+    // Update the parameters stored by this action
     this->robot = robot;
     this->coast = coast;
 
     return getNextIntent();
 }
 
-std::unique_ptr<Intent> StopAction::calculateNextIntent(
-    intent_coroutine::push_type& yield)
+void StopAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     do
     {
         yield(std::make_unique<StopIntent>(robot->id(), coast, 0));
-    } while (true);
+    } while (loop_forever || robot->velocity().len() > stopped_speed_threshold);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/stop_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/stop_action.cpp
@@ -3,11 +3,14 @@
 #include "ai/intent/stop_intent.h"
 
 StopAction::StopAction(double stopped_speed_threshold, bool loop_forever)
-        : Action(), stopped_speed_threshold(stopped_speed_threshold), loop_forever(loop_forever)
+    : Action(),
+      stopped_speed_threshold(stopped_speed_threshold),
+      loop_forever(loop_forever)
 {
 }
 
-std::unique_ptr<Intent> StopAction::updateStateAndGetNextIntent(const Robot& robot, bool coast)
+std::unique_ptr<Intent> StopAction::updateStateAndGetNextIntent(const Robot& robot,
+                                                                bool coast)
 {
     // Update the parameters stored by this action
     this->robot = robot;

--- a/src/thunderbots/software/ai/hl/stp/action/stop_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/stop_action.h
@@ -10,26 +10,28 @@
 class StopAction : public Action
 {
    public:
-    // We consider the robot to be stopped when the magnitude of its velocity is less than 5cm / s
-    // When robots are stationary, noise in the camera data can cause its velocity to be non-zero, which
-    // is why we use a non-zero value here.
+    // We consider the robot to be stopped when the magnitude of its velocity is less than
+    // 5cm / s When robots are stationary, noise in the camera data can cause its velocity
+    // to be non-zero, which is why we use a non-zero value here.
     static constexpr double ROBOT_STOPPED_SPEED_THRESHOLD = 0.05;
 
     /**
      * Creates a new StopAction
      *
-     * @param stopped_speed_threshold How slow the robot must be moving before the action is considered done
+     * @param stopped_speed_threshold How slow the robot must be moving before the action
+     * is considered done
      * @param loop_forever Continue yielding new Move Intents, even after we have reached
      *                     our goal
      */
-    explicit StopAction(double stopped_speed_threshold = ROBOT_STOPPED_SPEED_THRESHOLD, bool loop_forever = false);
+    explicit StopAction(double stopped_speed_threshold = ROBOT_STOPPED_SPEED_THRESHOLD,
+                        bool loop_forever              = false);
 
     /**
      * Returns the next Intent this StopAction wants to run, given the parameters.
      *
      * @param robot the robot that should stop
-     * @param coast Whether or not to coast to a stop. If this is false, the robot will try actively brake to come to
-     * a stop
+     * @param coast Whether or not to coast to a stop. If this is false, the robot will
+     * try actively brake to come to a stop
      *
      * @return A unique pointer to the Intent the StopAction wants to run.
      *

--- a/src/thunderbots/software/ai/hl/stp/action/stop_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/stop_action.h
@@ -13,7 +13,7 @@ class StopAction : public Action
     // We consider the robot to be stopped when the magnitude of its velocity is less than
     // 5cm / s When robots are stationary, noise in the camera data can cause its velocity
     // to be non-zero, which is why we use a non-zero value here.
-    static constexpr double ROBOT_STOPPED_SPEED_THRESHOLD = 0.05;
+    static constexpr double ROBOT_STOPPED_SPEED_THRESHOLD_DEFAULT = 0.05;
 
     /**
      * Creates a new StopAction
@@ -23,8 +23,9 @@ class StopAction : public Action
      * @param loop_forever Continue yielding new Move Intents, even after we have reached
      *                     our goal
      */
-    explicit StopAction(double stopped_speed_threshold = ROBOT_STOPPED_SPEED_THRESHOLD,
-                        bool loop_forever              = false);
+    explicit StopAction(
+        double stopped_speed_threshold = ROBOT_STOPPED_SPEED_THRESHOLD_DEFAULT,
+        bool loop_forever              = false);
 
     /**
      * Returns the next Intent this StopAction wants to run, given the parameters.

--- a/src/thunderbots/software/ai/hl/stp/action/stop_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/stop_action.h
@@ -10,16 +10,26 @@
 class StopAction : public Action
 {
    public:
+    // We consider the robot to be stopped when the magnitude of its velocity is less than 5cm / s
+    // When robots are stationary, noise in the camera data can cause its velocity to be non-zero, which
+    // is why we use a non-zero value here.
+    static constexpr double ROBOT_STOPPED_SPEED_THRESHOLD = 0.05;
+
     /**
      * Creates a new StopAction
+     *
+     * @param stopped_speed_threshold How slow the robot must be moving before the action is considered done
+     * @param loop_forever Continue yielding new Move Intents, even after we have reached
+     *                     our goal
      */
-    explicit StopAction();
+    explicit StopAction(double stopped_speed_threshold = ROBOT_STOPPED_SPEED_THRESHOLD, bool loop_forever = false);
 
     /**
      * Returns the next Intent this StopAction wants to run, given the parameters.
      *
      * @param robot the robot that should stop
-     * @param coast coasts if true, false will bring the robot to an abrupt stop
+     * @param coast Whether or not to coast to a stop. If this is false, the robot will try actively brake to come to
+     * a stop
      *
      * @return A unique pointer to the Intent the StopAction wants to run.
      *
@@ -27,9 +37,12 @@ class StopAction : public Action
     std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot, bool coast);
 
    private:
-    std::unique_ptr<Intent> calculateNextIntent(
-        intent_coroutine::push_type& yield) override;
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Action parameters
-    double coast;
+    // Whether or not the robot should coast to a stop
+    bool coast;
+    // The maximum speed the robot may be moving at to be considered stopped
+    double stopped_speed_threshold;
+    bool loop_forever;
 };

--- a/src/thunderbots/software/ai/hl/stp/play/stop_play.cpp
+++ b/src/thunderbots/software/ai/hl/stp/play/stop_play.cpp
@@ -1,0 +1,55 @@
+#include "ai/hl/stp/play/stop_play.h"
+
+#include "ai/hl/stp/play/play_factory.h"
+#include "ai/hl/stp/tactic/stop_tactic.h"
+
+const std::string StopPlay::name = "Stop Play";
+
+std::string StopPlay::getName() const
+{
+    return StopPlay::name;
+}
+
+bool StopPlay::isApplicable(const World &world) const
+{
+    return false;
+}
+
+bool StopPlay::invariantHolds(const World &world) const
+{
+    return true;
+}
+
+void StopPlay::getNextTactics(TacticCoroutine::push_type &yield)
+{
+    // Create Stop Tactics that will loop forever
+    auto stop_tactic_1 = std::make_shared<StopTactic>(false, true);
+    auto stop_tactic_2 = std::make_shared<StopTactic>(false, true);
+    auto stop_tactic_3 = std::make_shared<StopTactic>(false, true);
+    auto stop_tactic_4 = std::make_shared<StopTactic>(false, true);
+    auto stop_tactic_5 = std::make_shared<StopTactic>(false, true);
+    auto stop_tactic_6 = std::make_shared<StopTactic>(false, true);
+
+    do
+    {
+        stop_tactic_1->updateParams();
+        stop_tactic_2->updateParams();
+        stop_tactic_3->updateParams();
+        stop_tactic_4->updateParams();
+        stop_tactic_5->updateParams();
+        stop_tactic_6->updateParams();
+
+        // yield the Tactics this Play wants to run, in order of priority
+        yield({
+            stop_tactic_1,
+            stop_tactic_2,
+            stop_tactic_3,
+            stop_tactic_4,
+            stop_tactic_5,
+            stop_tactic_6
+        });
+    } while (true);
+}
+
+// Register this play in the PlayFactory
+static TPlayFactory<StopPlay> factory;

--- a/src/thunderbots/software/ai/hl/stp/play/stop_play.cpp
+++ b/src/thunderbots/software/ai/hl/stp/play/stop_play.cpp
@@ -40,14 +40,8 @@ void StopPlay::getNextTactics(TacticCoroutine::push_type &yield)
         stop_tactic_6->updateParams();
 
         // yield the Tactics this Play wants to run, in order of priority
-        yield({
-            stop_tactic_1,
-            stop_tactic_2,
-            stop_tactic_3,
-            stop_tactic_4,
-            stop_tactic_5,
-            stop_tactic_6
-        });
+        yield({stop_tactic_1, stop_tactic_2, stop_tactic_3, stop_tactic_4, stop_tactic_5,
+               stop_tactic_6});
     } while (true);
 }
 

--- a/src/thunderbots/software/ai/hl/stp/play/stop_play.h
+++ b/src/thunderbots/software/ai/hl/stp/play/stop_play.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "ai/hl/stp/play/play.h"
+
+/**
+ * A Play that stops all the robots on the field. This is primarily used to obey the
+ * referee "Halt" command, as well as a fallback for when we don't have a play assigned.
+ */
+class StopPlay : public Play
+{
+   public:
+    static const std::string name;
+
+    StopPlay() = default;
+
+    std::string getName() const override;
+
+    bool isApplicable(const World &world) const override;
+
+    bool invariantHolds(const World &world) const override;
+
+    void getNextTactics(TacticCoroutine::push_type &yield) override;
+};

--- a/src/thunderbots/software/ai/hl/stp/tactic/stop_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/stop_tactic.cpp
@@ -26,7 +26,8 @@ double StopTactic::calculateRobotCost(const Robot &robot, const World &world)
 
 void StopTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
 {
-    StopAction stop_action = StopAction(StopAction::ROBOT_STOPPED_SPEED_THRESHOLD, false);
+    StopAction stop_action =
+        StopAction(StopAction::ROBOT_STOPPED_SPEED_THRESHOLD_DEFAULT, false);
     do
     {
         yield(stop_action.updateStateAndGetNextIntent(*robot, this->coast));

--- a/src/thunderbots/software/ai/hl/stp/tactic/stop_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/stop_tactic.cpp
@@ -4,7 +4,9 @@
 
 #include "ai/hl/stp/action/stop_action.h"
 
-StopTactic::StopTactic(bool coast, bool loop_forever) : coast(coast), Tactic(loop_forever) {}
+StopTactic::StopTactic(bool coast, bool loop_forever) : coast(coast), Tactic(loop_forever)
+{
+}
 
 std::string StopTactic::getName() const
 {

--- a/src/thunderbots/software/ai/hl/stp/tactic/stop_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/stop_tactic.cpp
@@ -1,0 +1,32 @@
+#include "ai/hl/stp/tactic/stop_tactic.h"
+
+#include <algorithm>
+
+#include "ai/hl/stp/action/stop_action.h"
+
+StopTactic::StopTactic(bool coast, bool loop_forever) : coast(coast), Tactic(loop_forever) {}
+
+std::string StopTactic::getName() const
+{
+    return "Stop Tactic";
+}
+
+void StopTactic::updateParams()
+{
+    // The Stop Tactic has no parameters to update
+}
+
+double StopTactic::calculateRobotCost(const Robot &robot, const World &world)
+{
+    // Prefer all robots equally
+    return 0.5;
+}
+
+void StopTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
+{
+    StopAction stop_action = StopAction(StopAction::ROBOT_STOPPED_SPEED_THRESHOLD, false);
+    do
+    {
+        yield(stop_action.updateStateAndGetNextIntent(*robot, this->coast));
+    } while (!stop_action.done());
+}

--- a/src/thunderbots/software/ai/hl/stp/tactic/stop_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/stop_tactic.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "ai/hl/stp/action/move_action.h"
+#include "ai/hl/stp/tactic/tactic.h"
+
+/**
+ * The StopTactic will stop the robot from moving. The robot will actively try and brake to come to a halt unless
+ * is it told to coast, in which case it will coast to a stop.
+ */
+class StopTactic : public Tactic
+{
+   public:
+    /**
+     * Creates a new StopTactic
+     t
+     * @param loop_forever Whether or not this Tactic should never complete. If true, the
+     * tactic will be restarted every time it completes
+     */
+    explicit StopTactic(bool coast, bool loop_forever = false);
+
+    std::string getName() const override;
+
+    /**
+     * Updates the parameters for this StopTactic.
+     */
+    void updateParams();
+
+    /**
+     * Calculates the cost of assigning the given robot to this Tactic. Prefers all robots equally
+     *
+     * @param robot The robot to evaluate the cost for
+     * @param world The state of the world with which to perform the evaluation
+     * @return A cost in the range [0,1] indicating the cost of assigning the given robot
+     * to this tactic. Lower cost values indicate a more preferred robot.
+     */
+    double calculateRobotCost(const Robot& robot, const World& world) override;
+
+   private:
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
+
+    // Tactic parameters
+    // Whether or not the robot should coast to a stop
+    bool coast;
+};

--- a/src/thunderbots/software/ai/hl/stp/tactic/stop_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/stop_tactic.h
@@ -4,8 +4,8 @@
 #include "ai/hl/stp/tactic/tactic.h"
 
 /**
- * The StopTactic will stop the robot from moving. The robot will actively try and brake to come to a halt unless
- * is it told to coast, in which case it will coast to a stop.
+ * The StopTactic will stop the robot from moving. The robot will actively try and brake
+ * to come to a halt unless is it told to coast, in which case it will coast to a stop.
  */
 class StopTactic : public Tactic
 {
@@ -26,7 +26,8 @@ class StopTactic : public Tactic
     void updateParams();
 
     /**
-     * Calculates the cost of assigning the given robot to this Tactic. Prefers all robots equally
+     * Calculates the cost of assigning the given robot to this Tactic. Prefers all robots
+     * equally
      *
      * @param robot The robot to evaluate the cost for
      * @param world The state of the world with which to perform the evaluation

--- a/src/thunderbots/software/ai/passing/evaluation.cpp
+++ b/src/thunderbots/software/ai/passing/evaluation.cpp
@@ -187,7 +187,7 @@ double AI::Passing::calculateInterceptRisk(Robot enemy_robot, const Pass& pass)
         ENEMY_ROBOT_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED, ROBOT_MAX_RADIUS_METERS);
     Duration ball_time_to_pass_receive_position = pass.estimatePassDuration();
 
-    Duration time_until_pass = pass.startTime() - enemy_robot.lastUpdateTimestamp();
+    Duration time_until_pass     = pass.startTime() - enemy_robot.lastUpdateTimestamp();
     Duration enemy_reaction_time = Duration::fromSeconds(
         Util::DynamicParameters::AI::Passing::enemy_reaction_time.value());
 

--- a/src/thunderbots/software/test/ai/hl/stp/action/stop_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/stop_action.cpp
@@ -5,12 +5,11 @@
 #include "ai/intent/stop_intent.h"
 
 
-// StopAction should be yeilding stop_intents without coast
-TEST(StopAction, stop_action_with_coast)
+TEST(StopActionTest, robot_stopping_without_coasting_while_already_moving)
 {
-    Robot robot       = Robot(0, Point(10, 10), Vector(), Angle::zero(),
+    Robot robot       = Robot(0, Point(10, 10), Vector(1, 3), Angle::zero(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    StopAction action = StopAction();
+    StopAction action = StopAction(0.05, false);
 
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, false);
 
@@ -29,26 +28,17 @@ TEST(StopAction, stop_action_with_coast)
     }
 }
 
-// StopAction should be yeilding stop_intents with coast
-TEST(StopAction, stop_action_coast)
+TEST(StopAction, robot_stopping_while_already_stopped)
 {
     Robot robot       = Robot(0, Point(10, 10), Vector(), Angle::zero(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    StopAction action = StopAction();
+    StopAction action = StopAction(0.05, false);
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, true);
+    // We call the action twice. The first time the Intent will always be returned to
+    // ensure the Robot is doing the right thing. In all future calls, the action will be
+    // done and so will return a null pointer
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, false);
+    intent_ptr = action.updateStateAndGetNextIntent(robot, false);
 
-    // Check an intent was returned (the pointer is not null)
-    EXPECT_TRUE(intent_ptr);
-    EXPECT_FALSE(action.done());
-
-    try
-    {
-        StopIntent stop_intent = dynamic_cast<StopIntent &>(*intent_ptr);
-        EXPECT_EQ(0, stop_intent.getRobotId());
-    }
-    catch (...)
-    {
-        ADD_FAILURE() << "StopIntent was not returned by the StopAction!";
-    }
+    EXPECT_TRUE(action.done());
 }

--- a/src/thunderbots/software/test/ai/hl/stp/action/stop_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/stop_action.cpp
@@ -38,7 +38,7 @@ TEST(StopAction, robot_stopping_while_already_stopped)
     // ensure the Robot is doing the right thing. In all future calls, the action will be
     // done and so will return a null pointer
     auto intent_ptr = action.updateStateAndGetNextIntent(robot, false);
-    intent_ptr = action.updateStateAndGetNextIntent(robot, false);
+    intent_ptr      = action.updateStateAndGetNextIntent(robot, false);
 
     EXPECT_TRUE(action.done());
 }

--- a/src/thunderbots/software/test/ai/hl/stp/play/stop_play.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/play/stop_play.cpp
@@ -1,0 +1,41 @@
+#include "ai/hl/stp/play/stop_play.h"
+
+#include <gtest/gtest.h>
+
+#include "ai/hl/stp/tactic/stop_tactic.h"
+#include "test/test_util/test_util.h"
+
+TEST(StopPlayTest, test_example_play_invariant_always_holds)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+
+    StopPlay example_play;
+    EXPECT_TRUE(example_play.invariantHolds(world));
+}
+
+TEST(StopPlayTest, test_stop_play_returns_correct_tactics)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+
+    StopPlay example_play;
+    auto tactics = example_play.getTactics(world);
+
+    // Make sure something was returned
+    EXPECT_TRUE(tactics);
+
+    // Make sure the expected number of tactics was returned
+    EXPECT_EQ((*tactics).size(), 6);
+
+    // Make sure each tactic is an ExampleTactic
+    for (const auto& t : *tactics)
+    {
+        try
+        {
+            dynamic_cast<StopTactic*>(t.get());
+        }
+        catch (...)
+        {
+            ADD_FAILURE() << "StopTactic was not returned by the StopPlay!";
+        }
+    }
+}

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/stop_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/stop_tactic.cpp
@@ -5,9 +5,10 @@
 #include "ai/intent/stop_intent.h"
 #include "test/test_util/test_util.h"
 
-TEST(StopTacticTest, robot_stopping_without_coasting_while_already_moving) {
+TEST(StopTacticTest, robot_stopping_without_coasting_while_already_moving)
+{
     Robot robot       = Robot(0, Point(0, 0), Vector(2, -1), Angle::zero(),
-                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     StopTactic tactic = StopTactic(false, false);
     tactic.updateRobot(robot);
     tactic.updateParams();
@@ -29,9 +30,10 @@ TEST(StopTacticTest, robot_stopping_without_coasting_while_already_moving) {
     }
 }
 
-TEST(StopTacticTest, robot_stopping_while_already_stopped) {
+TEST(StopTacticTest, robot_stopping_while_already_stopped)
+{
     Robot robot       = Robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
-                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     StopTactic tactic = StopTactic(false, false);
     tactic.updateRobot(robot);
     tactic.updateParams();
@@ -64,6 +66,7 @@ TEST(StopTacticTest, test_calculate_robot_cost)
     StopTactic tactic = StopTactic(false, false);
     tactic.updateParams();
 
-    // We always expect the cost to be 0.5, because the StopTactic prefers all robots equally
+    // We always expect the cost to be 0.5, because the StopTactic prefers all robots
+    // equally
     EXPECT_EQ(0.5, tactic.calculateRobotCost(robot, world));
 }

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/stop_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/stop_tactic.cpp
@@ -1,0 +1,69 @@
+#include "ai/hl/stp/tactic/stop_tactic.h"
+
+#include <gtest/gtest.h>
+
+#include "ai/intent/stop_intent.h"
+#include "test/test_util/test_util.h"
+
+TEST(StopTacticTest, robot_stopping_without_coasting_while_already_moving) {
+    Robot robot       = Robot(0, Point(0, 0), Vector(2, -1), Angle::zero(),
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    StopTactic tactic = StopTactic(false, false);
+    tactic.updateRobot(robot);
+    tactic.updateParams();
+
+    auto intent_ptr = tactic.getNextIntent();
+
+    // Check an intent was returned (the pointer is not null)
+    ASSERT_TRUE(intent_ptr);
+    EXPECT_FALSE(tactic.done());
+
+    try
+    {
+        StopIntent stop_intent = dynamic_cast<StopIntent &>(*intent_ptr);
+        EXPECT_EQ(0, stop_intent.getRobotId());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "StopIntent was not returned by the StopTactic!";
+    }
+}
+
+TEST(StopTacticTest, robot_stopping_while_already_stopped) {
+    Robot robot       = Robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    StopTactic tactic = StopTactic(false, false);
+    tactic.updateRobot(robot);
+    tactic.updateParams();
+
+    auto intent_ptr = tactic.getNextIntent();
+
+    // Check an intent was returned (the pointer is not null)
+    ASSERT_TRUE(intent_ptr);
+    EXPECT_FALSE(tactic.done());
+
+    try
+    {
+        StopIntent stop_intent = dynamic_cast<StopIntent &>(*intent_ptr);
+        EXPECT_EQ(0, stop_intent.getRobotId());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "StopIntent was not returned by the StopTactic!";
+    }
+}
+
+TEST(StopTacticTest, test_calculate_robot_cost)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    world.updateFieldGeometry(::Test::TestUtil::createSSLDivBField());
+
+    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+
+    StopTactic tactic = StopTactic(false, false);
+    tactic.updateParams();
+
+    // We always expect the cost to be 0.5, because the StopTactic prefers all robots equally
+    EXPECT_EQ(0.5, tactic.calculateRobotCost(robot, world));
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Added the Stop Play. This Play stops all the robots on the field.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests, and manually verified it works in grsim.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #458 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
