### PR TITLE
RoboCup 2019 make vision multicast address a parameter

### DIFF
--- a/src/thunderbots/software/launch/ai.launch
+++ b/src/thunderbots/software/launch/ai.launch
@@ -6,9 +6,6 @@
 
     <param name="vision_multicast_address" value="$(optenv VISION_MULTICAST_ADDRESS 224.5.23.2)"/>
 
-    <!-- Start rosbag -->
-    <node name="rosbag_record_all" pkg="rosbag" type="record" args="-a -o $(find thunderbots)"/>
-
     <!-- Launch the network_input node -->
     <node name="network_input" pkg="thunderbots" type="network_input" output="screen" respawn="true" respawn_delay="10">
     </node>

--- a/src/thunderbots/software/launch/ai.launch
+++ b/src/thunderbots/software/launch/ai.launch
@@ -4,19 +4,24 @@
         Runs all of the AI nodes except for the backend (Grsim, MRF, etc.)
     -->
 
+    <param name="vision_multicast_address" value="$(optenv VISION_MULTICAST_ADDRESS 224.5.23.2)"/>
+
+    <!-- Start rosbag -->
+    <node name="rosbag_record_all" pkg="rosbag" type="record" args="-a -o $(find thunderbots)"/>
+
     <!-- Launch the network_input node -->
-    <node name="network_input" pkg="thunderbots" type="network_input" output="screen">
+    <node name="network_input" pkg="thunderbots" type="network_input" output="screen" respawn="true" respawn_delay="10">
     </node>
 
     <!-- Launch the ai logic node -->
-    <node name="ai_logic" pkg="thunderbots" type="ai_logic" output="screen">
+    <node name="ai_logic" pkg="thunderbots" type="ai_logic" output="screen" respawn="true">
     </node>
 
     <!-- Launch the dynamic parameters node -->
-    <node name="parameters" pkg="thunderbots" type="parameters" output="screen"/>
+    <node name="parameters" pkg="thunderbots" type="parameters" output="screen" respawn="true"/>
 
     <!-- Launch the rqt_reconfigure gui -->
-    <node name="rqt_reconfigure" pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen"/>
+    <node name="rqt_reconfigure" pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen" respawn="true"/>
 
     <!-- Run the corner-kick visualizer -->
     <include file="$(find corner_kick)/launch/corner_kick.launch" />

--- a/src/thunderbots/software/launch/ai_mrf.launch
+++ b/src/thunderbots/software/launch/ai_mrf.launch
@@ -7,6 +7,6 @@
     <include file="$(find thunderbots)/launch/ai.launch" />
 
     <!-- Launch the radio_communication node -->
-    <node name="radio_communication" pkg="thunderbots" type="radio_communication" output="screen" args="$(arg mrf_config)"/>
+    <node name="radio_communication" pkg="thunderbots" type="radio_communication" output="screen" args="$(arg mrf_config)" respawn="true"/>
 
 </launch>

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -23,7 +23,8 @@ NetworkClient::NetworkClient(ros::NodeHandle& node_handle)
     // Set up our connection over udp to receive vision packets
     try
     {
-        std::string vision_multicast_address = Util::Constants::SSL_VISION_DEFAULT_MULTICAST_ADDRESS;
+        std::string vision_multicast_address =
+            Util::Constants::SSL_VISION_DEFAULT_MULTICAST_ADDRESS;
         node_handle.getParam("/vision_multicast_address", vision_multicast_address);
 
         ssl_vision_client = std::make_unique<SSLVisionClient>(

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -23,7 +23,7 @@ NetworkClient::NetworkClient(ros::NodeHandle& node_handle)
     // Set up our connection over udp to receive vision packets
     try
     {
-        std::string vision_multicast_address = "224.5.23.2";
+        std::string vision_multicast_address = Util::Constants::SSL_VISION_DEFAULT_MULTICAST_ADDRESS;
         node_handle.getParam("/vision_multicast_address", vision_multicast_address);
 
         ssl_vision_client = std::make_unique<SSLVisionClient>(

--- a/src/thunderbots/software/network_input/networking/network_client.cpp
+++ b/src/thunderbots/software/network_input/networking/network_client.cpp
@@ -23,7 +23,7 @@ NetworkClient::NetworkClient(ros::NodeHandle& node_handle)
     // Set up our connection over udp to receive vision packets
     try
     {
-        std::string vision_multicast_address;
+        std::string vision_multicast_address = "224.5.23.2";
         node_handle.getParam("/vision_multicast_address", vision_multicast_address);
 
         ssl_vision_client = std::make_unique<SSLVisionClient>(

--- a/src/thunderbots/software/util/constants.h
+++ b/src/thunderbots/software/util/constants.h
@@ -27,6 +27,7 @@ namespace Util
         static const std::string JOY_NODE_TOPIC = "joy";
 
         // Networking and vision
+        static const std::string SSL_VISION_DEFAULT_MULTICAST_ADDRESS = "224.5.23.2";
         static const unsigned short SSL_VISION_MULTICAST_PORT = 10020;
 
         // GrSim networking and communication


### PR DESCRIPTION
### Description
Changes from RoboCup 2019. Updated launch files to restart nodes, and made the vision multicast address optionally set by an environment variable.

### Testing Done
unit tests still pass, validated with RoboCup gameplay

### Resolved Issues
None

### Length Justification
None