### PR TITLE
WIP: Add UI for ROS Parameters

### DIFF
--- a/src/corner_kick/src/App.tsx
+++ b/src/corner_kick/src/App.tsx
@@ -5,13 +5,9 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 
-import * as ROS from 'SRC/utils/ros';
-
 import { Visualizer } from './pages/Visualizer';
 import { createStore } from './store';
 import { Theme } from './style/Theme';
-
-import { actions } from './store/actions';
 
 const store = createStore();
 
@@ -23,40 +19,6 @@ export const App = () => (
     <Provider store={store}>
         <Theme>
             <Visualizer />
-            <button onClick={startRunAi}>Start run_ai</button>
-            <button onClick={stopRunAi}>Stop run_ai</button>
         </Theme>
     </Provider>
 );
-
-/**
- * Start run_ai
- */
-function startRunAi() {
-    ROS.sendRequestToService(
-        '/ai_control/set_parameters',
-        'dynamic_reconfigure/Reconfigure',
-        {
-            config: {
-                bools: [{ name: 'run_ai', value: true }],
-            },
-        },
-    );
-    store.dispatch(actions.rosParameters.setRunAI(true));
-}
-
-/**
- * Stop run_ai
- */
-function stopRunAi() {
-    ROS.sendRequestToService(
-        '/ai_control/set_parameters',
-        'dynamic_reconfigure/Reconfigure',
-        {
-            config: {
-                bools: [{ name: 'run_ai', value: false }],
-            },
-        },
-    );
-    store.dispatch(actions.rosParameters.setRunAI(false));
-}

--- a/src/corner_kick/src/pages/Visualizer/index.tsx
+++ b/src/corner_kick/src/pages/Visualizer/index.tsx
@@ -16,6 +16,7 @@ import { ILayer, IRootState } from 'SRC/types';
 
 import { LayersPanel } from './panels/LayersPanel';
 import { PlayTypePanel } from './panels/PlayTypePanel';
