### PR TITLE
Added slow flag

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
@@ -11,7 +11,7 @@ MoveAction::MoveAction(double close_to_dest_threshold, bool loop_forever)
 
 std::unique_ptr<Intent> MoveAction::updateStateAndGetNextIntent(
     const Robot& robot, Point destination, Angle final_orientation, double final_speed,
-    bool enable_dribbler, AutokickType autokick)
+    bool enable_dribbler, bool slow, AutokickType autokick)
 {
     // Update the parameters stored by this Action
     this->robot             = robot;
@@ -19,6 +19,7 @@ std::unique_ptr<Intent> MoveAction::updateStateAndGetNextIntent(
     this->final_orientation = final_orientation;
     this->final_speed       = final_speed;
     this->enable_dribbler   = enable_dribbler;
+    this->slow   = slow;
     this->autokick          = autokick;
 
     return getNextIntent();
@@ -34,7 +35,7 @@ void MoveAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<MoveIntent>(robot->id(), destination, final_orientation,
-                                           final_speed, 0, enable_dribbler, autokick));
+                                           final_speed, 0, enable_dribbler, slow, autokick));
     } while (loop_forever ||
              (robot->position() - destination).len() > close_to_dest_threshold);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<Intent> MoveAction::updateStateAndGetNextIntent(
     this->final_orientation = final_orientation;
     this->final_speed       = final_speed;
     this->enable_dribbler   = enable_dribbler;
-    this->slow   = slow;
+    this->slow              = slow;
     this->autokick          = autokick;
 
     return getNextIntent();
@@ -35,7 +35,8 @@ void MoveAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<MoveIntent>(robot->id(), destination, final_orientation,
-                                           final_speed, 0, enable_dribbler, slow, autokick));
+                                           final_speed, 0, enable_dribbler, slow,
+                                           autokick));
     } while (loop_forever ||
              (robot->position() - destination).len() > close_to_dest_threshold);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.h
@@ -34,6 +34,7 @@ class MoveAction : public Action
      * the destination
      * @param final_speed The final speed the robot should have at the destination
      * @param enable_dribbler Whether or not to enable the dribbler
+     * @param slow Whether or not to move slow
      * @param autokick This will enable the "break-beam" on the robot, that will
      * trigger the kicker or chippper to fire as soon as the ball is in front of it
      *
@@ -42,7 +43,7 @@ class MoveAction : public Action
      */
     std::unique_ptr<Intent> updateStateAndGetNextIntent(
         const Robot& robot, Point destination, Angle final_orientation,
-        double final_speed, bool enable_dribbler = false, AutokickType autokick = NONE);
+        double final_speed, bool enable_dribbler = false, bool slow = false, AutokickType autokick = NONE);
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;
@@ -52,6 +53,7 @@ class MoveAction : public Action
     Angle final_orientation;
     double final_speed;
     bool enable_dribbler;
+    bool slow;
     AutokickType autokick;
 
     double close_to_dest_threshold;

--- a/src/thunderbots/software/ai/hl/stp/action/move_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/move_action.h
@@ -43,7 +43,8 @@ class MoveAction : public Action
      */
     std::unique_ptr<Intent> updateStateAndGetNextIntent(
         const Robot& robot, Point destination, Angle final_orientation,
-        double final_speed, bool enable_dribbler = false, bool slow = false, AutokickType autokick = NONE);
+        double final_speed, bool enable_dribbler = false, bool slow = false,
+        AutokickType autokick = NONE);
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/thunderbots/software/ai/intent/move_intent.cpp
+++ b/src/thunderbots/software/ai/intent/move_intent.cpp
@@ -6,9 +6,10 @@
 const std::string MoveIntent::INTENT_NAME = "Move Intent";
 
 MoveIntent::MoveIntent(unsigned int robot_id, const Point &dest, const Angle &final_angle,
-                       double final_speed, unsigned int priority, bool enable_dribbler, bool slow,
-                       AutokickType autokick)
-    : MovePrimitive(robot_id, dest, final_angle, final_speed, enable_dribbler, slow, autokick),
+                       double final_speed, unsigned int priority, bool enable_dribbler,
+                       bool slow, AutokickType autokick)
+    : MovePrimitive(robot_id, dest, final_angle, final_speed, enable_dribbler, slow,
+                    autokick),
       Intent(priority),
       flags(MoveFlags::NONE),
       additional_obstacles({})

--- a/src/thunderbots/software/ai/intent/move_intent.cpp
+++ b/src/thunderbots/software/ai/intent/move_intent.cpp
@@ -6,9 +6,9 @@
 const std::string MoveIntent::INTENT_NAME = "Move Intent";
 
 MoveIntent::MoveIntent(unsigned int robot_id, const Point &dest, const Angle &final_angle,
-                       double final_speed, unsigned int priority, bool enable_dribbler,
+                       double final_speed, unsigned int priority, bool enable_dribbler, bool slow,
                        AutokickType autokick)
-    : MovePrimitive(robot_id, dest, final_angle, final_speed, enable_dribbler, autokick),
+    : MovePrimitive(robot_id, dest, final_angle, final_speed, enable_dribbler, slow, autokick),
       Intent(priority),
       flags(MoveFlags::NONE),
       additional_obstacles({})

