### PR TITLE
WIP: Modified Pivot Primitive

### DIFF
--- a/src/thunderbots/software/ai/hl/stp/action/pivot_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/pivot_action.cpp
@@ -36,18 +36,22 @@ void PivotAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         // If we're not in position to pivot, move to grab the ball
         if (!(robot->position()).isClose(pivot_point, 1.15))
         {
-            yield(std::make_unique<MoveIntent>(robot->id(), pivot_point, (pivot_point-robot->position()).orientation(),
-                                               0.0, 0, enable_dribbler));
-            LOG(DEBUG)<<"obtaining ball, moving!";
+            yield(std::make_unique<MoveIntent>(
+                robot->id(), pivot_point, (pivot_point - robot->position()).orientation(),
+                0.0, 0, enable_dribbler));
+            LOG(DEBUG) << "obtaining ball, moving!";
         }
         else if (Util::DynamicParameters::PivotAction::experimental.value())
         {
-            LOG(DEBUG)<<"EXPERIMENTAL ENABLED: ball has been obtainined, pivoting!";
+            LOG(DEBUG) << "EXPERIMENTAL ENABLED: ball has been obtainined, pivoting!";
 
             // if the robot is close enough to the final poision, call it a day
-            Angle threshold_angle = Angle::ofDegrees(Util::DynamicParameters::PivotAction::finish_angle_threshold.value()/2);
+            Angle threshold_angle = Angle::ofDegrees(
+                Util::DynamicParameters::PivotAction::finish_angle_threshold.value() / 2);
 
-            if(robot->orientation() >= (final_angle - threshold_angle) && robot->orientation() < (final_angle + threshold_angle)){
+            if (robot->orientation() >= (final_angle - threshold_angle) &&
+                robot->orientation() < (final_angle + threshold_angle))
+            {
                 LOG(DEBUG) << "Pivot angle reached threshold";
                 break;
             }
@@ -55,7 +59,8 @@ void PivotAction::calculateNextIntent(IntentCoroutine::push_type& yield)
             yield(std::make_unique<PivotIntent>(robot->id(), pivot_point, final_angle,
                                                 pivot_speed, enable_dribbler, 0));
         }
-        else{
+        else
+        {
             break;
         }
 

--- a/src/thunderbots/software/ai/hl/stp/action/pivot_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/pivot_action.cpp
@@ -5,50 +5,60 @@
 #include "geom/angle.h"
 #include "geom/util.h"
 #include "shared/constants.h"
+#include "util/logger/init.h"
+#include "util/parameter/dynamic_parameters.h"
 
 PivotAction::PivotAction() : Action() {}
 
 std::unique_ptr<Intent> PivotAction::updateStateAndGetNextIntent(const Robot& robot,
                                                                  Point pivot_point,
                                                                  Angle final_angle,
-                                                                 double pivot_radius)
+                                                                 Angle pivot_speed,
+                                                                 bool enable_dribbler)
 {
     // update the parameters stored by this action
-    this->robot        = robot;
-    this->pivot_point  = pivot_point;
-    this->final_angle  = final_angle;
-    this->pivot_radius = pivot_radius;
+    this->robot           = robot;
+    this->pivot_point     = pivot_point;
+    this->final_angle     = final_angle;
+    this->pivot_speed     = pivot_speed;
+    this->enable_dribbler = enable_dribbler;
 
     return getNextIntent();
 }
 
 void PivotAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
+    // Compute final position, to know when the robot is done
+    const double pivot_radius = BALL_MAX_RADIUS_METERS;
+
     do
     {
-        // Compute collinear point (point_of_entry), radius with away,
-        // between the robot and the pivot point. To move there before
-        // attempting to pivot
-        //
-        //                             |---radius---|
-        // (__) ---------------------- o -----------X
-        // robot                 point_of_entry
-
-        Vector unit_pivot_point_to_robot_pos =
-            (robot->position() - this->pivot_point).norm();
-        Point point_of_entry =
-            this->pivot_point + this->pivot_radius * unit_pivot_point_to_robot_pos;
-
-        // If we're not in position to pivot, move into position
-        if ((robot->position() - point_of_entry).len() > ROBOT_MAX_RADIUS_METERS)
+        // If we're not in position to pivot, move to grab the ball
+        if (!(robot->position()).isClose(pivot_point, 1.15))
         {
-            yield(std::make_unique<MoveIntent>(robot->id(), point_of_entry, Angle::zero(),
-                                               0.0, 0));
+            yield(std::make_unique<MoveIntent>(robot->id(), pivot_point, (pivot_point-robot->position()).orientation(),
+                                               0.0, 0, enable_dribbler));
+            LOG(DEBUG)<<"obtaining ball, moving!";
         }
-        else
+        else if (Util::DynamicParameters::PivotAction::experimental.value())
         {
+            LOG(DEBUG)<<"EXPERIMENTAL ENABLED: ball has been obtainined, pivoting!";
+
+            // if the robot is close enough to the final poision, call it a day
+            Angle threshold_angle = Angle::ofDegrees(Util::DynamicParameters::PivotAction::finish_angle_threshold.value()/2);
+
+            if(robot->orientation() >= (final_angle - threshold_angle) && robot->orientation() < (final_angle + threshold_angle)){
+                LOG(DEBUG) << "Pivot angle reached threshold";
+                break;
+            }
+
             yield(std::make_unique<PivotIntent>(robot->id(), pivot_point, final_angle,
-                                                pivot_radius, 0));
+                                                pivot_speed, enable_dribbler, 0));
         }
+        else{
+            break;
+        }
+
+
     } while (true);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/pivot_action.cpp
+++ b/src/thunderbots/software/ai/hl/stp/action/pivot_action.cpp
@@ -41,11 +41,9 @@ void PivotAction::calculateNextIntent(IntentCoroutine::push_type& yield)
                 0.0, 0, enable_dribbler));
             LOG(DEBUG) << "obtaining ball, moving!";
         }
-        else if (Util::DynamicParameters::PivotAction::experimental.value())
+        else
         {
-            LOG(DEBUG) << "EXPERIMENTAL ENABLED: ball has been obtainined, pivoting!";
-
-            // if the robot is close enough to the final poision, call it a day
+            // if the robot is close enough to the final position, call it a day
             Angle threshold_angle = Angle::ofDegrees(
                 Util::DynamicParameters::PivotAction::finish_angle_threshold.value() / 2);
 
@@ -59,11 +57,5 @@ void PivotAction::calculateNextIntent(IntentCoroutine::push_type& yield)
             yield(std::make_unique<PivotIntent>(robot->id(), pivot_point, final_angle,
                                                 pivot_speed, enable_dribbler, 0));
         }
-        else
-        {
-            break;
-        }
-
-
     } while (true);
 }

--- a/src/thunderbots/software/ai/hl/stp/action/pivot_action.h
+++ b/src/thunderbots/software/ai/hl/stp/action/pivot_action.h
@@ -22,7 +22,7 @@ class PivotAction : public Action
      * @param robot the robot that should perform the pivot
      * @param pivot_point the point around which the robot pivots
      * @param final_angle the absolute, not relative, final angle
