### PR TITLE
Added an autochip flag to the MovePrimitive

### DIFF
--- a/src/thunderbots/firmware/main/primitives/move.c
+++ b/src/thunderbots/firmware/main/primitives/move.c
@@ -182,6 +182,7 @@ static void move_start(const primitive_params_t *params)
 
     if(params->extra & 0x01) chicker_auto_arm(CHICKER_KICK, BALL_MAX_SPEED_METERS_PER_SECOND-1);
 	if(params->extra & 0x02) dribbler_set_speed(16000);
+    if(params->extra & 0x04) chicker_auto_arm(CHICKER_CHIP, 2);
 }
 
 /**

--- a/src/thunderbots/firmware/test/test.c
+++ b/src/thunderbots/firmware/test/test.c
@@ -7,63 +7,30 @@
 #include "quadratic_test.h"
 #include "shoot_test.h"
 #include "util_test.h"
-#include "check.h"
 #include <stdlib.h>
-#include "test.h"
 #include <stdio.h>
-
 #include "check.h"
-static int number_failed = 0;
-
 #include "test.h"
 
-void run_test(TCase *tc, Suite *s) {
-    suite_add_tcase(s, tc);
 static int number_failed = 0;
-    SRunner *sr = srunner_create(s);
 
-    srunner_run_all(sr, CK_NORMAL);
 void run_test(TCase *tc, Suite *s) {
     suite_add_tcase(s, tc);
-    number_failed += srunner_ntests_failed(sr);
     SRunner *sr = srunner_create(s);
-    srunner_free(sr);
     srunner_run_all(sr, CK_NORMAL);
-    printf("\n");
     number_failed += srunner_ntests_failed(sr);
-}
     srunner_free(sr);
-
     printf("\n");
-/**
 }
- * Main entry point for the test cases. Each test to run should 
 
- * be wrapped inside a function that should be added here so that
 /**
- * when the main function is called each test is run.
- */
  * Main entry point for the test cases. Each test to run should 
-int main(void)
  * be wrapped inside a function that should be added here so that
-{
  * when the main function is called each test is run.
  */
-    printf("\nStart Tests\n");
-    run_math_test();
-    run_matrix_test();
-    run_move_test();
-    run_physbot_test();
-    run_physics_test();
-    run_quadratic_test();
-    run_shoot_test();
-    run_util_test();
 int main(void)
-    (number_failed == 0) ? printf("All tests passed.\n") : printf("%d Tests failed.\n\n", number_failed);
 {
-    return 0;
     printf("\nStart Tests\n");
-}
     run_math_test();
     run_matrix_test();
     run_move_test();

--- a/src/thunderbots/firmware/test/test.c
+++ b/src/thunderbots/firmware/test/test.c
@@ -7,46 +7,49 @@
 #include "quadratic_test.h"
 #include "shoot_test.h"
 #include "util_test.h"
-#include "test.h"
-
+#include "check.h"
 #include <stdlib.h>
+#include "test.h"
 #include <stdio.h>
-static int number_failed = 0;
 
 #include "check.h"
-void run_test(TCase *tc, Suite *s) {
-#include "test.h"
-    suite_add_tcase(s, tc);
-
-    SRunner *sr = srunner_create(s);
-    srunner_run_all(sr, CK_NORMAL);
 static int number_failed = 0;
-    number_failed += srunner_ntests_failed(sr);
 
-    srunner_free(sr);
+#include "test.h"
+
 void run_test(TCase *tc, Suite *s) {
     suite_add_tcase(s, tc);
-    printf("\n");
+static int number_failed = 0;
     SRunner *sr = srunner_create(s);
-}
+
     srunner_run_all(sr, CK_NORMAL);
-
+void run_test(TCase *tc, Suite *s) {
+    suite_add_tcase(s, tc);
     number_failed += srunner_ntests_failed(sr);
-/**
+    SRunner *sr = srunner_create(s);
     srunner_free(sr);
- * Main entry point for the test cases. Each test to run should 
+    srunner_run_all(sr, CK_NORMAL);
     printf("\n");
- * be wrapped inside a function that should be added here so that
+    number_failed += srunner_ntests_failed(sr);
 }
- * when the main function is called each test is run.
+    srunner_free(sr);
 
- */
+    printf("\n");
 /**
-int main(void)
+}
  * Main entry point for the test cases. Each test to run should 
-{
-    printf("\nStart Tests\n");
+
  * be wrapped inside a function that should be added here so that
+/**
+ * when the main function is called each test is run.
+ */
+ * Main entry point for the test cases. Each test to run should 
+int main(void)
+ * be wrapped inside a function that should be added here so that
+{
+ * when the main function is called each test is run.
+ */
+    printf("\nStart Tests\n");
     run_math_test();
     run_matrix_test();
     run_move_test();
@@ -55,14 +58,12 @@ int main(void)
     run_quadratic_test();
     run_shoot_test();
     run_util_test();
- * when the main function is called each test is run.
-    (number_failed == 0) ? printf("All tests passed.\n") : printf("%d Tests failed.\n\n", number_failed);
- */
-    return 0;
 int main(void)
-}
+    (number_failed == 0) ? printf("All tests passed.\n") : printf("%d Tests failed.\n\n", number_failed);
 {
+    return 0;
     printf("\nStart Tests\n");
+}
     run_math_test();
     run_matrix_test();
     run_move_test();

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
@@ -11,7 +11,7 @@ MoveAction::MoveAction(double close_to_dest_threshold, bool loop_forever)
 
 std::unique_ptr<Intent> MoveAction::updateStateAndGetNextIntent(
     const Robot& robot, Point destination, Angle final_orientation, double final_speed,
-    bool enable_dribbler, AutokickFlag autokick)
+    bool enable_dribbler, AutokickType autokick)
 {
     // Update the parameters stored by this Action
     this->robot             = robot;

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
@@ -11,7 +11,7 @@ MoveAction::MoveAction(double close_to_dest_threshold, bool loop_forever)
 
 std::unique_ptr<Intent> MoveAction::updateStateAndGetNextIntent(
     const Robot& robot, Point destination, Angle final_orientation, double final_speed,
-    bool enable_dribbler, bool enable_autokick)
+    bool enable_dribbler, AutokickFlag autokick)
 {
     // Update the parameters stored by this Action
     this->robot             = robot;
@@ -19,7 +19,7 @@ std::unique_ptr<Intent> MoveAction::updateStateAndGetNextIntent(
     this->final_orientation = final_orientation;
     this->final_speed       = final_speed;
     this->enable_dribbler   = enable_dribbler;
-    this->enable_autokick   = enable_autokick;
+    this->autokick          = autokick;
 
     return getNextIntent();
 }
@@ -34,8 +34,7 @@ void MoveAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<MoveIntent>(robot->id(), destination, final_orientation,
-                                           final_speed, 0, enable_dribbler,
-                                           enable_autokick));
+                                           final_speed, 0, enable_dribbler, autokick));
     } while (loop_forever ||
              (robot->position() - destination).len() > close_to_dest_threshold);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ai/hl/stp/action/action.h"
