### PR TITLE
Enhanced Robot Status Handling

### DIFF
--- a/src/thunderbots/firmware/main/feedback.c
+++ b/src/thunderbots/firmware/main/feedback.c
@@ -47,6 +47,8 @@ static bool has_ball_after_antispam = false;
 static bool build_ids_pending = false;
 static TaskHandle_t feedback_task_handle;
 
+static int NUM_SENDS_BEFORE_CRASH = 10;
+
 static void feedback_task(void *UNUSED(param)) {
 	static uint8_t nullary_frame[] = {
 		9U, // Header length
@@ -225,6 +227,10 @@ static void feedback_task(void *UNUSED(param)) {
 				// So, try delivering the message again later.
 				pending_events |= EVENT_SEND_AUTOKICK;
 			}
+		}
+		if (--NUM_SENDS_BEFORE_CRASH < 0)
+		{
+			abort();
 		}
 	}
 

--- a/src/thunderbots/firmware/main/feedback.c
+++ b/src/thunderbots/firmware/main/feedback.c
@@ -47,8 +47,6 @@ static bool has_ball_after_antispam = false;
 static bool build_ids_pending = false;
 static TaskHandle_t feedback_task_handle;
 
-static int NUM_SENDS_BEFORE_CRASH = 10;
-
 static void feedback_task(void *UNUSED(param)) {
 	static uint8_t nullary_frame[] = {
 		9U, // Header length
@@ -227,10 +225,6 @@ static void feedback_task(void *UNUSED(param)) {
 				// So, try delivering the message again later.
 				pending_events |= EVENT_SEND_AUTOKICK;
 			}
-		}
-		if (--NUM_SENDS_BEFORE_CRASH < 0)
-		{
-			abort();
 		}
 	}
 

--- a/src/thunderbots/software/radio_communication/mrf/annunciator.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/annunciator.cpp
@@ -78,7 +78,7 @@ namespace
         std::vector<std::string> old_msgs;
 
         // Map of message to timestamp for edge-triggered messages
-        std::map<std::string, time_t> edge_triggered_msg_map;
+        std::map<std::string, time_t> et_messages;
 
     } RobotStatusState;
 
@@ -239,8 +239,7 @@ bool Annunciator::handle_robot_message(int index, const void *data, std::size_t 
                                             MRF::ERROR_ET_MESSAGES[i])
                                         {
                                             robot_status_states[index]
-                                                .edge_triggered_msg_map
-                                                    [MRF::ERROR_ET_MESSAGES[i]] =
+                                                .et_messages[MRF::ERROR_ET_MESSAGES[i]] =
                                                 time(nullptr);
                                         }
                                     }
@@ -335,7 +334,7 @@ bool Annunciator::handle_robot_message(int index, const void *data, std::size_t 
         }
     }
 