--- a/src/thunderbots/software/ai/intent/move_intent.h
+++ b/src/thunderbots/software/ai/intent/move_intent.h
@@ -22,13 +22,14 @@ class MoveIntent : public Intent, public MovePrimitive
      * @param priority The priority of this Intent. A larger number indicates a higher
      * priority
      * @param enable_dribbler Whether or not to enable the dribbler
+     * @param slow Whether or not to move slower (1 m/s)
      * @param autokick This will enable the "break-beam" on the robot, that will
      *                        trigger the kicker to fire as soon as the ball is in front
      *                        of it
      */
     explicit MoveIntent(unsigned int robot_id, const Point& dest,
                         const Angle& final_angle, double final_speed,
-                        unsigned int priority, bool enable_dribbler = false,
+                        unsigned int priority, bool enable_dribbler = false, bool slow = false,
                         AutokickType autokick = NONE);
 
     std::string getIntentName(void) const override;

--- a/src/thunderbots/software/ai/intent/move_intent.h
+++ b/src/thunderbots/software/ai/intent/move_intent.h
@@ -29,8 +29,8 @@ class MoveIntent : public Intent, public MovePrimitive
      */
     explicit MoveIntent(unsigned int robot_id, const Point& dest,
                         const Angle& final_angle, double final_speed,
-                        unsigned int priority, bool enable_dribbler = false, bool slow = false,
-                        AutokickType autokick = NONE);
+                        unsigned int priority, bool enable_dribbler = false,
+                        bool slow = false, AutokickType autokick = NONE);
 
     std::string getIntentName(void) const override;
 

--- a/src/thunderbots/software/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/move_primitive.cpp
@@ -1,4 +1,5 @@
-#include "ai/primitive/move_primitive.h" 
+#include "ai/primitive/move_primitive.h"
+
 #include "ai/primitive/visitor/primitive_visitor.h"
 
 const std::string MovePrimitive::PRIMITIVE_NAME = "Move Primitive";
@@ -27,7 +28,7 @@ MovePrimitive::MovePrimitive(const thunderbots_msgs::Primitive &primitive_msg)
     final_angle     = Angle::ofRadians(primitive_msg.parameters.at(2));
     final_speed     = primitive_msg.parameters.at(3);
     enable_dribbler = static_cast<bool>(primitive_msg.parameters.at(4));
-    slow = static_cast<bool>(primitive_msg.parameters.at(5));
+    slow            = static_cast<bool>(primitive_msg.parameters.at(5));
     if (primitive_msg.extra_bits.empty())
     {
         autokick = NONE;
@@ -85,8 +86,12 @@ bool MovePrimitive::isSlowEnabled() const
 
 std::vector<double> MovePrimitive::getParameters() const
 {
-    std::vector<double> parameters = {dest.x(), dest.y(), final_angle.toRadians(),
-                                      final_speed, (double)enable_dribbler, (double)slow};
+    std::vector<double> parameters = {dest.x(),
+                                      dest.y(),
+                                      final_angle.toRadians(),
+                                      final_speed,
+                                      (double)enable_dribbler,
+                                      (double)slow};
 
     return parameters;
 }
@@ -106,8 +111,7 @@ bool MovePrimitive::operator==(const MovePrimitive &other) const
     return this->robot_id == other.robot_id && this->dest == other.dest &&
            this->final_angle == other.final_angle &&
            this->final_speed == other.final_speed &&
-           this->enable_dribbler == other.enable_dribbler &&
-           this->slow == other.slow &&
+           this->enable_dribbler == other.enable_dribbler && this->slow == other.slow &&
            this->autokick == other.autokick;
 }
 

--- a/src/thunderbots/software/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/move_primitive.cpp
@@ -1,17 +1,17 @@
-#include "ai/primitive/move_primitive.h"
-
+#include "ai/primitive/move_primitive.h" 
 #include "ai/primitive/visitor/primitive_visitor.h"
 
 const std::string MovePrimitive::PRIMITIVE_NAME = "Move Primitive";
 
 MovePrimitive::MovePrimitive(unsigned int robot_id, const Point &dest,
                              const Angle &final_angle, double final_speed,
-                             bool enable_dribbler, AutokickType autokick)
+                             bool enable_dribbler, bool slow, AutokickType autokick)
     : robot_id(robot_id),
       dest(dest),
       final_angle(final_angle),
       final_speed(final_speed),
       enable_dribbler(enable_dribbler),
+      slow(slow),
       autokick(autokick)
 {
 }
@@ -27,6 +27,7 @@ MovePrimitive::MovePrimitive(const thunderbots_msgs::Primitive &primitive_msg)
     final_angle     = Angle::ofRadians(primitive_msg.parameters.at(2));
     final_speed     = primitive_msg.parameters.at(3);
     enable_dribbler = static_cast<bool>(primitive_msg.parameters.at(4));
+    slow = static_cast<bool>(primitive_msg.parameters.at(5));
     if (primitive_msg.extra_bits.empty())
     {
         autokick = NONE;
@@ -77,10 +78,15 @@ bool MovePrimitive::isDribblerEnabled() const
     return enable_dribbler;
 }
 
