### PR TITLE
WIP: Updated Dribbler Thermal Model

### DIFF
--- a/src/firmware/main/dribbler.c
+++ b/src/firmware/main/dribbler.c
@@ -1,9 +1,5 @@
 /**
- * \defgroup DRIBBLER Dribbler Functions
- *
- * \brief These functions handle overall operation of the dribbler, including PWM selection, torque limiting, and thermal modelling.
- *
- * @{
+ * These functions handle overall operation of the dribbler, including PWM selection, torque limiting, and thermal modelling.
  */
 #include "dribbler.h"
 #include "adc.h"
@@ -14,6 +10,10 @@
 #include "physics.h"
 #include <stdio.h>
 
+/**
+ * The following constants use values from this datasheet:
+ * https://www.maxongroup.com/medias/sys_master/root/8833419509790/19-EN-177.pdf
+ */
 #define NOMINAL_SPEED_RPM 50800
 #define NOMINAL_VOLTAGE 18.0f
 #define SPEED_CONSTANT (NOMINAL_SPEED_RPM / NOMINAL_VOLTAGE) // rpm per volt
@@ -41,7 +41,7 @@
 
 #define DRIBBLER_SPEED_BUFFER_ZONE 250 // RPM
 
-#define MAX_DRIBBLER_CURRENT 4.0 // Limit the max current the dribbler can draw when stalled
+#define MAX_DRIBBLER_CURRENT 4.0f // Limit the max current the dribbler can draw when stalled
 #define MAX_DELTA_VOLTAGE (MAX_DRIBBLER_CURRENT * (PHASE_RESISTANCE + SWITCH_RESISTANCE + MIN_RESISTANCE_UNDER_PWM70)) // Limit the current by limiting the max delta voltage we can apply
 #define MIN_RESISTANCE_UNDER_PWM70 1.5f
 

--- a/src/firmware/main/dribbler.c
+++ b/src/firmware/main/dribbler.c
@@ -14,19 +14,21 @@
 #include "physics.h"
 #include <stdio.h>
 
-#define SPEED_CONSTANT 3760.0f // rpm per volt—EC16 datasheet
+#define NOMINAL_SPEED_RPM 50800
+#define NOMINAL_VOLTAGE 18.0f
+#define SPEED_CONSTANT (NOMINAL_SPEED_RPM / NOMINAL_VOLTAGE) // rpm per volt
 #define VOLTS_PER_RPM (1.0f / SPEED_CONSTANT) // volts per rpm
 #define VOLTS_PER_RPT (VOLTS_PER_RPM * 60.0f * DRIBBLER_TICK_HZ) // volts per rpt, rpt=revolutions per tick
 #define VOLTS_PER_SPEED_UNIT (VOLTS_PER_RPT / 6.0f) // volts per Hall edge
-#define PHASE_RESISTANCE 0.403f // ohms—EC16 datasheet
+#define PHASE_RESISTANCE 0.512f // ohms—EC16 datasheet
 #define SWITCH_RESISTANCE (0.019f*2.0f) // ohms—AO4882 datasheet
 
-#define THERMAL_TIME_CONSTANT_WINDING 1.97f // seconds—EC16 datasheet
-#define THERMAL_RESISTANCE_WINDING 1.68f // kelvins per Watt—EC16 datasheet (winding to housing)
+#define THERMAL_TIME_CONSTANT_WINDING 2.17f // seconds—EC16 datasheet
+#define THERMAL_RESISTANCE_WINDING 1.8f // kelvins per Watt—EC16 datasheet (winding to housing)
 #define THERMAL_CAPACITANCE_WINDING (THERMAL_TIME_CONSTANT_WINDING / THERMAL_RESISTANCE_WINDING) // joules per kelvin
 
-#define THERMAL_TIME_CONSTANT_HOUSING 240.0f // seconds—EC16 datasheet
-#define THERMAL_RESISTANCE_HOUSING 16.3f // kelvins per Watt—EC16 datasheet (housing to ambient)
+#define THERMAL_TIME_CONSTANT_HOUSING 508.0f // seconds—EC16 datasheet
+#define THERMAL_RESISTANCE_HOUSING 20.3f // kelvins per Watt—EC16 datasheet (housing to ambient)
 #define THERMAL_CAPACITANCE_HOUSING (THERMAL_TIME_CONSTANT_HOUSING / THERMAL_RESISTANCE_HOUSING) // joules per kelvin
 
 #define THERMAL_AMBIENT 40.0f // °C—empirically estimated based on motor casing heatsinking to chassis
@@ -37,9 +39,9 @@
 #define THERMAL_WARNING_STOP_TEMPERATURE_WINDING (THERMAL_WARNING_START_TEMPERATURE_WINDING - 15.0f) // °C—chead
 #define THERMAL_WARNING_STOP_ENERGY_WINDING ((THERMAL_WARNING_STOP_TEMPERATURE_WINDING - THERMAL_AMBIENT) * THERMAL_CAPACITANCE_WINDING) // joules
 
-#define DRIBBLER_SPEED_BUFFER_ZONE 200 // RPM
+#define DRIBBLER_SPEED_BUFFER_ZONE 250 // RPM
 
-#define MAX_DRIBBLER_CURRENT 5 // Limit the max current the dribbler can draw when stalled
+#define MAX_DRIBBLER_CURRENT 4.0 // Limit the max current the dribbler can draw when stalled
 #define MAX_DELTA_VOLTAGE (MAX_DRIBBLER_CURRENT * (PHASE_RESISTANCE + SWITCH_RESISTANCE + MIN_RESISTANCE_UNDER_PWM70)) // Limit the current by limiting the max delta voltage we can apply
 #define MIN_RESISTANCE_UNDER_PWM70 1.5f
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

@hannahvsawiuk updated the dribbler motor thermal model, theoretically allowing for much higher dribbler motor speeds.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Needs IRL robot validation.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