-    for (auto const &et_msg : robot_status_states[index].edge_triggered_msg_map)
+    for (auto const &et_msg : robot_status_states[index].et_messages)
     {
         if (difftime(time(nullptr), et_msg.second) < ET_MESSAGE_KEEPALIVE_TIME)
         {
@@ -368,7 +367,7 @@ bool Annunciator::handle_robot_message(int index, const void *data, std::size_t 
     return to_beep;
 }
 
-void Annunciator::handle_status(uint8_t status)
+void Annunciator::handle_dongle_messages(uint8_t status)
 {
     dongle_messages.clear();
 

--- a/src/thunderbots/software/radio_communication/mrf/annunciator.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/annunciator.cpp
@@ -24,7 +24,7 @@ namespace
     /**
      * Amount of time to keep an edge-triggered message sending, in seconds.
      */
-    const int ET_MESSAGE_KEEPALIVE_TIME = 5;
+    const int ET_MESSAGE_KEEPALIVE_TIME = 10;
 
     /**
      * Represents a mapping from RSSI to decibels.
@@ -343,15 +343,16 @@ bool Annunciator::handle_robot_message(int index, const void *data, std::size_t 
         }
     }
 
-    // If is a new message that was present in the previous status update, return true
-    bool to_beep = false;
+    // If there is a new message that wasn't present in the previous status update, return
+    // true
+    bool new_msgs_present = false;
     for (std::string msg : new_msgs)
     {
         if (std::find(robot_status_states[index].old_msgs.begin(),
                       robot_status_states[index].old_msgs.end(),
                       msg) == robot_status_states[index].old_msgs.end())
         {
-            to_beep = true;
+            new_msgs_present = true;
             break;
         }
     }
@@ -365,10 +366,10 @@ bool Annunciator::handle_robot_message(int index, const void *data, std::size_t 
 
     // Publish robot status
     robot_status_publisher.publish(robot_status);
-    return to_beep;
+    return new_msgs_present;
 }
 
-void Annunciator::handle_dongle_messages(uint8_t status)
+std::vector<std::string> Annunciator::handle_dongle_messages(uint8_t status)
 {
     dongle_messages.clear();
 
@@ -393,4 +394,6 @@ void Annunciator::handle_dongle_messages(uint8_t status)
     {
         dongle_messages.push_back(MRF::RECEIVE_QUEUE_FULL_MESSAGE);
     }
+
+    return dongle_messages;
 }

--- a/src/thunderbots/software/radio_communication/mrf/annunciator.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/annunciator.cpp
@@ -334,6 +334,7 @@ bool Annunciator::handle_robot_message(int index, const void *data, std::size_t 
         }
     }
 
+    // Edge-triggered messages: keep sending message for ET_MESSAGE_KEEPALIVE_TIME seconds
     for (auto const &et_msg : robot_status_states[index].et_messages)
     {
         if (difftime(time(nullptr), et_msg.second) < ET_MESSAGE_KEEPALIVE_TIME)
@@ -342,7 +343,7 @@ bool Annunciator::handle_robot_message(int index, const void *data, std::size_t 
         }
     }
 
-    // If new message, beep the dongle
+    // If is a new message that was present in the previous status update, return true
     bool to_beep = false;
     for (std::string msg : new_msgs)
     {

--- a/src/thunderbots/software/radio_communication/mrf/annunciator.h
+++ b/src/thunderbots/software/radio_communication/mrf/annunciator.h
@@ -24,11 +24,10 @@ class Annunciator
      * @param lqi Link quality.
      * @param rssi Received signal strength indicator.
      *
-     * @return the fully-constructed RobotStatus that was published
+     * @return true if a dongle beep is required, false otherwise
      */
-    thunderbots_msgs::RobotStatus handle_robot_message(int index, const void* data,
-                                                       std::size_t len, uint8_t lqi,
-                                                       uint8_t rssi);
+    bool handle_robot_message(int index, const void* data, std::size_t len, uint8_t lqi,
+                              uint8_t rssi);
 
     /**
      * Handles general dongle messages.

--- a/src/thunderbots/software/radio_communication/mrf/annunciator.h
+++ b/src/thunderbots/software/radio_communication/mrf/annunciator.h
@@ -16,7 +16,7 @@ class Annunciator
     explicit Annunciator(ros::NodeHandle& node_handle);
 
     /**
-     * Handles diagnostics and messages for each robot.
+     * Decodes diagnostics and messages for each robot, and publishes them.
      * Returns a boolean if there were new messages since the last status update.
      *
      * @param index Robot number.
@@ -34,8 +34,9 @@ class Annunciator
      * Handles general dongle messages.
      *
      * @param status The uint8 encoding all the status data.
+     * @return vector of dongle messages sent from the dongle
      */
-    void handle_dongle_messages(uint8_t status);
+    std::vector<std::string> handle_dongle_messages(uint8_t status);
 
    private:
     ros::Publisher robot_status_publisher;

--- a/src/thunderbots/software/radio_communication/mrf/annunciator.h
+++ b/src/thunderbots/software/radio_communication/mrf/annunciator.h
@@ -16,7 +16,8 @@ class Annunciator
     explicit Annunciator(ros::NodeHandle& node_handle);
 
     /**
-     * Handles diagnostics for each robot.
+     * Handles diagnostics and messages for each robot.
+     * Returns a boolean if there were new messages since the last status update.
      *
      * @param index Robot number.
      * @param data The data of the status packet.
@@ -24,7 +25,7 @@ class Annunciator
      * @param lqi Link quality.
      * @param rssi Received signal strength indicator.
      *
-     * @return true if a dongle beep is required, false otherwise
+     * @return true if new messages since last status update
      */
     bool handle_robot_message(int index, const void* data, std::size_t len, uint8_t lqi,
                               uint8_t rssi);
@@ -34,7 +35,7 @@ class Annunciator
      *
      * @param status The uint8 encoding all the status data.
      */
-    void handle_status(uint8_t status);
+    void handle_dongle_messages(uint8_t status);
 
    private:
     ros::Publisher robot_status_publisher;

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -284,16 +284,20 @@ void MRFDongle::handle_mdrs(AsyncOperation<void> &op)
 void MRFDongle::handle_message(AsyncOperation<void> &, USB::BulkInTransfer &transfer)
 {
     transfer.result();
-
+    bool to_beep = false;
     // Only handle if there are more than 2 bytes in the transfer.
     if (transfer.size() > 2)
     {
         unsigned int robot = transfer.data()[0];
-        annunciator.handle_robot_message(robot, transfer.data() + 1, transfer.size() - 3,
-                                         transfer.data()[transfer.size() - 2],
-                                         transfer.data()[transfer.size() - 1]);
+        to_beep            = annunciator.handle_robot_message(
+            robot, transfer.data() + 1, transfer.size() - 3,
+            transfer.data()[transfer.size() - 2], transfer.data()[transfer.size() - 1]);
     }
     transfer.submit();
+    if (to_beep)
+    {
+        beep(ANNUNCIATOR_BEEP_LENGTH_MILLISECONDS);
+    }
 }
 
 void MRFDongle::handle_status(AsyncOperation<void> &)

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -304,7 +304,8 @@ void MRFDongle::handle_status(AsyncOperation<void> &)
 {
     status_transfer.result();
     estop_state = static_cast<EStopState>(status_transfer.data()[0] & 3U);
-    annunciator.handle_status(status_transfer.data()[0U]);
+    // TODO: beep on thesemessages later?
+    annunciator.handle_dongle_messages(status_transfer.data()[0U]);
     status_transfer.submit();
 }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Beep the dongle on arrival of new robot status messages, and keep edge-triggered messages in future status updates for 5 seconds.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Tested robot statuses and dongle beeping on multiple robots (generate new messages by disconnecting dribble motor), tested edge-triggered messages with firmware that crashes robot every few seconds.
### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
