### PR TITLE
make a bigger and better polygon contains point test and fix bugs it …

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
@@ -34,10 +34,10 @@ std::unique_ptr<Intent> ChipAction::updateStateAndGetNextIntent(
 void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     // How large the triangle is that defines the region where the robot is
-    // behind the ball and ready to kick.
-    // We want to keep the region small enough that we won't use the KickIntent from too
-    // far away (since the KickIntent doesn't avoid obstacles and we risk colliding
-    // with something), but large enough we can reasonably get in the region and kick the
+    // behind the ball and ready to chip.
+    // We want to keep the region small enough that we won't use the ChipIntent from too
+    // far away (since the ChipIntent doesn't avoid obstacles and we risk colliding
+    // with something), but large enough we can reasonably get in the region and chip the
     // ball successfully.
     // This value is 'X' in the ASCII art below
     double size_of_region_behind_ball = 4 * ROBOT_MAX_RADIUS_METERS;
@@ -65,11 +65,11 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     //
     //                             |
     //                             V
-    //                     direction of kick
+    //                     direction of chip
 
     do
     {
-        // A vector in the direction opposite the kick (behind the ball)
+        // A vector in the direction opposite the chip (behind the ball)
         Vector behind_ball =
             Vector::createFromAngle(this->chip_direction + Angle::half());
 
@@ -79,7 +79,7 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         // in the ASCII diagram
 
         // We make the region close enough to the ball so that the robot will still be
-        // inside it when taking the kick.
+        // inside it when taking the chip.
         Point behind_ball_vertex_A = chip_origin;
         Point behind_ball_vertex_B =
             behind_ball_vertex_A + behind_ball.norm(size_of_region_behind_ball) +
@@ -96,7 +96,7 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         Point point_behind_ball =
             chip_origin + behind_ball.norm(size_of_region_behind_ball * 3 / 4);
 
-        // If we're not in position to kick, move into position
+        // If we're not in position to chip, move into position
         if (!robot_behind_ball)
         {
             yield(std::make_unique<MoveIntent>(robot->id(), point_behind_ball,

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
@@ -55,9 +55,8 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     //                 X |      \     /
     //                   |       \   /
     //                   |        \ /
-    //                   >         A
-    //             ball ->         O
-    //
+    //    The ball is    >         A
+    //    at A
     //                             |
     //                             V
     //                     direction of chip

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.cpp
@@ -55,13 +55,8 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     //                 X |      \     /
     //                   |       \   /
     //                   |        \ /
-    //                   >         A       <
-    //                                     |
-    //                                     | 0 dist (Point A is where the ball is)
-    //                                     |
-    //                             O       |
-    //             ball ->        O O      <
-    //                             O
+    //                   >         A
+    //             ball ->         O
     //
     //                             |
     //                             V

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ai/hl/stp/action/action.h"
+#include "ai/world/ball.h"
 #include "geom/angle.h"
 #include "geom/point.h"
 
@@ -20,6 +21,7 @@ class ChipAction : public Action
      * Returns the next Intent this ChipAction wants to run, given the parameters.
      *
      * @param robot The robot that should perform the chip
+     * @param ball The ball being kicked
      * @param chip_origin The location where the chip will be taken
      * @param chip_direction The direction the Robot will chip in
      * @param chip_distance_meters The distance between the starting location
@@ -29,6 +31,7 @@ class ChipAction : public Action
      * ChipAction is done, returns an empty/null pointer
      */
     std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot,
+                                                        const Ball& ball,
                                                         Point chip_origin,
                                                         Angle chip_direction,
                                                         double chip_distance_meters);
@@ -37,6 +40,7 @@ class ChipAction : public Action
      * Returns the next Intent this ChipAction wants to run, given the parameters.
      *
      * @param robot The robot that should perform the chip
+     * @param ball The ball being kicked
      * @param chip_origin The location where the chip will be taken
      * @param chip_target The target to chip at
      * @param chip_distance_meters The distance between the starting location
@@ -46,6 +50,7 @@ class ChipAction : public Action
      * ChipAction is done, returns an empty/null pointer
      */
     std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot,
+                                                        const Ball& ball,
                                                         Point chip_origin,
                                                         Point chip_target,
                                                         double chip_distance_meters);
@@ -54,6 +59,7 @@ class ChipAction : public Action
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;
 
     // Action parameters
+    Ball ball;
     Point chip_origin;
     Angle chip_direction;
     double chip_distance_meters;

--- a/src/thunderbots/software/ai/hl/stp/action/chip_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/chip_action.h
@@ -39,6 +39,13 @@ class ChipAction : public Action
     /**
      * Returns the next Intent this ChipAction wants to run, given the parameters.
      *
+     * The ball and chip origin are given separately so that we can line up chips where
+     * the ball isn't present yet. For example, specifying where a chip will take place
+     * where the robot will meet the ball as it's moving. We need to be able to specify
+     * where the chip will take place even if the ball isn't there yet, which is why the
+     * chip_origin is separate. The ball is used for other calculations, such as when
+     * the ball has been chipped and the action is done.
+     *
      * @param robot The robot that should perform the chip
      * @param ball The ball being kicked
      * @param chip_origin The location where the chip will be taken

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -57,9 +57,8 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
     //                 X |      \     /
     //                   |       \   /
     //                   |        \ /
-    //                   >         A
-    //             ball ->         O
-    //
+    //    The ball is    >         A
+    //    at A
     //                             |
     //                             V
     //                     direction of kick

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -57,13 +57,8 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
     //                 X |      \     /
     //                   |       \   /
     //                   |        \ /
-    //                   >         A       <
-    //                                     |
-    //                                     | 0 dist (Point A is where the ball is)
-    //                                     |
-    //                             O       |
-    //             ball ->        O O      <
-    //                             O
+    //                   >         A
+    //             ball ->         O
     //
     //                             |
     //                             V

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.cpp
@@ -59,7 +59,7 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
     //                   |        \ /
     //                   >         A       <
     //                                     |
-    //                                     | DIST_TO_FRONT_OF_ROBOT / 2
+    //                                     | 0 dist (Point A is where the ball is)
     //                                     |
     //                             O       |
     //             ball ->        O O      <
@@ -96,9 +96,8 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
         bool robot_behind_ball = behind_ball_region.containsPoint(robot->position());
         // The point in the middle of the region behind the ball
         Point point_behind_ball =
-            kick_origin + behind_ball.norm(DIST_TO_FRONT_OF_ROBOT_METERS * 1 +
-                                           size_of_region_behind_ball / 2);
-        //
+            kick_origin + behind_ball.norm(size_of_region_behind_ball * 3 / 4);
+
         // If we're not in position to kick, move into position
         if (!robot_behind_ball)
         {
@@ -110,6 +109,5 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
             yield(std::make_unique<KickIntent>(robot->id(), kick_origin, kick_direction,
                                                kick_speed_meters_per_second, 0));
         }
-
     } while (true);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -37,6 +37,7 @@ class KickAction : public Action
      * Returns the next Intent this KickAction wants to run, given the parameters.
      *
      * @param robot The robot that should perform the kick
+     * @param ball The ball being kicked
      * @param kick_origin The location where the kick will be taken
      * @param kick_target The target to kick at
      * @param kick_speed_meters_per_second The speed of how fast the Robot

--- a/src/thunderbots/software/ai/hl/stp/action/kick_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/kick_action.h
@@ -36,6 +36,13 @@ class KickAction : public Action
     /**
      * Returns the next Intent this KickAction wants to run, given the parameters.
      *
+     * The ball and kick origin are given separately so that we can line up kicks where
+     * the ball isn't present yet. For example, specifying where a kick will take place
+     * where the robot will meet the ball as it's moving. We need to be able to specify
+     * where the kick will take place even if the ball isn't there yet, which is why the
+     * kick_origin is separate. The ball is used for other calculations, such as when
+     * the ball has been kicked and the action is done.
+     *
      * @param robot The robot that should perform the kick
      * @param ball The ball being kicked
      * @param kick_origin The location where the kick will be taken

--- a/src/thunderbots/software/geom/polygon.cpp
+++ b/src/thunderbots/software/geom/polygon.cpp
@@ -31,7 +31,7 @@ Polygon::Polygon(const std::initializer_list<Point>& _points)
 bool Polygon::containsPoint(const Point& point) const
 {
     // cast a ray from the point in the +x direction
-    Ray ray(point, point + Point(1, 0));
+    Ray ray(point, Point(1, 0));
     unsigned int num_intersections = 0;
     for (const Segment& seg : segments)
     {

--- a/src/thunderbots/software/geom/polygon.cpp
+++ b/src/thunderbots/software/geom/polygon.cpp
@@ -30,24 +30,37 @@ Polygon::Polygon(const std::initializer_list<Point>& _points)
 
 bool Polygon::containsPoint(const Point& point) const
 {
-    // cast a ray from the point in the +x direction
-    Ray ray(point, Point(1, 0));
-    unsigned int num_intersections = 0;
-    for (const Segment& seg : segments)
+    // This algorithm is from https://stackoverflow.com/a/16391873
+    // but does not include the bounding boxes.
+    //
+    // A quick description of the algorithm (also from the same post) is as follows:
+    // "I run a semi-infinite ray horizontally (increasing x, fixed y) out from the test
+    // point, and count how many edges it crosses. At each crossing, the ray switches
+    // between inside and outside. This is called the Jordan curve theorem."
+    //
+    // NOTE: This algorithm will treat boundaries on the bottom-left of the polygon
+    // different from the boundaries on the top-right of the polygon. This small
+    // inconsistency does not matter for our use cases, and actually has the benefit that
+    // should two distinct polygons share an edge, any point along this edge will be
+    // located in one and only one polygon.
+    bool point_is_contained = false;
+    int i                   = 0;
+    int j                   = points.size() - 1;
+    while (i < points.size())
     {
-        // one-definition rule, use anonymous namespace for
-        // intersects() in geom/util.h
-        if (::intersects(ray, seg))
+        if (((points.at(i).y() > point.y()) != (points.at(j).y() > point.y())) &&
+            (point.x() < (points.at(j).x() - points.at(i).x()) *
+                                 (point.y() - points.at(i).y()) /
+                                 (points.at(j).y() - points.at(i).y()) +
+                             points.at(i).x()))
         {
-            num_intersections++;
+            point_is_contained = !point_is_contained;
         }
+
+        j = i++;
     }
 
-    // if the ray intersects the polygon an odd number of times,
-    // it is inside the polygon, otherwise it is outside the polygon
-    // see
-    // https://stackoverflow.com/questions/217578/how-can-i-determine-whether-a-2d-point-is-within-a-polygon
-    return num_intersections % 2 != 0;
+    return point_is_contained;
 }
 
 bool Polygon::intersects(const Segment& segment) const

--- a/src/thunderbots/software/geom/util.cpp
+++ b/src/thunderbots/software/geom/util.cpp
@@ -176,8 +176,8 @@ bool contains(const Segment &out, const Point &in)
     {
         // If the segment and point are in a perfect vertical line, we must use Y
         // coordinate centric logic
-        if ((in.x() - out.getEnd().x() == 0) &&
-            (out.getEnd().x() - out.getSegStart().x() == 0))
+        if ((std::abs(in.x() - out.getEnd().x()) < EPS) &&
+            (std::abs(out.getEnd().x() - out.getSegStart().x()) < EPS))
         {
             // if collinear we only need to check one of the coordinates,
             // in this case we select Y because all X values are equal
@@ -198,7 +198,7 @@ bool contains(const Ray &out, const Point &in)
 {
     Point point_in_ray_direction = out.getRayStart() + out.getDirection();
     if (collinear(in, out.getRayStart(), point_in_ray_direction) &&
-        (in - out.getRayStart()).norm() == out.getDirection().norm())
+        (((in - out.getRayStart()).norm() - out.getDirection().norm()).len() < EPS))
     {
         return true;
     }

--- a/src/thunderbots/software/test/ai/hl/stp/action/chip_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/chip_action.cpp
@@ -7,164 +7,228 @@
 
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_positive_y)
 {
-    Robot robot       = Robot(0, Point(-0.5, 0), Vector(), Angle::zero(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(-0.3, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
-    auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
+                                                         Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    ChipIntent chip_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
-    EXPECT_EQ(0, chip_intent.getRobotId());
-    EXPECT_EQ(Point(0, 0), chip_intent.getChipOrigin());
-    EXPECT_EQ(Angle::zero(), chip_intent.getChipDirection());
-    EXPECT_EQ(5.0, chip_intent.getChipDistance());
+    try
+    {
+        ChipIntent kick_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
+        EXPECT_EQ(0, kick_intent.getRobotId());
+        EXPECT_EQ(Point(0, 0), kick_intent.getChipOrigin());
+        EXPECT_EQ(Angle::zero(), kick_intent.getChipDirection());
+        EXPECT_EQ(5.0, kick_intent.getChipDistance());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Chip intent not returned by Chip Action!";
+    }
 }
 
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_positive_y)
 {
-    Robot robot       = Robot(0, Point(-2.3, 2.1), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(-2.4, 2.3), Vector(), Angle::quarter(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({-2.5, 2.5}, robot.position(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(105), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    ChipIntent chip_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
-    EXPECT_EQ(0, chip_intent.getRobotId());
-    EXPECT_EQ(Point(-2.5, 2.5), chip_intent.getChipOrigin());
-    EXPECT_EQ(Angle::ofDegrees(105), chip_intent.getChipDirection());
-    EXPECT_EQ(5.0, chip_intent.getChipDistance());
+    try
+    {
+        ChipIntent kick_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
+        EXPECT_EQ(0, kick_intent.getRobotId());
+        EXPECT_EQ(Point(-2.5, 2.5), kick_intent.getChipOrigin());
+        EXPECT_EQ(Angle::ofDegrees(105), kick_intent.getChipDirection());
+        EXPECT_EQ(5.0, kick_intent.getChipDistance());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Chip intent not returned by Chip Action!";
+    }
 }
 
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_negative_x_negative_y)
 {
-    Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(0, 0), Vector(), Angle::quarter(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({-0.05, -0.2}, robot.position(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-0.1, -0.4),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(255), 3.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    ChipIntent chip_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
-    EXPECT_EQ(0, chip_intent.getRobotId());
-    EXPECT_EQ(Point(-0.1, -0.4), chip_intent.getChipOrigin());
-    EXPECT_EQ(Angle::ofDegrees(255), chip_intent.getChipDirection());
-    EXPECT_EQ(3.0, chip_intent.getChipDistance());
+    try
+    {
+        ChipIntent kick_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
+        EXPECT_EQ(0, kick_intent.getRobotId());
+        EXPECT_EQ(Point(-0.05, -0.2), kick_intent.getChipOrigin());
+        EXPECT_EQ(Angle::ofDegrees(255), kick_intent.getChipDirection());
+        EXPECT_EQ(3.0, kick_intent.getChipDistance());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Chip intent not returned by Chip Action!";
+    }
 }
 
 TEST(ChipActionTest, robot_behind_ball_chipping_towards_positive_x_negative_y)
 {
-    Robot robot       = Robot(0, Point(-0.25, 0.5), Vector(), Angle::threeQuarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(-0.125, 0.25), Vector(), Angle::threeQuarter(),
+                AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(306), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    ChipIntent chip_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
-    EXPECT_EQ(0, chip_intent.getRobotId());
-    EXPECT_EQ(Point(0, 0), chip_intent.getChipOrigin());
-    EXPECT_EQ(Angle::ofDegrees(306), chip_intent.getChipDirection());
-    EXPECT_EQ(5.0, chip_intent.getChipDistance());
+    try
+    {
+        ChipIntent kick_intent = dynamic_cast<ChipIntent &>(*intent_ptr);
+        EXPECT_EQ(0, kick_intent.getRobotId());
+        EXPECT_EQ(Point(0, 0), kick_intent.getChipOrigin());
+        EXPECT_EQ(Angle::ofDegrees(306), kick_intent.getChipDirection());
+        EXPECT_EQ(5.0, kick_intent.getChipDistance());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Chip intent not returned by Chip Action!";
+    }
 }
 
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_positive_y)
 {
-    Robot robot       = Robot(0, Point(-1, 0.0), Vector(), Angle::zero(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(-1, 0.0), Vector(), Angle::zero(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
-    auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 5.0);
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
+                                                         Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-    EXPECT_EQ(0, move_intent.getRobotId());
-    // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.28, 0), 0.1));
-    EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
-    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_EQ(0, move_intent.getRobotId());
+        // Check the MoveIntent is moving roughly behind the ball
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.18, 0), 0.1));
+        EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
+        EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Move intent not returned by Chip Action!";
+    }
 }
 
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_positive_y)
 {
-    Robot robot       = Robot(0, Point(-2, 5), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(-2, 5), Vector(), Angle::quarter(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({-2.5, 2.5}, robot.position(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-2.5, 2.5),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(105), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-    EXPECT_EQ(0, move_intent.getRobotId());
-    // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-2.45, 2.25), 0.1));
-    EXPECT_EQ(Angle::ofDegrees(105), move_intent.getFinalAngle());
-    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_EQ(0, move_intent.getRobotId());
+        // Check the MoveIntent is moving roughly behind the ball
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(-2.45, 2.25), 0.1));
+        EXPECT_EQ(Angle::ofDegrees(105), move_intent.getFinalAngle());
+        EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Move intent not returned by Chip Action!";
+    }
 }
 
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_negative_x_negative_y)
 {
-    Robot robot       = Robot(0, Point(0, 0), Vector(), Angle::quarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(0, 0), Vector(), Angle::quarter(), AngularVelocity::zero(),
+                Timestamp::fromSeconds(0));
+    Ball ball({-1, -4}, robot.position(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(-1, -4),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(255), 3.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-    EXPECT_EQ(0, move_intent.getRobotId());
-    // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.85, -3.75), 0.1));
-    EXPECT_EQ(Angle::ofDegrees(255), move_intent.getFinalAngle());
-    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_EQ(0, move_intent.getRobotId());
+        // Check the MoveIntent is moving roughly behind the ball
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.85, -3.75), 0.1));
+        EXPECT_EQ(Angle::ofDegrees(255), move_intent.getFinalAngle());
+        EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Move intent not returned by Chip Action!";
+    }
 }
 
 TEST(ChipActionTest, robot_not_behind_ball_chipping_towards_positive_x_negative_y)
 {
-    Robot robot       = Robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
-                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot robot(0, Point(0.5, 1), Vector(), Angle::threeQuarter(),
+                AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     ChipAction action = ChipAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, Point(0, 0),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(306), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
 
-    MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-    EXPECT_EQ(0, move_intent.getRobotId());
-    // Check the MoveIntent is moving roughly behind the ball
-    EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0.25), 0.1));
-    EXPECT_EQ(Angle::ofDegrees(306), move_intent.getFinalAngle());
-    EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_EQ(0, move_intent.getRobotId());
+        // Check the MoveIntent is moving roughly behind the ball
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.15, 0.25), 0.1));
+        EXPECT_EQ(Angle::ofDegrees(306), move_intent.getFinalAngle());
+        EXPECT_EQ(0.0, move_intent.getFinalSpeed());
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "Move intent not returned by Chip Action!";
+    }
 }

--- a/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/kick_action.cpp
@@ -7,13 +7,13 @@
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
 {
-    Robot robot(0, Point(-0.5, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
+    Robot robot(0, Point(-0.3, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
                 Timestamp::fromSeconds(0));
     Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, ball, Point(0, 0), Angle::zero(), 5.0);
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
+                                                         Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -35,12 +35,12 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_positive_y)
 
 TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_positive_y)
 {
-    Robot robot(0, Point(-2.3, 2.1), Vector(), Angle::quarter(), AngularVelocity::zero(),
+    Robot robot(0, Point(-2.4, 2.3), Vector(), Angle::quarter(), AngularVelocity::zero(),
                 Timestamp::fromSeconds(0));
-    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
+    Ball ball({-2.5, 2.5}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-2.5, 2.5),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(105), 5.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -65,10 +65,10 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_negative_x_negative_y)
 {
     Robot robot(0, Point(0, 0), Vector(), Angle::quarter(), AngularVelocity::zero(),
                 Timestamp::fromSeconds(0));
-    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
+    Ball ball({-0.05, -0.2}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-0.05, -0.2),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(255), 3.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -96,7 +96,7 @@ TEST(KickActionTest, robot_behind_ball_kicking_towards_positive_x_negative_y)
     Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(306), 5.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -124,8 +124,8 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y
     Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, ball, Point(0, 0), Angle::zero(), 5.0);
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
+                                                         Angle::zero(), 5.0);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -136,7 +136,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_positive_y
         MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
         EXPECT_EQ(0, move_intent.getRobotId());
         // Check the MoveIntent is moving roughly behind the ball
-        EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.28, 0), 0.1));
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(-0.18, 0), 0.1));
         EXPECT_EQ(Angle::zero(), move_intent.getFinalAngle());
         EXPECT_EQ(0.0, move_intent.getFinalSpeed());
     }
@@ -150,10 +150,10 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_positive_y
 {
     Robot robot(0, Point(-2, 5), Vector(), Angle::quarter(), AngularVelocity::zero(),
                 Timestamp::fromSeconds(0));
-    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
+    Ball ball({-2.5, 2.5}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-2.5, 2.5),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(105), 5.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -179,10 +179,10 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_negative_x_negative_y
 {
     Robot robot(0, Point(0, 0), Vector(), Angle::quarter(), AngularVelocity::zero(),
                 Timestamp::fromSeconds(0));
-    Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
+    Ball ball({-1, -4}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(-1, -4),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(255), 3.0);
 
     // Check an intent was returned (the pointer is not null)
@@ -211,7 +211,7 @@ TEST(KickActionTest, robot_not_behind_ball_kicking_towards_positive_x_negative_y
     Ball ball({0, 0}, robot.position(), Timestamp::fromSeconds(0));
     KickAction action = KickAction();
 
-    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, Point(0, 0),
+    auto intent_ptr = action.updateStateAndGetNextIntent(robot, ball, ball.position(),
                                                          Angle::ofDegrees(306), 5.0);
 
     // Check an intent was returned (the pointer is not null)

--- a/src/thunderbots/software/test/geom/polygon.cpp
+++ b/src/thunderbots/software/test/geom/polygon.cpp
@@ -176,6 +176,63 @@ TEST(PolygonTest, test_polygon_triangle_intersects_ray2)
     EXPECT_FALSE(triangle.intersects(ray));
 }
 
+// All of the below are what's known as "white box tests". That means these tests are
+// written with knowledge of how the function is implemented, to test certain internal
+// edge cases. These tests are written with the knowledge that the 'containsPoint'
+// function uses a ray that is shot in the +x direction
+TEST(
+    PolygonTest,
+    test_polygon_triangle_contains_point_with_point_outside_triangle_and_ray_intersecting_vertex)
+{
+    Polygon polygon({Point(0, 0), Point(1, 0), Point(0, 1)});
+    Point point(-1, 1);
+
+    bool result = polygon.containsPoint(point);
+    EXPECT_FALSE(result);
+}
+
+TEST(
+    PolygonTest,
+    test_polygon_triangle_contains_point_with_point_on_edge_of_triangle_and_ray_overlapping_segment)
+{
+    Polygon polygon({Point(0, 0), Point(1, 0), Point(0, 1)});
+    Point point(0.5, 0);
+
+    bool result = polygon.containsPoint(point);
+    EXPECT_TRUE(result);
+}
+
+TEST(
+    PolygonTest,
+    test_polygon_triangle_contains_point_with_point_inside_triangle_and_ray_intersecting_vertex)
+{
+    Polygon polygon({Point(1, 0), Point(0, 1), Point(0, -1)});
+    Point point(0.25, 0);
+
+    bool result = polygon.containsPoint(point);
+    EXPECT_TRUE(result);
+}
+
+TEST(
+    PolygonTest,
+    test_polygon_triangle_contains_point_with_point_outside_triangle_and_ray_overlapping_segment)
+{
+    Polygon polygon({Point(0, 0), Point(1, 0), Point(0, 1)});
+    Point point(-1, 0);
+
+    bool result = polygon.containsPoint(point);
+    EXPECT_FALSE(result);
+}
+
+TEST(PolygonTest, test_polygon_triangle_contains_point_with_point_on_vertex)
+{
+    Polygon polygon({Point(1, 0), Point(0, 1), Point(0, -1)});
+    Point point(0.25, 0);
+
+    bool result = polygon.containsPoint(point);
+    EXPECT_TRUE(result);
+}
+
 int main(int argc, char** argv)
 {
     std::cout << argv[0] << std::endl;

--- a/src/thunderbots/software/test/geom/polygon.cpp
+++ b/src/thunderbots/software/test/geom/polygon.cpp
@@ -66,6 +66,66 @@ TEST(PolygonTest, test_polygon_triangle_not_contains_point)
     EXPECT_FALSE(triangle.containsPoint(point));
 }
 
+TEST(PolygonTest, test_polygon_hexagon_contains_point)
+{
+    Point p1{-1.499421, 1.327846}, p2{-1.679421, 1.223923}, p3{-1.679421, 1.016077},
+        p4{-1.499421, 0.912154}, p5{-1.319421, 1.016077}, p6{-1.319421, 1.223923};
+
+    Point point;
+    Polygon hexagon{p1, p2, p3, p4, p5, p6};
+    point = Point{-1.050000, 0.090000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.050000, 0.180000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.230000, 0.360000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.140000, 0.450000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.320000, 0.540000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.410000, 0.630000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.410000, 0.720000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.500000, 0.810000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.410000, 0.810000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.320000, 0.810000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.230000, 0.810000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.320000, 0.900000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.410000, 0.990000};
+    EXPECT_TRUE(hexagon.containsPoint(point));
+    point = Point{-1.320000, 0.990000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.500000, 1.080000};
+    EXPECT_TRUE(hexagon.containsPoint(point));
+    point = Point{-1.410000, 1.080000};
+    EXPECT_TRUE(hexagon.containsPoint(point));
+    point = Point{-1.320000, 1.080000};
+    EXPECT_TRUE(hexagon.containsPoint(point));
+    point = Point{-1.500000, 1.170000};
+    EXPECT_TRUE(hexagon.containsPoint(point));
+    point = Point{-1.410000, 1.170000};
+    EXPECT_TRUE(hexagon.containsPoint(point));
+    point = Point{-1.410000, 1.170000};
+    EXPECT_TRUE(hexagon.containsPoint(point));
+    point = Point{-1.770000, 1.260000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.770000, 1.170000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.770000, 1.080000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.770000, 0.990000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+    point = Point{-1.680000, 0.990000};
+    EXPECT_FALSE(hexagon.containsPoint(point));
+}
+
+
 TEST(PolygonTest, test_polygon_triangle_intersects_line_segment)
 {
     Point p1{0.0f, 0.0f}, p2{1.0f, 0.0f}, p3{1.0f, 0.0f};


### PR DESCRIPTION
…uncovers

<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Made a test for existing code
Fixed latent bug in containsPoint
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Made a test for existing code
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #618
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
