### PR TITLE
change direct/Indirect free kick states to not require NORMAL_START state to resume play 

### DIFF
--- a/src/thunderbots/software/ai/world/game_state.cpp
+++ b/src/thunderbots/software/ai/world/game_state.cpp
@@ -201,22 +201,22 @@ void GameState::updateRefboxGameState(RefboxGameState gameState)
             our_restart    = false;
             break;
         case RefboxGameState::DIRECT_FREE_US:
-            state          = SETUP;
+            state          = PLAYING;
             restart_reason = DIRECT;
             our_restart    = true;
             break;
         case RefboxGameState::DIRECT_FREE_THEM:
-            state          = SETUP;
+            state          = PLAYING;
             restart_reason = DIRECT;
             our_restart    = false;
             break;
         case RefboxGameState::INDIRECT_FREE_US:
-            state          = SETUP;
+            state          = PLAYING;
             restart_reason = INDIRECT;
             our_restart    = true;
             break;
         case RefboxGameState::INDIRECT_FREE_THEM:
-            state          = SETUP;
+            state          = PLAYING;
             restart_reason = INDIRECT;
             our_restart    = false;
             break;

--- a/src/thunderbots/software/test/ai/world/game_state.cpp
+++ b/src/thunderbots/software/test/ai/world/game_state.cpp
@@ -166,7 +166,9 @@ PREDICATE_TEST(isStopped, RefboxGameState::STOP, RefboxGameState::GOAL_US,
                RefboxGameState::GOAL_THEM)
 // PLAYING state must be manually set after a transition from a restart state to
 // NORMAL_START
