### PR TITLE
RoboCup 2019 add ability to ignore selected vision data

### DIFF
--- a/src/thunderbots/software/network_input/backend.cpp
+++ b/src/thunderbots/software/network_input/backend.cpp
@@ -132,7 +132,17 @@ Ball Backend::getFilteredBallData(const std::vector<SSL_DetectionFrame> &detecti
             ball_detection.position =
                 Point(ball.x() * METERS_PER_MILLIMETER, ball.y() * METERS_PER_MILLIMETER);
             ball_detection.timestamp = Timestamp::fromSeconds(detection.t_capture());
-            ball_detections.push_back(ball_detection);
+
+            bool ignore_ball =
+                Util::DynamicParameters::AI::refbox::ignore_camera_data.value() &&
+                (Util::DynamicParameters::AI::refbox::min_valid_x.value() >
+                     ball_detection.position.x() ||
+                 Util::DynamicParameters::AI::refbox::max_valid_x.value() <
+                     ball_detection.position.x());
+            if (!ignore_ball)
+            {
+                ball_detections.push_back(ball_detection);
+            }
         }
     }
 
@@ -172,7 +182,17 @@ Team Backend::getFilteredFriendlyTeamData(std::vector<SSL_DetectionFrame> detect
             robot_detection.confidence = friendly_robot_detection.confidence();
             robot_detection.timestamp  = Timestamp::fromSeconds(detection.t_capture());
 
-            friendly_robot_detections.push_back(robot_detection);
+
+            bool ignore_robot =
+                Util::DynamicParameters::AI::refbox::ignore_camera_data.value() &&
+                (Util::DynamicParameters::AI::refbox::min_valid_x.value() >
+                     robot_detection.position.x() ||
+                 Util::DynamicParameters::AI::refbox::max_valid_x.value() <
+                     robot_detection.position.x());
+            if (!ignore_robot)
+            {
+                friendly_robot_detections.push_back(robot_detection);
+            }
         }
     }
 
@@ -209,7 +229,16 @@ Team Backend::getFilteredEnemyTeamData(const std::vector<SSL_DetectionFrame> &de
             robot_detection.confidence = enemy_robot_detection.confidence();
             robot_detection.timestamp  = Timestamp::fromSeconds(detection.t_capture());
 
-            enemy_robot_detections.push_back(robot_detection);
+            bool ignore_robot =
+                Util::DynamicParameters::AI::refbox::ignore_camera_data.value() &&
+                (Util::DynamicParameters::AI::refbox::min_valid_x.value() >
+                     robot_detection.position.x() ||
+                 Util::DynamicParameters::AI::refbox::max_valid_x.value() <
+                     robot_detection.position.x());
+            if (!ignore_robot)
+            {
+                enemy_robot_detections.push_back(robot_detection);
+            }
         }
     }
 

