### PR TITLE
Circle obstacles

### DIFF
--- a/src/thunderbots/software/ai/navigator/obstacle/obstacle.cpp
+++ b/src/thunderbots/software/ai/navigator/obstacle/obstacle.cpp
@@ -1,13 +1,17 @@
 
 #include "obstacle.h"
 
-
-const Polygon& Obstacle::getBoundaryPolygon() const
+const std::optional<Polygon> Obstacle::getBoundaryPolygon() const
 {
     return _polygon;
 }
 
-Obstacle::Obstacle(Polygon polygon) : _polygon(polygon) {}
+const std::optional<Circle> Obstacle::getBoundaryCircle() const
+{
+    return _circle;
+}
+
+Obstacle::Obstacle(Polygon polygon) : _polygon(std::make_optional<Polygon>(polygon)) {}
 
 Obstacle::Obstacle(Rectangle rectangle)
     : Obstacle({rectangle.swCorner(), rectangle.nwCorner(), rectangle.neCorner(),
@@ -171,4 +175,33 @@ Obstacle Obstacle::createBallObstacle(const Ball& ball,
 
     return createRobotObstacleFromPositionAndRadiusAndVelocity(
         ball.position(), radius_cushion, ball.velocity(), false);
+}
+
+bool Obstacle::containsPoint(const Point& point) const
+{
+    if (isPolygon())
+    {
+        return (*_polygon).containsPoint(point);
+    }
+    else
+    {
+        return ((point - (*_circle).getOrigin()).len() < (*_circle).getRadius());
+    }
+}
+
+bool Obstacle::intersects(const Segment& segment) const
+{
+    if (isPolygon())
+    {
+        return (*_polygon).intersects(segment);
+    }
+    else
+    {
+        return (dist((*_circle).getOrigin(), segment) <= (*_circle).getRadius());
+    }
+}
+
+bool Obstacle::isPolygon() const
+{
+    return (bool)_polygon;
 }

--- a/src/thunderbots/software/ai/navigator/obstacle/obstacle.cpp
+++ b/src/thunderbots/software/ai/navigator/obstacle/obstacle.cpp
@@ -19,18 +19,22 @@ Obstacle::Obstacle(Rectangle rectangle)
 {
 }
 
-Obstacle::Obstacle(const Point& circle_center, const double circle_radius,
-                   const int num_points)
-    : _polygon({})
+Obstacle::Obstacle(Circle circle) : _polygon(std::nullopt), _circle(circle) {}
+
+Obstacle Obstacle::createCircleObstacle(const Point& circle_centre,
+                                        const double circle_radius,
+                                        const double radius_scaling)
 {
-    std::vector<Point> poly_points;
-    for (size_t i = 0; i < num_points; i++)
-    {
-        poly_points.emplace_back(
-            circle_center +
-            Point(circle_radius, 0).rotate(Angle::ofDegrees(360.0 / num_points * i)));
-    }
-    _polygon = Polygon(poly_points);
+    // Add robot radius to account for path planning robot's size
+    return Obstacle(Circle(circle_centre,
+                           (circle_radius + ROBOT_MAX_RADIUS_METERS) * radius_scaling));
+}
+
+Obstacle Obstacle::createCircularRobotObstacle(const Robot& robot,
+                                               double radius_cushion_scaling)
+{
+    return createCircleObstacle(robot.position(), ROBOT_MAX_RADIUS_METERS,
+                                radius_cushion_scaling);
 }
 
 
@@ -175,6 +179,13 @@ Obstacle Obstacle::createBallObstacle(const Ball& ball,
 
     return createRobotObstacleFromPositionAndRadiusAndVelocity(
         ball.position(), radius_cushion, ball.velocity(), false);
+}
+
+Obstacle Obstacle::createCircularBallObstacle(const Ball& ball,
+                                              double additional_radius_cushion_buffer)
+{
+    return createCircleObstacle(
+        ball.position(), BALL_MAX_RADIUS_METERS + additional_radius_cushion_buffer, 1);
 }
 
 bool Obstacle::containsPoint(const Point& point) const

--- a/src/thunderbots/software/ai/navigator/obstacle/obstacle.h
+++ b/src/thunderbots/software/ai/navigator/obstacle/obstacle.h
@@ -8,6 +8,7 @@
 #include "ai/world/ball.h"
 #include "ai/world/robot.h"
 #include "geom/angle.h"
+#include "geom/circle.h"
 #include "geom/point.h"
 #include "geom/polygon.h"
 #include "geom/util.h"
@@ -117,13 +118,41 @@ class Obstacle
                                        double additional_radius_cushion_buffer,
                                        double additional_velocity_cushion_buffer);
 
-    const Polygon& getBoundaryPolygon() const;
+    const std::optional<Polygon> getBoundaryPolygon() const;
 
+    const std::optional<Circle> getBoundaryCircle() const;
+
+    bool containsPoint(const Point& point) const;
+
+    bool intersects(const Segment& segment) const;
+
+    bool isPolygon() const;
 
    private:
     static Obstacle createRobotObstacleFromPositionAndRadiusAndVelocity(
         Point position, double radius_cushion, Vector velocity_cushion_vector,
         bool enable_velocity_cushion);
     static double getRadiusCushionForHexagon(double radius);
-    Polygon _polygon;
+    std::optional<Polygon> _polygon;
+    std::optional<Circle> _circle;
 };
