### PR TITLE
Made ratePass Run 3x Faster

### DIFF
--- a/src/thunderbots/software/ai/passing/evaluation.cpp
+++ b/src/thunderbots/software/ai/passing/evaluation.cpp
@@ -158,7 +158,7 @@ double Passing::calculateInterceptRisk(const Team& enemy_team, const Pass& pass)
     return *std::max_element(enemy_intercept_risks.begin(), enemy_intercept_risks.end());
 }
 
-double Passing::calculateInterceptRisk(const Robot &enemy_robot, const Pass &pass)
+double Passing::calculateInterceptRisk(const Robot& enemy_robot, const Pass& pass)
 {
     // We estimate the intercept by the risk that the robot will get to the closest
     // point on the pass before the ball, and by the risk that the robot will get to
@@ -217,7 +217,7 @@ double Passing::calculateInterceptRisk(const Robot &enemy_robot, const Pass &pas
     return 1 - sigmoid(min_time_diff, 0, 1);
 }
 
-double Passing::ratePassFriendlyCapability(Team friendly_team, const Pass &pass,
+double Passing::ratePassFriendlyCapability(Team friendly_team, const Pass& pass,
                                            std::optional<unsigned int> passer_robot_id)
 {
     // Remove the passer robot from the friendly team before evaluating, as we assume

--- a/src/thunderbots/software/ai/passing/evaluation.cpp
+++ b/src/thunderbots/software/ai/passing/evaluation.cpp
@@ -146,7 +146,7 @@ double Passing::ratePassEnemyRisk(const Team& enemy_team, const Pass& pass)
 double Passing::calculateInterceptRisk(const Team& enemy_team, const Pass& pass)
 {
     // Return the highest risk for all the enemy robots, if there are any
-    auto enemy_robots = enemy_team.getAllRobots();
+    const std::vector<Robot>& enemy_robots = enemy_team.getAllRobots();
     if (enemy_robots.empty())
     {
         return 0;
@@ -158,7 +158,7 @@ double Passing::calculateInterceptRisk(const Team& enemy_team, const Pass& pass)
     return *std::max_element(enemy_intercept_risks.begin(), enemy_intercept_risks.end());
 }
 
-double Passing::calculateInterceptRisk(Robot enemy_robot, const Pass& pass)
+double Passing::calculateInterceptRisk(const Robot &enemy_robot, const Pass &pass)
 {
     // We estimate the intercept by the risk that the robot will get to the closest
     // point on the pass before the ball, and by the risk that the robot will get to
@@ -217,7 +217,7 @@ double Passing::calculateInterceptRisk(Robot enemy_robot, const Pass& pass)
     return 1 - sigmoid(min_time_diff, 0, 1);
 }
 
-double Passing::ratePassFriendlyCapability(Team friendly_team, const Pass& pass,
+double Passing::ratePassFriendlyCapability(Team friendly_team, const Pass &pass,
                                            std::optional<unsigned int> passer_robot_id)
 {
     // Remove the passer robot from the friendly team before evaluating, as we assume
@@ -241,7 +241,7 @@ double Passing::ratePassFriendlyCapability(Team friendly_team, const Pass& pass,
 
     // Get the robot that is closest to where the pass would be received
     Robot best_receiver = friendly_team.getAllRobots()[0];
-    for (Robot& robot : friendly_team.getAllRobots())
+    for (const Robot& robot : friendly_team.getAllRobots())
     {
         double distance = (robot.position() - pass.receiverPoint()).len();
         double curr_best_distance =

--- a/src/thunderbots/software/ai/passing/evaluation.h
+++ b/src/thunderbots/software/ai/passing/evaluation.h
@@ -82,7 +82,7 @@ namespace Passing
      *         be intercepted, and 0 indicating it's impossible for the pass to be
      *         intercepted
      */
-    double calculateInterceptRisk(const Robot &enemy_robot, const Pass &pass);
+    double calculateInterceptRisk(const Robot& enemy_robot, const Pass& pass);
 
 
     /**
@@ -102,7 +102,7 @@ namespace Passing
      *         friendly team to recieve the given pass, with 1 being very likely, 0
      *         being impossible
      */
-    double ratePassFriendlyCapability(Team friendly_team, const Pass &pass,
+    double ratePassFriendlyCapability(Team friendly_team, const Pass& pass,
                                       std::optional<unsigned int> passer_robot_id);
 
     /**

--- a/src/thunderbots/software/ai/passing/evaluation.h
+++ b/src/thunderbots/software/ai/passing/evaluation.h
@@ -82,7 +82,7 @@ namespace Passing
      *         be intercepted, and 0 indicating it's impossible for the pass to be
      *         intercepted
      */
-    double calculateInterceptRisk(Robot enemy_robot, const Pass& pass);
+    double calculateInterceptRisk(const Robot &enemy_robot, const Pass &pass);
 
 
     /**
@@ -102,7 +102,7 @@ namespace Passing
      *         friendly team to recieve the given pass, with 1 being very likely, 0
      *         being impossible
      */
-    double ratePassFriendlyCapability(Team friendly_team, const Pass& pass,
+    double ratePassFriendlyCapability(Team friendly_team, const Pass &pass,
                                       std::optional<unsigned int> passer_robot_id);
 
     /**

--- a/src/thunderbots/software/ai/world/team.cpp
+++ b/src/thunderbots/software/ai/world/team.cpp
@@ -38,9 +38,8 @@ void Team::updateRobots(const std::vector<Robot>& new_robots)
                 "Error: Multiple robots on the same team with the same id");
         }
 
-        auto it = std::find_if(team_robots.begin(), team_robots.end(), [&](const Robot& r){
-            return r.id() == robot.id();
-        });
+        auto it = std::find_if(team_robots.begin(), team_robots.end(),
+                               [&](const Robot& r) { return r.id() == robot.id(); });
         if (it != team_robots.end())
         {
             // The robot already exists on the team. Find and update the robot
@@ -100,11 +99,11 @@ void Team::removeExpiredRobots(const Timestamp& timestamp)
 
 void Team::removeRobotWithId(unsigned int robot_id)
 {
-    auto it = std::find_if(team_robots.begin(), team_robots.end(), [&](const Robot& r){
-        return r.id() == robot_id;
-    });
+    auto it = std::find_if(team_robots.begin(), team_robots.end(),
+                           [&](const Robot& r) { return r.id() == robot_id; });
 
-    if (it != team_robots.end()){
+    if (it != team_robots.end())
+    {
         team_robots.erase(it);
     }
 }
@@ -144,8 +143,10 @@ void Team::setRobotExpiryBuffer(const Duration& new_robot_expiry_buffer_duration
 
 std::optional<Robot> Team::getRobotById(const unsigned int id) const
 {
-    for (const Robot& robot : team_robots){
-        if (robot.id() == id){
+    for (const Robot& robot : team_robots)
+    {
+        if (robot.id() == id)
+        {
             return robot;
         }
     }
@@ -168,7 +169,7 @@ std::optional<unsigned int> Team::getGoalieID() const
     return goalie_id;
 }
 
-const std::vector<Robot> & Team::getAllRobots() const
+const std::vector<Robot>& Team::getAllRobots() const
 {
     return team_robots;
 }

--- a/src/thunderbots/software/ai/world/team.cpp
+++ b/src/thunderbots/software/ai/world/team.cpp
@@ -38,16 +38,18 @@ void Team::updateRobots(const std::vector<Robot>& new_robots)
                 "Error: Multiple robots on the same team with the same id");
         }
 
-        auto it = team_robots.find(robot.id());
+        auto it = std::find_if(team_robots.begin(), team_robots.end(), [&](const Robot& r){
+            return r.id() == robot.id();
+        });
         if (it != team_robots.end())
         {
             // The robot already exists on the team. Find and update the robot
-            team_robots.at(robot.id()).updateState(robot);
+            it->updateState(robot);
         }
         else
         {
             // This robot does not exist as part of the team yet. Add the new robot
-            team_robots.insert(std::make_pair(robot.id(), robot));
+            team_robots.emplace_back(robot);
         }
     }
 
@@ -67,7 +69,7 @@ void Team::updateStateToPredictedState(const Timestamp& timestamp)
     // Update the state of all robots to their predicted state
     for (auto it = team_robots.begin(); it != team_robots.end(); it++)
     {
-        it->second.updateStateToPredictedState(timestamp);
+        it->updateStateToPredictedState(timestamp);
     }
 
     updateTimestamp(timestamp);
@@ -79,7 +81,7 @@ void Team::removeExpiredRobots(const Timestamp& timestamp)
     // has passed, then remove the robot from the team
     for (auto it = team_robots.begin(); it != team_robots.end();)
     {
-        Duration time_diff = timestamp - it->second.lastUpdateTimestamp();
+        Duration time_diff = timestamp - it->lastUpdateTimestamp();
         if (time_diff.getSeconds() < 0)
         {
             throw std::invalid_argument(
@@ -98,7 +100,13 @@ void Team::removeExpiredRobots(const Timestamp& timestamp)
 
 void Team::removeRobotWithId(unsigned int robot_id)
 {
-    team_robots.erase(robot_id);
+    auto it = std::find_if(team_robots.begin(), team_robots.end(), [&](const Robot& r){
+        return r.id() == robot_id;
+    });
+
+    if (it != team_robots.end()){
+        team_robots.erase(it);
+    }
 }
 
 void Team::assignGoalie(unsigned int new_goalie_id)
@@ -136,10 +144,10 @@ void Team::setRobotExpiryBuffer(const Duration& new_robot_expiry_buffer_duration
 
 std::optional<Robot> Team::getRobotById(const unsigned int id) const
 {
-    auto it = team_robots.find(id);
-    if (it != team_robots.end())
-    {
-        return it->second;
+    for (const Robot& robot : team_robots){
+        if (robot.id() == id){
+            return robot;
+        }
     }
 
     return std::nullopt;
@@ -160,15 +168,9 @@ std::optional<unsigned int> Team::getGoalieID() const
     return goalie_id;
 }
 
-std::vector<Robot> Team::getAllRobots() const
+const std::vector<Robot> & Team::getAllRobots() const
 {
-    std::vector<Robot> all_robots;
-    for (auto it = team_robots.begin(); it != team_robots.end(); it++)
-    {
-        all_robots.emplace_back(it->second);
-    }
-
-    return all_robots;
+    return team_robots;
 }
 
 std::vector<Robot> Team::getAllRobotsExceptGoalie() const
@@ -177,11 +179,11 @@ std::vector<Robot> Team::getAllRobotsExceptGoalie() const
     std::vector<Robot> all_robots;
     for (auto it = team_robots.begin(); it != team_robots.end(); it++)
     {
-        if (goalie_robot && it->second == *goalie_robot)
+        if (goalie_robot && *it == *goalie_robot)
         {
             continue;
         }
-        all_robots.emplace_back(it->second);
+        all_robots.emplace_back(*it);
     }
 
     return all_robots;
@@ -248,7 +250,7 @@ void Team::updateTimestamp(Timestamp time_stamp)
 std::optional<Timestamp> Team::lastUpdateTimestamp() const
 {
     std::optional<Timestamp> most_recent_timestamp = std::nullopt;
-    for (Robot& robot : getAllRobots())
+    for (const Robot& robot : getAllRobots())
     {
         if (!most_recent_timestamp || robot.lastUpdateTimestamp() > most_recent_timestamp)
         {

--- a/src/thunderbots/software/ai/world/team.h
+++ b/src/thunderbots/software/ai/world/team.h
@@ -165,7 +165,7 @@ class Team
      *
      * @return a vector of all the robots on this team.
      */
-    std::vector<Robot> getAllRobots() const;
+    const std::vector<Robot> & getAllRobots() const;
 
     /**
      * Returns a vector of all the robots on this team excluding the goalie
@@ -234,9 +234,8 @@ class Team
      */
     Timestamp getMostRecentTimestampFromRobots();
 
-    // The map that contains the Robots for this team. The map makes it easier to
-    // guarantee we only have robots with unique IDs.
-    std::map<unsigned int, Robot> team_robots;
+    // The robots on this team
+    std::vector<Robot> team_robots;
 
     // The robot id of the goalie for this team
     std::optional<unsigned int> goalie_id;

--- a/src/thunderbots/software/ai/world/team.h
+++ b/src/thunderbots/software/ai/world/team.h
@@ -165,7 +165,7 @@ class Team
      *
      * @return a vector of all the robots on this team.
      */
-    const std::vector<Robot> & getAllRobots() const;
+    const std::vector<Robot>& getAllRobots() const;
 
     /**
      * Returns a vector of all the robots on this team excluding the goalie

--- a/src/thunderbots/software/test/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/thunderbots/software/test/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -284,5 +284,5 @@ TEST(TestThetaStarPathPlanner, performance)
     //    std::cout << "Took " <<
     //    std::chrono::duration_cast<std::chrono::microseconds>(duration).count() / 1000.0
     //    << "ms to run, average time of " <<
-    //    std::chrono::duration_cast<std::chrono::microseconds>(avg).count() / 1000.0;
+    //    std::chrono::duration_cast<std::chrono::microseconds>(avg).count() / 1000.0 << "ms";
 }

--- a/src/thunderbots/software/test/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/thunderbots/software/test/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -284,5 +284,6 @@ TEST(TestThetaStarPathPlanner, performance)
     //    std::cout << "Took " <<
     //    std::chrono::duration_cast<std::chrono::microseconds>(duration).count() / 1000.0
     //    << "ms to run, average time of " <<
-    //    std::chrono::duration_cast<std::chrono::microseconds>(avg).count() / 1000.0 << "ms";
+    //    std::chrono::duration_cast<std::chrono::microseconds>(avg).count() / 1000.0 <<
+    //    "ms";
 }

--- a/src/thunderbots/software/test/ai/passing/evaluation.cpp
+++ b/src/thunderbots/software/test/ai/passing/evaluation.cpp
@@ -145,13 +145,16 @@ TEST_F(PassingEvaluationTest, ratePass_speed_test)
 
     // At the time of this tests creation, ratePass ran at an average 0.105ms
     // in debug on an i7
-//    std::cout << "Took "
-//              << std::chrono::duration_cast<std::chrono::microseconds>(duration).count() /
-//                     1000.0
-//              << "ms to run, average time of "
-//              << std::chrono::duration_cast<std::chrono::microseconds>(avg).count() /
-//                     1000.0
-//              << "ms" << std::endl;
+    //    std::cout << "Took "
+    //              <<
+    //              std::chrono::duration_cast<std::chrono::microseconds>(duration).count()
+    //              /
+    //                     1000.0
+    //              << "ms to run, average time of "
+    //              << std::chrono::duration_cast<std::chrono::microseconds>(avg).count()
+    //              /
+    //                     1000.0
+    //              << "ms" << std::endl;
 }
 
 TEST_F(PassingEvaluationTest, ratePass_enemy_directly_on_pass_trajectory)

--- a/src/thunderbots/software/test/ai/passing/evaluation.cpp
+++ b/src/thunderbots/software/test/ai/passing/evaluation.cpp
@@ -14,11 +14,14 @@
 #include "ai/passing/evaluation.h"
 
 #include <gtest/gtest.h>
-#include <util/math_functions.h>
-#include <util/parameter/dynamic_parameters.h>
+
+#include <chrono>
+#include <random>
 
 #include "../shared/constants.h"
 #include "test/test_util/test_util.h"
+#include "util/math_functions.h"
+#include "util/parameter/dynamic_parameters.h"
 
 using namespace Passing;
 
@@ -47,6 +50,109 @@ class PassingEvaluationTest : public testing::Test
         Util::DynamicParameters::Passing::max_time_offset_for_pass_seconds.value();
     double avg_time_offset_for_pass_seconds;
 };
+
+TEST_F(PassingEvaluationTest, ratePass_speed_test)
+{
+    // This test does not assert anything. Rather, It can be used to guage how
+    // fast ratePass is running, and can be profiled in order to find areas
+    // of improvement for ratePass
+
+    const int num_passes_to_gen = 1000;
+
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+
+    world.updateEnemyTeamState(
+        Team(Duration::fromSeconds(10),
+             {
+                 Robot(0, {0, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(1, {1, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(2, {0, 1}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(3, {1.5, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(4, {0, 2}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(5, {2.5, -2}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(6, {3, -3}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+             }));
+    world.updateFriendlyTeamState(
+        Team(Duration::fromSeconds(10),
+             {
+                 Robot(0, {-0.2, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(1, {-1, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(2, {0, 1}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(3, {-1.5, 0}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(4, {0, -2}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(5, {-2.5, -2}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+                 Robot(6, {-3, -3}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+                       Timestamp::fromSeconds(0)),
+             }));
+
+    std::uniform_real_distribution x_distribution(-world.field().length() / 2,
+                                                  world.field().length() / 2);
+    std::uniform_real_distribution y_distribution(-world.field().width() / 2,
+                                                  world.field().width() / 2);
+
+    double curr_time = world.getMostRecentTimestamp().getSeconds();
+    double min_start_time_offset =
+        Util::DynamicParameters::Passing::min_time_offset_for_pass_seconds.value();
+    double max_start_time_offset =
+        Util::DynamicParameters::Passing::max_time_offset_for_pass_seconds.value();
+    std::uniform_real_distribution start_time_distribution(
+        curr_time + min_start_time_offset, curr_time + max_start_time_offset);
+    std::uniform_real_distribution speed_distribution(
+        Util::DynamicParameters::Passing::min_pass_speed_m_per_s.value(),
+        Util::DynamicParameters::Passing::max_pass_speed_m_per_s.value());
+
+    std::vector<Pass> passes;
+
+    std::mt19937 random_num_gen;
+    for (int i = 0; i < num_passes_to_gen; i++)
+    {
+        Point passer_point(x_distribution(random_num_gen),
+                           y_distribution(random_num_gen));
+        Point receiver_point(x_distribution(random_num_gen),
+                             y_distribution(random_num_gen));
+        Timestamp start_time =
+            Timestamp::fromSeconds(start_time_distribution(random_num_gen));
+        double pass_speed = speed_distribution(random_num_gen);
+
+        Pass p(passer_point, receiver_point, pass_speed, start_time);
+        passes.emplace_back(p);
+    }
+
+    auto start_time = std::chrono::system_clock::now();
+    for (auto pass : passes)
+    {
+        ratePass(world, pass, std::nullopt, std::nullopt);
+    }
+
+    auto end_time = std::chrono::system_clock::now();
+
+    std::chrono::duration<double> duration = end_time - start_time;
+
+    std::chrono::duration<double> avg = duration / (double)num_passes_to_gen;
+
+    // At the time of this tests creation, ratePass ran at an average 0.105ms
+    // in debug on an i7
+//    std::cout << "Took "
+//              << std::chrono::duration_cast<std::chrono::microseconds>(duration).count() /
+//                     1000.0
+//              << "ms to run, average time of "
+//              << std::chrono::duration_cast<std::chrono::microseconds>(avg).count() /
+//                     1000.0
+//              << "ms" << std::endl;
+}
 
 TEST_F(PassingEvaluationTest, ratePass_enemy_directly_on_pass_trajectory)
 {


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

Did some profiling of `ratePass`, added a performance test, and tweaked both the passing evaluation functions and the `Team` class for a 3x speed improvement when running 1000 iterations of `ratePass`. This brings it down to about 0.1ms in debug, 0.018ms in release.

This should make pass generation significantly faster.

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
