### PR TITLE
Added Parameter callbacks

### DIFF
--- a/src/thunderbots/software/CMakeLists.txt
+++ b/src/thunderbots/software/CMakeLists.txt
@@ -957,6 +957,13 @@ if (CATKIN_ENABLE_TESTING)
             ${catkin_LIBRARIES}
             )
 
+    catkin_add_gtest(parameter_test
+            test/util/parameter_test.cpp)
+    target_link_libraries(parameter_test
+            ${catkin_LIBRARIES}
+            tbots_parameter
+            )
+
 endif()
 
 ##### ROSTests / Integration Tests #####

--- a/src/thunderbots/software/test/util/parameter_test.cpp
+++ b/src/thunderbots/software/test/util/parameter_test.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+#include "software/util/parameter/parameter.h"
+
+TEST(ParameterTest, register_single_callback_test)
+{
+    Parameter<bool> test_param = Parameter<bool>("test_param", "parameters", false);
+    bool test_value = false;
+
+    // This callback will set the test_value (by reference) to the given value
+    auto callback = [&test_value](bool new_value) {
+        test_value = new_value;
+    };
+    test_param.registerCallbackFunction(callback);
+
+    EXPECT_FALSE(test_value);
+    test_param.setValue(true);
+    EXPECT_TRUE(test_value);
+}
+
+TEST(ParameterTest, register_multiple_unique_callbacks_test)
+{
+    Parameter<double> test_param = Parameter<double>("test_param", "parameters", 0.0);
+    double test_value_1 = 1.0;
+    double test_value_2 = -3.0;
+    double test_value_3 = 4.5;
+
+    auto callback_1 = [&test_value_1](double new_value) {
+        test_value_1 += new_value;
+    };
+    test_param.registerCallbackFunction(callback_1);
+
+    auto callback_2 = [&test_value_2](double new_value) {
+        test_value_2 -= new_value;
+    };
+    test_param.registerCallbackFunction(callback_2);
+
+    auto callback_3 = [&test_value_3](double new_value) {
+        test_value_3 *= new_value;
+    };
+    test_param.registerCallbackFunction(callback_3);
+
+    EXPECT_DOUBLE_EQ(test_value_1, 1.0);
+    EXPECT_DOUBLE_EQ(test_value_2, -3.0);
+    EXPECT_DOUBLE_EQ(test_value_3, 4.5);
+    test_param.setValue(2.0);
+    EXPECT_DOUBLE_EQ(test_value_1, 3.0);
+    EXPECT_DOUBLE_EQ(test_value_2, -5.0);
+    EXPECT_DOUBLE_EQ(test_value_3, 9);
+}
+
+TEST(ParameterTest, register_duplicate_callbacks_test)
+{
+    Parameter<int> test_param = Parameter<int>("test_param", "parameters", 0);
+    int test_value = 0;
+
+    // This callback will set the test_value (by reference) to the given value
+    auto callback = [&test_value](int new_value) {
+        test_value += new_value;
+    };
+    test_param.registerCallbackFunction(callback);
+    test_param.registerCallbackFunction(callback);
+
+    EXPECT_EQ(test_value, 0);
+    test_param.setValue(1);
+    EXPECT_EQ(test_value, 2);
+}
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "dynamic_parameters_ros_test");
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/thunderbots/software/test/util/parameter_test.cpp
+++ b/src/thunderbots/software/test/util/parameter_test.cpp
@@ -1,15 +1,14 @@
-#include <gtest/gtest.h>
 #include "software/util/parameter/parameter.h"