-     * @param pivot_radius the radius to maintain while pivoting
+     * @param pivot_speed angular speed to
      *
      * @return A unique pointer to the Intent the PivotAction wants to run. If the
      * PivotAction is done, returns an empty/null pointer
@@ -30,7 +30,8 @@ class PivotAction : public Action
     std::unique_ptr<Intent> updateStateAndGetNextIntent(const Robot& robot,
                                                         Point pivot_point,
                                                         Angle final_angle,
-                                                        double pivot_radius);
+                                                        Angle pivot_speed,
+                                                        bool enable_dribbler);
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;
@@ -38,5 +39,6 @@ class PivotAction : public Action
     // Action parameters
     Point pivot_point;
     Angle final_angle;
-    double pivot_radius;
+    Angle pivot_speed;
+    bool enable_dribbler;
 };

--- a/src/thunderbots/software/ai/intent/pivot_intent.cpp
+++ b/src/thunderbots/software/ai/intent/pivot_intent.cpp
@@ -5,9 +5,10 @@
 const std::string PivotIntent::INTENT_NAME = "Pivot Intent";
 
 PivotIntent::PivotIntent(unsigned int robot_id, const Point &pivot_point,
-                         const Angle &final_angle, const double pivot_radius,
-                         unsigned int priority)
-    : PivotPrimitive(robot_id, pivot_point, final_angle, pivot_radius), Intent(priority)
+                         const Angle &final_angle, const Angle &pivot_speed,
+                         bool enable_dribbler, unsigned int priority)
+    : PivotPrimitive(robot_id, pivot_point, final_angle, pivot_speed, enable_dribbler),
+      Intent(priority)
 {
 }
 

--- a/src/thunderbots/software/ai/intent/pivot_intent.h
+++ b/src/thunderbots/software/ai/intent/pivot_intent.h
@@ -21,8 +21,8 @@ class PivotIntent : public Intent, public PivotPrimitive
      * priority
      */
     explicit PivotIntent(unsigned int robot_id, const Point& pivot_point,
-                         const Angle& final_angle, const double pivot_radius,
-                         unsigned int priority);
+                         const Angle& final_angle, const Angle& pivot_radius,
+                         bool enable_dribbler, unsigned int priority);
 
     std::string getIntentName(void) const override;
 

--- a/src/thunderbots/software/ai/intent/pivot_intent.h
+++ b/src/thunderbots/software/ai/intent/pivot_intent.h
@@ -16,7 +16,8 @@ class PivotIntent : public Intent, public PivotPrimitive
      * @param dest The destination of the Movement
      * @param final_angle The final angle the robot should have at the end of the movement
      * @param pivot_speed The angular speed the robot should have while it pivots
-     * @param enable_dribbler Whether or not the dribbler should be spinning to hold the ball
+     * @param enable_dribbler Whether or not the dribbler should be spinning to hold the
+     * ball
      * @param priority The priority of this Intent. A larger number indicates a higher
      * priority
      */

--- a/src/thunderbots/software/ai/intent/pivot_intent.h
+++ b/src/thunderbots/software/ai/intent/pivot_intent.h
@@ -15,13 +15,13 @@ class PivotIntent : public Intent, public PivotPrimitive
      * @param robot_id The id of the robot that this Intent is for
      * @param dest The destination of the Movement
      * @param final_angle The final angle the robot should have at the end of the movement
-     * @param final_speed The final speed the robot should have when it arrives at its
-     * destination
+     * @param pivot_speed The angular speed the robot should have while it pivots
+     * @param enable_dribbler Whether or not the dribbler should be spinning to hold the ball
      * @param priority The priority of this Intent. A larger number indicates a higher
      * priority
      */
     explicit PivotIntent(unsigned int robot_id, const Point& pivot_point,
-                         const Angle& final_angle, const Angle& pivot_radius,
+                         const Angle& final_angle, const Angle& pivot_speed,
                          bool enable_dribbler, unsigned int priority);
 
     std::string getIntentName(void) const override;

--- a/src/thunderbots/software/ai/primitive/pivot_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/pivot_primitive.cpp
@@ -85,7 +85,8 @@ bool PivotPrimitive::operator==(const PivotPrimitive &other) const
 {
     return this->robot_id == other.robot_id && this->pivot_point == other.pivot_point &&
            this->final_angle == other.final_angle &&
-           this->pivot_speed == other.pivot_speed;
+           this->pivot_speed == other.pivot_speed &&
+           this->enable_dribbler == other.enable_dribbler;
 }
 
 bool PivotPrimitive::operator!=(const PivotPrimitive &other) const

--- a/src/thunderbots/software/ai/primitive/pivot_primitive.cpp
+++ b/src/thunderbots/software/ai/primitive/pivot_primitive.cpp
@@ -1,15 +1,18 @@
 #include "ai/primitive/pivot_primitive.h"
 
 #include "ai/primitive/visitor/primitive_visitor.h"
+#include "shared/constants.h"
 
 const std::string PivotPrimitive::PRIMITIVE_NAME = "Pivot Primitive";
 
 PivotPrimitive::PivotPrimitive(unsigned int robot_id, const Point &pivot_point,
-                               const Angle &final_angle, const double pivot_radius)
+                               const Angle &final_angle, const Angle &pivot_speed,
+                               bool enable_dribbler)
     : robot_id(robot_id),
       pivot_point(pivot_point),
       final_angle(final_angle),
-      pivot_radius(pivot_radius)
+      pivot_speed(pivot_speed),
+      enable_dribbler(enable_dribbler)
 {
 }
 
@@ -22,7 +25,8 @@ PivotPrimitive::PivotPrimitive(const thunderbots_msgs::Primitive &primitive_msg)
     double center_y = primitive_msg.parameters.at(1);
     pivot_point     = Point(center_x, center_y);
     final_angle     = Angle::ofRadians(primitive_msg.parameters.at(2));
-    pivot_radius    = primitive_msg.parameters.at(3);
+    pivot_speed     = Angle::ofRadians(primitive_msg.parameters.at(3));
+    enable_dribbler = static_cast<bool>(primitive_msg.extra_bits.at(0));
 }
 
 std::string PivotPrimitive::getPrimitiveName() const
@@ -45,21 +49,31 @@ Angle PivotPrimitive::getFinalAngle() const
     return final_angle;
 }
 
+Angle PivotPrimitive::getPivotSpeed() const
+{
+    return pivot_speed;
+}
+
 double PivotPrimitive::getPivotRadius() const
 {
-    return pivot_radius;
+    return BALL_MAX_RADIUS_METERS;
+}
+
+bool PivotPrimitive::isDribblerEnabled() const
+{
+    return enable_dribbler;
 }
 
 std::vector<double> PivotPrimitive::getParameters() const
 {
     std::vector<double> parameters = {pivot_point.x(), pivot_point.y(),
-                                      final_angle.toRadians(), pivot_radius};
+                                      final_angle.toRadians(), pivot_speed.toRadians()};
     return parameters;
 }
 
 std::vector<bool> PivotPrimitive::getExtraBits() const
 {
-    return std::vector<bool>();
+    return std::vector<bool>{enable_dribbler};
 }
 
 void PivotPrimitive::accept(PrimitiveVisitor &visitor) const
