### PR TITLE
Fix Vision Filters on SSL Vision

### DIFF
--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -1,6 +1,7 @@
 #include "network_input/networking/network_client.h"
 
 #include <boost/bind.hpp>
+#include <limits>
 
 #include "util/constants.h"
 #include "util/logger/init.h"
@@ -8,7 +9,7 @@
 #include "util/ros_messages.h"
 
 NetworkClient::NetworkClient(ros::NodeHandle& node_handle)
-    : backend(), io_service(), initial_packet_count(0), last_valid_t_capture(9999999)
+    : backend(), io_service(), initial_packet_count(0), last_valid_t_capture(std::numeric_limits<double>::max())
 {
     // Set up publishers
     world_publisher = node_handle.advertise<thunderbots_msgs::World>(
@@ -75,7 +76,8 @@ void NetworkClient::filterAndPublishVisionDataWrapper(SSL_WrapperPacket packet)
     {
         initial_packet_count++;
         if (packet.has_detection() &&
-            packet.detection().t_capture() < last_valid_t_capture)
+            packet.detection().t_capture() < last_valid_t_capture
+            && initial_packet_count > 50)
         {
             last_valid_t_capture = packet.detection().t_capture();
         }

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -9,7 +9,10 @@
 #include "util/ros_messages.h"
 
 NetworkClient::NetworkClient(ros::NodeHandle& node_handle)
-    : backend(), io_service(), initial_packet_count(0), last_valid_t_capture(std::numeric_limits<double>::max())
+    : backend(),
+      io_service(),
+      initial_packet_count(0),
+      last_valid_t_capture(std::numeric_limits<double>::max())
 {
     // Set up publishers
     world_publisher = node_handle.advertise<thunderbots_msgs::World>(
@@ -76,8 +79,7 @@ void NetworkClient::filterAndPublishVisionDataWrapper(SSL_WrapperPacket packet)
     {
         initial_packet_count++;
         if (packet.has_detection() &&
-            packet.detection().t_capture() < last_valid_t_capture
-            && initial_packet_count > 50)
+            packet.detection().t_capture() < last_valid_t_capture)
         {
             last_valid_t_capture = packet.detection().t_capture();
         }

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -91,7 +91,7 @@ void NetworkClient::filterAndPublishVisionDataWrapper(SSL_WrapperPacket packet)
         {
             filterAndPublishVisionData(packet);
         }
-        else if (packet.detection().t_capture() - last_valid_t_capture < 100)
+        else if (std::fabs(packet.detection().t_capture() - last_valid_t_capture) < 100)
         {
             last_valid_t_capture = packet.detection().t_capture();
             filterAndPublishVisionData(packet);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Changed the initialization of `last_valid_t_capture`

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
field tested with robots and SSL Vision
### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