+
+#include <gtest/gtest.h>
 
 TEST(ParameterTest, register_single_callback_test)
 {
     Parameter<bool> test_param = Parameter<bool>("test_param", "parameters", false);
-    bool test_value = false;
+    bool test_value            = false;
 
     // This callback will set the test_value (by reference) to the given value
-    auto callback = [&test_value](bool new_value) {
-        test_value = new_value;
-    };
+    auto callback = [&test_value](bool new_value) { test_value = new_value; };
     test_param.registerCallbackFunction(callback);
 
     EXPECT_FALSE(test_value);
@@ -20,23 +19,17 @@ TEST(ParameterTest, register_single_callback_test)
 TEST(ParameterTest, register_multiple_unique_callbacks_test)
 {
     Parameter<double> test_param = Parameter<double>("test_param", "parameters", 0.0);
-    double test_value_1 = 1.0;
-    double test_value_2 = -3.0;
-    double test_value_3 = 4.5;
+    double test_value_1          = 1.0;
+    double test_value_2          = -3.0;
+    double test_value_3          = 4.5;
 
-    auto callback_1 = [&test_value_1](double new_value) {
-        test_value_1 += new_value;
-    };
+    auto callback_1 = [&test_value_1](double new_value) { test_value_1 += new_value; };
     test_param.registerCallbackFunction(callback_1);
 
-    auto callback_2 = [&test_value_2](double new_value) {
-        test_value_2 -= new_value;
-    };
+    auto callback_2 = [&test_value_2](double new_value) { test_value_2 -= new_value; };
     test_param.registerCallbackFunction(callback_2);
 
-    auto callback_3 = [&test_value_3](double new_value) {
-        test_value_3 *= new_value;
-    };
+    auto callback_3 = [&test_value_3](double new_value) { test_value_3 *= new_value; };
     test_param.registerCallbackFunction(callback_3);
 
     EXPECT_DOUBLE_EQ(test_value_1, 1.0);
@@ -51,12 +44,10 @@ TEST(ParameterTest, register_multiple_unique_callbacks_test)
 TEST(ParameterTest, register_duplicate_callbacks_test)
 {
     Parameter<int> test_param = Parameter<int>("test_param", "parameters", 0);
-    int test_value = 0;
+    int test_value            = 0;
 
     // This callback will set the test_value (by reference) to the given value
-    auto callback = [&test_value](int new_value) {
-        test_value += new_value;
-    };
+    auto callback = [&test_value](int new_value) { test_value += new_value; };
     test_param.registerCallbackFunction(callback);
     test_param.registerCallbackFunction(callback);
 

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -241,6 +241,7 @@ class Parameter
     }
 
     std::mutex value_mutex_;
+    std::mutex callback_mutex_;
 
     // Store the value so it can be retrieved without fetching from the server again
     T value_;
@@ -251,7 +252,6 @@ class Parameter
     // Store the namespace of the parameter
     std::string namespace_;
 
-    std::mutex callback_mutex_;
     // A list of functions to call when a new parameter value is set
     std::vector<std::function<void(T)>> callback_functions;
 

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -73,7 +73,8 @@ class Parameter
     }
 
     /**
-     * Given the value, sets the value of this parameter
+     * Given the value, sets the value of this parameter and calls all registered
+     * callback functions with the new value
      *
      * @param new_value The new value to set
      */
@@ -131,6 +132,12 @@ class Parameter
                                                        this->value_);
     }
 
+    /**
+     * Registers a callback function to be called when the value of this parameter is
+     * changed with setValue
+     *
+     * @param callback The function to call when this parameter's value is changed
+     */
     void registerCallbackFunction(std::function<void(T)> callback)
     {
         std::scoped_lock callback_lock(this->callback_mutex_);

--- a/src/thunderbots/software/util/parameter/parameter.h
+++ b/src/thunderbots/software/util/parameter/parameter.h
@@ -82,7 +82,8 @@ class Parameter
         std::scoped_lock value_lock(this->value_mutex_);
         this->value_ = new_value;
         std::scoped_lock callback_lock(this->callback_mutex_);
-        for(auto callback_func : callback_functions) {
+        for (auto callback_func : callback_functions)
+        {
             callback_func(new_value);
         }
     }
@@ -130,7 +131,8 @@ class Parameter
                                                        this->value_);
     }
 
-    void registerCallbackFunction(std::function<void(T)> callback) {
+    void registerCallbackFunction(std::function<void(T)> callback)
+    {
         std::scoped_lock callback_lock(this->callback_mutex_);
         callback_functions.emplace_back(callback);
     }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Allows callback functions to be registered with Parameter objects. These functions will be called when the Parameter's value changes.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
unit tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Start of document comments**: each `.cpp` and `.h` file should have a comment at the start of it. See files in the `thunderbots/software/geom` folder for examples.
- [x] **Function comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the classes defined in `thunderbots/software/geom`
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
-->