@@ -71,7 +85,7 @@ bool PivotPrimitive::operator==(const PivotPrimitive &other) const
 {
     return this->robot_id == other.robot_id && this->pivot_point == other.pivot_point &&
            this->final_angle == other.final_angle &&
-           this->pivot_radius == other.pivot_radius;
+           this->pivot_speed == other.pivot_speed;
 }
 
 bool PivotPrimitive::operator!=(const PivotPrimitive &other) const

--- a/src/thunderbots/software/ai/primitive/pivot_primitive.h
+++ b/src/thunderbots/software/ai/primitive/pivot_primitive.h
@@ -11,10 +11,10 @@ class PivotPrimitive : public Primitive
     /**
      * Creates a new Pivot Primitive
      *
-     * Pivots the robot around the specified point (usually the ball) at a specified speed,
-     * maintaining a constant distance of (ball radius + robot radius) from this point.
-     * 	   The robot will pivot in the direction of the shortest path
-     * 	   Assume robot always faces the point around which it pivots
+     * Pivots the robot around the specified point (usually the ball) at a specified
+     * speed, maintaining a constant distance of (ball radius + robot radius) from this
+     * point. The robot will pivot in the direction of the shortest path Assume robot
+     * always faces the point around which it pivots
      *
      *
      * @param robot_id      The id of the robot to run this primitive

--- a/src/thunderbots/software/ai/primitive/pivot_primitive.h
+++ b/src/thunderbots/software/ai/primitive/pivot_primitive.h
@@ -23,7 +23,8 @@ class PivotPrimitive : public Primitive
      * @param pivot_radius  The distance from robot to pivot_point during movement
      */
     explicit PivotPrimitive(unsigned int robot_id, const Point &pivot_point,
-                            const Angle &final_angle, const double pivot_radius);
+                            const Angle &final_angle, const Angle &pivot_speed,
+                            bool enable_dribbler);
 
     /**
      * Create a new Pivot Primitive from a Primitive message
@@ -50,12 +51,21 @@ class PivotPrimitive : public Primitive
      */
     Angle getFinalAngle() const;
 
-    /**
-     * Get the robot's final orientation
-     *
-     * @return the radius the robot maintains during pivot (as double)
-     */
     double getPivotRadius() const;