+#include "ai/primitive/move_primitive.h"
 #include "geom/angle.h"
 #include "geom/point.h"
 
@@ -33,16 +34,16 @@ class MoveAction : public Action
      * the destination
      * @param final_speed The final speed the robot should have at the destination
      * @param enable_dribbler Whether or not to enable the dribbler
-     * @param enable_autokick This will enable the "break-beam" on the robot, that will
-     *                        trigger the kicker to fire as soon as the ball is in front
-     *                        of it
+     * @param autokick This will enable the "break-beam" on the robot, that will
+     *    *                 trigger the kicker to fire as soon as the ball is in front of
+     * it
      *
      * @return A unique pointer to the Intent the MoveAction wants to run. If the
      * MoveAction is done, returns an empty/null pointer
      */
     std::unique_ptr<Intent> updateStateAndGetNextIntent(
         const Robot& robot, Point destination, Angle final_orientation,
-        double final_speed, bool enable_dribbler = false, bool enable_autokick = false);
+        double final_speed, bool enable_dribbler = false, AutokickFlag autokick = NONE);
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;
@@ -52,7 +53,7 @@ class MoveAction : public Action
     Angle final_orientation;
     double final_speed;
     bool enable_dribbler;
-    bool enable_autokick;
+    AutokickFlag autokick;
 
     double close_to_dest_threshold;
     bool loop_forever;

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.h
@@ -35,15 +35,14 @@ class MoveAction : public Action
      * @param final_speed The final speed the robot should have at the destination
      * @param enable_dribbler Whether or not to enable the dribbler
      * @param autokick This will enable the "break-beam" on the robot, that will
-     *    *                 trigger the kicker to fire as soon as the ball is in front of
-     * it
+     * trigger the kicker or chippper to fire as soon as the ball is in front of it
      *
      * @return A unique pointer to the Intent the MoveAction wants to run. If the
      * MoveAction is done, returns an empty/null pointer
      */
     std::unique_ptr<Intent> updateStateAndGetNextIntent(
         const Robot& robot, Point destination, Angle final_orientation,
-        double final_speed, bool enable_dribbler = false, AutokickFlag autokick = NONE);
+        double final_speed, bool enable_dribbler = false, AutokickType autokick = NONE);
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;
@@ -53,7 +52,7 @@ class MoveAction : public Action
     Angle final_orientation;
     double final_speed;
     bool enable_dribbler;
-    AutokickFlag autokick;
+    AutokickType autokick;
 
     double close_to_dest_threshold;
     bool loop_forever;

--- a/src/thunderbots/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -79,7 +79,7 @@ void GoalieTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
             // The ball is heading towards the net. Move to block the shot
             goalie_pos  = closestPointOnSeg(*intersection1, goalie_movement_segment);
             next_intent = move_action.updateStateAndGetNextIntent(
-                *robot, goalie_pos, goalie_orientation, 0.0, false, true);
+                *robot, goalie_pos, goalie_orientation, 0.0, false, AUTOCHIP);
         }
         else if (ball.velocity().len() < BALL_SLOW_SPEED_THRESHOLD &&
                  field.pointInFriendlyDefenseArea(ball.position()))
@@ -113,10 +113,9 @@ void GoalieTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
             }
 
             next_intent = move_action.updateStateAndGetNextIntent(
-                *robot, goalie_pos, goalie_orientation, 0.0, false, true);
+                *robot, goalie_pos, goalie_orientation, 0.0, false, AUTOCHIP);
         }
 
-        // TODO: autokick with chipping?
         yield(std::move(next_intent));
 
     } while (!move_action.done());

