### PR TITLE
Added patrol tactic

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/tactic/patrol_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/patrol_tactic.cpp
@@ -1,0 +1,83 @@
+#include "ai/hl/stp/tactic/patrol_tactic.h"
+
+#include "ai/hl/stp/action/move_action.h"
+#include "ai/hl/stp/action/stop_action.h"
+#include "util/logger/init.h"
+
+PatrolTactic::PatrolTactic(const std::vector<Point> &points, double dist_from_points)
+    : Tactic(true),
+      patrol_points(points),
+      dist_from_points(dist_from_points),
+      orientation(Angle::zero()),
+      final_speed(0),
+      patrol_point_index(0)
+{
+}
+
+std::string PatrolTactic::getName() const
+{
+    return "Patrol Tactic";
+}
+
+void PatrolTactic::updateParams(Angle orientation, double final_speed)
+{
+    // Update the parameters stored by this Tactic
+    this->orientation = orientation;
+    this->final_speed = final_speed;
+}
+
+double PatrolTactic::calculateRobotCost(const Robot &robot, const World &world)
+{
+    if (patrol_points.empty())
+    {
+        return 0.0;
+    }
+    else if (this->robot)
+    {
+        // If we already assigned a robot to this tactic, prefer reassigning
+        // that robot
+        if (this->robot.value() == robot)
+        {
+            return 0.0;
+        }
+        else
+        {
+            return 1.0;
+        }
+    }
+    else
+    {
+        // Prefer robots that are close to the current patrol point
+        double dist = (robot.position() - patrol_points.at(patrol_point_index)).len();
+        double cost = dist / world.field().totalLength();
+        return std::clamp<double>(cost, 0, 1);
+    }
+}
+
+void PatrolTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
+{
+    if (patrol_points.empty())
+    {
+        StopAction stop_action = StopAction(false, true);
+        do
+        {
+            LOG(WARNING) << "Running a Patrol Tactic with no patrol points" << std::endl;
+            yield(stop_action.updateStateAndGetNextIntent(*robot, false));
+        } while (true);
+    }
+
+    MoveAction move_action = MoveAction(this->dist_from_points);
+    do
+    {
+        auto next_intent = move_action.updateStateAndGetNextIntent(
+            *robot, patrol_points.at(patrol_point_index), orientation, final_speed);
+        if (!next_intent || move_action.done())
+        {
+            patrol_point_index = (patrol_point_index + 1) % patrol_points.size();
+            next_intent        = move_action.updateStateAndGetNextIntent(
+                *robot, patrol_points.at(patrol_point_index), orientation, final_speed);
+        }
+
+        yield(std::move(next_intent));
+    } while (true);
+}

--- a/src/thunderbots/software/ai/hl/stp/tactic/patrol_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/patrol_tactic.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "ai/hl/stp/tactic/tactic.h"
+
+/**
+ * The PatrolTactic will make the robot continuously patrol through the positions it's
+ * given
+ */
+class PatrolTactic : public Tactic
+{
+   public:
+    /**
+     * Creates a new PatrolTactic
+     *
+     * @param points The sequence of points to patrol, in order
+     * @param dist_from_points How from from the current point in the patrol sequence the
+     * robot must be before it moves on to the next point
+     */
+    explicit PatrolTactic(const std::vector<Point>& points, double dist_from_points);
+
+    std::string getName() const override;
+
+    /**
+     * Updates the parameters for this PatrolTactic.
+     *
+     * @param orientation The orientation the robot should have while patrolling
+     * @param final_speed The final speed the robot should aim to have at each patrol
+     * point
+     */
+    void updateParams(Angle orientation, double final_speed);
+
+    /**
+     * Calculates the cost of assigning the given robot to this Tactic. If a robot is
+     * already assigned to this tactic, that robot is preferred to be assigned again.
+     * Otherwise, prefers robots closer to the current patrol point being moved to.
+     *
+     * @param robot The robot to evaluate the cost for
+     * @param world The state of the world with which to perform the evaluation
+     * @return A cost in the range [0,1] indicating the cost of assigning the given robot
+     * to this tactic. Lower cost values indicate a more preferred robot.
+     */
+    double calculateRobotCost(const Robot& robot, const World& world) override;
+
+   private:
+    void calculateNextIntent(IntentCoroutine::push_type& yield) override;
+
+    // Tactic parameters
+    // The list of points the robot will patrol, in order
+    std::vector<Point> patrol_points;
+    // How far the robot must be from each point before moving on to the next one
+    double dist_from_points;
+    // The orientation the robot should have when it arrives at its destination
+    Angle orientation;
+    // The final speed the robot will aim to have at each patrol point
+    double final_speed;
+    // The index of the patrol point currently being moved to
+    unsigned int patrol_point_index;
+};