+
+    /**
+     * Get the angular velocity for the pivot
+     *
+     * @return the angular velocity (rad/s) the robot maintains during pivot (as double)
+     */
+    Angle getPivotSpeed() const;
+
+    /**
+     * Check if the dribbler is enabled for this primitive
+     *
+     * @return true if dribbler is enabled
+     */
+    bool isDribblerEnabled() const;
 
     /**
      * Returns the generic vector of parameters for this Primitive
@@ -96,5 +106,6 @@ class PivotPrimitive : public Primitive
     unsigned int robot_id;
     Point pivot_point;
     Angle final_angle;
-    double pivot_radius;
+    Angle pivot_speed;
+    bool enable_dribbler;
 };

--- a/src/thunderbots/software/ai/primitive/pivot_primitive.h
+++ b/src/thunderbots/software/ai/primitive/pivot_primitive.h
@@ -11,8 +11,8 @@ class PivotPrimitive : public Primitive
     /**
      * Creates a new Pivot Primitive
      *
-     * Pivots the robot around the specified point, maintaining a constant
-     * distance from this point.
+     * Pivots the robot around the specified point (usually the ball) at a specified speed,
+     * maintaining a constant distance of (ball radius + robot radius) from this point.
      * 	   The robot will pivot in the direction of the shortest path
      * 	   Assume robot always faces the point around which it pivots
      *

--- a/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
+++ b/src/thunderbots/software/radio_communication/visitor/mrf_primitive_visitor.cpp
@@ -124,8 +124,8 @@ void MRFPrimitiveVisitor::visit(const PivotPrimitive &pivot_primitive)
         pivot_primitive.getPivotPoint().x() * MILLIMETERS_PER_METER,
         pivot_primitive.getPivotPoint().y() * MILLIMETERS_PER_METER,
         pivot_primitive.getFinalAngle().toRadians() * CENTIRADIANS_PER_RADIAN,
-        pivot_primitive.getPivotRadius() * MILLIMETERS_PER_METER};
-    radio_prim->extra_bits = 0;
+        pivot_primitive.getPivotSpeed().toRadians() * CENTIRADIANS_PER_RADIAN};
+    radio_prim->extra_bits = pivot_primitive.isDribblerEnabled();
 }
 
 void MRFPrimitiveVisitor::visit(const StopPrimitive &stop_primitive)

--- a/src/thunderbots/software/test/ai/hl/stp/action/pivot_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/pivot_action.cpp
@@ -32,15 +32,15 @@ TEST(PivotActionTest, robot_too_far_from_orbit)
     }
 }
 
-// PivotAction should be yielding pivot_intents as the robot is in orbit
-TEST(PivotActionTest, robot_in_robit)
+// PivotAction should be yielding pivot intents as the robot is close enough to the ball
+TEST(PivotActionTest, yield_pivotintent_when_close_to_ball)
 {
-    Robot robot = Robot(0, Point(1, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
-                        Timestamp::fromSeconds(0));
+    Robot robot        = Robot(0, Point(0.5, 0), Vector(), Angle::zero(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
     PivotAction action = PivotAction();
 
     auto intent_ptr = action.updateStateAndGetNextIntent(
-        robot, Point(0, 0), Angle::zero(), Angle::ofRadians(2.0), true);
+        robot, Point(0, 0), Angle::half(), Angle::ofRadians(2.0), true);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -48,12 +48,38 @@ TEST(PivotActionTest, robot_in_robit)
 
     try
     {
-        PivotIntent move_intent = dynamic_cast<PivotIntent &>(*intent_ptr);
-        EXPECT_EQ(0, move_intent.getRobotId());
+        PivotIntent pivot_intent = dynamic_cast<PivotIntent &>(*intent_ptr);
+        EXPECT_EQ(0, pivot_intent.getRobotId());
     }
     catch (...)
     {
         ADD_FAILURE()
             << "Pivot intent not returned by pivot action, even though robot was in orbit!";
+    }
+}
+
+// PivotAction should be yielding move intents when far from the ball
+TEST(PivotActionTest, yield_moveintent_when_far_from_ball)
+{
+    Robot robot        = Robot(0, Point(1.5, 0), Vector(), Angle::zero(),
+                        AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    PivotAction action = PivotAction();
+
+    auto intent_ptr = action.updateStateAndGetNextIntent(
+        robot, Point(0, 0), Angle::half(), Angle::ofRadians(2.0), true);
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+    EXPECT_FALSE(action.done());
+
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_EQ(0, move_intent.getRobotId());
+    }
+    catch (...)
+    {
+        ADD_FAILURE()
+            << "Move intent not returned by pivot action, even though robot was far away from the ball!";
     }
 }

--- a/src/thunderbots/software/test/ai/hl/stp/action/pivot_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/pivot_action.cpp
@@ -6,7 +6,7 @@
 #include "ai/intent/pivot_intent.h"
 
 
-// PivotAction should be yeilding move_intents as the robot is too far away from orbit
+// PivotAction should be yielding move_intents as the robot is too far away from orbit
 TEST(PivotActionTest, robot_too_far_from_orbit)
 {
     Robot robot        = Robot(0, Point(10, 10), Vector(), Angle::zero(),
@@ -14,7 +14,7 @@ TEST(PivotActionTest, robot_too_far_from_orbit)
     PivotAction action = PivotAction();
 
     auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 1.0);
+        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), Angle::ofRadians(2.0), true);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -32,7 +32,7 @@ TEST(PivotActionTest, robot_too_far_from_orbit)
     }
 }
 
-// PivotAction should be yeilding pivot_intents as the robot is in orbit
+// PivotAction should be yielding pivot_intents as the robot is in orbit
 TEST(PivotActionTest, robot_in_robit)
 {
     Robot robot = Robot(0, Point(1, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
@@ -40,7 +40,7 @@ TEST(PivotActionTest, robot_in_robit)
     PivotAction action = PivotAction();
 
     auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), 1.0);
+        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), Angle::ofRadians(2.0), true);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);

--- a/src/thunderbots/software/test/ai/hl/stp/action/pivot_action.cpp
+++ b/src/thunderbots/software/test/ai/hl/stp/action/pivot_action.cpp
@@ -13,8 +13,8 @@ TEST(PivotActionTest, robot_too_far_from_orbit)
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
     PivotAction action = PivotAction();
 
-    auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), Angle::ofRadians(2.0), true);
+    auto intent_ptr = action.updateStateAndGetNextIntent(
+        robot, Point(0, 0), Angle::zero(), Angle::ofRadians(2.0), true);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
@@ -39,8 +39,8 @@ TEST(PivotActionTest, robot_in_robit)
                         Timestamp::fromSeconds(0));
     PivotAction action = PivotAction();
 
-    auto intent_ptr =
-        action.updateStateAndGetNextIntent(robot, Point(0, 0), Angle::zero(), Angle::ofRadians(2.0), true);
+    auto intent_ptr = action.updateStateAndGetNextIntent(
+        robot, Point(0, 0), Angle::zero(), Angle::ofRadians(2.0), true);
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);

--- a/src/thunderbots/software/test/ai/intent/pivot_intent.cpp
+++ b/src/thunderbots/software/test/ai/intent/pivot_intent.cpp
@@ -9,7 +9,7 @@
 
 TEST(PivotIntentTest, intent_name_test)
 {
-    PivotIntent pivot_intent = PivotIntent(0, Point(), Angle::zero(), 0, 0);
+    PivotIntent pivot_intent       = PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 0);
 
     EXPECT_EQ("Pivot Intent", pivot_intent.getIntentName());
 }
@@ -18,16 +18,16 @@ TEST(PivotIntentTest, intent_name_test)
 // since Intents inherit from Primitives
 TEST(PivotIntentTest, test_equality_operator_intents_equal)
 {
-    PivotIntent pivot_intent       = PivotIntent(0, Point(), Angle::zero(), 0, 0);
-    PivotIntent pivot_intent_other = PivotIntent(0, Point(), Angle::zero(), 0, 0);
+    PivotIntent pivot_intent       = PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 0);
+    PivotIntent pivot_intent_other = PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 0);
 
     EXPECT_EQ(pivot_intent, pivot_intent_other);
 }
 
 TEST(PivotIntentTest, test_inequality_operator_with_mismatched_priorities)
 {
-    PivotIntent pivot_intent       = PivotIntent(0, Point(), Angle::zero(), 0, 1);
-    PivotIntent pivot_intent_other = PivotIntent(0, Point(), Angle::zero(), 0, 3);
+    PivotIntent pivot_intent       = PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 1);
+    PivotIntent pivot_intent_other = PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 3);
 
     EXPECT_NE(pivot_intent, pivot_intent_other);
 }

--- a/src/thunderbots/software/test/ai/intent/pivot_intent.cpp
+++ b/src/thunderbots/software/test/ai/intent/pivot_intent.cpp
@@ -9,7 +9,8 @@
 
 TEST(PivotIntentTest, intent_name_test)
 {
-    PivotIntent pivot_intent       = PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 0);
+    PivotIntent pivot_intent =
+        PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 0);
 
     EXPECT_EQ("Pivot Intent", pivot_intent.getIntentName());
 }
@@ -18,16 +19,20 @@ TEST(PivotIntentTest, intent_name_test)
 // since Intents inherit from Primitives
 TEST(PivotIntentTest, test_equality_operator_intents_equal)
 {
-    PivotIntent pivot_intent       = PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 0);
-    PivotIntent pivot_intent_other = PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 0);
+    PivotIntent pivot_intent =
+        PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 0);
+    PivotIntent pivot_intent_other =
+        PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 0);
 
     EXPECT_EQ(pivot_intent, pivot_intent_other);
 }
 
 TEST(PivotIntentTest, test_inequality_operator_with_mismatched_priorities)
 {
-    PivotIntent pivot_intent       = PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 1);
-    PivotIntent pivot_intent_other = PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 3);
+    PivotIntent pivot_intent =
+        PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 1);
+    PivotIntent pivot_intent_other =
+        PivotIntent(0, Point(), Angle::zero(), Angle::half(), true, 3);
 
     EXPECT_NE(pivot_intent, pivot_intent_other);
 }

--- a/src/thunderbots/software/test/ai/navigator/path_planning_navigator/path_planning_navigator.cpp
+++ b/src/thunderbots/software/test/ai/navigator/path_planning_navigator/path_planning_navigator.cpp
@@ -143,14 +143,14 @@ TEST(PathPlanningNavigatorTest, convert_pivot_intent_to_pivot_primitive)
 
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(
-        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), 3.2, 1));
+        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(3.2), true, 1));
 
     auto primitive_ptrs = pathplanningNavigator.getAssignedPrimitives(world, intents);
 
     // Make sure we got exactly 1 primitive back
     EXPECT_EQ(primitive_ptrs.size(), 1);
 
-    auto expected_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), 3.2);
+    auto expected_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(1.2), true);
     auto primitive          = dynamic_cast<PivotPrimitive &>(*(primitive_ptrs.at(0)));
     EXPECT_EQ(expected_primitive, primitive);
 }
@@ -181,7 +181,7 @@ TEST(PathPlanningNavigatorTest, convert_multiple_intents_to_primitives)
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(std::make_unique<StopIntent>(0, false, 1));
     intents.emplace_back(
-        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), 3.2, 1));
+        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(3.2), true, 1));
     //    intents.emplace_back(
     //        std::make_unique<MoveIntent>(0, Point(), Angle::quarter(), 0, 1));
 
@@ -193,7 +193,7 @@ TEST(PathPlanningNavigatorTest, convert_multiple_intents_to_primitives)
     auto expected_stop_primitive = StopPrimitive(0, false);
     auto stop_primitive          = dynamic_cast<StopPrimitive &>(*(primitive_ptrs.at(0)));
     EXPECT_EQ(expected_stop_primitive, stop_primitive);
-    auto expected_pivot_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), 3.2);
+    auto expected_pivot_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(2.2), true);
     auto pivot_primitive = dynamic_cast<PivotPrimitive &>(*(primitive_ptrs.at(1)));
     EXPECT_EQ(expected_pivot_primitive, pivot_primitive);
 }

--- a/src/thunderbots/software/test/ai/navigator/path_planning_navigator/path_planning_navigator.cpp
+++ b/src/thunderbots/software/test/ai/navigator/path_planning_navigator/path_planning_navigator.cpp
@@ -142,16 +142,17 @@ TEST(PathPlanningNavigatorTest, convert_pivot_intent_to_pivot_primitive)
     PathPlanningNavigator pathplanningNavigator;
 
     std::vector<std::unique_ptr<Intent>> intents;
-    intents.emplace_back(
-        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(3.2), true, 1));
+    intents.emplace_back(std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(),
+                                                       Angle::ofRadians(3.2), true, 1));
 
     auto primitive_ptrs = pathplanningNavigator.getAssignedPrimitives(world, intents);
 
     // Make sure we got exactly 1 primitive back
     EXPECT_EQ(primitive_ptrs.size(), 1);
 
-    auto expected_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(1.2), true);
-    auto primitive          = dynamic_cast<PivotPrimitive &>(*(primitive_ptrs.at(0)));
+    auto expected_primitive =
+        PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(3.2), true);
+    auto primitive = dynamic_cast<PivotPrimitive &>(*(primitive_ptrs.at(0)));
     EXPECT_EQ(expected_primitive, primitive);
 }
 
@@ -180,8 +181,8 @@ TEST(PathPlanningNavigatorTest, convert_multiple_intents_to_primitives)
 
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(std::make_unique<StopIntent>(0, false, 1));
-    intents.emplace_back(
-        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(3.2), true, 1));
+    intents.emplace_back(std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(),
+                                                       Angle::ofRadians(2.2), true, 1));
     //    intents.emplace_back(
     //        std::make_unique<MoveIntent>(0, Point(), Angle::quarter(), 0, 1));
 
@@ -193,7 +194,8 @@ TEST(PathPlanningNavigatorTest, convert_multiple_intents_to_primitives)
     auto expected_stop_primitive = StopPrimitive(0, false);
     auto stop_primitive          = dynamic_cast<StopPrimitive &>(*(primitive_ptrs.at(0)));
     EXPECT_EQ(expected_stop_primitive, stop_primitive);
-    auto expected_pivot_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(2.2), true);
+    auto expected_pivot_primitive =
+        PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(2.2), true);
     auto pivot_primitive = dynamic_cast<PivotPrimitive &>(*(primitive_ptrs.at(1)));
     EXPECT_EQ(expected_pivot_primitive, pivot_primitive);
 }

--- a/src/thunderbots/software/test/ai/navigator/placeholder_navigator/placeholder_navigator.cpp
+++ b/src/thunderbots/software/test/ai/navigator/placeholder_navigator/placeholder_navigator.cpp
@@ -161,16 +161,17 @@ TEST(PlaceholderNavigatorTest, convert_pivot_intent_to_pivot_primitive)
     PlaceholderNavigator placeholderNavigator;
 
     std::vector<std::unique_ptr<Intent>> intents;
-    intents.emplace_back(
-        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(1.25), true, 1));
+    intents.emplace_back(std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(),
+                                                       Angle::ofRadians(1.25), true, 1));
 
     auto primitive_ptrs = placeholderNavigator.getAssignedPrimitives(world, intents);
 
     // Make sure we got exactly 1 primitive back
     EXPECT_EQ(primitive_ptrs.size(), 1);
 
-    auto expected_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(1.25), true);
-    auto primitive          = dynamic_cast<PivotPrimitive &>(*(primitive_ptrs.at(0)));
+    auto expected_primitive =
+        PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(1.25), true);
+    auto primitive = dynamic_cast<PivotPrimitive &>(*(primitive_ptrs.at(0)));
     EXPECT_EQ(expected_primitive, primitive);
 }
 
@@ -199,8 +200,8 @@ TEST(PlaceholderNavigatorTest, convert_multiple_intents_to_primitives)
 
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(std::make_unique<StopIntent>(0, false, 1));
-    intents.emplace_back(
-        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(3.2), true, 1));
+    intents.emplace_back(std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(),
+                                                       Angle::ofRadians(3.2), true, 1));
     intents.emplace_back(
         std::make_unique<MoveIntent>(0, Point(), Angle::quarter(), 0, 1));
 
@@ -212,7 +213,8 @@ TEST(PlaceholderNavigatorTest, convert_multiple_intents_to_primitives)
     auto expected_stop_primitive = StopPrimitive(0, false);
     auto stop_primitive          = dynamic_cast<StopPrimitive &>(*(primitive_ptrs.at(0)));
     EXPECT_EQ(expected_stop_primitive, stop_primitive);
-    auto expected_pivot_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(3.2), true);
+    auto expected_pivot_primitive =
+        PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(3.2), true);
     auto pivot_primitive = dynamic_cast<PivotPrimitive &>(*(primitive_ptrs.at(1)));
     EXPECT_EQ(expected_pivot_primitive, pivot_primitive);
     auto expected_move_primitive = MovePrimitive(0, Point(), Angle::quarter(), 0);

--- a/src/thunderbots/software/test/ai/navigator/placeholder_navigator/placeholder_navigator.cpp
+++ b/src/thunderbots/software/test/ai/navigator/placeholder_navigator/placeholder_navigator.cpp
@@ -162,14 +162,14 @@ TEST(PlaceholderNavigatorTest, convert_pivot_intent_to_pivot_primitive)
 
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(
-        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), 3.2, 1));
+        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(1.25), true, 1));
 
     auto primitive_ptrs = placeholderNavigator.getAssignedPrimitives(world, intents);
 
     // Make sure we got exactly 1 primitive back
     EXPECT_EQ(primitive_ptrs.size(), 1);
 
-    auto expected_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), 3.2);
+    auto expected_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(1.25), true);
     auto primitive          = dynamic_cast<PivotPrimitive &>(*(primitive_ptrs.at(0)));
     EXPECT_EQ(expected_primitive, primitive);
 }
@@ -200,7 +200,7 @@ TEST(PlaceholderNavigatorTest, convert_multiple_intents_to_primitives)
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(std::make_unique<StopIntent>(0, false, 1));
     intents.emplace_back(
-        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), 3.2, 1));
+        std::make_unique<PivotIntent>(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(3.2), true, 1));
     intents.emplace_back(
         std::make_unique<MoveIntent>(0, Point(), Angle::quarter(), 0, 1));
 
@@ -212,7 +212,7 @@ TEST(PlaceholderNavigatorTest, convert_multiple_intents_to_primitives)
     auto expected_stop_primitive = StopPrimitive(0, false);
     auto stop_primitive          = dynamic_cast<StopPrimitive &>(*(primitive_ptrs.at(0)));
     EXPECT_EQ(expected_stop_primitive, stop_primitive);
-    auto expected_pivot_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), 3.2);
+    auto expected_pivot_primitive = PivotPrimitive(0, Point(1, 0.4), Angle::half(), Angle::ofRadians(3.2), true);
     auto pivot_primitive = dynamic_cast<PivotPrimitive &>(*(primitive_ptrs.at(1)));
     EXPECT_EQ(expected_pivot_primitive, pivot_primitive);
     auto expected_move_primitive = MovePrimitive(0, Point(), Angle::quarter(), 0);

--- a/src/thunderbots/software/test/ai/primitive/pivot_primitive.cpp
+++ b/src/thunderbots/software/test/ai/primitive/pivot_primitive.cpp
@@ -1,6 +1,5 @@
 /**
  * This file contains the unit tests for the PivotPrimitive class
- *
  */
 
 #include "ai/primitive/pivot_primitive.h"