--- a/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -107,7 +107,7 @@ void ReceiverTactic::calculateNextIntent(IntentCoroutine::push_type& yield)
                 getOneTimeShotPositionAndOrientation(*robot, ball, best_shot_target);
 
             yield(move_action.updateStateAndGetNextIntent(
-                *robot, ideal_position, ideal_orientation, 0, false, true));
+                *robot, ideal_position, ideal_orientation, 0, false, AUTOKICK));
 
             // Calculations to check for termination conditions
             ball_to_robot_vector = robot->position() - ball.position();
@@ -129,7 +129,7 @@ void ReceiverTactic::calculateNextIntent(IntentCoroutine::push_type& yield)
 
             // Move into position with the dribbler on
             yield(move_action.updateStateAndGetNextIntent(
-                *robot, ball_receive_pos, ball_receive_orientation, 0, true, false));
+                *robot, ball_receive_pos, ball_receive_orientation, 0, true, NONE));
         }
     }
 }

--- a/src/thunderbots/software/ai/intent/move_intent.cpp
+++ b/src/thunderbots/software/ai/intent/move_intent.cpp
@@ -7,9 +7,8 @@ const std::string MoveIntent::INTENT_NAME = "Move Intent";
 
 MoveIntent::MoveIntent(unsigned int robot_id, const Point &dest, const Angle &final_angle,
                        double final_speed, unsigned int priority, bool enable_dribbler,
-                       bool enable_autokick)
-    : MovePrimitive(robot_id, dest, final_angle, final_speed, enable_dribbler,
-                    enable_autokick),
+                       AutokickFlag autokick)
+    : MovePrimitive(robot_id, dest, final_angle, final_speed, enable_dribbler, autokick),
       Intent(priority),
       flags(MoveFlags::NONE)
 {

--- a/src/thunderbots/software/ai/intent/move_intent.cpp
+++ b/src/thunderbots/software/ai/intent/move_intent.cpp
@@ -7,7 +7,7 @@ const std::string MoveIntent::INTENT_NAME = "Move Intent";
 
 MoveIntent::MoveIntent(unsigned int robot_id, const Point &dest, const Angle &final_angle,
                        double final_speed, unsigned int priority, bool enable_dribbler,
-                       AutokickFlag autokick)
+                       AutokickType autokick)
     : MovePrimitive(robot_id, dest, final_angle, final_speed, enable_dribbler, autokick),
       Intent(priority),
       flags(MoveFlags::NONE)

--- a/src/thunderbots/software/ai/intent/move_intent.h
+++ b/src/thunderbots/software/ai/intent/move_intent.h
@@ -21,14 +21,14 @@ class MoveIntent : public Intent, public MovePrimitive
      * @param priority The priority of this Intent. A larger number indicates a higher
      * priority
      * @param enable_dribbler Whether or not to enable the dribbler
-     * @param enable_autokick This will enable the "break-beam" on the robot, that will
+     * @param autokick This will enable the "break-beam" on the robot, that will
      *                        trigger the kicker to fire as soon as the ball is in front
      *                        of it
      */
     explicit MoveIntent(unsigned int robot_id, const Point& dest,
                         const Angle& final_angle, double final_speed,
                         unsigned int priority, bool enable_dribbler = false,
-                        bool enable_autokick = false);
+                        AutokickFlag autokick = NONE);
 
     std::string getIntentName(void) const override;
 

--- a/src/thunderbots/software/ai/intent/move_intent.h
+++ b/src/thunderbots/software/ai/intent/move_intent.h
@@ -28,7 +28,7 @@ class MoveIntent : public Intent, public MovePrimitive
     explicit MoveIntent(unsigned int robot_id, const Point& dest,
                         const Angle& final_angle, double final_speed,
                         unsigned int priority, bool enable_dribbler = false,
-                        AutokickFlag autokick = NONE);
+                        AutokickType autokick = NONE);
 
     std::string getIntentName(void) const override;
 

--- a/src/thunderbots/software/ai/navigator/util.cpp
+++ b/src/thunderbots/software/ai/navigator/util.cpp
@@ -12,7 +12,7 @@ double calculateTransitionSpeedBetweenSegments(const Point &p1, const Point &p2,
 std::vector<MovePrimitive> convertToMovePrimitives(unsigned int robot_id,
                                                    const std::vector<Point> &points,
                                                    bool enable_dribbler,
-                                                   bool enable_autokick)
+                                                   AutokickFlag autokick)
 {
     std::vector<MovePrimitive> movePrimitives;
     movePrimitives.reserve(points.size());
@@ -31,9 +31,8 @@ std::vector<MovePrimitive> convertToMovePrimitives(unsigned int robot_id,
                                                                   next_next_point, 0);
         }
 
-        MovePrimitive movePrimitive =
-            MovePrimitive(robot_id, point, point.orientation(), final_speed,
-                          enable_dribbler, enable_autokick);
+        MovePrimitive movePrimitive = MovePrimitive(
+            robot_id, point, point.orientation(), final_speed, enable_dribbler, autokick);
         movePrimitives.emplace_back(movePrimitive);
     }
 

