### PR TITLE
Clion Install Script fixes

### DIFF
--- a/environment_setup/install_clion.sh
+++ b/environment_setup/install_clion.sh
@@ -44,10 +44,10 @@ else
 	mkdir -p /tmp/bazelbuild
 	tar xfz /tmp/bazelbuild.tar.gz -C /tmp/bazelbuild
 	cd /tmp/bazelbuild/intellij*
-	sudo bazel build //clwb:clwb_bazel_zip --define=ij_product=clion-${clion_major_version}
+	bazel build //clwb:clwb_bazel_zip --define=ij_product=clion-${clion_major_version}
 
 	# Copy the compiled plugin to the CLion directory
-	mkdir -p ~/.CLion${clion_major_version}/config/plugins
+	mkdir -p $clion_plugin_dir
 	unzip bazel-bin/clwb/clwb_bazel.zip -d $clion_plugin_dir
 
 	# Cleanup

--- a/environment_setup/install_clion.sh
+++ b/environment_setup/install_clion.sh
@@ -44,7 +44,7 @@ else
 	mkdir -p /tmp/bazelbuild
 	tar xfz /tmp/bazelbuild.tar.gz -C /tmp/bazelbuild
 	cd /tmp/bazelbuild/intellij*
-	bazel build //clwb:clwb_bazel_zip --define=ij_product=clion-${clion_major_version}
+	sudo bazel build //clwb:clwb_bazel_zip --define=ij_product=clion-${clion_major_version}
 
 	# Copy the compiled plugin to the CLion directory
 	mkdir -p $clion_plugin_dir


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Fixed a few small things in the CLion setup script I noticed when using it today
* Re-used the clion plugin path variable
* Removed `sudo` from the `bazel build` command to build the plugin since this also causes the cache to be owned by `root` if the `install_clion.sh` script is run before the user tries to `bazel build` themselves

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Works on my machine

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