+bool MovePrimitive::isSlowEnabled() const
+{
+    return slow;
+}
+
 std::vector<double> MovePrimitive::getParameters() const
 {
     std::vector<double> parameters = {dest.x(), dest.y(), final_angle.toRadians(),
-                                      final_speed, (double)enable_dribbler};
+                                      final_speed, (double)enable_dribbler, (double)slow};
 
     return parameters;
 }
@@ -101,6 +107,7 @@ bool MovePrimitive::operator==(const MovePrimitive &other) const
            this->final_angle == other.final_angle &&
            this->final_speed == other.final_speed &&
            this->enable_dribbler == other.enable_dribbler &&
+           this->slow == other.slow &&
            this->autokick == other.autokick;
 }
 

--- a/src/thunderbots/software/ai/primitive/move_primitive.h
+++ b/src/thunderbots/software/ai/primitive/move_primitive.h
@@ -32,13 +32,14 @@ class MovePrimitive : public Primitive
      * @param final_speed The final speed the Robot should have when it reaches
      * its destination at the end of the movement
      * @param enable_dribbler Whether or not to enable the dribbler
+     * @param slow Whether or not to move at a slower speed (1m/s)
      * @param autokick A flag indicating if autokick should be enabled while the robot is
      * moving. This will enable the "break-beam" on the robot that will trigger the kicker
      * or chipper to fire as soon as the ball is in front of it
      */
     explicit MovePrimitive(unsigned int robot_id, const Point &dest,
                            const Angle &final_angle, double final_speed,
-                           bool enable_dribbler = false, AutokickType autokick = NONE);
+                           bool enable_dribbler = false, bool slow = false, AutokickType autokick = NONE);
 
     /**
      * Creates a new Move Primitive from a Primitive message
@@ -99,7 +100,7 @@ class MovePrimitive : public Primitive
      * Returns the generic vector of parameters for this Primitive
      *
      * @return A vector of the form {dest.x(), dest.y(), final_angle.toRadians(),
-     *                               final_speed, enable_dribbler, enable_autokick}
+     *                               final_speed, enable_dribbler, slow}
      */
     std::vector<double> getParameters() const override;
 
@@ -135,5 +136,6 @@ class MovePrimitive : public Primitive
     Angle final_angle;
     double final_speed;
     bool enable_dribbler;
+    bool slow;
     AutokickType autokick;
 };

--- a/src/thunderbots/software/ai/primitive/move_primitive.h
+++ b/src/thunderbots/software/ai/primitive/move_primitive.h
@@ -39,7 +39,8 @@ class MovePrimitive : public Primitive
      */
     explicit MovePrimitive(unsigned int robot_id, const Point &dest,
                            const Angle &final_angle, double final_speed,
-                           bool enable_dribbler = false, bool slow = false, AutokickType autokick = NONE);
+                           bool enable_dribbler = false, bool slow = false,
+                           AutokickType autokick = NONE);
 
     /**
      * Creates a new Move Primitive from a Primitive message
@@ -95,6 +96,13 @@ class MovePrimitive : public Primitive
      * @return whether or not the dribbler should be enabled while moving
      */
     bool isDribblerEnabled() const;
+
+    /**
+     * Gets whether or not the robot should be moving slow
+     *
+     * @return whether or not the robot should be moving slow
+     */
+    bool isSlowEnabled() const;
 
     /**
      * Returns the generic vector of parameters for this Primitive

--- a/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
+++ b/src/thunderbots/software/test/ai/primitive/move_primitive.cpp
@@ -32,21 +32,29 @@ TEST(MovePrimTest, autokick_and_dribble_disabled_by_default)
 
 TEST(MovePrimTest, get_dribble_enabled)
 {
-    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, true, NONE);
+    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, true, false, NONE);
     EXPECT_TRUE(move_prim.isDribblerEnabled());
     EXPECT_EQ(move_prim.getAutoKickType(), NONE);
 }
 
+TEST(MovePrimTest, get_slow_enabled)
+{
+    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, true, false, NONE);
+    EXPECT_FALSE(move_prim.isSlowEnabled());
+}
+
 TEST(MovePrimTest, get_autokick_enabled)
 {
-    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, false, AUTOKICK);
+    MovePrimitive move_prim =
+        MovePrimitive(0, Point(), Angle(), 0.0, false, false, AUTOKICK);
     EXPECT_FALSE(move_prim.isDribblerEnabled());
     EXPECT_EQ(move_prim.getAutoKickType(), AUTOKICK);
 }
 
 TEST(MovePrimTest, get_autochip_enabled)
 {
-    MovePrimitive move_prim = MovePrimitive(0, Point(), Angle(), 0.0, false, AUTOCHIP);
+    MovePrimitive move_prim =
+        MovePrimitive(0, Point(), Angle(), 0.0, false, false, AUTOCHIP);
     EXPECT_FALSE(move_prim.isDribblerEnabled());
     EXPECT_EQ(move_prim.getAutoKickType(), AUTOCHIP);
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