@@ -10,7 +9,7 @@
 
 TEST(PivotPrimTest, primitive_name_test)
 {
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), 0);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), false);
 
     EXPECT_EQ("Pivot Primitive", pivot_prim.getPrimitiveName());
 }
@@ -19,7 +18,7 @@ TEST(PivotPrimTest, get_robot_id_test)
 {
     unsigned int robot_id = 4U;
 
-    PivotPrimitive pivot_prim = PivotPrimitive(robot_id, Point(), Angle(), 0);
+    PivotPrimitive pivot_prim = PivotPrimitive(4, Point(), Angle(), Angle(), false);
 
     EXPECT_EQ(robot_id, pivot_prim.getRobotId());
 }
@@ -29,24 +28,24 @@ TEST(PivotPrimTest, parameter_array_test)
     const unsigned int robot_id = 6U;
     const Point pivot_point     = Point(-1, 2);
     const Angle final_angle     = Angle::ofRadians(1.5);
-    const double pivot_radius   = 2.5;
+    const Angle pivot_speed     = Angle::ofRadians(1.0);
 
     PivotPrimitive pivot_prim =
-        PivotPrimitive(robot_id, pivot_point, final_angle, pivot_radius);
+        PivotPrimitive(robot_id, pivot_point, final_angle, pivot_speed, true);
 
     std::vector<double> param_array = pivot_prim.getParameters();
 
     EXPECT_DOUBLE_EQ(pivot_point.x(), param_array[0]);
     EXPECT_DOUBLE_EQ(pivot_point.y(), param_array[1]);
     EXPECT_DOUBLE_EQ(final_angle.toRadians(), param_array[2]);