+
+inline std::ostream& operator<<(std::ostream& os, const Obstacle& o)
+{
+    if (o.isPolygon())
+    {
+        os << "Obstacle is the polygon {";
+        for (const Point& point : (*o.getBoundaryPolygon()).getPoints())
+        {
+            os << point << ",";
+        }
+        os << "}";
+    }
+    else
+    {
+        os << "Obstacle is the circle with origin "
+           << (*o.getBoundaryCircle()).getOrigin() << " and radius "
+           << (*o.getBoundaryCircle()).getRadius();
+    }
+    return os;
+}

--- a/src/thunderbots/software/ai/navigator/obstacle/obstacle.h
+++ b/src/thunderbots/software/ai/navigator/obstacle/obstacle.h
@@ -32,18 +32,29 @@ class Obstacle
     Obstacle(Rectangle rectangle);
 
     /**
-     * Approximate the circle defined by the given parameters
+     * Create an obstacle from a circle
      *
-     * @param circle_center The center point of the circle
-     * @param circle_radius The radius of the circle
-     * @param num_points The number of points to use to approximate the circle as a
-     *                   polygon
+     * @param circle
      */
-    Obstacle(const Point& circle_center, const double circle_radius,
-             const int num_points);
+    Obstacle(Circle circle);
+
+    /**
+     * Circle obstacle defined by the given parameters
+     *
+     * @param circle_centre The centre point of the circle
+     * @param circle_radius The radius of the circle
+     * @param radius_scaling How much to scale the radius
+     *
+     * @return circle shaped obstacle
+     */
+    static Obstacle createCircleObstacle(const Point& circle_centre,
+                                         const double circle_radius,
+                                         const double radius_scaling);
 
     static Obstacle createRobotObstacle(const Robot& robot, bool enable_velocity_cushion);
 
+    static Obstacle createCircularRobotObstacle(const Robot& robot,
+                                                double radius_cushion_scaling);
 
     /*
      * Gets the boundary polygon around the given primitive that other robots
@@ -117,6 +128,18 @@ class Obstacle
     static Obstacle createBallObstacle(const Ball& ball,
                                        double additional_radius_cushion_buffer,
                                        double additional_velocity_cushion_buffer);
+
+    /**
+     * Circle obstacle around ball with additional_radius_cushion_buffer
+     *
+     * @param ball                              ball to make obstacle around
+     * @param additional_radius_cushion_buffer  extra buffer around obstacle
+     *
+     * @return obstacle around the ball
+     */
+    static Obstacle createCircularBallObstacle(const Ball& ball,
+                                               double additional_radius_cushion_buffer);
+
 
     const std::optional<Polygon> getBoundaryPolygon() const;
 