--- a/src/thunderbots/software/network_input/backend.cpp
+++ b/src/thunderbots/software/network_input/backend.cpp
@@ -133,12 +133,12 @@ Ball Backend::getFilteredBallData(const std::vector<SSL_DetectionFrame> &detecti
                 Point(ball.x() * METERS_PER_MILLIMETER, ball.y() * METERS_PER_MILLIMETER);
             ball_detection.timestamp = Timestamp::fromSeconds(detection.t_capture());
 
-            bool ignore_ball =
-                Util::DynamicParameters::AI::refbox::ignore_camera_data.value() &&
-                (Util::DynamicParameters::AI::refbox::min_valid_x.value() >
+            bool ball_position_invalid =
+                Util::DynamicParameters::AI::refbox::min_valid_x.value() >
                      ball_detection.position.x() ||
                  Util::DynamicParameters::AI::refbox::max_valid_x.value() <
-                     ball_detection.position.x());
+                     ball_detection.position.x();
+            bool ignore_ball = Util::DynamicParameters::AI::refbox::ignore_invalid_camera_data.value() && ball_position_invalid;
             if (!ignore_ball)
             {
                 ball_detections.push_back(ball_detection);
@@ -183,12 +183,12 @@ Team Backend::getFilteredFriendlyTeamData(std::vector<SSL_DetectionFrame> detect
             robot_detection.timestamp  = Timestamp::fromSeconds(detection.t_capture());
 
 
-            bool ignore_robot =
-                Util::DynamicParameters::AI::refbox::ignore_camera_data.value() &&
-                (Util::DynamicParameters::AI::refbox::min_valid_x.value() >
+            bool robot_position_invalid =
+                Util::DynamicParameters::AI::refbox::min_valid_x.value() >
                      robot_detection.position.x() ||
                  Util::DynamicParameters::AI::refbox::max_valid_x.value() <
-                     robot_detection.position.x());
+                     robot_detection.position.x();
+            bool ignore_robot = Util::DynamicParameters::AI::refbox::ignore_invalid_camera_data.value() && robot_position_invalid;
             if (!ignore_robot)
             {
                 friendly_robot_detections.push_back(robot_detection);
@@ -229,12 +229,12 @@ Team Backend::getFilteredEnemyTeamData(const std::vector<SSL_DetectionFrame> &de
             robot_detection.confidence = enemy_robot_detection.confidence();
             robot_detection.timestamp  = Timestamp::fromSeconds(detection.t_capture());
 
-            bool ignore_robot =
-                Util::DynamicParameters::AI::refbox::ignore_camera_data.value() &&
-                (Util::DynamicParameters::AI::refbox::min_valid_x.value() >
+            bool robot_position_invalid =
+                Util::DynamicParameters::AI::refbox::min_valid_x.value() >
                      robot_detection.position.x() ||
                  Util::DynamicParameters::AI::refbox::max_valid_x.value() <
-                     robot_detection.position.x());
+                     robot_detection.position.x();
+            bool ignore_robot = Util::DynamicParameters::AI::refbox::ignore_invalid_camera_data.value() && robot_position_invalid;
             if (!ignore_robot)
             {
                 enemy_robot_detections.push_back(robot_detection);

--- a/src/thunderbots/software/network_input/backend.cpp
+++ b/src/thunderbots/software/network_input/backend.cpp
@@ -135,10 +135,12 @@ Ball Backend::getFilteredBallData(const std::vector<SSL_DetectionFrame> &detecti
 
             bool ball_position_invalid =
                 Util::DynamicParameters::AI::refbox::min_valid_x.value() >
-                     ball_detection.position.x() ||
-                 Util::DynamicParameters::AI::refbox::max_valid_x.value() <
-                     ball_detection.position.x();
-            bool ignore_ball = Util::DynamicParameters::AI::refbox::ignore_invalid_camera_data.value() && ball_position_invalid;
+                    ball_detection.position.x() ||
+                Util::DynamicParameters::AI::refbox::max_valid_x.value() <
+                    ball_detection.position.x();
+            bool ignore_ball =
+                Util::DynamicParameters::AI::refbox::ignore_invalid_camera_data.value() &&
+                ball_position_invalid;
             if (!ignore_ball)
             {
                 ball_detections.push_back(ball_detection);
@@ -185,10 +187,12 @@ Team Backend::getFilteredFriendlyTeamData(std::vector<SSL_DetectionFrame> detect
 
             bool robot_position_invalid =
                 Util::DynamicParameters::AI::refbox::min_valid_x.value() >
-                     robot_detection.position.x() ||
-                 Util::DynamicParameters::AI::refbox::max_valid_x.value() <
-                     robot_detection.position.x();
-            bool ignore_robot = Util::DynamicParameters::AI::refbox::ignore_invalid_camera_data.value() && robot_position_invalid;
+                    robot_detection.position.x() ||
+                Util::DynamicParameters::AI::refbox::max_valid_x.value() <
+                    robot_detection.position.x();
+            bool ignore_robot =
+                Util::DynamicParameters::AI::refbox::ignore_invalid_camera_data.value() &&
+                robot_position_invalid;
             if (!ignore_robot)
             {
                 friendly_robot_detections.push_back(robot_detection);
@@ -231,10 +235,12 @@ Team Backend::getFilteredEnemyTeamData(const std::vector<SSL_DetectionFrame> &de
 
             bool robot_position_invalid =
                 Util::DynamicParameters::AI::refbox::min_valid_x.value() >
-                     robot_detection.position.x() ||
-                 Util::DynamicParameters::AI::refbox::max_valid_x.value() <
-                     robot_detection.position.x();
-            bool ignore_robot = Util::DynamicParameters::AI::refbox::ignore_invalid_camera_data.value() && robot_position_invalid;
+                    robot_detection.position.x() ||
+                Util::DynamicParameters::AI::refbox::max_valid_x.value() <
+                    robot_detection.position.x();
+            bool ignore_robot =
+                Util::DynamicParameters::AI::refbox::ignore_invalid_camera_data.value() &&
+                robot_position_invalid;
             if (!ignore_robot)
             {
                 enemy_robot_detections.push_back(robot_detection);

--- a/src/thunderbots/software/util/parameter/config/ai_control.yaml
+++ b/src/thunderbots/software/util/parameter/config/ai_control.yaml
@@ -78,4 +78,23 @@ AI:
       default: 0
       description: >-
         The id of the enemy goalie
+    ignore_camera_data:
+      type: "bool"
+      default: false
+      description: >-
+        foo
+    min_valid_x:
+      type: "double"
+      min: -10.0
+      max: 10.0
+      default: -10.0
+      description: >-
+        foo
+    max_valid_x:
+      type: "double"
+      min: -10.0
+      max: 10.0
+      default: 10.0
+      description: >-
+        foo
 

--- a/src/thunderbots/software/util/parameter/config/ai_control.yaml
+++ b/src/thunderbots/software/util/parameter/config/ai_control.yaml
@@ -78,23 +78,26 @@ AI:
       default: 0
       description: >-
         The id of the enemy goalie
-    ignore_camera_data:
+    ignore_invalid_camera_data:
       type: "bool"
       default: false
       description: >-
-        foo
+        Whether or not to ignore invalid camera data. If this value is true, any ball or robot detections that are not
+        within the min and max valid x coordinates will be ignored. If this value is false, all data is collected as
+        normal and not ignored.
     min_valid_x:
       type: "double"
       min: -10.0
       max: 10.0
       default: -10.0
       description: >-
-        foo
+        When ignore_invalid_camera_data is true, any robot or ball detection with an x-coordinate less than this value
+        is ignored.
     max_valid_x:
       type: "double"
       min: -10.0
       max: 10.0
       default: 10.0
       description: >-
-        foo
-
+        When ignore_invalid_camera_data is true, any robot or ball detection with an x-coordinate greater than this
+        value is ignored.


### PR DESCRIPTION
### Description
Changes from RoboCup 2019. Added ability to ignore vision data by x-coordinate range.

### Testing Done
unit tests still pass, validated with RoboCup gameplay

### Resolved Issues
None

### Length Justification
None