-    EXPECT_DOUBLE_EQ(pivot_radius, param_array[3]);
+    EXPECT_DOUBLE_EQ(pivot_speed.toRadians(), param_array[3]);
 }
 
 TEST(PivotPrimTest, get_pivot_point_test)
 {
     Point pivot_point = Point(-4, 3);
 
-    PivotPrimitive pivot_prim = PivotPrimitive(0, pivot_point, Angle(), 0);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, pivot_point, Angle(), Angle(), false);
 
     EXPECT_EQ(pivot_point, pivot_prim.getPivotPoint());
 }
@@ -55,66 +54,74 @@ TEST(PivotPrimTest, get_final_angle_test)
 {
     Angle final_angle = Angle::ofRadians(1.51);
 
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), final_angle, 0);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), final_angle, Angle(), false);
 
     EXPECT_EQ(final_angle, pivot_prim.getFinalAngle());
 }
 
-TEST(PivotPrimTest, get_pivot_radius_test)
+TEST(PivotPrimTest, get_pivot_speed_test)
 {
-    double pivot_radius = 1.85;
+    Angle pivot_speed = Angle::ofRadians(1.2);
 
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), pivot_radius);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), pivot_speed, true);
 
-    EXPECT_DOUBLE_EQ(pivot_radius, pivot_prim.getPivotRadius());
+    EXPECT_DOUBLE_EQ(pivot_speed.toRadians(), pivot_prim.getPivotSpeed().toRadians());
 }
 
-TEST(PivotPrimTest, get_extra_bit_array_test)
+TEST(PivotPrimTest, get_extra_bit_array_dribbler_off_test)
 {
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), 0);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), false);
 
     std::vector<bool> extra_bit_array = pivot_prim.getExtraBits();
 
-    EXPECT_EQ(extra_bit_array, std::vector<bool>());
+    EXPECT_EQ(extra_bit_array, std::vector<bool>{false});
+}
+
+TEST(PivotPrimTest, get_extra_bit_array_dribbler_on_test)
+{
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
+
+    std::vector<bool> extra_bit_array = pivot_prim.getExtraBits();
+
+    EXPECT_EQ(extra_bit_array, std::vector<bool>{true});
 }
 
 TEST(PivotPrimTest, test_equality_operator_primitives_equal)
 {
-    PivotPrimitive pivot_prim       = PivotPrimitive(0, Point(), Angle(), 0);
-    PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(), Angle(), 0);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
+    PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(), Angle(), Angle(), true);
 
     EXPECT_EQ(pivot_prim, pivot_prim_other);
 }
 
 TEST(PivotPrimTest, test_inequality_operator_with_mismatched_robot_id)
 {
-    PivotPrimitive pivot_prim       = PivotPrimitive(0, Point(), Angle(), 0);
-    PivotPrimitive pivot_prim_other = PivotPrimitive(8, Point(), Angle(), 0);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
+    PivotPrimitive pivot_prim_other = PivotPrimitive(8, Point(), Angle(), Angle(), true);
 
     EXPECT_NE(pivot_prim, pivot_prim_other);
 }
 
 TEST(PivotPrimTest, test_inequality_operator_with_mismatched_pivot_point)
 {
-    PivotPrimitive pivot_prim       = PivotPrimitive(0, Point(), Angle(), 0);
-    PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(1, 1), Angle(), 0);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
+    PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(1, 1), Angle(), Angle(), true);
 
     EXPECT_NE(pivot_prim, pivot_prim_other);
 }
 
 TEST(PivotPrimTest, test_inequality_operator_with_mismatched_final_angle)
 {
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), 0);
-    PivotPrimitive pivot_prim_other =
-        PivotPrimitive(0, Point(), Angle::threeQuarter(), 0);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
+    PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(), Angle::threeQuarter(), Angle(), true);
 
     EXPECT_NE(pivot_prim, pivot_prim_other);
 }
 
-TEST(PivotPrimTest, test_inequality_operator_with_mismatched_pivot_radius)
+TEST(PivotPrimTest, test_inequality_operator_with_mismatched_pivot_speed)
 {
-    PivotPrimitive pivot_prim       = PivotPrimitive(0, Point(), Angle(), 1);
-    PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(), Angle(), 1.25);
+    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
+    PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(), Angle(), Angle::threeQuarter(), true);
 
     EXPECT_NE(pivot_prim, pivot_prim_other);
 }

--- a/src/thunderbots/software/test/ai/primitive/pivot_primitive.cpp
+++ b/src/thunderbots/software/test/ai/primitive/pivot_primitive.cpp
@@ -88,7 +88,7 @@ TEST(PivotPrimTest, get_extra_bit_array_dribbler_on_test)
 
 TEST(PivotPrimTest, test_equality_operator_primitives_equal)
 {
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
+    PivotPrimitive pivot_prim       = PivotPrimitive(0, Point(), Angle(), Angle(), true);
     PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(), Angle(), Angle(), true);
 
     EXPECT_EQ(pivot_prim, pivot_prim_other);