--- a/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -13,8 +13,11 @@ ThetaStarPathPlanner::ThetaStarPathPlanner(Field field,
                                            const std::vector<Obstacle> &obstacles)
     : field_(field), obstacles_(obstacles)
 {
-    numRows = (int)(field_.totalLength() / SIZE_OF_GRID_CELL_IN_METERS);
-    numCols = (int)(field_.totalWidth() / SIZE_OF_GRID_CELL_IN_METERS);
+    // account for robot radius
+    numRows = (int)((field_.totalLength() - 2 * ROBOT_MAX_RADIUS_METERS) /
+                    SIZE_OF_GRID_CELL_IN_METERS);
+    numCols = (int)((field_.totalWidth() - 2 * ROBOT_MAX_RADIUS_METERS) /
+                    SIZE_OF_GRID_CELL_IN_METERS);
 }
 
 bool ThetaStarPathPlanner::isValid(int row, int col)
@@ -480,13 +483,19 @@ bool ThetaStarPathPlanner::isValidAndFreeOfObstacles(Point p)
 
 Point ThetaStarPathPlanner::convertCellToPoint(int row, int col)
 {
-    return Point((row * SIZE_OF_GRID_CELL_IN_METERS) - (field_.totalLength() / 2.0),
-                 (col * SIZE_OF_GRID_CELL_IN_METERS) - (field_.totalWidth() / 2.0));
+    // account for robot radius
+    return Point((row * SIZE_OF_GRID_CELL_IN_METERS) -
+                     (field_.totalLength() / 2.0 - ROBOT_MAX_RADIUS_METERS),
+                 (col * SIZE_OF_GRID_CELL_IN_METERS) -
+                     (field_.totalWidth() / 2.0 - ROBOT_MAX_RADIUS_METERS));
 }
 
 ThetaStarPathPlanner::CellCoordinate ThetaStarPathPlanner::convertPointToCell(Point p)
 {
+    // account for robot radius
     return std::make_pair(
-        (int)((p.x() + (field_.totalLength() / 2.0)) / SIZE_OF_GRID_CELL_IN_METERS),
-        (int)((p.y() + (field_.totalWidth() / 2.0)) / SIZE_OF_GRID_CELL_IN_METERS));
+        (int)((p.x() + (field_.totalLength() / 2.0 - ROBOT_MAX_RADIUS_METERS)) /
+              SIZE_OF_GRID_CELL_IN_METERS),
+        (int)((p.y() + (field_.totalWidth() / 2.0 - ROBOT_MAX_RADIUS_METERS)) /
+              SIZE_OF_GRID_CELL_IN_METERS));
 }

--- a/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -211,6 +211,11 @@ std::optional<std::vector<Point>> ThetaStarPathPlanner::findPath(const Point &st
         return std::nullopt;
     }
 
+    // If the destination GridCell is within one grid size of start
+    if ((start - destination).len() < SIZE_OF_GRID_CELL_IN_METERS)
+    {
+        return std::make_optional<std::vector<Point>>({start, destination});
+    }
 
     // The source is blocked
     if (isUnBlocked(src.first, src.second) == false)
@@ -239,12 +244,6 @@ std::optional<std::vector<Point>> ThetaStarPathPlanner::findPath(const Point &st
         {
             return std::nullopt;
         }
-    }
-
-    // If the destination GridCell is the same as source GridCell
-    if (isDestination(src.first, src.second, dest) == true)
-    {
-        return std::make_optional<std::vector<Point>>({start, destination});
     }
 
     closedList =

