### PR TITLE
Add PassWithRating struct encapsulating Pass object and its rating

### DIFF
--- a/src/software/ai/hl/stp/play/corner_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/corner_kick_play.cpp
@@ -114,8 +114,7 @@ void CornerKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
 
     PassGenerator pass_generator(world, world.ball().position());
 
-    std::pair<Pass, double> best_pass_and_score_so_far =
-        pass_generator.getBestPassSoFar();
+    PassWithRating best_pass_and_score_so_far = pass_generator.getBestPassSoFar();
 
     // Wait for a robot to be assigned to align to take the corner
     while (!align_to_ball_tactic->getAssignedRobot())
@@ -163,21 +162,21 @@ void CornerKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
                bait_move_tactic_1, bait_move_tactic_2});
 
         best_pass_and_score_so_far = pass_generator.getBestPassSoFar();
-        LOG(DEBUG) << "Best pass found so far is: " << best_pass_and_score_so_far.first;
-        LOG(DEBUG) << "    with score: " << best_pass_and_score_so_far.second;
+        LOG(DEBUG) << "Best pass found so far is: " << best_pass_and_score_so_far.pass;
+        LOG(DEBUG) << "    with score: " << best_pass_and_score_so_far.rating;
 
         Duration time_since_commit_stage_start =
             world.getMostRecentTimestamp() - commit_stage_start_time;
         min_score = 1 - std::min(time_since_commit_stage_start.getSeconds() /
                                      MAX_TIME_TO_COMMIT_TO_PASS.getSeconds(),
                                  1.0);
-    } while (best_pass_and_score_so_far.second < min_score);
+    } while (best_pass_and_score_so_far.rating < min_score);
 
     // Commit to a pass
-    Pass pass = best_pass_and_score_so_far.first;
+    Pass pass = best_pass_and_score_so_far.pass;
 
-    LOG(DEBUG) << "Committing to pass: " << best_pass_and_score_so_far.first;
-    LOG(DEBUG) << "Score of pass we committed to: " << best_pass_and_score_so_far.second;
+    LOG(DEBUG) << "Committing to pass: " << best_pass_and_score_so_far.pass;
+    LOG(DEBUG) << "Score of pass we committed to: " << best_pass_and_score_so_far.rating;
 
     // Destruct the PassGenerator and CherryPick tactics (which contain a PassGenerator
     // each) to save a significant number of CPU cycles

--- a/src/software/ai/hl/stp/play/free_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/free_kick_play.cpp
@@ -84,8 +84,7 @@ void FreeKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     pass_generator.setTargetRegion(
         Rectangle(Point(-(world.field().length() / 4), world.field().width() / 2),
                   world.field().enemyCornerNeg()));
-    std::pair<Pass, double> best_pass_and_score_so_far =
-        pass_generator.getBestPassSoFar();
+    PassWithRating best_pass_and_score_so_far = pass_generator.getBestPassSoFar();
 
     // Wait for a good pass by starting out only looking for "perfect" passes (with a
     // score of 1) and decreasing this threshold over time
@@ -136,8 +135,8 @@ void FreeKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
         updateCherryPickTactics({cherry_pick_tactic_pos_y, cherry_pick_tactic_neg_y});
         updatePassGenerator(pass_generator);
 
-        LOG(DEBUG) << "Best pass so far is: " << best_pass_and_score_so_far.first;
-        LOG(DEBUG) << "      with score of: " << best_pass_and_score_so_far.second;
+        LOG(DEBUG) << "Best pass so far is: " << best_pass_and_score_so_far.pass;
+        LOG(DEBUG) << "      with score of: " << best_pass_and_score_so_far.rating;
 
         yield({shoot_tactic, cherry_pick_tactic_neg_y, cherry_pick_tactic_pos_y,
                crease_defender_left, crease_defender_right});
@@ -155,7 +154,7 @@ void FreeKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
         // We're ready to pass if we have a robot assigned in the PassGenerator as the
         // passer and the PassGenerator has found a pass above our current threshold
         ready_to_pass = set_passer_robot_in_passgenerator &&