@@ -96,7 +96,7 @@ TEST(PivotPrimTest, test_equality_operator_primitives_equal)
 
 TEST(PivotPrimTest, test_inequality_operator_with_mismatched_robot_id)
 {
-    PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
+    PivotPrimitive pivot_prim       = PivotPrimitive(0, Point(), Angle(), Angle(), true);
     PivotPrimitive pivot_prim_other = PivotPrimitive(8, Point(), Angle(), Angle(), true);
 
     EXPECT_NE(pivot_prim, pivot_prim_other);
@@ -105,7 +105,8 @@ TEST(PivotPrimTest, test_inequality_operator_with_mismatched_robot_id)
 TEST(PivotPrimTest, test_inequality_operator_with_mismatched_pivot_point)
 {
     PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
-    PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(1, 1), Angle(), Angle(), true);
+    PivotPrimitive pivot_prim_other =
+        PivotPrimitive(0, Point(1, 1), Angle(), Angle(), true);
 
     EXPECT_NE(pivot_prim, pivot_prim_other);
 }
@@ -113,7 +114,8 @@ TEST(PivotPrimTest, test_inequality_operator_with_mismatched_pivot_point)
 TEST(PivotPrimTest, test_inequality_operator_with_mismatched_final_angle)
 {
     PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
-    PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(), Angle::threeQuarter(), Angle(), true);
+    PivotPrimitive pivot_prim_other =
+        PivotPrimitive(0, Point(), Angle::threeQuarter(), Angle(), true);
 
     EXPECT_NE(pivot_prim, pivot_prim_other);
 }
@@ -121,7 +123,8 @@ TEST(PivotPrimTest, test_inequality_operator_with_mismatched_final_angle)
 TEST(PivotPrimTest, test_inequality_operator_with_mismatched_pivot_speed)
 {
     PivotPrimitive pivot_prim = PivotPrimitive(0, Point(), Angle(), Angle(), true);
-    PivotPrimitive pivot_prim_other = PivotPrimitive(0, Point(), Angle(), Angle::threeQuarter(), true);
+    PivotPrimitive pivot_prim_other =
+        PivotPrimitive(0, Point(), Angle(), Angle::threeQuarter(), true);
 
     EXPECT_NE(pivot_prim, pivot_prim_other);
 }