--- a/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -469,7 +469,7 @@ bool ThetaStarPathPlanner::isValidAndFreeOfObstacles(Point p)
     {
         for (auto &obstacle : obstacles_)
         {
-            if (obstacle.getBoundaryPolygon().containsPoint(p))
+            if (obstacle.containsPoint(p))
             {
                 return false;
             }

--- a/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -35,7 +35,7 @@ bool ThetaStarPathPlanner::isUnBlocked(int row, int col)
         Point p = convertCellToPoint(row, col);
         for (auto &obstacle : obstacles_)
         {
-            if (obstacle.getBoundaryPolygon().containsPoint(p))
+            if (obstacle.containsPoint(p))
             {
                 blocked = true;
                 break;

--- a/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.h
+++ b/src/thunderbots/software/ai/navigator/path_planner/theta_star_path_planner.h
@@ -197,7 +197,7 @@ class ThetaStarPathPlanner : public PathPlanner
     static constexpr double CLOSE_TO_DEST_THRESHOLD = 0.01;
 
     // increase in threshold to reduce oscillation
-    static constexpr int BLOCKED_DESINATION_OSCILLATION_MITIGATION = 4;
+    static constexpr int BLOCKED_DESINATION_OSCILLATION_MITIGATION = 3;
 
     // resolution for searching for unblocked point around a blocked destination
     static constexpr double BLOCKED_DESTINATION_SEARCH_RESOLUTION = 10.0;

--- a/src/thunderbots/software/ai/navigator/path_planning_navigator/path_planning_navigator.cpp
+++ b/src/thunderbots/software/ai/navigator/path_planning_navigator/path_planning_navigator.cpp
@@ -112,7 +112,9 @@ void PathPlanningNavigator::visit(const MoveIntent &move_intent)
 
     for (auto &robot : world.enemyTeam().getAllRobots())
     {
-        Obstacle o = Obstacle::createRobotObstacleWithScalingParams(robot, 1.2, 0);
+        //@todo consider using velocity obstacles: Obstacle o =
+        //Obstacle::createRobotObstacleWithScalingParams(robot, 1.2, 0);
+        Obstacle o = Obstacle::createCircularRobotObstacle(robot, 1.2);
         obstacles.push_back(o);
     }
 
@@ -125,7 +127,7 @@ void PathPlanningNavigator::visit(const MoveIntent &move_intent)
             // skip current robot
             continue;
         }
-        Obstacle o = Obstacle::createRobotObstacleWithScalingParams(robot, 1.2, 0);
+        Obstacle o = Obstacle::createCircularRobotObstacle(robot, 1.2);
         obstacles.push_back(o);
     }
 
@@ -210,17 +212,10 @@ std::optional<Obstacle> PathPlanningNavigator::obstacleFromAvoidArea(AvoidArea a
             rectangle.expand(OBSTACLE_INFLATION_DIST + 0.2);
             return Obstacle(rectangle);
         case AvoidArea::CENTER_CIRCLE:
-            // We tack on an extra buffer here because we only approximate the circle,
-            // and we can afford to be extra safe here
-            return Obstacle(
-                world.field().centerPoint(),
-                world.field().centreCircleRadius() + OBSTACLE_INFLATION_DIST + 0.1,
-                NUM_POINTS_IN_CIRCLE_POLY);
+            return Obstacle::createCircleObstacle(
+                world.field().centerPoint(), world.field().centreCircleRadius(), 1.2);
         case AvoidArea::HALF_METER_AROUND_BALL:
-            // We tack on an extra buffer here because we only approximate the circle,
-            // and we can afford to be extra safe here
-            return Obstacle(world.ball().position(), 0.5 + OBSTACLE_INFLATION_DIST + 0.1,
-                            NUM_POINTS_IN_CIRCLE_POLY);
+            return Obstacle::createCircleObstacle(world.ball().position(), 0.5, 1.2);
         case AvoidArea::ENEMY_HALF:
             rectangle =
                 Rectangle({0, world.field().width() / 2}, world.field().enemyCornerNeg());

--- a/src/thunderbots/software/ai/navigator/path_planning_navigator/path_planning_navigator.cpp
+++ b/src/thunderbots/software/ai/navigator/path_planning_navigator/path_planning_navigator.cpp
@@ -113,7 +113,7 @@ void PathPlanningNavigator::visit(const MoveIntent &move_intent)
     for (auto &robot : world.enemyTeam().getAllRobots())
     {
         //@todo consider using velocity obstacles: Obstacle o =
-        //Obstacle::createRobotObstacleWithScalingParams(robot, 1.2, 0);
+        // Obstacle::createRobotObstacleWithScalingParams(robot, 1.2, 0);
         Obstacle o = Obstacle::createCircularRobotObstacle(robot, 1.2);
         obstacles.push_back(o);
     }

--- a/src/thunderbots/software/test/ai/navigator/obstacle/obstacle.cpp
+++ b/src/thunderbots/software/test/ai/navigator/obstacle/obstacle.cpp
@@ -18,31 +18,37 @@ TEST(NavigatorObstacleTest, default_velocity_obstacle_polygon)
 {
     double TEST_EPSILON    = 1e-3;
     Timestamp current_time = Timestamp::fromSeconds(123);
-    Robot robot = Robot(3, Point(0.0, 0.0), Vector(0.0, 0.0), Angle::ofRadians(2.2),
+    Robot robot    = Robot(3, Point(0.0, 0.0), Vector(0.0, 0.0), Angle::ofRadians(2.2),
                         AngularVelocity::ofRadians(-0.6), current_time);
-    Polygon pg  = Obstacle::createRobotObstacleWithScalingParams(robot, 1.0, 1.0)
-                     .getBoundaryPolygon();
+    auto p_pointer = Obstacle::createRobotObstacleWithScalingParams(robot, 1.0, 1.0)
+                         .getBoundaryPolygon();
 
-    // visually verified
-    Point pt0 = Point(0, 0.208);
-    Point pt1 = Point(-0.18, 0.104);
-    Point pt2 = Point(-0.18, -0.104);
-    Point pt3 = Point(0, -0.208);
-    Point pt4 = Point(0.18, -0.104);
-    Point pt5 = Point(0.18, 0.104);
-    EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
-    EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+    EXPECT_TRUE(p_pointer);
+
+    if (p_pointer)
+    {
+        Polygon pg = *p_pointer;
+        // visually verified
+        Point pt0 = Point(0, 0.208);
+        Point pt1 = Point(-0.18, 0.104);
+        Point pt2 = Point(-0.18, -0.104);
+        Point pt3 = Point(0, -0.208);
+        Point pt4 = Point(0.18, -0.104);
+        Point pt5 = Point(0.18, 0.104);
+        EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
+        EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+    }
 }
 
 // obstacle with robot radius factor = 1, velocity projection factor = 1
@@ -53,28 +59,35 @@ TEST(NavigatorObstacleTest, shifted_scaling_velocity_obstacle_polygon)
     Timestamp current_time = Timestamp::fromSeconds(123);
     Robot robot            = Robot(3, Point(1, 2), Vector(3, 2), Angle::ofRadians(2.2),
                         AngularVelocity::ofRadians(-0.6), current_time);
-    Polygon pg = Obstacle::createRobotObstacleWithScalingParams(robot, 1.0, 1.0)
-                     .getBoundaryPolygon();
-    // visually verified
-    Point pt0 = Point(0.885, 2.173);
-    Point pt1 = Point(.793, 1.987);
-    Point pt2 = Point(.908, 1.814);
-    Point pt3 = Point(1.115, 1.827);
-    Point pt4 = Point(4.115, 3.827);
-    Point pt5 = Point(3.885, 4.173);
-    EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
-    EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+    auto p_pointer = Obstacle::createRobotObstacleWithScalingParams(robot, 1.0, 1.0)
+                         .getBoundaryPolygon();
+
+    EXPECT_TRUE(p_pointer);
+
+    if (p_pointer)
+    {
+        Polygon pg = *p_pointer;
+        // visually verified
+        Point pt0 = Point(0.885, 2.173);
+        Point pt1 = Point(.793, 1.987);
+        Point pt2 = Point(.908, 1.814);
+        Point pt3 = Point(1.115, 1.827);
+        Point pt4 = Point(4.115, 3.827);
+        Point pt5 = Point(3.885, 4.173);
+        EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
+        EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+    }
 }
 
 // obstacle with robot radius factor = 1.2, velocity projection factor = 1.4
@@ -85,28 +98,35 @@ TEST(NavigatorObstacleTest, shifted_scaled_up_velocity_obstacle_polygon)
     Timestamp current_time = Timestamp::fromSeconds(123);
     Robot robot            = Robot(3, Point(-1, -2), Vector(-3, 2), Angle::ofRadians(2.2),
                         AngularVelocity::ofRadians(-0.6), current_time);
-    Polygon pg = Obstacle::createRobotObstacleWithScalingParams(robot, 1.2, 1.4)
-                     .getBoundaryPolygon();
-    // visually verified
-    Point pt0 = Point(-1.138, -2.208);
-    Point pt1 = Point(-.889, -2.224);
-    Point pt2 = Point(-0.751, -2.016);
-    Point pt3 = Point(-0.862, -1.792);
-    Point pt4 = Point(-5.062, 1.008);
-    Point pt5 = Point(-5.338, 0.592);
-    EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
-    EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+    auto p_pointer = Obstacle::createRobotObstacleWithScalingParams(robot, 1.2, 1.4)
+                         .getBoundaryPolygon();
+
+    EXPECT_TRUE(p_pointer);
+
+    if (p_pointer)
+    {
+        Polygon pg = *p_pointer;
+        // visually verified
+        Point pt0 = Point(-1.138, -2.208);
+        Point pt1 = Point(-.889, -2.224);
+        Point pt2 = Point(-0.751, -2.016);
+        Point pt3 = Point(-0.862, -1.792);
+        Point pt4 = Point(-5.062, 1.008);
+        Point pt5 = Point(-5.338, 0.592);
+        EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
+        EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+    }
 }
 
 // obstacle with robot additional radius buffer = 0, additional velocity projection buffer
@@ -117,28 +137,35 @@ TEST(NavigatorObstacleTest, shifted_no_buffer_velocity_obstacle_polygon)
     Timestamp current_time = Timestamp::fromSeconds(123);
     Robot robot            = Robot(3, Point(1, 2), Vector(3, 2), Angle::ofRadians(2.2),
                         AngularVelocity::ofRadians(-0.6), current_time);
-    Polygon pg = Obstacle::createRobotObstacleWithBufferParams(robot, true, 0.0, 0.0)
-                     .getBoundaryPolygon();
-    // visually verified
-    Point pt0 = Point(0.885, 2.173);
-    Point pt1 = Point(.793, 1.987);
-    Point pt2 = Point(.908, 1.814);
-    Point pt3 = Point(1.115, 1.827);
-    Point pt4 = Point(4.115, 3.827);
-    Point pt5 = Point(3.885, 4.173);
-    EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
-    EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+    auto p_pointer = Obstacle::createRobotObstacleWithBufferParams(robot, true, 0.0, 0.0)
+                         .getBoundaryPolygon();
+
+    EXPECT_TRUE(p_pointer);
+
+    if (p_pointer)
+    {
+        Polygon pg = *p_pointer;
+        // visually verified
+        Point pt0 = Point(0.885, 2.173);
+        Point pt1 = Point(.793, 1.987);
+        Point pt2 = Point(.908, 1.814);
+        Point pt3 = Point(1.115, 1.827);
+        Point pt4 = Point(4.115, 3.827);
+        Point pt5 = Point(3.885, 4.173);
+        EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
+        EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+    }
 }
 
 // obstacle with robot additional radius buffer = 0.4, additional velocity projection
@@ -149,28 +176,35 @@ TEST(NavigatorObstacleTest, shifted_with_buffer_velocity_obstacle_polygon)
     Timestamp current_time = Timestamp::fromSeconds(123);
     Robot robot            = Robot(3, Point(-1, -2), Vector(-3, 2), Angle::ofRadians(2.2),
                         AngularVelocity::ofRadians(-0.6), current_time);
-    Polygon pg = Obstacle::createRobotObstacleWithBufferParams(robot, true, 0.4, 1.8)
-                     .getBoundaryPolygon();
-    // visually verified
-    Point pt0 = Point(-1.628, -2.941);
-    Point pt1 = Point(-0.498, -3.014);
-    Point pt2 = Point(0.129, -2.073);
-    Point pt3 = Point(-0.372, -1.058);
-    Point pt4 = Point(-4.87, 1.94);
-    Point pt5 = Point(-6.125, 0.057);
-    EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
-    EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
-    EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+    auto p_pointer = Obstacle::createRobotObstacleWithBufferParams(robot, true, 0.4, 1.8)
+                         .getBoundaryPolygon();
+
+    EXPECT_TRUE(p_pointer);
+
+    if (p_pointer)
+    {
+        Polygon pg = *p_pointer;
+        // visually verified
+        Point pt0 = Point(-1.628, -2.941);
+        Point pt1 = Point(-0.498, -3.014);
+        Point pt2 = Point(0.129, -2.073);
+        Point pt3 = Point(-0.372, -1.058);
+        Point pt4 = Point(-4.87, 1.94);
+        Point pt5 = Point(-6.125, 0.057);
+        EXPECT_DOUBLE_EQ(pg.getPoints().size(), 6);
+        EXPECT_NEAR(pg.getPoints()[0].x(), pt0.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[0].y(), pt0.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[1].x(), pt1.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[1].y(), pt1.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[2].x(), pt2.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[2].y(), pt2.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[3].x(), pt3.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[3].y(), pt3.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[4].x(), pt4.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[4].y(), pt4.y(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[5].x(), pt5.x(), TEST_EPSILON);
+        EXPECT_NEAR(pg.getPoints()[5].y(), pt5.y(), TEST_EPSILON);
+    }
 }
 
 TEST(NavigatorObstacleTest, create_from_rectangle)

--- a/src/thunderbots/software/test/ai/navigator/obstacle/obstacle.cpp
+++ b/src/thunderbots/software/test/ai/navigator/obstacle/obstacle.cpp
@@ -217,22 +217,17 @@ TEST(NavigatorObstacleTest, create_from_rectangle)
         {2, 1},
         {2, -3},
     });