+import { SettingsPanel } from './panels/SettingsPanel';
 
 // We request the layer data from the store
 const mapStateToProps = (state: IRootState) => ({
@@ -79,6 +80,7 @@ class VisualizerInternal extends React.Component<IVisualizerProps> {
                         toggleVisibility={this.onLayerVisibilityToggle}
                     />
                     <PlayTypePanel {...this.props} />
+                    <SettingsPanel />
                 </Portal>
                 <Portal portalLocation={PortalLocation.MAIN}>
                     <Canvas canvasManager={this.canvasManager} />

--- a/src/corner_kick/src/pages/Visualizer/panels/SettingsPanel/index.tsx
+++ b/src/corner_kick/src/pages/Visualizer/panels/SettingsPanel/index.tsx
@@ -1,0 +1,316 @@
+/***
+ * This file defines the UI to view the current tactic
+ */
+
+import { Button } from '@blueprintjs/core';
+import { Box } from '@rebass/grid';
+import * as React from 'react';
+import * as ROS from 'SRC/utils/ros';
+
+/**
+ * Describes a panel showing the current tactics in the AI.
+ */
+export const SettingsPanel = () => {
+    function startRunAi() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'run_ai', value: true }],
+                },
+            },
+        );
+    }
+
+    function stopRunAi() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'run_ai', value: false }],
+                },
+            },
+        );
+    }
+
+    function enableOverrideRefboxFriendlyTeamColor() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'override_refbox_friendly_team_color', value: true }],
+                },
+            },
+        );
+    }
+
+    function disableOverrideRefboxFriendlyTeamColor() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [
+                        { name: 'override_refbox_friendly_team_color', value: false },
+                    ],
+                },
+            },
+        );
+    }
+
+    function enableFriendlyColorYellow() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'friendly_color_yellow', value: true }],
+                },
+            },
+        );
+    }
+
+    function disableFriendlyColorYellow() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'friendly_color_yellow', value: false }],
+                },
+            },
+        );
+    }
+
+    function enableOverrideRefboxDefendingSide() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'override_refbox_defending_side', value: true }],
+                },
+            },
+        );
+    }
+
+    function disableOverrideRefboxDefendingSide() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'override_refbox_defending_side', value: false }],
+                },
+            },
+        );
+    }
+
+    function enableDefendingPositiveSide() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'defending_positive_side', value: true }],
+                },
+            },
+        );
+    }
+
+    function disableDefendingPositiveSide() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'defending_positive_side', value: false }],
+                },
+            },
+        );
+    }
+
+    function enableOverrideRefboxPlay() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'override_refbox_play', value: true }],
+                },
+            },
+        );
+    }
+
+    function disableOverrideRefboxPlay() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'override_refbox_play', value: false }],
+                },
+            },
+        );
+    }
+
+    function enableOverrideAiPlay() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'override_ai_play', value: true }],
+                },
+            },
+        );
+    }
+
+    function disableOverrideAiPlay() {
+        ROS.sendRequestToService(
+            '/ai_control/set_parameters',
+            'dynamic_reconfigure/Reconfigure',
+            {
+                config: {
+                    bools: [{ name: 'override_ai_play', value: false }],
+                },
+            },
+        );
+    }
+
+    return (
+        <Box>
+            <div>
+                <div>
+                    <Button
+                        intent="success"
+                        minimal={true}
+                        text="Start run_ai"
+                        onClick={startRunAi}
+                    />
+                    <Button
+                        intent="danger"
+                        minimal={true}
+                        text="Stop run_ai"
+                        onClick={stopRunAi}
+                    />
+                </div>
+                <div>
+                    <Button
+                        intent="success"
+                        minimal={true}
+                        text="Enable override_refbox_friendly_team_color"
+                        onClick={enableOverrideRefboxFriendlyTeamColor}
+                    />
+                    <Button
+                        intent="danger"
+                        minimal={true}
+                        text="Disable override_refbox_friendly_team_color"
+                        onClick={disableOverrideRefboxFriendlyTeamColor}
+                    />
+                </div>
+                <div>
+                    <Button
+                        intent="success"
+                        minimal={true}
+                        text="Enable friendly_color_yellow"
+                        onClick={enableFriendlyColorYellow}
+                    />
+                    <Button
+                        intent="danger"
+                        minimal={true}
+                        text="Disable friendly_color_yellow"
+                        onClick={disableFriendlyColorYellow}
+                    />
+                </div>
+                <div>
+                    <Button
+                        intent="success"
+                        minimal={true}
+                        text="Enable Override_refbox_defending_side"
+                        onClick={enableOverrideRefboxDefendingSide}
+                    />
+                    <Button
+                        intent="danger"
+                        minimal={true}
+                        text="Disable Override_refbox_defending_side"
+                        onClick={disableOverrideRefboxDefendingSide}
+                    />
+                </div>
+                <div>
+                    <Button
+                        intent="success"
+                        minimal={true}
+                        text="Enable friendly_color_yellow"
+                        onClick={enableDefendingPositiveSide}
+                    />
+                    <Button
+                        intent="danger"
+                        minimal={true}
+                        text="Disable friendly_color_yellow"
+                        onClick={disableDefendingPositiveSide}
+                    />
+                </div>
+                <div>
+                    <Button
+                        intent="success"
+                        minimal={true}
+                        text="Enable override_refbox_defending_side"
+                        onClick={enableOverrideRefboxPlay}
+                    />
+                    <Button
+                        intent="danger"
+                        minimal={true}
+                        text="Disable override_refbox_defending_side"
+                        onClick={disableOverrideRefboxPlay}
+                    />
+                </div>{' '}
+                <div>
+                    <Button
+                        intent="success"
+                        minimal={true}
+                        text="Enable defending_positive_side"
+                        onClick={enableDefendingPositiveSide}
+                    />
+                    <Button
+                        intent="danger"
+                        minimal={true}
+                        text="Disable defending_positive_side"
+                        onClick={disableDefendingPositiveSide}
+                    />
+                </div>
+                <div>
+                    <Button
+                        intent="success"
+                        minimal={true}
+                        text="Enable override_refbox_play"
+                        onClick={enableOverrideRefboxPlay}
+                    />
+                    <Button
+                        intent="danger"
+                        minimal={true}
+                        text="Disable override_refbox_play"
+                        onClick={disableOverrideRefboxPlay}
+                    />
+                </div>
+                <div>
+                    <Button
+                        intent="success"
+                        minimal={true}
+                        text="Enable override_ai_play"
+                        onClick={enableOverrideAiPlay}
+                    />
+                    <Button
+                        intent="danger"
+                        minimal={true}
+                        text="Disable override_ai_play"
+                        onClick={disableOverrideAiPlay}
+                    />
+                </div>
+            </div>
+        </Box>
+    );
+};


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

This PR is a work in progress for the ROS parameter setting UI in the Visualizer. Currently, only the booleans are done and are able to communicate to the parameter server.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

Resolves #632 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
