### PR TITLE
Reduce oscillation when destination is blocked

### DIFF
--- a/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -186,7 +186,6 @@ std::optional<std::vector<Point>> ThetaStarPathPlanner::findPath(const Point &st
     Point closest_destination = findClosestFreePoint(destination);
     src                       = convertPointToCell(start);
     dest                      = convertPointToCell(closest_destination);
-    std::cout << "here" << std::endl;
     // If the source is out of range
     if (isValid(src.first, src.second) == false)
     {
@@ -202,7 +201,8 @@ std::optional<std::vector<Point>> ThetaStarPathPlanner::findPath(const Point &st
     }
 
     if ((start - destination).len() < CLOSE_TO_DEST_THRESHOLD ||
-        (start - closest_destination).len() < (CLOSE_TO_DEST_THRESHOLD * 2))
+        (start - closest_destination).len() <
+            (CLOSE_TO_DEST_THRESHOLD * BLOCKED_DESINATION_OSCILLATION_MITIGATION))
     {
         // start and destination, or start and closest_destination, within threshold
         return std::nullopt;
@@ -382,10 +382,11 @@ Point ThetaStarPathPlanner::findClosestFreePoint(Point p)
 {
     if (!isValidAndFreeOfObstacles(p))
     {
-        int xc = (int)(p.x() * RESOLUTION_FACTOR);
-        int yc = (int)(p.y() * RESOLUTION_FACTOR);
+        int xc = (int)(p.x() * BLOCKED_DESTINATION_SEARCH_RESOLUTION);
+        int yc = (int)(p.y() * BLOCKED_DESTINATION_SEARCH_RESOLUTION);
 
-        for (int r = 1; r < field_.totalWidth() * RESOLUTION_FACTOR; r++)
+        for (int r = 1; r < field_.totalWidth() * BLOCKED_DESTINATION_SEARCH_RESOLUTION;
+             r++)
         {
             int x = 0, y = r;
             int d = 3 - 2 * r;
@@ -394,10 +395,12 @@ Point ThetaStarPathPlanner::findClosestFreePoint(Point p)
             {
                 for (int inner : {-1, 1})
                 {
-                    Point p1 = Point((double)(xc + outer * x) / RESOLUTION_FACTOR,
-                                     (double)(yc + inner * y) / RESOLUTION_FACTOR);
-                    Point p2 = Point((double)(xc + outer * y) / RESOLUTION_FACTOR,
-                                     (double)(yc + inner * x) / RESOLUTION_FACTOR);
+                    Point p1 = Point(
+                        (double)(xc + outer * x) / BLOCKED_DESTINATION_SEARCH_RESOLUTION,
+                        (double)(yc + inner * y) / BLOCKED_DESTINATION_SEARCH_RESOLUTION);
+                    Point p2 = Point(
+                        (double)(xc + outer * y) / BLOCKED_DESTINATION_SEARCH_RESOLUTION,
+                        (double)(yc + inner * x) / BLOCKED_DESTINATION_SEARCH_RESOLUTION);
                     if (isValidAndFreeOfObstacles(p1))
                     {
                         return p1;
@@ -433,10 +436,12 @@ Point ThetaStarPathPlanner::findClosestFreePoint(Point p)
                 {
                     for (int inner : {-1, 1})
                     {
-                        Point p1 = Point((xc + outer * x) / RESOLUTION_FACTOR,
-                                         (yc + inner * y) / RESOLUTION_FACTOR);
-                        Point p2 = Point((xc + outer * y) / RESOLUTION_FACTOR,
-                                         (yc + inner * x) / RESOLUTION_FACTOR);
+                        Point p1 = Point(
+                            (xc + outer * x) / BLOCKED_DESTINATION_SEARCH_RESOLUTION,
+                            (yc + inner * y) / BLOCKED_DESTINATION_SEARCH_RESOLUTION);
+                        Point p2 = Point(
+                            (xc + outer * y) / BLOCKED_DESTINATION_SEARCH_RESOLUTION,
+                            (yc + inner * x) / BLOCKED_DESTINATION_SEARCH_RESOLUTION);
                         if (isValidAndFreeOfObstacles(p1))
                         {
                             return p1;

--- a/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.h
+++ b/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.h
@@ -192,13 +192,14 @@ class ThetaStarPathPlanner : public PathPlanner
      */
     CellCoordinate convertPointToCell(Point p);
 
-    static constexpr double CLOSE_TO_DEST_THRESHOLD =
-        0.01;  // if close to destination then return no path
-    static constexpr int BLOCKED_DESINATION_OSCILLATION_MITIGATION =
-        4;  // increase in threshold to reduce oscillation
-    static constexpr double BLOCKED_DESTINATION_SEARCH_RESOLUTION =
-        10.0;  // resolution for searching for unblocked point around a blocked
-               // destination
+    // if close to destination then return no path
+    static constexpr double CLOSE_TO_DEST_THRESHOLD = 0.01;
+
+    // increase in threshold to reduce oscillation
+    static constexpr int BLOCKED_DESINATION_OSCILLATION_MITIGATION = 4;
+
+    // resolution for searching for unblocked point around a blocked destination
+    static constexpr double BLOCKED_DESTINATION_SEARCH_RESOLUTION = 10.0;
 
     // only change this value
     static constexpr int GRID_DIVISION_FACTOR = 1;  // the n in the O(n^2) algorithm :p

--- a/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.h
+++ b/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.h
@@ -192,8 +192,13 @@ class ThetaStarPathPlanner : public PathPlanner
      */
     CellCoordinate convertPointToCell(Point p);
 
-    static constexpr double CLOSE_TO_DEST_THRESHOLD = 0.01;
-    static constexpr double RESOLUTION_FACTOR       = 100.0;
+    static constexpr double CLOSE_TO_DEST_THRESHOLD =
+        0.01;  // if close to destination then return no path
+    static constexpr int BLOCKED_DESINATION_OSCILLATION_MITIGATION =
+        4;  // increase in threshold to reduce oscillation
+    static constexpr double BLOCKED_DESTINATION_SEARCH_RESOLUTION =
+        10.0;  // resolution for searching for unblocked point around a blocked
+               // destination
 
     // only change this value
     static constexpr int GRID_DIVISION_FACTOR = 1;  // the n in the O(n^2) algorithm :p


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Tune some factors to reduce oscillation when destination is blocked
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
grsim
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