-    EXPECT_EQ(expected.getPoints(), obstacle.getBoundaryPolygon().getPoints());
+    EXPECT_TRUE((bool) obstacle.getBoundaryPolygon());
+    EXPECT_EQ(expected.getPoints(), (*obstacle.getBoundaryPolygon()).getPoints());
 }
 
 TEST(NavigatorObstacleTest, create_from_circle)
 {
-    Obstacle obstacle({2, 2}, 1, 8);
+    Obstacle obstacle = Obstacle::createCircleObstacle({2, 2}, 1, 1);
 
-    Polygon expected = Polygon({
-        Point(2, 2) + Vector(1, 0).rotate(Angle::ofDegrees(0)),
-        Point(2, 2) + Vector(1, 0).rotate(Angle::ofDegrees(45)),
-        Point(2, 2) + Vector(1, 0).rotate(Angle::ofDegrees(90)),
-        Point(2, 2) + Vector(1, 0).rotate(Angle::ofDegrees(135)),
-        Point(2, 2) + Vector(1, 0).rotate(Angle::ofDegrees(180)),
-        Point(2, 2) + Vector(1, 0).rotate(Angle::ofDegrees(225)),
-        Point(2, 2) + Vector(1, 0).rotate(Angle::ofDegrees(270)),
-        Point(2, 2) + Vector(1, 0).rotate(Angle::ofDegrees(315)),
-    });
-    EXPECT_EQ(expected.getPoints(), obstacle.getBoundaryPolygon().getPoints());
+    EXPECT_FALSE(obstacle.isPolygon());
+    EXPECT_TRUE(obstacle.getBoundaryCircle());
+
+    EXPECT_EQ((*obstacle.getBoundaryCircle()).getRadius(), (1 + ROBOT_MAX_RADIUS_METERS));
+    EXPECT_EQ((*obstacle.getBoundaryCircle()).getOrigin(), Point({2,2}));
 }

