### PR TITLE
patch-round-1: kickoff orientation, stop and goalie

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/play/kickoff_friendly_play.cpp
+++ b/src/thunderbots/software/ai/hl/stp/play/kickoff_friendly_play.cpp
@@ -106,7 +106,7 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         // setup 5 kickoff positions in order of priority
         for (int i = 0; i < kickoff_setup_positions.size(); i++)
         {
-            move_tactics.at(i)->updateParams(kickoff_setup_positions.at(i), Angle::half(),
+            move_tactics.at(i)->updateParams(kickoff_setup_positions.at(i), Angle::zero(),
                                              0);
             result.emplace_back(move_tactics.at(i));
         }
@@ -137,7 +137,7 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         // 1 will be assigned to the rest of the robots
         for (int i = 1; i < kickoff_setup_positions.size(); i++)
         {
-            move_tactics.at(i)->updateParams(kickoff_setup_positions.at(i), Angle::half(),
+            move_tactics.at(i)->updateParams(kickoff_setup_positions.at(i), Angle::zero(),
                                              0);
             result.emplace_back(move_tactics.at(i));
         }

--- a/src/thunderbots/software/ai/hl/stp/play/stop_play.cpp
+++ b/src/thunderbots/software/ai/hl/stp/play/stop_play.cpp
@@ -108,7 +108,7 @@ void StopPlay::getNextTactics(TacticCoroutine::push_type &yield)
         // line from the center of the goal to the ball intersects. A robot will be placed
         // on that line, and the other two will be on either side
         Point ball_defense_point_center =
-            world.ball().position() + 0.5 * goal_to_ball_unit_vector;
+            world.ball().position() + (0.5 + ROBOT_MAX_RADIUS_METERS) * goal_to_ball_unit_vector;
         Point ball_defense_point_left =
             ball_defense_point_center -
             robot_positioning_unit_vector * 4 * ROBOT_MAX_RADIUS_METERS;

--- a/src/thunderbots/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/thunderbots/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -119,7 +119,7 @@ void GoalieTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
 
             // restrict the goalie to a semicircle inscribed inside the defense area
             Point goalie_restricted_pos =
-                field.friendlyGoal() - (field.friendlyDefenseArea().width() *
+                field.friendlyGoal() - ((field.friendlyDefenseArea().width() - ROBOT_MAX_RADIUS_METERS)*
                                         (field.friendlyGoal() - goalie_pos).norm());
 
             // restrict the point to be within the defense area

--- a/src/thunderbots/software/network_input/backend.cpp
+++ b/src/thunderbots/software/network_input/backend.cpp
@@ -238,7 +238,60 @@ Team Backend::getFilteredEnemyTeamData(const std::vector<SSL_DetectionFrame> &de
 thunderbots_msgs::RefboxData Backend::getRefboxDataMsg(const Referee &packet)
 {
     thunderbots_msgs::RefboxData refbox_data;
-    refbox_data.command.command = getTeamCommand(packet.command());
+    if (Util::DynamicParameters::AI::refbox::override_refbox_play.value())
+    {
+        auto refbox_override_play =
+            Util::DynamicParameters::AI::refbox::current_refbox_play.value();
+        if ("HALT" == refbox_override_play)
+            refbox_data.command.command = thunderbots_msgs::RefboxCommand::HALT;
+        if ("STOP" == refbox_override_play)
+            refbox_data.command.command = thunderbots_msgs::RefboxCommand::STOP;
+        if ("NORMAL_START" == refbox_override_play)
+            refbox_data.command.command = thunderbots_msgs::RefboxCommand::NORMAL_START;
+        if ("FORCE_START" == refbox_override_play)
+            refbox_data.command.command = thunderbots_msgs::RefboxCommand::FORCE_START;
+        if ("PREPARE_KICKOFF_US" == refbox_override_play)
+            refbox_data.command.command =
+                thunderbots_msgs::RefboxCommand::PREPARE_KICKOFF_US;
+        if ("PREPARE_KICKOFF_THEM" == refbox_override_play)
+            refbox_data.command.command =
+                thunderbots_msgs::RefboxCommand::PREPARE_PENALTY_THEM;
+        if ("PREPARE_PENALTY_US" == refbox_override_play)
+            refbox_data.command.command =
+                thunderbots_msgs::RefboxCommand::PREPARE_PENALTY_US;
+        if ("PREPARE_PENALTY_THEM" == refbox_override_play)
+            refbox_data.command.command =
+                thunderbots_msgs::RefboxCommand::PREPARE_PENALTY_THEM;
+        if ("DIRECT_FREE_US" == refbox_override_play)
+            refbox_data.command.command = thunderbots_msgs::RefboxCommand::DIRECT_FREE_US;
+        if ("DIRECT_FREE_THEM" == refbox_override_play)
+            refbox_data.command.command =
+                thunderbots_msgs::RefboxCommand::DIRECT_FREE_THEM;
+        if ("INDIRECT_FREE_US" == refbox_override_play)
+            refbox_data.command.command =
+                thunderbots_msgs::RefboxCommand::INDIRECT_FREE_US;
+        if ("INDIRECT_FREE_THEM" == refbox_override_play)
+            refbox_data.command.command =
+                thunderbots_msgs::RefboxCommand::INDIRECT_FREE_THEM;
+        if ("TIMEOUT_US" == refbox_override_play)
+            refbox_data.command.command = thunderbots_msgs::RefboxCommand::TIMEOUT_US;
+        if ("TIMEOUT_THEM" == refbox_override_play)
+            refbox_data.command.command = thunderbots_msgs::RefboxCommand::TIMEOUT_THEM;
+        if ("GOAL_US" == refbox_override_play)
+            refbox_data.command.command = thunderbots_msgs::RefboxCommand::GOAL_US;
+        if ("GOAL_THEM" == refbox_override_play)
+            refbox_data.command.command = thunderbots_msgs::RefboxCommand::GOAL_THEM;
+        if ("BALL_PLACEMENT_US" == refbox_override_play)
+            refbox_data.command.command =
+                thunderbots_msgs::RefboxCommand::BALL_PLACEMENT_US;
+        if ("BALL_PLACEMENT_THEM" == refbox_override_play)
+            refbox_data.command.command =
+                thunderbots_msgs::RefboxCommand::BALL_PLACEMENT_THEM;
+    }
+    else
+    {
+        refbox_data.command.command = getTeamCommand(packet.command());
+    }
     setOurFieldSide(packet.blue_team_on_positive_half());
     auto designated_position = refboxGlobalToLocalPoint(packet.designated_position());
     refbox_data.ball_placement_point.x = designated_position.x();

--- a/src/thunderbots/software/util/parameter/config/ai_control.yaml
+++ b/src/thunderbots/software/util/parameter/config/ai_control.yaml
@@ -38,7 +38,26 @@ AI:
           specified by current_play parameter
     current_refbox_play:
       type: "string"
-      default: "Halt"
+      default: "HALT"
+      options:
+        - "HALT"
+        - "STOP"
+        - "NORMAL_START"
+        - "FORCE_START"
+        - "PREPARE_KICKOFF_US" 
+        - "PREPARE_KICKOFF_THEM"
+        - "PREPARE_PENALTY_US"
+        - "PREPARE_PENALTY_THEM"
+        - "DIRECT_FREE_US"
+        - "DIRECT_FREE_THEM"
+        - "INDIRECT_FREE_US"
+        - "INDIRECT_FREE_THEM"
+        - "TIMEOUT_US"
+        - "TIMEOUT_THEM"
+        - "GOAL_US"
+        - "GOAL_THEM"
+        - "BALL_PLACEMENT_US"
+        - "BALL_PLACEMENT_THEM"
       description: >- 
           Specifies the refbox play that should be in use
     override_refbox_defending_side:


### PR DESCRIPTION
- kickoff orientation fixed to look the right way
- goalie tactic obeys radius, and stays within net
- stop play obeys radius and backups to account for ROBOT_RADIUS

<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
