### PR TITLE
libusb clean shutdown and Robocup MRF channel changes

### DIFF
--- a/src/thunderbots/firmware/main/main.c
+++ b/src/thunderbots/firmware/main/main.c
@@ -338,10 +338,10 @@ static void run_normal(void) {
 		bool symbol_rate;
 		uint16_t pan;
 	} mrf_profiles[4] = {
-		{ 25, false, 0x1846U },
-		{ 25, false, 0x1847U },
-		{ 25, false, 0x1848U },
-		{ 25, false, 0x1849U },
+		{ 23, false, 0x1846U },
+		{ 23, false, 0x1847U },
+		{ 23, false, 0x1848U },
+		{ 23, false, 0x1849U },
 	};
 	
 	// Assign a mrf profile.

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -4,8 +4,6 @@
 #include <thunderbots_msgs/PrimitiveArray.h>
 #include <thunderbots_msgs/World.h>
 
-#include <csignal>
-
 #include "ai/primitive/primitive.h"
 #include "ai/primitive/primitive_factory.h"
 #include "geom/point.h"
@@ -70,15 +68,6 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
     backend_ptr->send_vision_packet();
 }
 
-void signalHandler(int signum)
-{
-    LOG(DEBUG) << "Ctrl-C signal caught" << std::endl;
-
-    // Destroys backend, allowing everything libusb-related to
-    // exit gracefully.
-    backend_ptr.reset();
-}
-
 int main(int argc, char** argv)
 {
     // Init ROS node
@@ -87,9 +76,6 @@ int main(int argc, char** argv)
 
     // Initialize the logger
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
-
-    // Register signal handler (has to be after ros::init)
-    signal(SIGINT, signalHandler);
 
     // Set radio configuration from cmdline, init backend
     int config  = std::stoi(argv[MRF_CONFIG_ARGV_INDEX], nullptr, 0);

--- a/src/thunderbots/software/radio_communication/main.cpp
+++ b/src/thunderbots/software/radio_communication/main.cpp
@@ -4,8 +4,6 @@
 #include <thunderbots_msgs/PrimitiveArray.h>
 #include <thunderbots_msgs/World.h>
 
-#include <csignal>
-
 #include "ai/primitive/primitive.h"
 #include "ai/primitive/primitive_factory.h"
 #include "geom/point.h"
@@ -66,15 +64,6 @@ void worldUpdateCallback(const thunderbots_msgs::World::ConstPtr& msg)
     backend_ptr->send_vision_packet(robots, ball);
 }
 