--- a/src/thunderbots/software/test/ai/primitive/primitive_factory.cpp
+++ b/src/thunderbots/software/test/ai/primitive/primitive_factory.cpp
@@ -223,10 +223,11 @@ TEST(PivotPrimTest, convert_PivotPrimitive_to_message_and_back_to_PivotPrimitive
     const unsigned int robot_id = 2U;
     const Point pivot_point     = Point(2, -1);
     const Angle final_angle     = Angle::ofRadians(2.56);
-    const double pivot_radius   = .78;
+    const Angle pivot_speed     = Angle::ofRadians(3.14);
+    const bool  enable_dribbler = true;
 
     PivotPrimitive pivot_prim =
-        PivotPrimitive(robot_id, pivot_point, final_angle, pivot_radius);
+        PivotPrimitive(robot_id, pivot_point, final_angle, pivot_speed, enable_dribbler);
 
     thunderbots_msgs::Primitive prim_msg = pivot_prim.createMsg();
     std::unique_ptr<Primitive> new_prim =
@@ -238,8 +239,8 @@ TEST(PivotPrimTest, convert_PivotPrimitive_to_message_and_back_to_PivotPrimitive
     EXPECT_DOUBLE_EQ(pivot_point.x(), parameters[0]);
     EXPECT_DOUBLE_EQ(pivot_point.y(), parameters[1]);
     EXPECT_DOUBLE_EQ(final_angle.toRadians(), parameters[2]);
-    EXPECT_DOUBLE_EQ(pivot_radius, parameters[3]);
-    EXPECT_EQ(std::vector<bool>(), new_prim->getExtraBits());
+    EXPECT_DOUBLE_EQ(pivot_speed.toRadians(), parameters[3]);
+    EXPECT_EQ(std::vector<bool>{true}, new_prim->getExtraBits());
 }
 
 // Test that we can correctly translate a StopPrimitive like:

--- a/src/thunderbots/software/test/ai/primitive/primitive_factory.cpp
+++ b/src/thunderbots/software/test/ai/primitive/primitive_factory.cpp
@@ -224,7 +224,7 @@ TEST(PivotPrimTest, convert_PivotPrimitive_to_message_and_back_to_PivotPrimitive
     const Point pivot_point     = Point(2, -1);
     const Angle final_angle     = Angle::ofRadians(2.56);
     const Angle pivot_speed     = Angle::ofRadians(3.14);
-    const bool  enable_dribbler = true;
+    const bool enable_dribbler  = true;
 
     PivotPrimitive pivot_prim =
         PivotPrimitive(robot_id, pivot_point, final_angle, pivot_speed, enable_dribbler);

--- a/src/thunderbots/software/test/grsim_communication/pivot_primitive.cpp
+++ b/src/thunderbots/software/test/grsim_communication/pivot_primitive.cpp
@@ -54,25 +54,6 @@ MotionController::PositionCommand get_motion_command(Robot& robot,
     return motionCommand;
 }
 
-// robot is already at the final position, and receives a pivot request to the same
-// position in this case, it should not do another rotation
-TEST_P(GrsimCommandPrimitiveVisitorParameterizedTest,
-       visit_pivot_primtive_robot_should_not_move)
-{
-    // robot is at current pivot point + (1,0)
-    Robot robot = Robot(1, GetParam() + Point(1, 0), Vector(0, 0), Angle::ofRadians(0.0),
-                        AngularVelocity::ofRadians(0.0), Timestamp::fromSeconds(0));
-
-    // asked to pivot to zero degress from current point, with a radius of 1 which should
-    // resolve to pivot point + (1,0)
-    PivotPrimitive primitive = PivotPrimitive(1, GetParam(), Angle::zero(), Angle::zero(), false);
-
-    auto motion_command = get_motion_command(robot, primitive);
-
-    EXPECT_EQ(motion_command.global_destination.x(), robot.position().x());
-    EXPECT_EQ(motion_command.global_destination.y(), robot.position().y());
-}
-
 // robot needs to pick the shortest path to rotate, based on where it is and the magnitude
 // of of the vector from its next position to the final position.
 
@@ -83,7 +64,8 @@ TEST_P(GrsimCommandPrimitiveVisitorParameterizedTest, visit_pivot_primtive_clock
     // (chosen far so all values pivot cw) which should result in a cw rotation on all
     // parameterized pivot points
     PivotPrimitive primitive =
-        PivotPrimitive(1, Point(10, -10), Angle::ofRadians(-1 / 4 * M_PI), Angle::ofRadians(1.24), false);
+        PivotPrimitive(1, Point(10, -10), Angle::ofRadians(-1 / 4 * M_PI),
+                       Angle::ofRadians(1.24), false);
 
     // place the robot in the first quadrant, should rotate CW
     Robot robot = Robot(1, GetParam(), Vector(0, 0), Angle::ofRadians(0.0),
@@ -115,8 +97,8 @@ TEST_P(GrsimCommandPrimitiveVisitorParameterizedTest,
     // asked to pivot to 3/4 pi above x axis, with radius of 10, from point (-10, 10)
     // (chosen far so all values pivot ccw) which should result in a cw rotation on all
     // parameterized pivot points
-    PivotPrimitive primitive =
-        PivotPrimitive(1, Point(-10, 10), Angle::ofRadians(3 / 4 * M_PI), Angle::ofRadians(1.24), false);
+    PivotPrimitive primitive = PivotPrimitive(
+        1, Point(-10, 10), Angle::ofRadians(3 / 4 * M_PI), Angle::ofRadians(1.24), false);
 
     // place the robot in the first quadrant, should rotate CW
     Robot robot = Robot(1, GetParam(), Vector(0, 0), Angle::ofRadians(0.0),

--- a/src/thunderbots/software/test/grsim_communication/pivot_primitive.cpp
+++ b/src/thunderbots/software/test/grsim_communication/pivot_primitive.cpp
@@ -65,7 +65,7 @@ TEST_P(GrsimCommandPrimitiveVisitorParameterizedTest,
 
     // asked to pivot to zero degress from current point, with a radius of 1 which should
     // resolve to pivot point + (1,0)
-    PivotPrimitive primitive = PivotPrimitive(1, GetParam(), Angle::zero(), 1);
+    PivotPrimitive primitive = PivotPrimitive(1, GetParam(), Angle::zero(), Angle::zero(), false);
 
     auto motion_command = get_motion_command(robot, primitive);
 
@@ -83,7 +83,7 @@ TEST_P(GrsimCommandPrimitiveVisitorParameterizedTest, visit_pivot_primtive_clock
     // (chosen far so all values pivot cw) which should result in a cw rotation on all
     // parameterized pivot points
     PivotPrimitive primitive =
-        PivotPrimitive(1, Point(10, -10), Angle::ofRadians(-1 / 4 * M_PI), 10);
+        PivotPrimitive(1, Point(10, -10), Angle::ofRadians(-1 / 4 * M_PI), Angle::ofRadians(1.24), false);
 
     // place the robot in the first quadrant, should rotate CW
     Robot robot = Robot(1, GetParam(), Vector(0, 0), Angle::ofRadians(0.0),
@@ -116,7 +116,7 @@ TEST_P(GrsimCommandPrimitiveVisitorParameterizedTest,
     // (chosen far so all values pivot ccw) which should result in a cw rotation on all
     // parameterized pivot points
     PivotPrimitive primitive =
-        PivotPrimitive(1, Point(-10, 10), Angle::ofRadians(3 / 4 * M_PI), 10);
+        PivotPrimitive(1, Point(-10, 10), Angle::ofRadians(3 / 4 * M_PI), Angle::ofRadians(1.24), false);
 
     // place the robot in the first quadrant, should rotate CW
     Robot robot = Robot(1, GetParam(), Vector(0, 0), Angle::ofRadians(0.0),

--- a/src/thunderbots/software/test/radio_communication/visitor/mrf_primitive_visitor.cpp
+++ b/src/thunderbots/software/test/radio_communication/visitor/mrf_primitive_visitor.cpp
@@ -209,12 +209,13 @@ TEST(MRFPrimitiveVisitorTest, visit_movespin_primitive)
 
 TEST(MRFPrimitiveVisitorTest, visit_pivot_primitive)
 {
-    PivotPrimitive primitive(11, Point(22, 33.3), Angle::half(), 2.33);
+    PivotPrimitive primitive(11, Point(22, 33.3), Angle::half(), Angle::ofRadians(2.71), true);
     RadioPrimitive expected_radio_primitive;
     expected_radio_primitive.prim_type   = FirmwarePrimitiveType::PIVOT;
     expected_radio_primitive.param_array = {22 * 1000, 33.3 * 1000,
-                                            Angle::half().toRadians() * 100, 2.33 * 1000};
-    expected_radio_primitive.extra_bits  = 0;
+                                            Angle::half().toRadians() * 100, 
+                                            Angle::ofRadians(2.71).toRadians() * 100};
+    expected_radio_primitive.extra_bits  = 1;
 
     MRFPrimitiveVisitor prim_visitor;
     primitive.accept(prim_visitor);

--- a/src/thunderbots/software/test/radio_communication/visitor/mrf_primitive_visitor.cpp
+++ b/src/thunderbots/software/test/radio_communication/visitor/mrf_primitive_visitor.cpp
@@ -209,11 +209,12 @@ TEST(MRFPrimitiveVisitorTest, visit_movespin_primitive)
 
 TEST(MRFPrimitiveVisitorTest, visit_pivot_primitive)
 {
-    PivotPrimitive primitive(11, Point(22, 33.3), Angle::half(), Angle::ofRadians(2.71), true);
+    PivotPrimitive primitive(11, Point(22, 33.3), Angle::half(), Angle::ofRadians(2.71),
+                             true);
     RadioPrimitive expected_radio_primitive;
     expected_radio_primitive.prim_type   = FirmwarePrimitiveType::PIVOT;
     expected_radio_primitive.param_array = {22 * 1000, 33.3 * 1000,
-                                            Angle::half().toRadians() * 100, 
+                                            Angle::half().toRadians() * 100,
                                             Angle::ofRadians(2.71).toRadians() * 100};
     expected_radio_primitive.extra_bits  = 1;
 

--- a/src/thunderbots/software/util/parameter/config/ai.yaml
+++ b/src/thunderbots/software/util/parameter/config/ai.yaml
@@ -243,10 +243,6 @@ GoalieTactic:
         The block cone buffer is the extra distance to add on either side of the robot
         to allow to it be further back in the block cone
 PivotAction:
-  experimental:
-      type: "bool"
-      default: false
-      description: If toggled, then loose ball will attempt to pivot with bottom parameters
   arb_scaling:
       min: 0.0
       max: 10.0

--- a/src/thunderbots/software/util/parameter/config/ai.yaml
+++ b/src/thunderbots/software/util/parameter/config/ai.yaml
@@ -235,6 +235,25 @@ GoalieTactic:
       description: >-
         The block cone buffer is the extra distance to add on either side of the robot
         to allow to it be further back in the block cone
+PivotAction:
+  experimental:
+      type: "bool"
+      default: false
+      description: If toggled, then loose ball will attempt to pivot with bottom parameters
+  arb_scaling:
+      min: 0.0
+      max: 10.0
+      type: "double"
+      default: 1.0
+      description: How quickly to pivot
+  finish_angle_threshold:
+      min: 0.0
+      max: 360.0
+      type: "double"
+      default: 5.0
+      description: >-
+          How much tolerance in degrees we allow for the final angle before annoucing
+          pivot has finished
 RobotCapabilities:
   broken_dribblers:
     default: ""


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Pivot primitive now pivots at a fixed radius around the ball (roughly ball radius + robot radius), with the angular now a parameter. This work was started at competition and is still in development.
End goal is a CMU-style pivot where we can pivot with the ball in the dribbler.

### Testing Done
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

still fixing the unit tests help

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [ ] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
