### PR TITLE
Add default Play and make parts of AI controllable

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -711,10 +711,14 @@ if (CATKIN_ENABLE_TESTING)
 
     catkin_add_gtest(stp_test
             ai/hl/stp/stp.cpp
+            ai/hl/stp/action/action.cpp
+            ai/hl/stp/action/stop_action.cpp
             ai/hl/stp/tactic/tactic.cpp
+            ai/hl/stp/tactic/stop_tactic.cpp
             test/ai/hl/stp/test_tactics/move_test_tactic.cpp
             test/ai/hl/stp/test_tactics/stop_test_tactic.cpp
             ai/hl/stp/play/play.cpp
+            ai/hl/stp/play/stop_play.cpp
             ai/hl/stp/play/play_factory.cpp
             test/ai/hl/stp/test_plays/move_test_play.cpp
             test/ai/hl/stp/test_plays/stop_test_play.cpp

--- a/src/thunderbots/software/ai/hl/stp/stp.cpp
+++ b/src/thunderbots/software/ai/hl/stp/stp.cpp
@@ -18,12 +18,15 @@ STP::STP(long random_seed) : random_number_generator(random_seed) {}
 
 std::vector<std::unique_ptr<Intent>> STP::getIntents(const World& world)
 {
-    bool override_play = Util::DynamicParameters::AI::override_ai_play.value();
-    bool override_play_value_changed =
-        Util::DynamicParameters::AI::override_ai_play.valueUpdated();
-    std::string override_play_name = Util::DynamicParameters::AI::current_ai_play.value();
+    previous_override_play = override_play;
+    override_play          = Util::DynamicParameters::AI::override_ai_play.value();
+    bool override_play_value_changed = previous_override_play != override_play;
+
+    previous_override_play_name = override_play_name;
+    override_play_name          = Util::DynamicParameters::AI::current_ai_play.value();
     bool override_play_name_value_changed =
-        Util::DynamicParameters::AI::current_ai_play.valueUpdated();
+        previous_override_play_name != override_play_name;
+
     auto all_play_names = PlayFactory::getRegisteredPlayNames();
 
     // Assign a new play if we don't currently have a play assigned, the current play's

--- a/src/thunderbots/software/ai/hl/stp/stp.cpp
+++ b/src/thunderbots/software/ai/hl/stp/stp.cpp
@@ -20,10 +20,10 @@ std::vector<std::unique_ptr<Intent>> STP::getIntents(const World& world)
 {
     bool override_play = Util::DynamicParameters::AI::override_ai_play.value();
     bool override_play_value_changed =
-        Util::DynamicParameters::AI::override_ai_play.valueChanged();
+        Util::DynamicParameters::AI::override_ai_play.valueUpdated();
     std::string override_play_name = Util::DynamicParameters::AI::current_ai_play.value();
     bool override_play_name_value_changed =
-        Util::DynamicParameters::AI::current_ai_play.valueChanged();
+        Util::DynamicParameters::AI::current_ai_play.valueUpdated();
     auto all_play_names = PlayFactory::getRegisteredPlayNames();
 
     // Assign a new play if we don't currently have a play assigned, the current play's

--- a/src/thunderbots/software/ai/hl/stp/stp.h
+++ b/src/thunderbots/software/ai/hl/stp/stp.h
@@ -81,4 +81,8 @@ class STP : public HL
     std::optional<std::vector<std::shared_ptr<Tactic>>> current_tactics;
     // The random number generator
     std::mt19937 random_number_generator;
+    std::string override_play_name;
+    std::string previous_override_play_name;
+    bool override_play;
+    bool previous_override_play;
 };

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -177,6 +177,12 @@ void NetworkClient::filterAndPublishVisionData(SSL_WrapperPacket packet)
         world_msg.enemy_team = enemy_team_msg;
     }
 
+    if (Util::DynamicParameters::AI::refbox::override_refbox_defending_side.value() &&
+        Util::DynamicParameters::AI::refbox::defending_positive_side.value())
+    {
+        world_msg = Util::ROSMessages::invertMsgFieldSide(world_msg);
+    }
+
     world_publisher.publish(world_msg);
 }
 

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -177,6 +177,9 @@ void NetworkClient::filterAndPublishVisionData(SSL_WrapperPacket packet)
         world_msg.enemy_team = enemy_team_msg;
     }
 