--- a/src/thunderbots/software/ai/navigator/util.cpp
+++ b/src/thunderbots/software/ai/navigator/util.cpp
@@ -12,7 +12,7 @@ double calculateTransitionSpeedBetweenSegments(const Point &p1, const Point &p2,
 std::vector<MovePrimitive> convertToMovePrimitives(unsigned int robot_id,
                                                    const std::vector<Point> &points,
                                                    bool enable_dribbler,
-                                                   AutokickFlag autokick)
+                                                   AutokickType autokick)
 {
     std::vector<MovePrimitive> movePrimitives;
     movePrimitives.reserve(points.size());

--- a/src/thunderbots/software/ai/navigator/util.h
+++ b/src/thunderbots/software/ai/navigator/util.h
@@ -31,7 +31,7 @@ double calculateTransitionSpeedBetweenSegments(const Point &p1, const Point &p2,
 std::vector<MovePrimitive> convertToMovePrimitives(unsigned int robot_id,
                                                    const std::vector<Point> &points,
                                                    bool enable_dribbler,
-                                                   bool enable_autokick);
+                                                   AutokickFlag autokick);
 /**
  * Calculates how much a point is trespassing in another point's space.
  *

--- a/src/thunderbots/software/ai/navigator/util.h
+++ b/src/thunderbots/software/ai/navigator/util.h
@@ -31,7 +31,7 @@ double calculateTransitionSpeedBetweenSegments(const Point &p1, const Point &p2,
 std::vector<MovePrimitive> convertToMovePrimitives(unsigned int robot_id,
                                                    const std::vector<Point> &points,
                                                    bool enable_dribbler,
-                                                   AutokickFlag autokick);
+                                                   AutokickType autokick);
 /**
  * Calculates how much a point is trespassing in another point's space.
  *

--- a/src/thunderbots/software/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/move_primitive.cpp
@@ -6,7 +6,7 @@ const std::string MovePrimitive::PRIMITIVE_NAME = "Move Primitive";
 
 MovePrimitive::MovePrimitive(unsigned int robot_id, const Point &dest,
                              const Angle &final_angle, double final_speed,
-                             bool enable_dribbler, AutokickFlag autokick)
+                             bool enable_dribbler, AutokickType autokick)
     : robot_id(robot_id),
       dest(dest),
       final_angle(final_angle),
@@ -67,7 +67,7 @@ double MovePrimitive::getFinalSpeed() const
     return final_speed;
 }
 
-AutokickFlag MovePrimitive::getAutoKickFlag() const
+AutokickType MovePrimitive::getAutoKickType() const
 {
     return autokick;
 }

--- a/src/thunderbots/software/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/move_primitive.cpp
@@ -6,13 +6,13 @@ const std::string MovePrimitive::PRIMITIVE_NAME = "Move Primitive";
 
 MovePrimitive::MovePrimitive(unsigned int robot_id, const Point &dest,
                              const Angle &final_angle, double final_speed,
-                             bool enable_dribbler, bool enable_autokick)
+                             bool enable_dribbler, AutokickFlag autokick)
     : robot_id(robot_id),
       dest(dest),
       final_angle(final_angle),
       final_speed(final_speed),
       enable_dribbler(enable_dribbler),
-      enable_autokick(enable_autokick)
+      autokick(autokick)
 {
 }
 
@@ -27,7 +27,18 @@ MovePrimitive::MovePrimitive(const thunderbots_msgs::Primitive &primitive_msg)
     final_angle     = Angle::ofRadians(primitive_msg.parameters.at(2));
     final_speed     = primitive_msg.parameters.at(3);
     enable_dribbler = static_cast<bool>(primitive_msg.parameters.at(4));
-    enable_autokick = static_cast<bool>(primitive_msg.parameters.at(5));
+    if (primitive_msg.extra_bits.empty())
+    {
+        autokick = NONE;
+    }
+    else if (primitive_msg.extra_bits.at(0))
+    {
+        autokick = AUTOKICK;
+    }
+    else if (primitive_msg.extra_bits.at(1))
+    {
+        autokick = AUTOCHIP;
+    }
 }
 
 
@@ -56,9 +67,9 @@ double MovePrimitive::getFinalSpeed() const
     return final_speed;
 }
 
-bool MovePrimitive::isAutoKickEnabled() const
+AutokickFlag MovePrimitive::getAutoKickFlag() const
 {
-    return enable_autokick;
+    return autokick;
 }
 
 bool MovePrimitive::isDribblerEnabled() const
@@ -68,19 +79,15 @@ bool MovePrimitive::isDribblerEnabled() const
 
 std::vector<double> MovePrimitive::getParameters() const
 {
-    std::vector<double> parameters = {dest.x(),
-                                      dest.y(),
-                                      final_angle.toRadians(),
-                                      final_speed,
-                                      (double)enable_dribbler,
-                                      (double)enable_autokick};
+    std::vector<double> parameters = {dest.x(), dest.y(), final_angle.toRadians(),
+                                      final_speed, (double)enable_dribbler};
 
     return parameters;
 }
 
 std::vector<bool> MovePrimitive::getExtraBits() const
 {
-    return std::vector<bool>();
+    return std::vector<bool>(autokick == AUTOKICK, autokick == AUTOCHIP);
 }
 
 void MovePrimitive::accept(PrimitiveVisitor &visitor) const
@@ -94,7 +101,7 @@ bool MovePrimitive::operator==(const MovePrimitive &other) const
            this->final_angle == other.final_angle &&
            this->final_speed == other.final_speed &&
            this->enable_dribbler == other.enable_dribbler &&
-           this->enable_autokick == other.enable_autokick;
+           this->autokick == other.autokick;
 }
 
 bool MovePrimitive::operator!=(const MovePrimitive &other) const

--- a/src/thunderbots/software/ai/primitive/move_primitive.h
+++ b/src/thunderbots/software/ai/primitive/move_primitive.h
@@ -9,6 +9,13 @@
 #include "geom/angle.h"
 #include "geom/point.h"
 
+enum AutokickFlag
+{
+    NONE,
+    AUTOKICK,
+    AUTOCHIP
+};
+
 class MovePrimitive : public Primitive
 {
    public:
@@ -25,13 +32,13 @@ class MovePrimitive : public Primitive
      * @param final_speed The final speed the Robot should have when it reaches
      * its destination at the end of the movement
      * @param enable_dribbler Whether or not to enable the dribbler
-     * @param enable_autokick This will enable the "break-beam" on the robot, that will
-     *                        trigger the kicker to fire as soon as the ball is in front
-     *                        of it
+     * @param autokick A flag indicating if autokick should be enabled while the robot is
+     * moving. This will enable the "break-beam" on the robot that will trigger the kicker
+     * or chipper to fire as soon as the ball is in front of it
      */
     explicit MovePrimitive(unsigned int robot_id, const Point &dest,
                            const Angle &final_angle, double final_speed,
-                           bool enable_dribbler = false, bool enable_autokick = false);
+                           bool enable_dribbler = false, AutokickFlag autokick = NONE);
 
     /**
      * Creates a new Move Primitive from a Primitive message
@@ -79,7 +86,7 @@ class MovePrimitive : public Primitive
      *
      * @return whether or not auto-kick should be enabled while moving
      */
