### PR TITLE
Change layer ordering by id

### DIFF
--- a/src/corner_kick/src/pages/Visualizer/index.tsx
+++ b/src/corner_kick/src/pages/Visualizer/index.tsx
@@ -23,7 +23,6 @@ import { RobotStatusPanel } from './panels/RobotStatusPanel/index';
 // We request the layer data from the store
 const mapStateToProps = (state: IRootState) => ({
     layers: state.canvas.layers,
-    layerOrder: state.canvas.layerOrder,
     playType: state.thunderbots.playType,
     playName: state.thunderbots.playName,
     tactics: state.thunderbots.tactics,
@@ -44,7 +43,6 @@ const mapDispatchToProps = (dispatch: Dispatch<RootAction>) =>
 
 interface IVisualizerProps {
     layers: { [id: number]: ILayer };
-    layerOrder: number[];
     playType: string;
     playName: string;
     tactics: string[];
@@ -75,9 +73,11 @@ class VisualizerInternal extends React.Component<IVisualizerProps> {
     }
 
     public render() {
-        // We use the layer order information in the store to create an ordered
+        // We use the id number in the store to create an ordered
         // array of the layers to be consumed by our UI.
-        const orderedLayers = this.props.layerOrder.map((key) => this.props.layers[key]);
+        const orderedLayers = Object.values(this.props.layers).sort(
+            (a, b) => b.id - a.id,
+        );
 
         // Update layer ordering and visibility
         this.canvasManager.handleLayerOperations(orderedLayers);

--- a/src/corner_kick/src/pages/Visualizer/panels/LayersPanel/index.tsx
+++ b/src/corner_kick/src/pages/Visualizer/panels/LayersPanel/index.tsx
@@ -34,23 +34,26 @@ export const LayersPanel = (props: ILayersProps) => {
     return (
         <>
             {layers.length > 0 ? (
-                layers.map((layer) => (
-                    <Flex
-                        width="100%"
-                        py="4px"
-                        px="16px"
-                        alignItems="center"
-                        justifyContent="space-between"
-                        key={layer.id}
-                    >
-                        {layer.id}
-                        <Button
-                            icon={layer.visible ? 'eye-open' : 'eye-off'}
-                            minimal={true}
-                            onClick={() => toggleVisibility(layer.id)}
-                        />
-                    </Flex>
-                ))
+                layers
+                    .slice(0)
+                    .reverse()
+                    .map((layer) => (
+                        <Flex
+                            width="100%"
+                            py="4px"
+                            px="16px"
+                            alignItems="center"
+                            justifyContent="space-between"
+                            key={layer.id}
+                        >
+                            {layer.id}
+                            <Button
+                                icon={layer.visible ? 'eye-open' : 'eye-off'}
+                                minimal={true}
+                                onClick={() => toggleVisibility(layer.id)}
+                            />
+                        </Flex>
+                    ))
             ) : (
                 <Flex
                     width="100%"

--- a/src/corner_kick/src/store/reducers/canvas.ts
+++ b/src/corner_kick/src/store/reducers/canvas.ts
@@ -12,7 +12,6 @@ export type CanvasAction = ActionType<typeof canvas>;
 
 const defaultState: ICanvasState = {
     layers: {},
-    layerOrder: [],
 };
 
 export default (state: ICanvasState = defaultState, action: CanvasAction) => {
@@ -22,15 +21,10 @@ export default (state: ICanvasState = defaultState, action: CanvasAction) => {
         // on top of old ones)
         case getType(canvas.addLayer):
             const { payload } = action;
-            const { layers, layerOrder } = state;
+            const { layers } = state;
             return {
                 ...state,
                 layers: { ...layers, [payload.id]: payload },
-                layerOrder: [
-                    ...layerOrder.slice(0, payload.id),
-                    payload.id,
-                    ...layerOrder.slice(payload.id),
-                ],
             };
         // Here, we toggle the visibility of the layer specified by the action
         case getType(canvas.toggleLayerVisibility):

--- a/src/corner_kick/src/store/reducers/canvas.ts
+++ b/src/corner_kick/src/store/reducers/canvas.ts
@@ -21,10 +21,16 @@ export default (state: ICanvasState = defaultState, action: CanvasAction) => {
         // append it in the layer display order (aka. the new layer is displayed
         // on top of old ones)
         case getType(canvas.addLayer):
+            const { payload } = action;
+            const { layers, layerOrder } = state;
             return {
                 ...state,
-                layers: { ...state.layers, [action.payload.id]: action.payload },
-                layerOrder: [...state.layerOrder, action.payload.id],
+                layers: { ...layers, [payload.id]: payload },
+                layerOrder: [
+                    ...layerOrder.slice(0, payload.id),
+                    payload.id,
+                    ...layerOrder.slice(payload.id),
+                ],
             };
         // Here, we toggle the visibility of the layer specified by the action
         case getType(canvas.toggleLayerVisibility):

--- a/src/corner_kick/src/types/state.ts
+++ b/src/corner_kick/src/types/state.ts
@@ -22,7 +22,6 @@ export interface IRootState {
  */
 export interface ICanvasState {
     layers: { [id: number]: ILayer };
-    layerOrder: number[];
 }
 
 /**


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

This PR changes the layer ordering in the Canvas to be by id (layer number) rather than the time the layer was received.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

**Please test this PR for me, I'm at work**

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

See Slack

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