--- a/src/thunderbots/software/test/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/thunderbots/software/test/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -236,24 +236,24 @@ TEST(TestThetaStarPathPlanner, performance){
     // improvement
     std::vector<std::vector<Obstacle>> obstacle_sets = {
             {
-                Obstacle({0,0}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({0,0.5}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({0,1.0}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({0,1.5}, ROBOT_MAX_RADIUS_METERS, 16),
+                Obstacle::createCircleObstacle({0,0}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({0,0.5}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({0,1.0}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({0,1.5}, ROBOT_MAX_RADIUS_METERS, 1),
             },
             {
-                Obstacle({0,0}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({0,0.5}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({0,1.0}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({0,1.5}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({-0.5,0}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({-0.5,0.5}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({-0.5,1.0}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({-0.5,1.5}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({0.5,0}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({0.5,0.5}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({0.5,1.0}, ROBOT_MAX_RADIUS_METERS, 16),
-                Obstacle({0.5,1.5}, ROBOT_MAX_RADIUS_METERS, 16),
+                Obstacle::createCircleObstacle({0,0}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({0,0.5}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({0,1.0}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({0,1.5}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({-0.5,0}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({-0.5,0.5}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({-0.5,1.0}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({-0.5,1.5}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({0.5,0}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({0.5,0.5}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({0.5,1.0}, ROBOT_MAX_RADIUS_METERS, 1),
+                Obstacle::createCircleObstacle({0.5,1.5}, ROBOT_MAX_RADIUS_METERS, 1),
             }
     };
     Field field = ::Test::TestUtil::createSSLDivBField();

--- a/src/thunderbots/software/test/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/thunderbots/software/test/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -21,18 +21,6 @@ void printPath(std::vector<Point> path_points)
     printf("\n");
 }
 
-std::string getObstacleAsString(const Obstacle& obstacle)
-{
-    std::stringstream ss;
-    ss << "{";
-    for (const Point& point : obstacle.getBoundaryPolygon().getPoints())
-    {
-        ss << point << ",";
-    }
-    ss << "}";
-    return ss.str();
-}
-
 void checkPathDoesNotExceedBoundingBox(std::vector<Point> path_points,
                                        Rectangle bounding_box)
 {
@@ -52,9 +40,9 @@ void checkPathDoesNotIntersectObstacle(std::vector<Point> path_points,
     {
         for (auto const& obstacle : obstacles)
         {
-            EXPECT_FALSE(obstacle.getBoundaryPolygon().containsPoint(path_points[0]))
+            EXPECT_FALSE(obstacle.containsPoint(path_points[0]))
                 << "Only point on path " << path_points[0] << " is in obstacle "
-                << getObstacleAsString(obstacle);
+                << obstacle;
         }
     }
 
@@ -64,9 +52,9 @@ void checkPathDoesNotIntersectObstacle(std::vector<Point> path_points,
         Segment path_segment(path_points[i], path_points[i + 1]);
         for (auto const& obstacle : obstacles)
         {
-            EXPECT_FALSE(obstacle.getBoundaryPolygon().intersects(path_segment))
+            EXPECT_FALSE(obstacle.intersects(path_segment))
                 << "Line segment {" << path_points[i] << "," << path_points[i + 1]
-                << "} intersects obstacle " << getObstacleAsString(obstacle);
+                << "} intersects obstacle " << obstacle;
         }
     }
 }
@@ -113,10 +101,8 @@ TEST(TestThetaStarPathPlanner, test_theta_star_path_planner_blocked_dest)
     Point start{0, 0}, dest{2.7, 0};
 
     // Place a rectangle over our destination location
-    std::vector<Obstacle> obstacles = {
-
-        Obstacle(
-            Polygon({Point(3.5, 1), Point(2.5, 1), Point(2.5, -1), Point(3.5, -1)}))};
+    std::vector<Obstacle> obstacles = {Obstacle(
+        Polygon({Point(3.5, 1), Point(2.5, 1), Point(2.5, -1), Point(3.5, -1)}))};
 
     std::unique_ptr<PathPlanner> planner =
         std::make_unique<ThetaStarPathPlanner>(field, obstacles);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
* Add and integrate circle obstacles, implement << operator for obstacles

* reduce some oscillation as robot approaches blocked destination

* reduce field size to account for robot radius
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
grsim - doesn't change functionality except field edge
### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