--- a/src/thunderbots/software/ai/hl/stp/tactic/patrol_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/patrol_tactic.h
@@ -13,21 +13,24 @@ class PatrolTactic : public Tactic
      * Creates a new PatrolTactic
      *
      * @param points The sequence of points to patrol, in order
-     * @param dist_from_points How from from the current point in the patrol sequence the
-     * robot must be before it moves on to the next point
+     * @param at_patrol_point_tolerance How from from the current point in the
+     * patrol sequence the robot must be before it moves on to the next point
+     * @param linear_speed_at_patrol_points The desired linear speed
+     * of the robot at each patrol point
      */
-    explicit PatrolTactic(const std::vector<Point>& points, double dist_from_points);
+    explicit PatrolTactic(const std::vector<Point>& points,
+                          double at_patrol_point_tolerance,
+                          double linear_speed_at_patrol_points);
 
     std::string getName() const override;
 
     /**
      * Updates the parameters for this PatrolTactic.
      *
-     * @param orientation The orientation the robot should have while patrolling
-     * @param final_speed The final speed the robot should aim to have at each patrol
-     * point
+     * @param orientation_at_patrol_points The orientation the robot
+     * should have while patrolling
      */
-    void updateParams(Angle orientation, double final_speed);
+    void updateParams(Angle orientation_at_patrol_points);
 
     /**
      * Calculates the cost of assigning the given robot to this Tactic. If a robot is
@@ -47,12 +50,12 @@ class PatrolTactic : public Tactic
     // Tactic parameters
     // The list of points the robot will patrol, in order
     std::vector<Point> patrol_points;
-    // How far the robot must be from each point before moving on to the next one
-    double dist_from_points;
+    // How far the robot must be from each patrol point before moving on to the next one
+    double at_patrol_point_tolerance;
     // The orientation the robot should have when it arrives at its destination
-    Angle orientation;
+    Angle orientation_at_patrol_points;
     // The final speed the robot will aim to have at each patrol point
-    double final_speed;
-    // The index of the patrol point currently being moved to
+    double linear_speed_at_patrol_points;
+    // The desired linear speed of the robot at each patrol point
     unsigned int patrol_point_index;
 };

--- a/src/thunderbots/software/ai/hl/stp/tactic/patrol_tactic.h
+++ b/src/thunderbots/software/ai/hl/stp/tactic/patrol_tactic.h
@@ -54,7 +54,9 @@ class PatrolTactic : public Tactic
     double at_patrol_point_tolerance;
     // The orientation the robot should have when it arrives at its destination
     Angle orientation_at_patrol_points;
-    // The final speed the robot will aim to have at each patrol point
+    // The final speed the robot will aim to have at each patrol point. Combined with the
+    // 'at_patrol_point_tolerance', this affect whether the robot will stop at each patrol
+    // point, or maintain speed and roughly drive through them
     double linear_speed_at_patrol_points;
     // The desired linear speed of the robot at each patrol point
     unsigned int patrol_point_index;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
This PR adds a patrol tactic that can patrol a series of points.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
grsim testing

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