-PREDICATE_TEST(isPlaying, RefboxGameState::FORCE_START)
+PREDICATE_TEST(isPlaying, RefboxGameState::FORCE_START, RefboxGameState::DIRECT_FREE_US,
+               RefboxGameState::DIRECT_FREE_THEM, RefboxGameState::INDIRECT_FREE_US,
+               RefboxGameState::INDIRECT_FREE_THEM)
 PREDICATE_TEST(isKickoff, RefboxGameState::PREPARE_KICKOFF_US,
                RefboxGameState::PREPARE_KICKOFF_THEM)
 PREDICATE_TEST(isPenalty, RefboxGameState::PREPARE_PENALTY_US,
@@ -193,22 +195,20 @@ PREDICATE_TEST(isTheirFreeKick, RefboxGameState::DIRECT_FREE_THEM,
 PREDICATE_TEST(isTheirBallPlacement, RefboxGameState::BALL_PLACEMENT_THEM)
 PREDICATE_TEST(
     isSetupRestart, RefboxGameState::PREPARE_KICKOFF_US,
-    RefboxGameState::PREPARE_KICKOFF_THEM, RefboxGameState::DIRECT_FREE_US,
-    RefboxGameState::DIRECT_FREE_THEM, RefboxGameState::INDIRECT_FREE_US,
-    RefboxGameState::INDIRECT_FREE_THEM, RefboxGameState::BALL_PLACEMENT_US,
+    RefboxGameState::PREPARE_KICKOFF_THEM, RefboxGameState::BALL_PLACEMENT_US,
     RefboxGameState::BALL_PLACEMENT_THEM,
     // NORMAL_START is a ready state until the restart is cleared when the ball moves
     RefboxGameState::NORMAL_START, RefboxGameState::PREPARE_PENALTY_US,
     RefboxGameState::PREPARE_PENALTY_THEM)
 PREDICATE_TEST(isSetupState, RefboxGameState::PREPARE_KICKOFF_US,
-               RefboxGameState::PREPARE_KICKOFF_THEM, RefboxGameState::DIRECT_FREE_US,
-               RefboxGameState::DIRECT_FREE_THEM, RefboxGameState::INDIRECT_FREE_US,
-               RefboxGameState::INDIRECT_FREE_THEM, RefboxGameState::BALL_PLACEMENT_US,
+               RefboxGameState::PREPARE_KICKOFF_THEM, RefboxGameState::BALL_PLACEMENT_US,
                RefboxGameState::BALL_PLACEMENT_THEM, RefboxGameState::PREPARE_PENALTY_US,
                RefboxGameState::PREPARE_PENALTY_THEM)
 PREDICATE_TEST(isReadyState, RefboxGameState::NORMAL_START)
 // canKick needs to be tested with a proper restart sequence
-PREDICATE_TEST(canKick, RefboxGameState::FORCE_START)
+PREDICATE_TEST(canKick, RefboxGameState::FORCE_START, RefboxGameState::DIRECT_FREE_US,
+               RefboxGameState::DIRECT_FREE_THEM, RefboxGameState::INDIRECT_FREE_US,
+               RefboxGameState::INDIRECT_FREE_THEM)
 PREDICATE_TEST(stayOnSide, RefboxGameState::PREPARE_KICKOFF_THEM)
 PREDICATE_TEST(stayBehindPenaltyLine, RefboxGameState::PREPARE_PENALTY_THEM,
                RefboxGameState::PREPARE_PENALTY_US)
@@ -343,99 +343,4 @@ TEST_F(GameStateRestartTest, penalty_them_restart_test)
     game_state.setRestartCompleted();
     EXPECT_TRUE(game_state.isPlaying());
     EXPECT_FALSE(game_state.isPenalty());
-}
-
-TEST_F(GameStateRestartTest, direct_free_us_restart_test)
-{
-    GameState game_state;
-
-    RefboxGameState restart_type = RefboxGameState::DIRECT_FREE_US;
-
-    // STOP -> restart_type is how restarts occur during games
-    game_state.updateRefboxGameState(RefboxGameState::STOP);
-    game_state.updateRefboxGameState(restart_type);
-
-    // verify game_state is in the correct state
-    EXPECT_TRUE(game_state.isSetupState());
-    EXPECT_TRUE(game_state.isDirectFree());
-    EXPECT_TRUE(game_state.isOurRestart());
-    EXPECT_TRUE(game_state.isOurDirect());
-
-    // restart_type -> NORMAL_START happens next
-    game_state.updateRefboxGameState(RefboxGameState::NORMAL_START);
-
-    // verify state again
-    EXPECT_TRUE(game_state.isReadyState());
-    EXPECT_TRUE(game_state.isDirectFree());
-    EXPECT_TRUE(game_state.isOurRestart());
-    EXPECT_TRUE(game_state.isOurDirect());
-
-    // restart state is cleared when the ball is kicked, enter regular
-    // playing state
-    game_state.setRestartCompleted();
-    EXPECT_TRUE(game_state.isPlaying());
-    EXPECT_FALSE(game_state.isDirectFree());
-}
-
-TEST_F(GameStateRestartTest, direct_free_them_restart_test)
-{
-    GameState game_state;
-
-    RefboxGameState restart_type = RefboxGameState::DIRECT_FREE_THEM;
-    // STOP -> restart_type is how restarts occur during games
-    game_state.updateRefboxGameState(RefboxGameState::STOP);
-    game_state.updateRefboxGameState(restart_type);
-
-    // verify game_state is in the correct state
-    EXPECT_TRUE(game_state.isSetupState());
-    EXPECT_TRUE(game_state.isDirectFree());
-    EXPECT_FALSE(game_state.isOurRestart());
-    EXPECT_TRUE(game_state.isTheirDirect());
-
-    // restart_type -> NORMAL_START happens next
-    game_state.updateRefboxGameState(RefboxGameState::NORMAL_START);
-
-    // verify state again
-    EXPECT_TRUE(game_state.isReadyState());
-    EXPECT_TRUE(game_state.isDirectFree());
-    EXPECT_FALSE(game_state.isOurRestart());
-    EXPECT_TRUE(game_state.isTheirDirect());
-
-    // restart state is cleared when the ball is kicked, enter regular
-    // playing state
-    game_state.setRestartCompleted();
-    EXPECT_TRUE(game_state.isPlaying());
-    EXPECT_FALSE(game_state.isDirectFree());
-}
-
-TEST_F(GameStateRestartTest, indirect_free_us_restart_test)
-{
-    GameState game_state;
-
-    RefboxGameState restart_type = RefboxGameState::INDIRECT_FREE_US;
-
-    // STOP -> restart_type is how restarts occur during games
-    game_state.updateRefboxGameState(RefboxGameState::STOP);
-    game_state.updateRefboxGameState(restart_type);
-
-    // verify game_state is in the correct state
-    EXPECT_TRUE(game_state.isSetupState());
-    EXPECT_TRUE(game_state.isIndirectFree());
-    EXPECT_TRUE(game_state.isOurRestart());
-    EXPECT_TRUE(game_state.isOurIndirect());
-
-    // restart_type -> NORMAL_START happens next
-    game_state.updateRefboxGameState(RefboxGameState::NORMAL_START);
-
-    // verify state again
-    EXPECT_TRUE(game_state.isReadyState());
-    EXPECT_TRUE(game_state.isIndirectFree());
-    EXPECT_TRUE(game_state.isOurRestart());
-    EXPECT_TRUE(game_state.isOurIndirect());
-
-    // restart state is cleared when the ball is kicked, enter regular
-    // playing state
-    game_state.setRestartCompleted();
-    EXPECT_TRUE(game_state.isPlaying());
-    EXPECT_FALSE(game_state.isIndirectFree());
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

change direct/Indirect free kick states to not require NORMAL_START state to resume play 

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

fix existing unit tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

Resolves #315 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