-    bool isAutoKickEnabled() const;
+    AutokickFlag getAutoKickFlag() const;
 
     /**
      * Gets whether or not the dribbler should be enabled while moving
@@ -128,5 +135,5 @@ class MovePrimitive : public Primitive
     Angle final_angle;
     double final_speed;
     bool enable_dribbler;
-    bool enable_autokick;
+    AutokickFlag autokick;
 };

--- a/src/thunderbots/software/ai/primitive/move_primitive.h
+++ b/src/thunderbots/software/ai/primitive/move_primitive.h
@@ -9,7 +9,7 @@
 #include "geom/angle.h"
 #include "geom/point.h"
 
-enum AutokickFlag
+enum AutokickType
 {
     NONE,
     AUTOKICK,
@@ -38,7 +38,7 @@ class MovePrimitive : public Primitive
      */
     explicit MovePrimitive(unsigned int robot_id, const Point &dest,
                            const Angle &final_angle, double final_speed,
-                           bool enable_dribbler = false, AutokickFlag autokick = NONE);
+                           bool enable_dribbler = false, AutokickType autokick = NONE);
 
     /**
      * Creates a new Move Primitive from a Primitive message
@@ -86,7 +86,7 @@ class MovePrimitive : public Primitive
      *
      * @return whether or not auto-kick should be enabled while moving
      */
