### PR TITLE
Add setValue function to parameter

### DIFF
--- a/src/thunderbots/software/test/util/test_dynamic_parameters.cpp
+++ b/src/thunderbots/software/test/util/test_dynamic_parameters.cpp
@@ -91,7 +91,7 @@ TYPED_TEST(RegistryTest, constructor_test)
     try
     {
         ASSERT_EQ(test_param.getRegistry().count("test_all_type_params"), 1);
-        ASSERT_EQ(test_param.getRegistry().at("test_all_type_params")->value(),
+        ASSERT_EQ(test_param.getRegistry().at("test_all_type_params").second->value(),
                   unique_value);
     }
     catch (...)

--- a/src/thunderbots/software/test/util/test_parameter_exists.cpp
+++ b/src/thunderbots/software/test/util/test_parameter_exists.cpp
@@ -84,19 +84,19 @@ int main(int argc, char** argv)
     // grab parameters of each type from its respective registry
     for (const auto& pair : Parameter<int32_t>::getRegistry())
     {
-        int_parameters.push_back(*pair.second);
+        int_parameters.push_back(*pair.second.second);
     }
     for (const auto& pair : Parameter<double>::getRegistry())
     {
-        double_parameters.push_back(*pair.second);
+        double_parameters.push_back(*pair.second.second);
     }
     for (const auto& pair : Parameter<bool>::getRegistry())
     {
-        bool_parameters.push_back(*pair.second);
+        bool_parameters.push_back(*pair.second.second);
     }
     for (const auto& pair : Parameter<std::string>::getRegistry())
     {
-        string_parameters.push_back(*pair.second);
+        string_parameters.push_back(*pair.second.second);
     }
 
     // run tests

--- a/src/thunderbots/software/util/constants.h
+++ b/src/thunderbots/software/util/constants.h
@@ -28,7 +28,7 @@ namespace Util
 
         // Networking and vision
         static const std::string SSL_VISION_DEFAULT_MULTICAST_ADDRESS = "224.5.23.2";
-        static const unsigned short SSL_VISION_MULTICAST_PORT = 10020;
+        static const unsigned short SSL_VISION_MULTICAST_PORT         = 10020;
 
         // GrSim networking and communication
         // TODO: BETTER NAMES

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -73,14 +73,14 @@ class Parameter
         {
             auto& param_in_registry = Parameter<T>::getMutableRegistry().at(this->name_);
 
-            param_in_registry.first->lock();
+            std::scoped_lock lock(*param_in_registry.first);
             auto value = param_in_registry.second->value_;
-            param_in_registry.first->unlock();
 
             return value;
         }
 
-        // TODO fix this on ROS removal to throw an exception, ideally we do not
+        // TODO https://github.com/UBC-Thunderbots/Software/issues/738
+        // fix this on ROS removal to throw an exception, ideally we do not
         // want to return a value here as params that aren't in the registry are not
         // threadsafe
         else
@@ -102,12 +102,11 @@ class Parameter
         if (Parameter<T>::getMutableRegistry().count(this->name_))
         {
             auto& param_in_registry = Parameter<T>::getMutableRegistry().at(this->name_);
-            param_in_registry.first->lock();
+            std::scoped_lock lock(*param_in_registry.first);
             param_in_registry->value_ = new_value;
-            param_in_registry.first->unlock();
         }
 
-        // TODO fix this on ROS removal to throw an exception, ideally we do not
+        // TODO https://github.com/UBC-Thunderbots/Software/issues/738
         // want to store a value here as params that aren't in the registry are not
         // threadsafe
         else
@@ -224,9 +223,8 @@ class Parameter
     {
         for (const auto& pair : Parameter<T>::getRegistry())
         {
-            pair.second.first->lock();
+            std::scoped_lock lock(*pair.second.first);
             pair.second.second->updateValueFromROSParameterServer();
-            pair.second.first->unlock();
         }
     }
 
@@ -240,9 +238,8 @@ class Parameter
     {
         for (const auto& pair : Parameter<T>::getRegistry())
         {
-            pair.second.first->lock();
+            std::scoped_lock lock(*pair.second.first);
             pair.second.second->updateParameterFromConfigMsg(updates);
-            pair.second.first->unlock();
         }
     }
 

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <vector>
 
 // messages for dynamic_reconfigure
 #include <dynamic_reconfigure/BoolParameter.h>
@@ -261,7 +260,7 @@ class Parameter
     getMutableRegistry()
     {
         // our registry needs to hold onto a unique mutex to access the parameters in the
-        // registry as mutexes cannot be moved or
+        // registry as mutexes cannot be moved or copied
         static std::map<std::string, std::pair<std::unique_ptr<std::mutex>,
                                                std::unique_ptr<Parameter<T>>>>
             instance;

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -165,8 +165,8 @@ class Parameter
      *
      * @return An immutable reference to the Parameter registry
      */
-    static const std::map<std::string,
-                          std::pair<std::unique_ptr<std::mutex>, std::unique_ptr<Parameter<T>>>>&
+    static const std::map<std::string, std::pair<std::unique_ptr<std::mutex>,
+                                                 std::unique_ptr<Parameter<T>>>>&
     getRegistry()
     {
         return Parameter<T>::getMutableRegistry();

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -73,7 +73,7 @@ class Parameter
         {
             auto& param_in_registry = Parameter<T>::getMutableRegistry().at(this->name_);
 
-            std::scoped_lock lock(*param_in_registry.first);
+            std::scoped_lock lock(*(param_in_registry.first));
             auto value = param_in_registry.second->value_;
 
             return value;
@@ -102,7 +102,7 @@ class Parameter
         if (Parameter<T>::getMutableRegistry().count(this->name_))
         {
             auto& param_in_registry = Parameter<T>::getMutableRegistry().at(this->name_);
-            std::scoped_lock lock(*param_in_registry.first);
+            std::scoped_lock lock(*(param_in_registry.first));
             param_in_registry->value_ = new_value;
         }
 
@@ -223,7 +223,7 @@ class Parameter
     {
         for (const auto& pair : Parameter<T>::getRegistry())
         {
-            std::scoped_lock lock(*pair.second.first);
+            std::scoped_lock lock(*(pair.second.first));
             pair.second.second->updateValueFromROSParameterServer();
         }
     }
@@ -238,7 +238,7 @@ class Parameter
     {
         for (const auto& pair : Parameter<T>::getRegistry())
         {
-            std::scoped_lock lock(*pair.second.first);
+            std::scoped_lock lock(*(pair.second.first));
             pair.second.second->updateParameterFromConfigMsg(updates);
         }
     }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Addes a setter for dynamic parameters and improves thread safety
### Testing Done
manually tested with print statements
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
n/a
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification
N/A
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