-void signalHandler(int signum)
-{
-    LOG(DEBUG) << "Ctrl-C signal caught" << std::endl;
-
-    // Destroys backend, allowing everything libusb-related to
-    // exit gracefully.
-    backend_ptr.reset();
-}
-
 int main(int argc, char** argv)
 {
     // Init ROS node
@@ -83,9 +72,6 @@ int main(int argc, char** argv)
 
     // Initialize the logger
     Util::Logger::LoggerSingleton::initializeLogger(node_handle);
-
-    // Register signal handler (has to be after ros::init)
-    signal(SIGINT, signalHandler);
 
     // Set radio configuration from cmdline, init backend
     int config  = std::stoi(argv[MRF_CONFIG_ARGV_INDEX], nullptr, 0);

--- a/src/thunderbots/software/radio_communication/mrf/dongle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/dongle.cpp
@@ -31,10 +31,10 @@ namespace
     // different PANs and/or channels
     constexpr int NUM_DEFAULT_CONFIGS                      = 4;
     const RadioConfig DEFAULT_CONFIGS[NUM_DEFAULT_CONFIGS] = {
-        {25U, 250, 0x1846U},
-        {25U, 250, 0x1847U},
-        {25U, 250, 0x1848U},
-        {25U, 250, 0x1849U},
+        {23U, 250, 0x1846U},
+        {23U, 250, 0x1847U},
+        {23U, 250, 0x1848U},
+        {23U, 250, 0x1849U},
     };
 
     const unsigned int ANNUNCIATOR_BEEP_LENGTH_MILLISECONDS = 750;  // milliseconds

--- a/src/thunderbots/software/radio_communication/mrf/usb/devicehandle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/usb/devicehandle.cpp
@@ -29,6 +29,7 @@ USB::DeviceHandle::DeviceHandle(const Device &device)
 {
     check_fn("libusb_open", libusb_open(device.device, &handle), 0);
     init_descriptors();
+    // TODO add device to libusb context
 }
 
 USB::DeviceHandle::DeviceHandle(Context &context, unsigned int vendor_id,
@@ -52,6 +53,7 @@ USB::DeviceHandle::DeviceHandle(Context &context, unsigned int vendor_id,
 
             check_fn("libusb_open", libusb_open(device.device, &handle), 0);
             init_descriptors();
+            context.open_devices.push_back(this);
             return;
         }
     }
@@ -61,23 +63,23 @@ USB::DeviceHandle::DeviceHandle(Context &context, unsigned int vendor_id,
 
 USB::DeviceHandle::~DeviceHandle()
 {
-    try
-    {
-        while (submitted_transfer_count)
-        {
-            check_fn("libusb_handle_events", libusb_handle_events(context), 0);
-        }
-    }
-    catch (const std::exception &exp)
-    {
-        try
-        {
-            LOG(WARNING) << exp.what() << std::endl;
-        }
-        catch (...)
-        {
-        }
-    }
+    // try
+    // {
+    //     while (submitted_transfer_count)
+    //     {
+    //         check_fn("libusb_handle_events", libusb_handle_events(context), 0);
+    //     }
+    // }
+    // catch (const std::exception &exp)
+    // {
+    //     try
+    //     {
+    //         LOG(WARNING) << exp.what() << std::endl;
+    //     }
+    //     catch (...)
+    //     {
+    //     }
+    // }
     libusb_close(handle);
 }
 

--- a/src/thunderbots/software/radio_communication/mrf/usb/devicehandle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/usb/devicehandle.cpp
@@ -29,7 +29,6 @@ USB::DeviceHandle::DeviceHandle(const Device &device)
 {
     check_fn("libusb_open", libusb_open(device.device, &handle), 0);
     init_descriptors();
-    // TODO add device to libusb context
 }
 
 USB::DeviceHandle::DeviceHandle(Context &context, unsigned int vendor_id,
@@ -63,26 +62,7 @@ USB::DeviceHandle::DeviceHandle(Context &context, unsigned int vendor_id,
 
 USB::DeviceHandle::~DeviceHandle()
 {
-    // try
-    // {
-    //     while (submitted_transfer_count)
-    //     {
-    //         check_fn("libusb_handle_events", libusb_handle_events(context), 0);
-    //     }
-    // }
-    // catch (const std::exception &exp)
-    // {
-    //     try
-    //     {
-    //         LOG(WARNING) << exp.what() << std::endl;
-    //     }
-    //     catch (...)
-    //     {
-    //     }
-    // }
     libusb_close(handle);
-
-    LOG(DEBUG) << "DeviceHandle destroyed";
 }
 
 void USB::DeviceHandle::reset()

--- a/src/thunderbots/software/radio_communication/mrf/usb/devicehandle.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/usb/devicehandle.cpp
@@ -81,6 +81,8 @@ USB::DeviceHandle::~DeviceHandle()
     //     }
     // }
     libusb_close(handle);
+
+    LOG(DEBUG) << "DeviceHandle destroyed";
 }
 
 void USB::DeviceHandle::reset()

--- a/src/thunderbots/software/radio_communication/mrf/usb/libusb.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/usb/libusb.cpp
@@ -23,7 +23,7 @@ namespace
     bool running;
 }  // namespace
 
-USB::Context::Context() : open_devices(0)
+USB::Context::Context()
 {
     // Init libusb
     check_fn("libusb_init", libusb_init(&context), 0);

--- a/src/thunderbots/software/radio_communication/mrf/usb/libusb.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/usb/libusb.cpp
@@ -23,7 +23,7 @@ namespace
     bool running;
 }  // namespace
 
-USB::Context::Context()
+USB::Context::Context() : open_devices(0)
 {
     // Init libusb
     check_fn("libusb_init", libusb_init(&context), 0);
@@ -40,6 +40,14 @@ USB::Context::~Context()
 {
     // Terminate event thread
     running = false;
+
+    // Close all devices
+    for (auto &dev : open_devices)
+    {
+        dev->~DeviceHandle();
+    }
+
+    // This wakes up libusb_handle_events, now let the thread join
     libusb_event_thread.join();
 
     // Cleanup libusb

--- a/src/thunderbots/software/radio_communication/mrf/usb/libusb.cpp
+++ b/src/thunderbots/software/radio_communication/mrf/usb/libusb.cpp
@@ -33,6 +33,8 @@ USB::Context::Context() : open_devices(0)
     libusb_event_thread = std::thread([&]() {
         while (running)
             libusb_handle_events(context);
+
+        LOG(DEBUG) << "Event thread exiting";
     });
 }
 
@@ -53,6 +55,8 @@ USB::Context::~Context()
     // Cleanup libusb
     libusb_exit(context);
     context = nullptr;
+
+    LOG(DEBUG) << "Context destroyed";
 }
 
 USB::ConfigurationSetter::ConfigurationSetter(DeviceHandle &device, int configuration)

--- a/src/thunderbots/software/radio_communication/mrf/usb/libusb.h
+++ b/src/thunderbots/software/radio_communication/mrf/usb/libusb.h
@@ -46,7 +46,7 @@ namespace USB
         ~Context();
 
        protected:
-        std::vector<USB::DeviceHandle*> open_devices;
+        std::vector<USB::DeviceHandle *> open_devices;
 
        private:
         friend class DeviceList;

--- a/src/thunderbots/software/radio_communication/mrf/usb/libusb.h
+++ b/src/thunderbots/software/radio_communication/mrf/usb/libusb.h
@@ -45,6 +45,9 @@ namespace USB
          */
         ~Context();
 
+       protected:
+        std::vector<USB::DeviceHandle*> open_devices;
+
        private:
         friend class DeviceList;
         friend class DeviceHandle;

--- a/src/thunderbots/software/util/logger/custom_g3log_sinks.h
+++ b/src/thunderbots/software/util/logger/custom_g3log_sinks.h
@@ -90,7 +90,7 @@ namespace Util
                 }
                 else
                 {
-                    throw std::invalid_argument("Unrecognized value for g3log_log_level");
+                    ROS_WARN("Unrecognized value for g3log_log_level");
                 }
             }
         };


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