-    AutokickFlag getAutoKickFlag() const;
+    AutokickType getAutoKickType() const;
 
     /**
      * Gets whether or not the dribbler should be enabled while moving
@@ -135,5 +135,5 @@ class MovePrimitive : public Primitive
     Angle final_angle;
     double final_speed;
     bool enable_dribbler;
-    AutokickFlag autokick;
+    AutokickType autokick;
 };

--- a/src/thunderbots/software/grsim_communication/grsim_command_primitive_visitor.cpp
+++ b/src/thunderbots/software/grsim_communication/grsim_command_primitive_visitor.cpp
@@ -189,8 +189,8 @@ void GrsimCommandPrimitiveVisitor::visit(const MovePrimitive &move_primitive)
     motion_controller_command = MotionController::PositionCommand(
         move_primitive.getDestination(), move_primitive.getFinalAngle(),
         move_primitive.getFinalSpeed(), move_primitive.isDribblerEnabled() ? 1000.0 : 0,
-        move_primitive.getAutoKickFlag() == AUTOKICK,
-        move_primitive.getAutoKickFlag() == AUTOCHIP);
+        move_primitive.getAutoKickType() == AUTOKICK,
+        move_primitive.getAutoKickType() == AUTOCHIP);
 }
 
 void GrsimCommandPrimitiveVisitor::visit(const MoveSpinPrimitive &move_spin_primitive)

--- a/src/thunderbots/software/grsim_communication/grsim_command_primitive_visitor.cpp
+++ b/src/thunderbots/software/grsim_communication/grsim_command_primitive_visitor.cpp
@@ -187,15 +187,19 @@ void GrsimCommandPrimitiveVisitor::visit(const KickPrimitive &kick_primitive)
 void GrsimCommandPrimitiveVisitor::visit(const MovePrimitive &move_primitive)
 {
     double kick_speed = 0.0;
-    if(move_primitive.getAutoKickType() == AUTOKICK) {
+    if (move_primitive.getAutoKickType() == AUTOKICK)
+    {
         kick_speed = BALL_MAX_SPEED_METERS_PER_SECOND - 1;
-    }else if(move_primitive.getAutoKickType() == AUTOCHIP){
+    }
+    else if (move_primitive.getAutoKickType() == AUTOCHIP)
+    {
         kick_speed = 2.0;
     }
 
     motion_controller_command = MotionController::PositionCommand(
         move_primitive.getDestination(), move_primitive.getFinalAngle(),
-        move_primitive.getFinalSpeed(), kick_speed, move_primitive.getAutoKickType() != NONE, move_primitive.isDribblerEnabled());
+        move_primitive.getFinalSpeed(), kick_speed,
+        move_primitive.getAutoKickType() != NONE, move_primitive.isDribblerEnabled());
 }
 
 void GrsimCommandPrimitiveVisitor::visit(const MoveSpinPrimitive &move_spin_primitive)

--- a/src/thunderbots/software/grsim_communication/grsim_command_primitive_visitor.cpp
+++ b/src/thunderbots/software/grsim_communication/grsim_command_primitive_visitor.cpp
@@ -188,7 +188,9 @@ void GrsimCommandPrimitiveVisitor::visit(const MovePrimitive &move_primitive)
 {
     motion_controller_command = MotionController::PositionCommand(
         move_primitive.getDestination(), move_primitive.getFinalAngle(),
-        move_primitive.getFinalSpeed(), 0.0, false, false);
+        move_primitive.getFinalSpeed(), move_primitive.isDribblerEnabled() ? 1000.0 : 0,
+        move_primitive.getAutoKickFlag() == AUTOKICK,
+        move_primitive.getAutoKickFlag() == AUTOCHIP);
 }
 
 void GrsimCommandPrimitiveVisitor::visit(const MoveSpinPrimitive &move_spin_primitive)

--- a/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
+++ b/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
@@ -98,9 +98,9 @@ void MRFPrimitiveVisitor::visit(const MovePrimitive &move_primitive)
         move_primitive.getFinalAngle().toRadians() * CENTIRADIANS_PER_RADIAN,
         move_primitive.getFinalSpeed() * MILLIMETERS_PER_METER};
     radio_prim->extra_bits = 0;
-    radio_prim->extra_bits |= (move_primitive.getAutoKickFlag() == AUTOKICK) * 0x01;
+    radio_prim->extra_bits |= (move_primitive.getAutoKickType() == AUTOKICK) * 0x01;
     radio_prim->extra_bits |= move_primitive.isDribblerEnabled() * 0x02;
-    radio_prim->extra_bits |= (move_primitive.getAutoKickFlag() == AUTOCHIP) * 0x04;
+    radio_prim->extra_bits |= (move_primitive.getAutoKickType() == AUTOCHIP) * 0x04;
 }
 
 void MRFPrimitiveVisitor::visit(const MoveSpinPrimitive &movespin_primitive)

--- a/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
+++ b/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
@@ -98,8 +98,9 @@ void MRFPrimitiveVisitor::visit(const MovePrimitive &move_primitive)
         move_primitive.getFinalAngle().toRadians() * CENTIRADIANS_PER_RADIAN,
         move_primitive.getFinalSpeed() * MILLIMETERS_PER_METER};
     radio_prim->extra_bits = 0;
-    radio_prim->extra_bits |= move_primitive.isAutoKickEnabled() * 0x01;
+    radio_prim->extra_bits |= (move_primitive.getAutoKickFlag() == AUTOKICK) * 0x01;
     radio_prim->extra_bits |= move_primitive.isDribblerEnabled() * 0x02;
+    radio_prim->extra_bits |= (move_primitive.getAutoKickFlag() == AUTOCHIP) * 0x04;
 }
 
 void MRFPrimitiveVisitor::visit(const MoveSpinPrimitive &movespin_primitive)

--- a/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
@@ -23,7 +23,7 @@ TEST(MoveActionTest, robot_far_from_destination)
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
     EXPECT_FALSE(move_intent.isDribblerEnabled());
-    EXPECT_FALSE(move_intent.isAutoKickEnabled());
+    EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
 }
 
 TEST(MoveActionTest, robot_at_destination)
@@ -69,7 +69,7 @@ TEST(MoveActionTest, robot_far_from_destination_autokick_turned_on)
     MoveAction action = MoveAction(0.05);
 
     auto intent_ptr = action.updateStateAndGetNextIntent(
-        robot, Point(1, 0), Angle::quarter(), 1.0, false, true);
+        robot, Point(1, 0), Angle::quarter(), 1.0, false, AUTOKICK);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -81,7 +81,7 @@ TEST(MoveActionTest, robot_far_from_destination_autokick_turned_on)
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
     EXPECT_FALSE(move_intent.isDribblerEnabled());
-    EXPECT_TRUE(move_intent.isAutoKickEnabled());
+    EXPECT_EQ(move_intent.getAutoKickFlag(), AUTOKICK);
 }
 
 TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
@@ -91,7 +91,7 @@ TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
     MoveAction action = MoveAction(0.05);
 
     auto intent_ptr = action.updateStateAndGetNextIntent(
-        robot, Point(1, 0), Angle::quarter(), 1.0, true, false);
+        robot, Point(1, 0), Angle::quarter(), 1.0, true, NONE);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -103,5 +103,5 @@ TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
     EXPECT_TRUE(move_intent.isDribblerEnabled());
-    EXPECT_FALSE(move_intent.isAutoKickEnabled());
+    EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
 }

--- a/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/move_action.cpp
@@ -23,7 +23,7 @@ TEST(MoveActionTest, robot_far_from_destination)
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
     EXPECT_FALSE(move_intent.isDribblerEnabled());
-    EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
+    EXPECT_EQ(move_intent.getAutoKickType(), NONE);
 }
 
 TEST(MoveActionTest, robot_at_destination)
@@ -81,7 +81,7 @@ TEST(MoveActionTest, robot_far_from_destination_autokick_turned_on)
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
     EXPECT_FALSE(move_intent.isDribblerEnabled());
-    EXPECT_EQ(move_intent.getAutoKickFlag(), AUTOKICK);
+    EXPECT_EQ(move_intent.getAutoKickType(), AUTOKICK);
 }
 
 TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
@@ -103,5 +103,5 @@ TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
     EXPECT_TRUE(move_intent.isDribblerEnabled());
-    EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
+    EXPECT_EQ(move_intent.getAutoKickType(), NONE);
 }

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -41,7 +41,7 @@ TEST(ReceiverTacticTest, robot_not_at_receive_position_pass_not_started)
     EXPECT_DOUBLE_EQ(0.0, move_intent.getDestination().y());
     EXPECT_EQ((pass.receiverOrientation() + shot_dir) / 2, move_intent.getFinalAngle());
     EXPECT_FALSE(move_intent.isDribblerEnabled());
-    EXPECT_FALSE(move_intent.isAutoKickEnabled());
+    EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
 }
 
 TEST(ReceiverTacticTest, robot_at_receive_position_pass_not_started)
@@ -80,7 +80,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_not_started)
         EXPECT_EQ((pass.receiverOrientation() + shot_dir) / 2,
                   move_intent.getFinalAngle());
         EXPECT_FALSE(move_intent.isDribblerEnabled());
-        EXPECT_FALSE(move_intent.isAutoKickEnabled());
+        EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
     }
 }
 
@@ -120,7 +120,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_open_angle_
     EXPECT_GT(move_intent.getFinalAngle().toDegrees(), -90);
 
     EXPECT_FALSE(move_intent.isDribblerEnabled());
-    EXPECT_TRUE(move_intent.isAutoKickEnabled());
+    EXPECT_EQ(move_intent.getAutoKickFlag(), AUTOKICK);
 }
 
 TEST(ReceiverTacticTest,
@@ -156,7 +156,7 @@ TEST(ReceiverTacticTest,
     EXPECT_EQ(pass.receiverOrientation(), move_intent.getFinalAngle());
 
     EXPECT_TRUE(move_intent.isDribblerEnabled());
-    EXPECT_FALSE(move_intent.isAutoKickEnabled());
+    EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
 }
 
 TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_blocked)
@@ -199,7 +199,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_blocked)
     EXPECT_EQ(pass.receiverOrientation(), move_intent.getFinalAngle());
 
     EXPECT_TRUE(move_intent.isDribblerEnabled());
-    EXPECT_FALSE(move_intent.isAutoKickEnabled());
+    EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
 }
 
 TEST(ReceiverTacticTest, robot_at_receive_position_pass_received)

--- a/src/thunderbots/software/test/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -41,7 +41,7 @@ TEST(ReceiverTacticTest, robot_not_at_receive_position_pass_not_started)
     EXPECT_DOUBLE_EQ(0.0, move_intent.getDestination().y());
     EXPECT_EQ((pass.receiverOrientation() + shot_dir) / 2, move_intent.getFinalAngle());
     EXPECT_FALSE(move_intent.isDribblerEnabled());
-    EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
+    EXPECT_EQ(move_intent.getAutoKickType(), NONE);
 }
 
 TEST(ReceiverTacticTest, robot_at_receive_position_pass_not_started)
@@ -80,7 +80,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_not_started)
         EXPECT_EQ((pass.receiverOrientation() + shot_dir) / 2,
                   move_intent.getFinalAngle());
         EXPECT_FALSE(move_intent.isDribblerEnabled());
-        EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
+        EXPECT_EQ(move_intent.getAutoKickType(), NONE);
     }
 }
 
@@ -120,7 +120,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_open_angle_
     EXPECT_GT(move_intent.getFinalAngle().toDegrees(), -90);
 
     EXPECT_FALSE(move_intent.isDribblerEnabled());
-    EXPECT_EQ(move_intent.getAutoKickFlag(), AUTOKICK);
+    EXPECT_EQ(move_intent.getAutoKickType(), AUTOKICK);
 }
 
 TEST(ReceiverTacticTest,
@@ -156,7 +156,7 @@ TEST(ReceiverTacticTest,
     EXPECT_EQ(pass.receiverOrientation(), move_intent.getFinalAngle());
 
     EXPECT_TRUE(move_intent.isDribblerEnabled());
-    EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
+    EXPECT_EQ(move_intent.getAutoKickType(), NONE);
 }
 
 TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_blocked)
@@ -199,7 +199,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_blocked)
     EXPECT_EQ(pass.receiverOrientation(), move_intent.getFinalAngle());
 
     EXPECT_TRUE(move_intent.isDribblerEnabled());
-    EXPECT_EQ(move_intent.getAutoKickFlag(), NONE);
+    EXPECT_EQ(move_intent.getAutoKickType(), NONE);
 }
 
 TEST(ReceiverTacticTest, robot_at_receive_position_pass_received)

--- a/src/thunderbots/software/test/ai/navigator/util.cpp
+++ b/src/thunderbots/software/test/ai/navigator/util.cpp
@@ -86,7 +86,7 @@ TEST(NavUtilTest, convertPointsToMovePrimitives_test)
     std::vector<Point> points = {point1, point2, point3};
 
     std::vector<MovePrimitive> movePrimitives =
-        convertToMovePrimitives(robot_id, points, false, false);
+        convertToMovePrimitives(robot_id, points, false, NONE);
 
     // testing point 1
     MovePrimitive movePrimitive1 = movePrimitives.at(0);
@@ -116,7 +116,7 @@ TEST(NavUtilTest, convertNoPointsToMovePrimitives_test)
 
     std::vector<Point> points = {};
     std::vector<MovePrimitive> movePrimitives =
-        convertToMovePrimitives(robot_id, points, false, false);
+        convertToMovePrimitives(robot_id, points, false, NONE);
 
     EXPECT_THROW(movePrimitives.at(0), std::out_of_range);
 }

--- a/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
@@ -26,7 +26,7 @@ TEST(MovePrimTest, get_robot_id_test)
 TEST(MovePrimTest, autokick_and_dribble_disabled_by_default)
 {
     MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0);
-    EXPECT_FALSE(move_prim.getAutoKickFlag());
+    EXPECT_FALSE(move_prim.getAutoKickType());
     EXPECT_FALSE(move_prim.isDribblerEnabled());
 }
 
@@ -34,21 +34,21 @@ TEST(MovePrimTest, get_dribble_enabled)
 {
     MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, true, NONE);
     EXPECT_TRUE(move_prim.isDribblerEnabled());
-    EXPECT_EQ(move_prim.getAutoKickFlag(), NONE);
+    EXPECT_EQ(move_prim.getAutoKickType(), NONE);
 }
 
 TEST(MovePrimTest, get_autokick_enabled)
 {
     MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, false, AUTOKICK);
     EXPECT_FALSE(move_prim.isDribblerEnabled());
-    EXPECT_EQ(move_prim.getAutoKickFlag(), AUTOKICK);
+    EXPECT_EQ(move_prim.getAutoKickType(), AUTOKICK);
 }
 
 TEST(MovePrimTest, get_autochip_enabled)
 {
     MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, false, AUTOCHIP);
     EXPECT_FALSE(move_prim.isDribblerEnabled());
-    EXPECT_EQ(move_prim.getAutoKickFlag(), AUTOCHIP);
+    EXPECT_EQ(move_prim.getAutoKickType(), AUTOCHIP);
 }
 
 TEST(MovePrimTest, parameter_array_test)

--- a/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
@@ -26,22 +26,29 @@ TEST(MovePrimTest, get_robot_id_test)
 TEST(MovePrimTest, autokick_and_dribble_disabled_by_default)
 {
     MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0);
-    EXPECT_FALSE(move_prim.isAutoKickEnabled());
+    EXPECT_FALSE(move_prim.getAutoKickFlag());
     EXPECT_FALSE(move_prim.isDribblerEnabled());
 }
 
 TEST(MovePrimTest, get_dribble_enabled)
 {
-    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, true, false);
+    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, true, NONE);
     EXPECT_TRUE(move_prim.isDribblerEnabled());
-    EXPECT_FALSE(move_prim.isAutoKickEnabled());
+    EXPECT_EQ(move_prim.getAutoKickFlag(), NONE);
 }
 
 TEST(MovePrimTest, get_autokick_enabled)
 {
-    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, false, true);
+    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, false, AUTOKICK);
     EXPECT_FALSE(move_prim.isDribblerEnabled());
-    EXPECT_TRUE(move_prim.isAutoKickEnabled());
+    EXPECT_EQ(move_prim.getAutoKickFlag(), AUTOKICK);
+}
+
+TEST(MovePrimTest, get_autochip_enabled)
+{
+    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, false, AUTOCHIP);
+    EXPECT_FALSE(move_prim.isDribblerEnabled());
+    EXPECT_EQ(move_prim.getAutoKickFlag(), AUTOCHIP);
 }
 
 TEST(MovePrimTest, parameter_array_test)

--- a/src/thunderbots/software/test/radio_communication/visitor/mrf_primitive_visitor.cpp
+++ b/src/thunderbots/software/test/radio_communication/visitor/mrf_primitive_visitor.cpp
@@ -147,7 +147,7 @@ TEST(MRFPrimitiveVisitorTest, visit_move_primitive_autokick_and_dribble_off)
 
 TEST(MRFPrimitiveVisitorTest, visit_move_primitive_autokick_enabled_dribble_off)
 {
-    MovePrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33, false, true);
+    MovePrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33, false, AUTOKICK);
     RadioPrimitive expected_radio_primitive;
     expected_radio_primitive.prim_type   = FirmwarePrimitiveType::MOVE;
     expected_radio_primitive.param_array = {22 * 1000, 33.3 * 1000,
@@ -162,7 +162,7 @@ TEST(MRFPrimitiveVisitorTest, visit_move_primitive_autokick_enabled_dribble_off)
 
 TEST(MRFPrimitiveVisitorTest, visit_move_primitive_dribble_enabled_autokick_off)
 {
-    MovePrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33, true, false);
+    MovePrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33, true, NONE);
     RadioPrimitive expected_radio_primitive;
     expected_radio_primitive.prim_type   = FirmwarePrimitiveType::MOVE;
     expected_radio_primitive.param_array = {22 * 1000, 33.3 * 1000,
@@ -177,7 +177,7 @@ TEST(MRFPrimitiveVisitorTest, visit_move_primitive_dribble_enabled_autokick_off)
 
 TEST(MRFPrimitiveVisitorTest, visit_move_primitive_autokick_and_dribble_enabled)
 {
-    MovePrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33, true, true);
+    MovePrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33, true, AUTOKICK);
     RadioPrimitive expected_radio_primitive;
     expected_radio_primitive.prim_type   = FirmwarePrimitiveType::MOVE;
     expected_radio_primitive.param_array = {22 * 1000, 33.3 * 1000,


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
This PR adds an autochip flag to the MovePrimitive, similar to the existing autokick. This allows the robot to chip when the breakbeam is fired. The autokick / autochip now uses enum flags to indicate which to do, since both can't be done at the same time.

_**This will require flashing firmware in order to test**_

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests all pass. Needs field testing.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