+    // We invert the field side if we explicitly choose to override the values provided by
+    // refbox. The 'defending_positive_side' parameter dictates the side we are defending
+    // if we are overriding the value
     if (Util::DynamicParameters::AI::refbox::override_refbox_defending_side.value() &&
         Util::DynamicParameters::AI::refbox::defending_positive_side.value())
     {

--- a/src/thunderbots/software/test/ai/hl/stp/stp.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/stp.cpp
@@ -7,6 +7,7 @@
 #include <exception>
 
 #include "ai/hl/stp/play/play_factory.h"
+#include "ai/hl/stp/play/stop_play.h"
 #include "test/ai/hl/stp/test_plays/move_test_play.h"
 #include "test/ai/hl/stp/test_plays/stop_test_play.h"
 #include "test/test_util/test_util.h"
@@ -28,9 +29,12 @@ class STPTest : public ::testing::Test
 TEST_F(STPTest, test_only_test_plays_are_registered_in_play_factory)
 {
     auto play_names = PlayFactory::getRegisteredPlayNames();
-    EXPECT_EQ(play_names.size(), 2);
+    EXPECT_EQ(play_names.size(), 3);
     EXPECT_EQ(std::count(play_names.begin(), play_names.end(), MoveTestPlay::name), 1);
     EXPECT_EQ(std::count(play_names.begin(), play_names.end(), StopTestPlay::name), 1);
+    // We also expect the normal StopPlay since it is used in core functions in stp.cpp so
+    // has to be included in the tests
+    EXPECT_EQ(std::count(play_names.begin(), play_names.end(), StopPlay::name), 1);
 }
 
 TEST_F(STPTest, test_exception_thrown_when_no_play_applicable)

--- a/src/thunderbots/software/util/parameter/config/ai_control.yaml
+++ b/src/thunderbots/software/util/parameter/config/ai_control.yaml
@@ -31,7 +31,7 @@ AI:
           Specifies the refbox play that should be in use
     override_refbox_defending_side:
       type: "bool"
-      default: false
+      default: true
       description: >-
           Overrides the defending side provided by refbox, 
           with defending_positive_side parameter

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -79,11 +79,16 @@ class Parameter
     }
 
     /**
-     * Returns true if the value has recently changed, and false otherwise
+     * Returns true if the value of this parameter has been updated, either manually or
+     * from an automatic dynamic reconfigure message. Once this value is read, the return
+     * value is reset to false until the parameter is updated again. This makes the
+     * assumption that this function is only being called once / being called in one place
+     * per parameter, otherwise subsequent calls would not detect the update.
      *
-     * @return true if the value has recently changed, and false otherwise
+     * @return true if the value of this parameter has been updated since this function
+     * was last called, and false otherwise
      */
-    const bool valueChanged()
+    const bool valueUpdated()
     {
         bool ret = this->value_changed;
 

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -43,10 +43,9 @@ class Parameter
     explicit Parameter<T>(const std::string& parameter_name,
                           const std::string& parameter_namespace, T default_value)
     {
-        this->name_         = parameter_name;
-        this->namespace_    = parameter_namespace;
-        this->value_        = default_value;
-        this->value_changed = false;
+        this->name_      = parameter_name;
+        this->namespace_ = parameter_namespace;
+        this->value_     = default_value;
 
         Parameter<T>::registerParameter(std::make_unique<Parameter<T>>(*this));
     }
@@ -77,36 +76,6 @@ class Parameter
         // if the parameter hasn't been registered yet, return default value
         return this->value_;
     }
-
-    /**
-     * Returns true if the value of this parameter has been updated, either manually or
-     * from an automatic dynamic reconfigure message. Once this value is read, the return
-     * value is reset to false until the parameter is updated again. This makes the
-     * assumption that this function is only being called once / being called in one place
-     * per parameter, otherwise subsequent calls would not detect the update.
-     *
-     * @return true if the value of this parameter has been updated since this function
-     * was last called, and false otherwise
-     */
-    const bool valueUpdated()
-    {
-        bool ret = this->value_changed;
-
-        // get the value from the parameter in the registry
-        if (Parameter<T>::getMutableRegistry().count(this->name_))
-        {
-            auto& param_in_registry = Parameter<T>::getMutableRegistry().at(this->name_);
-            ret                     = param_in_registry->value_changed;
-            param_in_registry->value_changed = false;
-        }
-        else
-        {
-            value_changed = false;
-        }
-
-        return ret;
-    }
-
     /**
      * Returns the name of this parameter
      *
@@ -121,6 +90,7 @@ class Parameter
      * Checks if the parameter currently exists in the ros parameter server
      *
      * @return true if the parameter exists, false otherwise
+     *
      */
     const bool existsInParameterServer() const
     {
@@ -134,7 +104,6 @@ class Parameter
     void updateValueFromROSParameterServer()
     {
         ros::param::get(getROSParameterPath(), this->value_);
-        value_changed = true;
     }
 
     /**
@@ -148,7 +117,6 @@ class Parameter
     {
         dynamic_reconfigure::ConfigTools::getParameter(*updates, this->name_,
                                                        this->value_);
-        value_changed = true;
     }
 
     /**
@@ -253,9 +221,6 @@ class Parameter
 
     // Store the namespace of the parameter
     std::string namespace_;
-
-    // Whether or not this parameter value has recently changed
-    bool value_changed;
 
     /**
      * Returns a mutable configuration msg that will hold all the

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -43,11 +43,10 @@ class Parameter
     explicit Parameter<T>(const std::string& parameter_name,
                           const std::string& parameter_namespace, T default_value)
     {
-        this->name_          = parameter_name;
-        this->namespace_     = parameter_namespace;
-        this->value_         = default_value;
-        this->previous_value = default_value;
-        this->value_changed  = false;
+        this->name_         = parameter_name;
+        this->namespace_    = parameter_namespace;
+        this->value_        = default_value;
+        this->value_changed = false;
 
         Parameter<T>::registerParameter(std::make_unique<Parameter<T>>(*this));
     }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
* If no play is selected, the AI defaults to the Stop Play
* If a tactic is done but the play is still running, the assigned robot will be given a Stop Intent to prevent it from doing anything crazy until a new tactic is assigned
* The Play override works and now plays can be chosen using dynamic parameters
* Defending side override works, and now the defending side can be changed using dynamic parameters

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Existing tests pass, manually verified everything works in grsim

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #410 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