-                        best_pass_and_score_so_far.second < min_pass_score_threshold;
+                        best_pass_and_score_so_far.rating < min_pass_score_threshold;
 
         // If we've assigned a robot as the passer in the PassGenerator, we lower
         // our threshold based on how long the PassGenerator as been running since
@@ -184,11 +183,11 @@ void FreeKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     if (!shoot_tactic->hasShotAvailable())
     {
         // Commit to a pass
-        Pass pass = best_pass_and_score_so_far.first;
+        Pass pass = best_pass_and_score_so_far.pass;
 
-        LOG(DEBUG) << "Committing to pass: " << best_pass_and_score_so_far.first;
+        LOG(DEBUG) << "Committing to pass: " << best_pass_and_score_so_far.pass;
         LOG(DEBUG) << "Score of pass we committed to: "
-                   << best_pass_and_score_so_far.second;
+                   << best_pass_and_score_so_far.rating;
 
         // Perform the pass and wait until the receiver is finished
         auto passer   = std::make_shared<PasserTactic>(pass, world.ball(), false);

--- a/src/software/ai/passing/BUILD
+++ b/src/software/ai/passing/BUILD
@@ -46,12 +46,21 @@ cc_test(
 )
 
 cc_library(
+    name = "pass_with_rating",
+    hdrs = ["pass_with_rating.h"],
+    deps = [
+        ":pass",
+    ],
+)
+
+cc_library(
     name = "pass_generator",
     srcs = ["pass_generator.cpp"],
     hdrs = ["pass_generator.h"],
     deps = [
         ":evaluation",
         ":pass",
+        ":pass_with_rating",
         "//software/ai/world",
         "//software/util/optimization:gradient_descent",
     ],

--- a/src/software/ai/passing/pass_generator.cpp
+++ b/src/software/ai/passing/pass_generator.cpp
@@ -56,14 +56,14 @@ void PassGenerator::setPasserRobotId(unsigned int robot_id)
     this->passer_robot_id = robot_id;
 }
 
-std::pair<Pass, double> PassGenerator::getBestPassSoFar()
+PassWithRating PassGenerator::getBestPassSoFar()
 {
     // Take ownership of the best_known_pass for the duration of this function
     std::lock_guard<std::mutex> best_known_pass_lock(best_known_pass_mutex);
 
     Pass best_known_pass_copy = best_known_pass;
-    return std::make_pair<Pass, double>(std::move(best_known_pass_copy),
-                                        ratePass(best_known_pass));
+
+    return PassWithRating{std::move(best_known_pass_copy), ratePass(best_known_pass)};
 }
 
 void PassGenerator::setTargetRegion(std::optional<Rectangle> area)

--- a/src/software/ai/passing/pass_generator.h
+++ b/src/software/ai/passing/pass_generator.h
@@ -5,6 +5,7 @@
 #include <thread>
 
 #include "software/ai/passing/pass.h"
+#include "software/ai/passing/pass_with_rating.h"
 #include "software/ai/world/world.h"
 #include "software/util/optimization/gradient_descent_optimizer.h"
 #include "software/util/parameter/dynamic_parameters.h"
@@ -108,7 +109,7 @@ namespace Passing
          *
          * @return The best currently known pass and the rating of that pass (in [0-1])
          */
-        std::pair<Pass, double> getBestPassSoFar();
+        PassWithRating getBestPassSoFar();
 
         /**
          * Destructs this PassGenerator

--- a/src/software/ai/passing/pass_with_rating.h
+++ b/src/software/ai/passing/pass_with_rating.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "software/ai/passing/pass.h"
+
+using namespace Passing;
+
+struct PassWithRating
+{
+    Pass pass;
+    double rating;
+};


### PR DESCRIPTION
### Description

- Added a new ```PassWithRating``` struct to encapsulate a ```Pass``` object and its rating. 
- Replaced any instance of ```std::pair<Pass, double>``` that used to represent a ```Pass``` and its rating with this new struct.

### Testing Done

- Old unit tests still pass

### Resolved Issues
- Resolves #810 

### Misc
~~Small thing but maybe this struct should be called ```PassWithRating``` instead or the double member field could be named ```quality```.~~
Struct is now called PassWithRating.