### PR TITLE
Add Shot class and replaced usages of pair<Point, Angle>

### DIFF
--- a/src/software/ai/hl/stp/evaluation/calc_best_shot.cpp
+++ b/src/software/ai/hl/stp/evaluation/calc_best_shot.cpp
@@ -103,7 +103,7 @@ namespace Evaluation
         Angle goal_angle = acuteVertexAngle(field.friendlyGoalpostPos(), shot_origin,
                                             field.friendlyGoalpostNeg())
                                .abs();
-        return shot.angle.toDegrees() / goal_angle.toDegrees();
+        return shot.getAngle().toDegrees() / goal_angle.toDegrees();
     }
 
     double calcShotOpenEnemyNetPercentage(const Field &field, const Point &shot_origin,
@@ -112,6 +112,6 @@ namespace Evaluation
         Angle goal_angle = acuteVertexAngle(field.enemyGoalpostPos(), shot_origin,
                                             field.enemyGoalpostNeg())
                                .abs();
-        return shot.angle.toDegrees() / goal_angle.toDegrees();
+        return shot.getAngle().toDegrees() / goal_angle.toDegrees();
     }
 }  // namespace Evaluation

--- a/src/software/ai/hl/stp/evaluation/calc_best_shot.cpp
+++ b/src/software/ai/hl/stp/evaluation/calc_best_shot.cpp
@@ -103,7 +103,7 @@ namespace Evaluation
         Angle goal_angle = acuteVertexAngle(field.friendlyGoalpostPos(), shot_origin,
                                             field.friendlyGoalpostNeg())
                                .abs();
-        return shot.getAngle().toDegrees() / goal_angle.toDegrees();
+        return shot.getOpenAngle().toDegrees() / goal_angle.toDegrees();
     }
 
     double calcShotOpenEnemyNetPercentage(const Field &field, const Point &shot_origin,
@@ -112,6 +112,6 @@ namespace Evaluation
         Angle goal_angle = acuteVertexAngle(field.enemyGoalpostPos(), shot_origin,
                                             field.enemyGoalpostNeg())
                                .abs();
-        return shot.getAngle().toDegrees() / goal_angle.toDegrees();
+        return shot.getOpenAngle().toDegrees() / goal_angle.toDegrees();
     }
 }  // namespace Evaluation

--- a/src/software/ai/hl/stp/evaluation/calc_best_shot.cpp
+++ b/src/software/ai/hl/stp/evaluation/calc_best_shot.cpp
@@ -4,18 +4,19 @@
 
 namespace Evaluation
 {
-    std::optional<std::pair<Point, Angle>> calcBestShotOnGoal(
-        const Point &goal_post_neg, const Point &goal_post_pos, const Point &p,
-        const std::vector<Point> &obstacles, double radius)
+    std::optional<Shot> calcBestShotOnGoal(const Point &goal_post_neg,
+                                           const Point &goal_post_pos, const Point &p,
+                                           const std::vector<Point> &obstacles,
+                                           double radius)
     {
         // Use angleSweepCircle function to get the pair
         return angleSweepCircles(p, goal_post_neg, goal_post_pos, obstacles, radius);
     }
 
-    std::optional<std::pair<Point, Angle>> calcBestShotOnGoal(
-        const Field &field, const Team &friendly_team, const Team &enemy_team,
-        const Point &point, bool shoot_on_enemy_goal, double radius,
-        const std::vector<Robot> &robots_to_ignore)
+    std::optional<Shot> calcBestShotOnGoal(const Field &field, const Team &friendly_team,
+                                           const Team &enemy_team, const Point &point,
+                                           bool shoot_on_enemy_goal, double radius,
+                                           const std::vector<Robot> &robots_to_ignore)
     {
         std::vector<Point> obstacles;
         for (const Robot &enemy_robot : enemy_team.getAllRobots())
@@ -37,7 +38,7 @@ namespace Evaluation
             }
         }
 
-        std::optional<std::pair<Point, Angle>> best_shot;
+        std::optional<Shot> best_shot;
 
         // Calculate the best_shot based on what goal we're shooting at
         if (shoot_on_enemy_goal)
@@ -56,7 +57,7 @@ namespace Evaluation
         return best_shot;
     }
 
-    std::optional<std::pair<Point, Angle>> calcBestShotOnEnemyGoal(
+    std::optional<Shot> calcBestShotOnEnemyGoal(
         const Field &field, const Team &friendly_team, const Team &enemy_team,
         const Robot &robot, double radius, const std::vector<Robot> &robots_to_ignore)
     {
@@ -67,7 +68,7 @@ namespace Evaluation
                                        radius, all_robots_to_ignore);
     }
 
-    std::optional<std::pair<Point, Angle>> calcBestShotOnEnemyGoal(
+    std::optional<Shot> calcBestShotOnEnemyGoal(
         const Field &field, const Team &friendly_team, const Team &enemy_team,
         const Point &shot_origin, double radius,
         const std::vector<Robot> &robots_to_ignore)
@@ -76,7 +77,7 @@ namespace Evaluation
                                   radius, robots_to_ignore);
     }
 
-    std::optional<std::pair<Point, Angle>> calcBestShotOnFriendlyGoal(
+    std::optional<Shot> calcBestShotOnFriendlyGoal(
         const Field &field, const Team &friendly_team, const Team &enemy_team,
         const Robot &robot, double radius, const std::vector<Robot> &robots_to_ignore)
     {
@@ -87,7 +88,7 @@ namespace Evaluation
                                           robot.position(), radius, all_robots_to_ignore);
     }
 
-    std::optional<std::pair<Point, Angle>> calcBestShotOnFriendlyGoal(
+    std::optional<Shot> calcBestShotOnFriendlyGoal(
         const Field &field, const Team &friendly_team, const Team &enemy_team,
         const Point &shot_origin, double radius,
         const std::vector<Robot> &robots_to_ignore)
@@ -97,20 +98,20 @@ namespace Evaluation
     }
 
     double calcShotOpenFriendlyNetPercentage(const Field &field, const Point &shot_origin,
-                                             const std::pair<Point, Angle> &shot)
+                                             const Shot &shot)
     {
         Angle goal_angle = acuteVertexAngle(field.friendlyGoalpostPos(), shot_origin,
                                             field.friendlyGoalpostNeg())
                                .abs();
-        return shot.second.toDegrees() / goal_angle.toDegrees();
+        return shot.angle.toDegrees() / goal_angle.toDegrees();
     }
 
     double calcShotOpenEnemyNetPercentage(const Field &field, const Point &shot_origin,
-                                          const std::pair<Point, Angle> &shot)
+                                          const Shot &shot)
     {
         Angle goal_angle = acuteVertexAngle(field.enemyGoalpostPos(), shot_origin,
                                             field.enemyGoalpostNeg())
                                .abs();
-        return shot.second.toDegrees() / goal_angle.toDegrees();
+        return shot.angle.toDegrees() / goal_angle.toDegrees();
     }
 }  // namespace Evaluation

--- a/src/software/ai/hl/stp/evaluation/calc_best_shot.h
+++ b/src/software/ai/hl/stp/evaluation/calc_best_shot.h
@@ -5,6 +5,7 @@
 #include "software/world/field.h"
 #include "software/world/robot.h"
 #include "software/world/world.h"
+#include "software/geom/shot.h"
 
 namespace Evaluation
 {
@@ -19,15 +20,16 @@ namespace Evaluation
      * @param obstacles The locations of any obstacles on the field that may obstruct the
      * shot. These are treated as circular obstacles, and are usually used to represent
      * robots on the field.
-     * @param radius The radius of the given obstacles
+     * @param radius The radius of the given obstacles>
      *
      * @return the best target to shoot at and the largest open angle interval for the
      * shot (this is the total angle between the obstacles on either side of the shot
      * vector). If no shot is possible, returns `std::nullopt`
      */
-    std::optional<std::pair<Point, Angle>> calcBestShotOnGoal(
-        const Point &goal_post_neg, const Point &goal_post_pos, const Point &p,
-        const std::vector<Point> &obstacles, double radius);
+    std::optional<Shot> calcBestShotOnGoal(const Point &goal_post_neg,
+                                           const Point &goal_post_pos, const Point &p,
+                                           const std::vector<Point> &obstacles,
+                                           double radius);
 
     /**
      * Finds the best shot on the specified goal, and returns the best target to shoot at
@@ -51,7 +53,7 @@ namespace Evaluation
      * shot (this is the total angle between the obstacles on either side of the shot
      * vector). If no shot can be found, returns std::nullopt
      */
-    std::optional<std::pair<Point, Angle>> calcBestShotOnGoal(
+    std::optional<Shot> calcBestShotOnGoal(
         const Field &field, const Team &friendly_team, const Team &enemy_team,
         const Point &point, bool shoot_at_enemy_goal,
         double radius                              = ROBOT_MAX_RADIUS_METERS,
@@ -76,7 +78,7 @@ namespace Evaluation
      * shot (this is the total angle between the obstacles on either side of the shot
      * vector). If no shot can be found, returns std::nullopt
      */
-    std::optional<std::pair<Point, Angle>> calcBestShotOnEnemyGoal(
+    std::optional<Shot> calcBestShotOnEnemyGoal(
         const Field &field, const Team &friendly_team, const Team &enemy_team,
         const Robot &robot, double radius = ROBOT_MAX_RADIUS_METERS,
         const std::vector<Robot> &robots_to_ignore = {});
@@ -100,7 +102,7 @@ namespace Evaluation
      * shot (this is the total angle between the obstacles on either side of the shot
      * vector). If no shot can be found, returns std::nullopt
      */
-    std::optional<std::pair<Point, Angle>> calcBestShotOnEnemyGoal(
+    std::optional<Shot> calcBestShotOnEnemyGoal(
         const Field &field, const Team &friendly_team, const Team &enemy_team,
         const Point &shot_origin, double radius = ROBOT_MAX_RADIUS_METERS,
         const std::vector<Robot> &robots_to_ignore = {});
@@ -124,7 +126,7 @@ namespace Evaluation
      * shot (this is the total angle between the obstacles on either side of the shot
      * vector). If no shot can be found, returns std::nullopt
      */
-    std::optional<std::pair<Point, Angle>> calcBestShotOnFriendlyGoal(
+    std::optional<Shot> calcBestShotOnFriendlyGoal(
         const Field &field, const Team &friendly_team, const Team &enemy_team,
         const Robot &robot, double radius = ROBOT_MAX_RADIUS_METERS,
         const std::vector<Robot> &robots_to_ignore = {});
@@ -148,7 +150,7 @@ namespace Evaluation
      * shot (this is the total angle between the obstacles on either side of the shot
      * vector). If no shot can be found, returns std::nullopt
      */
-    std::optional<std::pair<Point, Angle>> calcBestShotOnFriendlyGoal(
+    std::optional<Shot> calcBestShotOnFriendlyGoal(
         const Field &field, const Team &friendly_team, const Team &enemy_team,
         const Point &shot_origin, double radius = ROBOT_MAX_RADIUS_METERS,
         const std::vector<Robot> &robots_to_ignore = {});
@@ -164,7 +166,7 @@ namespace Evaluation
      *         being taken on. Larger numbers mean a larger percentage of the net is open
      */
     double calcShotOpenFriendlyNetPercentage(const Field &field, const Point &shot_origin,
-                                             const std::pair<Point, Angle> &shot);
+                                             const Shot &shot);
 
     /**
      * Calculates the percentage of the enemy net that a given shot is aiming for
@@ -177,6 +179,6 @@ namespace Evaluation
      *         being taken on. Larger numbers mean a larger percentage of the net is open
      */
     double calcShotOpenEnemyNetPercentage(const Field &field, const Point &shot_origin,
-                                          const std::pair<Point, Angle> &shot);
+                                          const Shot &shot);
 
 }  // namespace Evaluation

--- a/src/software/ai/hl/stp/evaluation/calc_best_shot.h
+++ b/src/software/ai/hl/stp/evaluation/calc_best_shot.h
@@ -2,10 +2,10 @@
 
 #include "shared/constants.h"
 #include "software/geom/point.h"
+#include "software/geom/shot.h"
 #include "software/world/field.h"
 #include "software/world/robot.h"
 #include "software/world/world.h"
-#include "software/geom/shot.h"
 
 namespace Evaluation
 {

--- a/src/software/ai/hl/stp/evaluation/calc_best_shot.h
+++ b/src/software/ai/hl/stp/evaluation/calc_best_shot.h
@@ -20,7 +20,7 @@ namespace Evaluation
      * @param obstacles The locations of any obstacles on the field that may obstruct the
      * shot. These are treated as circular obstacles, and are usually used to represent
      * robots on the field.
-     * @param radius The radius of the given obstacles>
+     * @param radius The radius of the given obstacles
      *
      * @return the best target to shoot at and the largest open angle interval for the
      * shot (this is the total angle between the obstacles on either side of the shot

--- a/src/software/ai/hl/stp/evaluation/calc_best_shot_test.cpp
+++ b/src/software/ai/hl/stp/evaluation/calc_best_shot_test.cpp
@@ -26,8 +26,8 @@ TEST(CalcBestShotTest, calc_best_shot_on_enemy_goal_with_no_obstacles)
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->first.isClose(world.field().enemyGoal(), 0.05));
-    EXPECT_NEAR(result->second.toDegrees(), 12, 5);
+    EXPECT_TRUE(result->point.isClose(world.field().enemyGoal(), 0.05));
+    EXPECT_NEAR(result->angle.toDegrees(), 12, 5);
 }
 
 TEST(CalcBestShotTest, calc_best_shot_on_friendly_goal_with_no_obstacles)
@@ -45,8 +45,8 @@ TEST(CalcBestShotTest, calc_best_shot_on_friendly_goal_with_no_obstacles)
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->first.isClose(world.field().friendlyGoal(), 0.05));
-    EXPECT_NEAR(result->second.toDegrees(), 12, 5);
+    EXPECT_TRUE(result->point.isClose(world.field().friendlyGoal(), 0.05));
+    EXPECT_NEAR(result->angle.toDegrees(), 12, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -70,8 +70,8 @@ TEST(CalcBestShotTest,
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->first.isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->second.toDegrees(), 6, 5);
+    EXPECT_TRUE(result->point.isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->angle.toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -96,8 +96,8 @@ TEST(CalcBestShotTest,
     ASSERT_TRUE(result);
 
     EXPECT_TRUE(
-        result->first.isClose(Point(world.field().friendlyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->second.toDegrees(), 6, 5);
+        result->point.isClose(Point(world.field().friendlyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->angle.toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -124,8 +124,8 @@ TEST(CalcBestShotTest,
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->first.isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->second.toDegrees(), 6, 5);
+    EXPECT_TRUE(result->point.isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->angle.toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -153,8 +153,8 @@ TEST(CalcBestShotTest,
     ASSERT_TRUE(result);
 
     EXPECT_TRUE(
-        result->first.isClose(Point(world.field().friendlyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->second.toDegrees(), 6, 5);
+        result->point.isClose(Point(world.field().friendlyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->angle.toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest, calc_best_shot_on_enemy_goal_with_all_shots_blocked_by_obstacles)
@@ -205,7 +205,7 @@ TEST(CalcBestShotTest, calc_open_enemy_net_percentage_with_unblocked_net)
     World world                  = ::Test::TestUtil::createBlankTestingWorld();
     Field field                  = ::Test::TestUtil::createSSLDivBField();
     Point shot_origin            = world.field().enemyGoal() - Vector(0.5, 0);
-    std::pair<Point, Angle> shot = {world.field().enemyGoal(), Angle::ofDegrees(90)};
+    Shot shot                    = {world.field().enemyGoal(), Angle::ofDegrees(90)};
 
     auto result = Evaluation::calcShotOpenEnemyNetPercentage(field, shot_origin, shot);
 
@@ -218,8 +218,7 @@ TEST(CalcBestShotTest, calc_open_enemy_net_percentage_with_partially_blocked_net
     World world                  = ::Test::TestUtil::createBlankTestingWorld();
     Field field                  = ::Test::TestUtil::createSSLDivBField();
     Point shot_origin            = world.field().enemyGoal() - Vector(0.5, 0);
-    std::pair<Point, Angle> shot = {world.field().enemyGoal() + Vector(0, 0.25),
-                                    Angle::ofDegrees(45)};
+    Shot shot = {world.field().enemyGoal() + Vector(0, 0.25), Angle::ofDegrees(45)};
 
     auto result = Evaluation::calcShotOpenEnemyNetPercentage(field, shot_origin, shot);
 
@@ -232,7 +231,7 @@ TEST(CalcBestShotTest, calc_open_enemy_net_percentage_with_fully_blocked_net)
     World world                  = ::Test::TestUtil::createBlankTestingWorld();
     Field field                  = ::Test::TestUtil::createSSLDivBField();
     Point shot_origin            = world.field().enemyGoal() - Vector(0.5, 0);
-    std::pair<Point, Angle> shot = {world.field().enemyGoal(), Angle::zero()};
+    Shot shot                    = {world.field().enemyGoal(), Angle::zero()};
 
     auto result = Evaluation::calcShotOpenFriendlyNetPercentage(field, shot_origin, shot);
 
@@ -245,7 +244,7 @@ TEST(CalcBestShotTest, calc_open_friendly_net_percentage_with_unblocked_net)
     World world                  = ::Test::TestUtil::createBlankTestingWorld();
     Field field                  = ::Test::TestUtil::createSSLDivBField();
     Point shot_origin            = world.field().friendlyGoal() + Vector(0.5, 0);
-    std::pair<Point, Angle> shot = {world.field().enemyGoal(), Angle::ofDegrees(90)};
+    Shot shot                    = {world.field().enemyGoal(), Angle::ofDegrees(90)};
 
     auto result = Evaluation::calcShotOpenFriendlyNetPercentage(field, shot_origin, shot);
 
@@ -258,8 +257,7 @@ TEST(CalcBestShotTest, calc_open_friendly_net_percentage_with_partially_blocked_
     World world                  = ::Test::TestUtil::createBlankTestingWorld();
     Field field                  = ::Test::TestUtil::createSSLDivBField();
     Point shot_origin            = world.field().friendlyGoal() + Vector(0.5, 0);
-    std::pair<Point, Angle> shot = {world.field().enemyGoal() + Vector(0, 0.25),
-                                    Angle::ofDegrees(45)};
+    Shot shot = {world.field().enemyGoal() + Vector(0, 0.25), Angle::ofDegrees(45)};
 
     auto result = Evaluation::calcShotOpenFriendlyNetPercentage(field, shot_origin, shot);
 
@@ -272,7 +270,7 @@ TEST(CalcBestShotTest, calc_open_friendly_net_percentage_with_fully_blocked_net)
     World world                  = ::Test::TestUtil::createBlankTestingWorld();
     Field field                  = ::Test::TestUtil::createSSLDivBField();
     Point shot_origin            = world.field().enemyGoal() + Vector(0.5, 0);
-    std::pair<Point, Angle> shot = {world.field().enemyGoal(), Angle::zero()};
+    Shot shot                    = {world.field().enemyGoal(), Angle::zero()};
 
     auto result = Evaluation::calcShotOpenEnemyNetPercentage(field, shot_origin, shot);
 

--- a/src/software/ai/hl/stp/evaluation/calc_best_shot_test.cpp
+++ b/src/software/ai/hl/stp/evaluation/calc_best_shot_test.cpp
@@ -26,8 +26,8 @@ TEST(CalcBestShotTest, calc_best_shot_on_enemy_goal_with_no_obstacles)
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->getPoint().isClose(world.field().enemyGoal(), 0.05));
-    EXPECT_NEAR(result->getAngle().toDegrees(), 12, 5);
+    EXPECT_TRUE(result->getPointToShootAt().isClose(world.field().enemyGoal(), 0.05));
+    EXPECT_NEAR(result->getOpenAngle().toDegrees(), 12, 5);
 }
 
 TEST(CalcBestShotTest, calc_best_shot_on_friendly_goal_with_no_obstacles)
@@ -45,8 +45,8 @@ TEST(CalcBestShotTest, calc_best_shot_on_friendly_goal_with_no_obstacles)
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->getPoint().isClose(world.field().friendlyGoal(), 0.05));
-    EXPECT_NEAR(result->getAngle().toDegrees(), 12, 5);
+    EXPECT_TRUE(result->getPointToShootAt().isClose(world.field().friendlyGoal(), 0.05));
+    EXPECT_NEAR(result->getOpenAngle().toDegrees(), 12, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -70,9 +70,9 @@ TEST(CalcBestShotTest,
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(
-        result->getPoint().isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->getAngle().toDegrees(), 6, 5);
+    EXPECT_TRUE(result->getPointToShootAt().isClose(
+        Point(world.field().enemyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->getOpenAngle().toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -96,9 +96,9 @@ TEST(CalcBestShotTest,
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(
-        result->getPoint().isClose(Point(world.field().friendlyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->getAngle().toDegrees(), 6, 5);
+    EXPECT_TRUE(result->getPointToShootAt().isClose(
+        Point(world.field().friendlyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->getOpenAngle().toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -125,9 +125,9 @@ TEST(CalcBestShotTest,
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(
-        result->getPoint().isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->getAngle().toDegrees(), 6, 5);
+    EXPECT_TRUE(result->getPointToShootAt().isClose(
+        Point(world.field().enemyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->getOpenAngle().toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -154,9 +154,9 @@ TEST(CalcBestShotTest,
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(
-        result->getPoint().isClose(Point(world.field().friendlyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->getAngle().toDegrees(), 6, 5);
+    EXPECT_TRUE(result->getPointToShootAt().isClose(
+        Point(world.field().friendlyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->getOpenAngle().toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest, calc_best_shot_on_enemy_goal_with_all_shots_blocked_by_obstacles)

--- a/src/software/ai/hl/stp/evaluation/calc_best_shot_test.cpp
+++ b/src/software/ai/hl/stp/evaluation/calc_best_shot_test.cpp
@@ -70,7 +70,8 @@ TEST(CalcBestShotTest,
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->getPoint().isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
+    EXPECT_TRUE(
+        result->getPoint().isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
     EXPECT_NEAR(result->getAngle().toDegrees(), 6, 5);
 }
 
@@ -124,7 +125,8 @@ TEST(CalcBestShotTest,
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->getPoint().isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
+    EXPECT_TRUE(
+        result->getPoint().isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
     EXPECT_NEAR(result->getAngle().toDegrees(), 6, 5);
 }
 

--- a/src/software/ai/hl/stp/evaluation/calc_best_shot_test.cpp
+++ b/src/software/ai/hl/stp/evaluation/calc_best_shot_test.cpp
@@ -26,8 +26,8 @@ TEST(CalcBestShotTest, calc_best_shot_on_enemy_goal_with_no_obstacles)
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->point.isClose(world.field().enemyGoal(), 0.05));
-    EXPECT_NEAR(result->angle.toDegrees(), 12, 5);
+    EXPECT_TRUE(result->getPoint().isClose(world.field().enemyGoal(), 0.05));
+    EXPECT_NEAR(result->getAngle().toDegrees(), 12, 5);
 }
 
 TEST(CalcBestShotTest, calc_best_shot_on_friendly_goal_with_no_obstacles)
@@ -45,8 +45,8 @@ TEST(CalcBestShotTest, calc_best_shot_on_friendly_goal_with_no_obstacles)
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->point.isClose(world.field().friendlyGoal(), 0.05));
-    EXPECT_NEAR(result->angle.toDegrees(), 12, 5);
+    EXPECT_TRUE(result->getPoint().isClose(world.field().friendlyGoal(), 0.05));
+    EXPECT_NEAR(result->getAngle().toDegrees(), 12, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -70,8 +70,8 @@ TEST(CalcBestShotTest,
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->point.isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->angle.toDegrees(), 6, 5);
+    EXPECT_TRUE(result->getPoint().isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->getAngle().toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -96,8 +96,8 @@ TEST(CalcBestShotTest,
     ASSERT_TRUE(result);
 
     EXPECT_TRUE(
-        result->point.isClose(Point(world.field().friendlyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->angle.toDegrees(), 6, 5);
+        result->getPoint().isClose(Point(world.field().friendlyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->getAngle().toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -124,8 +124,8 @@ TEST(CalcBestShotTest,
     // We expect to be able to find a shot
     ASSERT_TRUE(result);
 
-    EXPECT_TRUE(result->point.isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->angle.toDegrees(), 6, 5);
+    EXPECT_TRUE(result->getPoint().isClose(Point(world.field().enemyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->getAngle().toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest,
@@ -153,8 +153,8 @@ TEST(CalcBestShotTest,
     ASSERT_TRUE(result);
 
     EXPECT_TRUE(
-        result->point.isClose(Point(world.field().friendlyGoal().x(), -0.3), 0.05));
-    EXPECT_NEAR(result->angle.toDegrees(), 6, 5);
+        result->getPoint().isClose(Point(world.field().friendlyGoal().x(), -0.3), 0.05));
+    EXPECT_NEAR(result->getAngle().toDegrees(), 6, 5);
 }
 
 TEST(CalcBestShotTest, calc_best_shot_on_enemy_goal_with_all_shots_blocked_by_obstacles)

--- a/src/software/ai/hl/stp/evaluation/enemy_threat.cpp
+++ b/src/software/ai/hl/stp/evaluation/enemy_threat.cpp
@@ -250,8 +250,8 @@ std::vector<Evaluation::EnemyThreat> Evaluation::getAllEnemyThreats(
                                                                      enemy_team, robot);
         if (best_shot_data)
         {
-            best_shot_angle  = best_shot_data->angle;
-            best_shot_target = best_shot_data->point;
+            best_shot_angle  = best_shot_data->getAngle();
+            best_shot_target = best_shot_data->getPoint();
         }
 
         // Set default values. If the robot can't be passed to we set the number of passes

--- a/src/software/ai/hl/stp/evaluation/enemy_threat.cpp
+++ b/src/software/ai/hl/stp/evaluation/enemy_threat.cpp
@@ -250,8 +250,8 @@ std::vector<Evaluation::EnemyThreat> Evaluation::getAllEnemyThreats(
                                                                      enemy_team, robot);
         if (best_shot_data)
         {
-            best_shot_angle  = best_shot_data->getAngle();
-            best_shot_target = best_shot_data->getPoint();
+            best_shot_angle  = best_shot_data->getOpenAngle();
+            best_shot_target = best_shot_data->getPointToShootAt();
         }
 
         // Set default values. If the robot can't be passed to we set the number of passes

--- a/src/software/ai/hl/stp/evaluation/enemy_threat.cpp
+++ b/src/software/ai/hl/stp/evaluation/enemy_threat.cpp
@@ -250,8 +250,8 @@ std::vector<Evaluation::EnemyThreat> Evaluation::getAllEnemyThreats(
                                                                      enemy_team, robot);
         if (best_shot_data)
         {
-            best_shot_angle  = best_shot_data->second;
-            best_shot_target = best_shot_data->first;
+            best_shot_angle  = best_shot_data->angle;
+            best_shot_target = best_shot_data->point;
         }
 
         // Set default values. If the robot can't be passed to we set the number of passes

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
@@ -137,7 +137,7 @@ std::optional<std::pair<Point, Angle>> CreaseDefenderTactic::calculateDesiredSta
         auto best_shot = Evaluation::calcBestShotOnFriendlyGoal(
             field, friendly_team, enemy_team, ball.position(), ROBOT_MAX_RADIUS_METERS,
             {robot});
-        Vector shot_vector = best_shot->getPoint() - ball.position();
+        Vector shot_vector = best_shot->getPointToShootAt() - ball.position();
         Ray shot_ray       = Ray(ball.position(), shot_vector);
 
         // Figure out where the best shot intersects the path the

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
@@ -137,7 +137,7 @@ std::optional<std::pair<Point, Angle>> CreaseDefenderTactic::calculateDesiredSta
         auto best_shot = Evaluation::calcBestShotOnFriendlyGoal(
             field, friendly_team, enemy_team, ball.position(), ROBOT_MAX_RADIUS_METERS,
             {robot});
-        Vector shot_vector = best_shot->point - ball.position();
+        Vector shot_vector = best_shot->getPoint() - ball.position();
         Ray shot_ray       = Ray(ball.position(), shot_vector);
 
         // Figure out where the best shot intersects the path the

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
@@ -137,7 +137,7 @@ std::optional<std::pair<Point, Angle>> CreaseDefenderTactic::calculateDesiredSta
         auto best_shot = Evaluation::calcBestShotOnFriendlyGoal(
             field, friendly_team, enemy_team, ball.position(), ROBOT_MAX_RADIUS_METERS,
             {robot});
-        Vector shot_vector = best_shot->first - ball.position();
+        Vector shot_vector = best_shot->point - ball.position();
         Ray shot_ray       = Ray(ball.position(), shot_vector);
 
         // Figure out where the best shot intersects the path the

--- a/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -103,8 +103,9 @@ void ReceiverTactic::calculateNextIntent(IntentCoroutine::push_type& yield)
         // (or moving slowly because we can't be certain of the velocity vector if it is)
         while (ball_robot_angle.abs() < Angle::ofDegrees(90) || ball_velocity.len() < 0.5)
         {
-            Shot shot = getOneTimeShotPositionAndOrientation(*robot, ball, best_shot_target);
-            Point ideal_position = shot.getPoint();
+            Shot shot =
+                getOneTimeShotPositionAndOrientation(*robot, ball, best_shot_target);
+            Point ideal_position    = shot.getPoint();
             Angle ideal_orientation = shot.getAngle();
 
             yield(move_action.updateStateAndGetNextIntent(

--- a/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -67,7 +67,7 @@ void ReceiverTactic::calculateNextIntent(IntentCoroutine::push_type& yield)
         Angle desired_angle                         = pass.receiverOrientation();
         if (shot)
         {
-            auto target_position = shot->getPoint();
+            auto target_position = shot->getPointToShootAt();
             Angle shot_angle = (target_position - robot->position()).orientation();
             // If we do have a valid shot on net, orient the robot to face in between
             // the pass vector and shot vector, so the robot can quickly orient itself
@@ -91,7 +91,7 @@ void ReceiverTactic::calculateNextIntent(IntentCoroutine::push_type& yield)
     if (best_shot)
     {
         LOG(DEBUG) << "Taking one-touch shot";
-        auto best_shot_target = best_shot->getPoint();
+        auto best_shot_target = best_shot->getPointToShootAt();
 
         // The angle between the ball velocity and a vector from the ball to the robot
         Vector ball_velocity = ball.velocity();
@@ -105,8 +105,8 @@ void ReceiverTactic::calculateNextIntent(IntentCoroutine::push_type& yield)
         {
             Shot shot =
                 getOneTimeShotPositionAndOrientation(*robot, ball, best_shot_target);
-            Point ideal_position    = shot.getPoint();
-            Angle ideal_orientation = shot.getAngle();
+            Point ideal_position    = shot.getPointToShootAt();
+            Angle ideal_orientation = shot.getOpenAngle();
 
             yield(move_action.updateStateAndGetNextIntent(
                 *robot, ideal_position, ideal_orientation, 0, false, false, AUTOKICK));
@@ -180,7 +180,8 @@ std::optional<Shot> ReceiverTactic::findFeasibleShot()
     double net_percent_open;
     if (best_shot_opt)
     {
-        Vector robot_to_shot_target = best_shot_opt->getPoint() - robot->position();
+        Vector robot_to_shot_target =
+            best_shot_opt->getPointToShootAt() - robot->position();
         abs_angle_between_pass_and_shot_vectors =
             (robot_to_ball.orientation() - robot_to_shot_target.orientation())
                 .angleMod()
@@ -190,7 +191,8 @@ std::optional<Shot> ReceiverTactic::findFeasibleShot()
             acuteVertexAngle(field.friendlyGoalpostPos(), robot->position(),
                              field.friendlyGoalpostNeg())
                 .abs();
-        net_percent_open = best_shot_opt->getAngle().toDegrees() / goal_angle.toDegrees();
+        net_percent_open =
+            best_shot_opt->getOpenAngle().toDegrees() / goal_angle.toDegrees();
     }
 
     // If we have a shot with a sufficiently large enough opening, and the deflection

--- a/src/software/ai/hl/stp/tactic/receiver_tactic.h
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic.h
@@ -6,6 +6,7 @@
 #include "software/ai/hl/stp/tactic/tactic.h"
 #include "software/ai/passing/pass.h"
 #include "software/geom/ray.h"
+#include "software/geom/shot.h"
 
 /**
  * This tactic is for a robot receiving a pass. It should be used in conjunction with
@@ -75,11 +76,11 @@ class ReceiverTactic : public Tactic
      * @param robot The receiver robot
      * @param ball The ball
      * @param best_shot_target The point the receiver robot should shoot at
-     * @return A pair containing the position and orientation the receiver robot should
-     * have in order to perform a one-time shot
+     * @return A Shot object containing the position and orientation the receiver robot
+     * should have in order to perform a one-time shot
      */
-    static std::pair<Point, Angle> getOneTimeShotPositionAndOrientation(
-        const Robot& robot, const Ball& ball, const Point& best_shot_target);
+    static Shot getOneTimeShotPositionAndOrientation(const Robot& robot, const Ball& ball,
+                                                     const Point& best_shot_target);
 
    private:
     // The minimum proportion of open net we're shooting on vs the entire size of the net
@@ -98,10 +99,10 @@ class ReceiverTactic : public Tactic
      * A feasible shot is one where the robot does not have to rotate to much to
      * take the shot, and there is a sufficient percentage of the net open for the shot.
      *
-     * @return A pair of a Point to shoot at and the open angle the shot could
+     * @return A Shot object with a Point to shoot at and the open angle the shot could
      *         go through, or std::nullopt if there is no feasible shot
      */
-    std::optional<std::pair<Point, Angle>> findFeasibleShot();
+    std::optional<Shot> findFeasibleShot();
 
     // The field the pass is occuring on
     Field field;

--- a/src/software/ai/hl/stp/tactic/receiver_tactic.h
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic.h
@@ -76,8 +76,8 @@ class ReceiverTactic : public Tactic
      * @param robot The receiver robot
      * @param ball The ball
      * @param best_shot_target The point the receiver robot should shoot at
-     * @return A Shot object containing the position and orientation the receiver robot
-     * should have in order to perform a one-time shot
+     * @return A Shot that the given robot can perform with the given ball in order to
+     * shoot at the given point
      */
     static Shot getOneTimeShotPositionAndOrientation(const Robot& robot, const Ball& ball,
                                                      const Point& best_shot_target);
@@ -99,8 +99,7 @@ class ReceiverTactic : public Tactic
      * A feasible shot is one where the robot does not have to rotate to much to
      * take the shot, and there is a sufficient percentage of the net open for the shot.
      *
-     * @return A Shot object with a Point to shoot at and the open angle the shot could
-     *         go through, or std::nullopt if there is no feasible shot
+     * @return A feasible shot or std::nullopt if there is no feasible shot
      */
     std::optional<Shot> findFeasibleShot();
 

--- a/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
@@ -350,7 +350,7 @@ TEST_P(OneTimeShotPositionTest, test_receiver_moves_to_correct_one_time_shot_pos
 
     Shot shot = ReceiverTactic::getOneTimeShotPositionAndOrientation(robot, ball,
                                                                      best_shot_target);
-    Point ideal_position = shot.getPoint();
+    Point ideal_position    = shot.getPoint();
     Angle ideal_orientation = shot.getAngle();
 
     // The position where the ball should make contact with the receiver robot

--- a/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
@@ -348,9 +348,10 @@ TEST_P(OneTimeShotPositionTest, test_receiver_moves_to_correct_one_time_shot_pos
     // Create a best shot towards the center of the enemy goal
     Point best_shot_target = Point(4.5, 0);
 
-    auto [ideal_position, ideal_orientation] =
-        ReceiverTactic::getOneTimeShotPositionAndOrientation(robot, ball,
-                                                             best_shot_target);
+    Shot shot = ReceiverTactic::getOneTimeShotPositionAndOrientation(robot, ball,
+                                                                     best_shot_target);
+    Point ideal_position = shot.getPoint();
+    Angle ideal_orientation = shot.getAngle();
 
     // The position where the ball should make contact with the receiver robot
     Point ball_contact_position =

--- a/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
@@ -350,8 +350,8 @@ TEST_P(OneTimeShotPositionTest, test_receiver_moves_to_correct_one_time_shot_pos
 
     Shot shot = ReceiverTactic::getOneTimeShotPositionAndOrientation(robot, ball,
                                                                      best_shot_target);
-    Point ideal_position    = shot.getPoint();
-    Angle ideal_orientation = shot.getAngle();
+    Point ideal_position    = shot.getPointToShootAt();
+    Angle ideal_orientation = shot.getOpenAngle();
 
     // The position where the ball should make contact with the receiver robot
     Point ball_contact_position =

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -93,7 +93,7 @@ void ShadowEnemyTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
             if (best_enemy_shot_opt)
             {
                 enemy_shot_vector =
-                    best_enemy_shot_opt->getPoint() - enemy_robot.position();
+                    best_enemy_shot_opt->getPointToShootAt() - enemy_robot.position();
             }
             else
             {

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -92,7 +92,7 @@ void ShadowEnemyTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
             Vector enemy_shot_vector = Vector(0, 0);
             if (best_enemy_shot_opt)
             {
-                enemy_shot_vector = best_enemy_shot_opt->first - enemy_robot.position();
+                enemy_shot_vector = best_enemy_shot_opt->point - enemy_robot.position();
             }
             else
             {

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -92,7 +92,7 @@ void ShadowEnemyTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
             Vector enemy_shot_vector = Vector(0, 0);
             if (best_enemy_shot_opt)
             {
-                enemy_shot_vector = best_enemy_shot_opt->point - enemy_robot.position();
+                enemy_shot_vector = best_enemy_shot_opt->getPoint() - enemy_robot.position();
             }
             else
             {

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -92,7 +92,8 @@ void ShadowEnemyTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
             Vector enemy_shot_vector = Vector(0, 0);
             if (best_enemy_shot_opt)
             {
-                enemy_shot_vector = best_enemy_shot_opt->getPoint() - enemy_robot.position();
+                enemy_shot_vector =
+                    best_enemy_shot_opt->getPoint() - enemy_robot.position();
             }
             else
             {

--- a/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
@@ -109,7 +109,7 @@ void ShootGoalTactic::shootUntilShotBlocked(KickAction &kick_action,
         if (!isEnemyAboutToStealBall())
         {
             yield(kick_action.updateStateAndGetNextIntent(
-                *robot, ball, ball.position(), shot_target->point,
+                *robot, ball, ball.position(), shot_target->getPoint(),
                 BALL_MAX_SPEED_METERS_PER_SECOND - 0.5));
         }
         else
@@ -119,7 +119,7 @@ void ShootGoalTactic::shootUntilShotBlocked(KickAction &kick_action,
             // the point we are targeting since that may take more time to realign to, and
             // we need to be very quick so the enemy doesn't get the ball
             yield(chip_action.updateStateAndGetNextIntent(*robot, ball, ball.position(),
-                                                          shot_target->point, CHIP_DIST));
+                                                          shot_target->getPoint(), CHIP_DIST));
         }
 
         shot_target = Evaluation::calcBestShotOnEnemyGoal(field, friendly_team,
@@ -138,7 +138,7 @@ void ShootGoalTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
     {
         auto shot_target = Evaluation::calcBestShotOnEnemyGoal(
             field, friendly_team, enemy_team, ball.position());
-        if (shot_target && shot_target->angle > min_net_open_angle)
+        if (shot_target && shot_target->getAngle() > min_net_open_angle)
         {
             // Once we have determined we can take a shot, continue to try shoot until the
             // shot is entirely blocked

--- a/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
@@ -118,8 +118,8 @@ void ShootGoalTactic::shootUntilShotBlocked(KickAction &kick_action,
             // steal the ball we chip instead to just get over the enemy. We do not adjust
             // the point we are targeting since that may take more time to realign to, and
             // we need to be very quick so the enemy doesn't get the ball
-            yield(chip_action.updateStateAndGetNextIntent(*robot, ball, ball.position(),
-                                                          shot_target->getPoint(), CHIP_DIST));
+            yield(chip_action.updateStateAndGetNextIntent(
+                *robot, ball, ball.position(), shot_target->getPoint(), CHIP_DIST));
         }
 
         shot_target = Evaluation::calcBestShotOnEnemyGoal(field, friendly_team,

--- a/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
@@ -109,7 +109,7 @@ void ShootGoalTactic::shootUntilShotBlocked(KickAction &kick_action,
         if (!isEnemyAboutToStealBall())
         {
             yield(kick_action.updateStateAndGetNextIntent(
-                *robot, ball, ball.position(), shot_target->first,
+                *robot, ball, ball.position(), shot_target->point,
                 BALL_MAX_SPEED_METERS_PER_SECOND - 0.5));
         }
         else
@@ -119,7 +119,7 @@ void ShootGoalTactic::shootUntilShotBlocked(KickAction &kick_action,
             // the point we are targeting since that may take more time to realign to, and
             // we need to be very quick so the enemy doesn't get the ball
             yield(chip_action.updateStateAndGetNextIntent(*robot, ball, ball.position(),
-                                                          shot_target->first, CHIP_DIST));
+                                                          shot_target->point, CHIP_DIST));
         }
 
         shot_target = Evaluation::calcBestShotOnEnemyGoal(field, friendly_team,
@@ -138,7 +138,7 @@ void ShootGoalTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
     {
         auto shot_target = Evaluation::calcBestShotOnEnemyGoal(
             field, friendly_team, enemy_team, ball.position());
-        if (shot_target && shot_target->second > min_net_open_angle)
+        if (shot_target && shot_target->angle > min_net_open_angle)
         {
             // Once we have determined we can take a shot, continue to try shoot until the
             // shot is entirely blocked

--- a/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
@@ -109,7 +109,7 @@ void ShootGoalTactic::shootUntilShotBlocked(KickAction &kick_action,
         if (!isEnemyAboutToStealBall())
         {
             yield(kick_action.updateStateAndGetNextIntent(
-                *robot, ball, ball.position(), shot_target->getPoint(),
+                *robot, ball, ball.position(), shot_target->getPointToShootAt(),
                 BALL_MAX_SPEED_METERS_PER_SECOND - 0.5));
         }
         else
@@ -119,7 +119,8 @@ void ShootGoalTactic::shootUntilShotBlocked(KickAction &kick_action,
             // the point we are targeting since that may take more time to realign to, and
             // we need to be very quick so the enemy doesn't get the ball
             yield(chip_action.updateStateAndGetNextIntent(
-                *robot, ball, ball.position(), shot_target->getPoint(), CHIP_DIST));
+                *robot, ball, ball.position(), shot_target->getPointToShootAt(),
+                CHIP_DIST));
         }
 
         shot_target = Evaluation::calcBestShotOnEnemyGoal(field, friendly_team,
@@ -138,7 +139,7 @@ void ShootGoalTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
     {
         auto shot_target = Evaluation::calcBestShotOnEnemyGoal(
             field, friendly_team, enemy_team, ball.position());
-        if (shot_target && shot_target->getAngle() > min_net_open_angle)
+        if (shot_target && shot_target->getOpenAngle() > min_net_open_angle)
         {
             // Once we have determined we can take a shot, continue to try shoot until the
             // shot is entirely blocked

--- a/src/software/ai/passing/evaluation.cpp
+++ b/src/software/ai/passing/evaluation.cpp
@@ -88,7 +88,7 @@ double Passing::ratePassShootScore(const Field& field, const Team& enemy_team,
     Point shot_target        = field.enemyGoal();
     if (shot_opt)
     {
-        open_angle_to_goal = shot_opt->second;
+        open_angle_to_goal = shot_opt->angle;
     }
 
     // Figure out what the maximum open angle of the goal could be from the receiver pos.

--- a/src/software/ai/passing/evaluation.cpp
+++ b/src/software/ai/passing/evaluation.cpp
@@ -88,7 +88,7 @@ double Passing::ratePassShootScore(const Field& field, const Team& enemy_team,
     Point shot_target        = field.enemyGoal();
     if (shot_opt)
     {
-        open_angle_to_goal = shot_opt->angle;
+        open_angle_to_goal = shot_opt->getAngle();
     }
 
     // Figure out what the maximum open angle of the goal could be from the receiver pos.

--- a/src/software/ai/passing/evaluation.cpp
+++ b/src/software/ai/passing/evaluation.cpp
@@ -88,7 +88,7 @@ double Passing::ratePassShootScore(const Field& field, const Team& enemy_team,
     Point shot_target        = field.enemyGoal();
     if (shot_opt)
     {
-        open_angle_to_goal = shot_opt->getAngle();
+        open_angle_to_goal = shot_opt->getOpenAngle();
     }
 
     // Figure out what the maximum open angle of the goal could be from the receiver pos.

--- a/src/software/geom/BUILD
+++ b/src/software/geom/BUILD
@@ -5,6 +5,7 @@ cc_library(
     srcs = [
         "polygon.cpp",
         "rectangle.cpp",
+        "shot.cpp",
         "util.cpp",
     ],
     hdrs = [
@@ -16,6 +17,7 @@ cc_library(
         "ray.h",
         "rectangle.h",
         "segment.h",
+        "shot.h",
         "util.h",
     ],
     copts = [

--- a/src/software/geom/shot.cpp
+++ b/src/software/geom/shot.cpp
@@ -1,0 +1,3 @@
+#include "software/geom/shot.h"
+
+Shot::Shot(Point point, Angle angle) : point(point), angle(angle) {}

--- a/src/software/geom/shot.cpp
+++ b/src/software/geom/shot.cpp
@@ -1,3 +1,13 @@
 #include "software/geom/shot.h"
 
 Shot::Shot(Point point, Angle angle) : point(point), angle(angle) {}
+
+Point Shot::getPoint() const
+{
+    return point;
+}
+
+Angle Shot::getAngle() const
+{
+    return angle;
+}

--- a/src/software/geom/shot.cpp
+++ b/src/software/geom/shot.cpp
@@ -2,12 +2,12 @@
 
 Shot::Shot(Point point, Angle angle) : point(point), angle(angle) {}
 
-Point Shot::getPoint() const
+Point Shot::getPointToShootAt() const
 {
     return point;
 }
 
-Angle Shot::getAngle() const
+Angle Shot::getOpenAngle() const
 {
     return angle;
 }

--- a/src/software/geom/shot.h
+++ b/src/software/geom/shot.h
@@ -15,6 +15,19 @@ class Shot
     Shot(Point point, Angle angle);
 
     /**
+     * Returns a point, the target to shoot at.
+     * @return a point, representing the target to shoot at.
+     */
+    Point getPoint() const;
+
+    /**
+     * Returns an angle between the obstacles on either side of the shot vector.
+     * @return an angle between the obstacles on either side of the shot vector.
+     */
+    Angle getAngle() const;
+
+   private:
+    /**
      * The target of the shot
      *
      */

--- a/src/software/geom/shot.h
+++ b/src/software/geom/shot.h
@@ -9,7 +9,7 @@ class Shot
      * Creates a shot with the given target and angle
      *
      * @param point The target to shoot at
-     * @param angle The angle between the obstacles on either side of the shot vector
+     * @param angle The angle formed by the shot origin, and the edges of the two obstacles closest to the shot path
      *
      */
     Shot(Point point, Angle angle);
@@ -21,8 +21,8 @@ class Shot
     Point getPointToShootAt() const;
 
     /**
-     * Returns an angle between the obstacles on either side of the shot vector.
-     * @return an angle between the obstacles on either side of the shot vector.
+     * Returns the angle formed by the shot origin, and the edges of the two obstacles closest to the shot path
+     * @return the angle formed by the shot origin, and the edges of the two obstacles closest to the shot path
      */
     Angle getOpenAngle() const;
 
@@ -34,7 +34,20 @@ class Shot
     Point point;
 
     /**
-     * The angle between the obstacles on either side of the shot vector
+     * The angle formed by the shot origin, and the edges of the two obstacles closest to the shot path
+     *
+                             XXXXO - Obstacle
+                         XXXX    |
+                     XXXX        |
+                 XXXX            |
+        Robot - R ============== T - Target
+                 XXXX            |
+                     XXXX        |
+                         XXXX    |
+                             XXXXO - Obstacle
+
+        The angle formed by '|' in between the obstacles
+        '=' represents the shot vector
      *
      */
     Angle angle;

--- a/src/software/geom/shot.h
+++ b/src/software/geom/shot.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "software/geom/point.h"
+
+class Shot
+{
+   public:
+    /**
+     * Creates a shot with the given target and angle
+     *
+     * @param point The target to shoot at
+     * @param angle The angle between the obstacles on either side of the shot vector
+     *
+     */
+    Shot(Point point, Angle angle);
+
+    /**
+     * The target of the shot
+     *
+     */
+    Point point;
+
+    /**
+     * The angle between the obstacles on either side of the shot vector
+     *
+     */
+    Angle angle;
+};

--- a/src/software/geom/shot.h
+++ b/src/software/geom/shot.h
@@ -9,7 +9,8 @@ class Shot
      * Creates a shot with the given target and angle
      *
      * @param point The target to shoot at
-     * @param angle The angle formed by the shot origin, and the edges of the two obstacles closest to the shot path
+     * @param angle The angle formed by the shot origin, and the edges of the two
+     * obstacles closest to the shot path
      *
      */
     Shot(Point point, Angle angle);
@@ -21,8 +22,10 @@ class Shot
     Point getPointToShootAt() const;
 
     /**
-     * Returns the angle formed by the shot origin, and the edges of the two obstacles closest to the shot path
-     * @return the angle formed by the shot origin, and the edges of the two obstacles closest to the shot path
+     * Returns the angle formed by the shot origin, and the edges of the two obstacles
+     * closest to the shot path
+     * @return the angle formed by the shot origin, and the edges of the two obstacles
+     * closest to the shot path
      */
     Angle getOpenAngle() const;
 
@@ -34,7 +37,8 @@ class Shot
     Point point;
 
     /**
-     * The angle formed by the shot origin, and the edges of the two obstacles closest to the shot path
+     * The angle formed by the shot origin, and the edges of the two obstacles closest to
+     the shot path
      *
                              XXXXO - Obstacle
                          XXXX    |

--- a/src/software/geom/shot.h
+++ b/src/software/geom/shot.h
@@ -18,13 +18,13 @@ class Shot
      * Returns a point, the target to shoot at.
      * @return a point, representing the target to shoot at.
      */
-    Point getPoint() const;
+    Point getPointToShootAt() const;
 
     /**
      * Returns an angle between the obstacles on either side of the shot vector.
      * @return an angle between the obstacles on either side of the shot vector.
      */
-    Angle getAngle() const;
+    Angle getOpenAngle() const;
 
    private:
     /**

--- a/src/software/geom/util.cpp
+++ b/src/software/geom/util.cpp
@@ -459,7 +459,7 @@ std::optional<Shot> angleSweepCircles(const Vector &src, const Vector &p1,
 
     // Sort by the interval angle (ie. the open angle the shot is going through)
     std::sort(possible_shots.begin(), possible_shots.end(),
-              [](auto s1, auto s2) { return s1.getAngle() > s2.getAngle(); });
+              [](auto s1, auto s2) { return s1.getOpenAngle() > s2.getOpenAngle(); });
 
     // Return the shot through the largest open interval if there are any
     if (possible_shots.empty())

--- a/src/software/geom/util.cpp
+++ b/src/software/geom/util.cpp
@@ -459,7 +459,7 @@ std::optional<Shot> angleSweepCircles(const Vector &src, const Vector &p1,
 
     // Sort by the interval angle (ie. the open angle the shot is going through)
     std::sort(possible_shots.begin(), possible_shots.end(),
-              [](auto s1, auto s2) { return s1.angle > s2.angle; });
+              [](auto s1, auto s2) { return s1.getAngle() > s2.getAngle(); });
 
     // Return the shot through the largest open interval if there are any
     if (possible_shots.empty())

--- a/src/software/geom/util.cpp
+++ b/src/software/geom/util.cpp
@@ -322,9 +322,10 @@ Segment getSide(const LegacyPolygon<N> &poly, unsigned int i)
     return Segment(getVertex(poly, i), getVertex(poly, (i + 1) % N));
 }
 
-std::vector<std::pair<Point, Angle>> angleSweepCirclesAll(
-    const Vector &src, const Vector &p1, const Vector &p2,
-    const std::vector<Point> &obstacles, const double &radius)
+std::vector<Shot> angleSweepCirclesAll(const Vector &src, const Vector &p1,
+                                       const Vector &p2,
+                                       const std::vector<Point> &obstacles,
+                                       const double &radius)
 {
     Angle p1_angle = (p1 - src).orientation();
     Angle p2_angle = (p2 - src).orientation();
@@ -355,7 +356,8 @@ std::vector<std::pair<Point, Angle>> angleSweepCirclesAll(
                 return {};
             }
         }
-        return {std::make_pair(collinear_seg.toVector(), Angle::zero())};
+
+        return {Shot(collinear_seg.toVector(), Angle::zero())};
     }
 
     // "Sweep" a line from the `src` to the target line segment, and create an "event"
@@ -402,7 +404,7 @@ std::vector<std::pair<Point, Angle>> angleSweepCirclesAll(
     {
         // No obstacles in the way, so just return a range hitting the entire target
         // line segment
-        return {std::make_pair((p1 + p2) / 2, end_angle - start_angle)};
+        return {Shot((p1 + p2) / 2, end_angle - start_angle)};
     }
 
     // Sort the events by angle
@@ -429,7 +431,7 @@ std::vector<std::pair<Point, Angle>> angleSweepCirclesAll(
     {
         events_collapsed.emplace_back(std::make_pair(end_angle - start_angle, -1));
     }
-    std::vector<std::pair<Point, Angle>> result;
+    std::vector<Shot> result;
     for (int i = 0; i < events_collapsed.size() - 1; i += 2)
     {
         // Calculate the center of this range on the target line segement
@@ -440,23 +442,24 @@ std::vector<std::pair<Point, Angle>> angleSweepCirclesAll(
         Vector inter      = lineIntersection(src, src + ray, p1, p2).value();
 
         // Offset the final values by the start angle
-        result.emplace_back(std::make_pair(inter, range_end - range_start));
+        result.emplace_back(Shot(inter, range_end - range_start));
     }
 
     return result;
 }
 
-std::optional<std::pair<Point, Angle>> angleSweepCircles(
-    const Vector &src, const Vector &p1, const Vector &p2,
-    const std::vector<Vector> &obstacles, const double &radius)
+std::optional<Shot> angleSweepCircles(const Vector &src, const Vector &p1,
+                                      const Vector &p2,
+                                      const std::vector<Vector> &obstacles,
+                                      const double &radius)
 {
     // Get all possible shots we could take
-    std::vector<std::pair<Point, Angle>> possible_shots =
+    std::vector<Shot> possible_shots =
         angleSweepCirclesAll(src, p1, p2, obstacles, radius);
 
     // Sort by the interval angle (ie. the open angle the shot is going through)
     std::sort(possible_shots.begin(), possible_shots.end(),
-              [](auto p1, auto p2) { return p1.second > p2.second; });
+              [](auto s1, auto s2) { return s1.angle > s2.angle; });
 
     // Return the shot through the largest open interval if there are any
     if (possible_shots.empty())

--- a/src/software/geom/util.h
+++ b/src/software/geom/util.h
@@ -10,6 +10,7 @@
 #include "software/geom/ray.h"
 #include "software/geom/rectangle.h"
 #include "software/geom/segment.h"
+#include "software/geom/shot.h"
 
 template <size_t N>
 using LegacyPolygon       = std::array<Vector, N>;
@@ -160,13 +161,13 @@ bool collinear(const Point &a, const Point &b, const Point &c);
  *
  * @param radius the radii of the obstacles.
  *
- * @return The best point to aim for in the target area and the size of the open interval
- *         through which a shot from the current point to the best point would go. If no
- *         shot could be found, returns std::nullopt
+ * @return The Shot with the best point to aim for in the target area and the size of the
+ * open interval through which a shot from the current point to the best point would go.
+ * If no shot could be found, returns std::nullopt
  */
-std::optional<std::pair<Vector, Angle>> angleSweepCircles(
-    const Point &src, const Point &p1, const Point &p2,
-    const std::vector<Point> &obstacles, const double &radius);
+std::optional<Shot> angleSweepCircles(const Point &src, const Point &p1, const Point &p2,
+                                      const std::vector<Point> &obstacles,
+                                      const double &radius);
 
 /**
  * Performs an angle sweep.
@@ -186,19 +187,18 @@ std::optional<std::pair<Vector, Angle>> angleSweepCircles(
  *
  * @param radius the radii of the obstacles.
  *
- * @return A vector of possible (ie. not blocked) pairs of points to shoot to in the
- *         target area,  and the size of the open interval for that point.
- *         ie. for a return point `p` and angle `a`, if `v` is a vector from `src` to `p`,
- *         then the open interval through which we are shooting is from `angle(v) - a/2`
- *         to `angle(v) + a/2`
- *         If lines src -> p1 and src -> p2 are collinear and src -> p1 is not blocked by
- *         an obstacle, the result will contain a single pair of the direction of
- *         src -> p1 and zero angle if the line is not blocked by an obstacle.
- *         An empty vector is returned if the preconditions aren't satisfied.
+ * @return A vector of possible (ie. not blocked) Shots, each with a point to shoot to in
+ * the target area,  and the size of the open interval for that point. ie. for a return
+ * point `p` and angle `a`, if `v` is a vector from `src` to `p`, then the open interval
+ * through which we are shooting is from `angle(v) - a/2` to `angle(v) + a/2` If lines src
+ * -> p1 and src -> p2 are collinear and src -> p1 is not blocked by an obstacle, the
+ * result will contain a single pair of the direction of src -> p1 and zero angle if the
+ * line is not blocked by an obstacle. An empty vector is returned if the preconditions
+ * aren't satisfied.
  */
-std::vector<std::pair<Point, Angle>> angleSweepCirclesAll(
-    const Point &src, const Point &p1, const Point &p2,
-    const std::vector<Point> &obstacles, const double &radius);
+std::vector<Shot> angleSweepCirclesAll(const Point &src, const Point &p1, const Point &p2,
+                                       const std::vector<Point> &obstacles,
+                                       const double &radius);
 
 /**
  * returns a list of points that lie on the border of the circle

--- a/src/software/geom/util.h
+++ b/src/software/geom/util.h
@@ -161,9 +161,7 @@ bool collinear(const Point &a, const Point &b, const Point &c);
  *
  * @param radius the radii of the obstacles.
  *
- * @return The Shot with the best point to aim for in the target area and the size of the
- * open interval through which a shot from the current point to the best point would go.
- * If no shot could be found, returns std::nullopt
+ * @return A feasible shot or std::nullopt if there is no feasible shot
  */
 std::optional<Shot> angleSweepCircles(const Point &src, const Point &p1, const Point &p2,
                                       const std::vector<Point> &obstacles,
@@ -187,12 +185,9 @@ std::optional<Shot> angleSweepCircles(const Point &src, const Point &p1, const P
  *
  * @param radius the radii of the obstacles.
  *
- * @return A vector of possible (ie. not blocked) Shots, each with a point to shoot to in
- * the target area,  and the size of the open interval for that point. ie. for a return
- * point `p` and angle `a`, if `v` is a vector from `src` to `p`, then the open interval
- * through which we are shooting is from `angle(v) - a/2` to `angle(v) + a/2` If lines src
+ * @return A vector of possible (ie. not blocked) Shots. If lines src
  * -> p1 and src -> p2 are collinear and src -> p1 is not blocked by an obstacle, the
- * result will contain a single pair of the direction of src -> p1 and zero angle if the
+ * result will contain a single Shot of the direction of src -> p1 and zero angle if the
  * line is not blocked by an obstacle. An empty vector is returned if the preconditions
  * aren't satisfied.
  */

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -261,8 +261,8 @@ TEST(GeomUtilTest, test_angle_sweep_circles)
 
     Shot testshot = *testshot_opt;
 
-    EXPECT_TRUE((testshot.point.norm() - Point(0, 1)).len() < 0.0001);
-    EXPECT_NEAR(75.449, testshot.angle.toDegrees(), 1e-4);
+    EXPECT_TRUE((testshot.getPoint().norm() - Point(0, 1)).len() < 0.0001);
+    EXPECT_NEAR(75.449, testshot.getAngle().toDegrees(), 1e-4);
 
     obs.clear();
     obs.push_back(Point(-4, 6));
@@ -277,8 +277,8 @@ TEST(GeomUtilTest, test_angle_sweep_circles)
 
     testshot = *testshot_opt;
 
-    EXPECT_TRUE((testshot.point.norm() - Point(-0.0805897, 0.996747)).len() < 0.0001);
-    EXPECT_NEAR(42.1928, testshot.angle.toDegrees(), 1e-4);
+    EXPECT_TRUE((testshot.getPoint().norm() - Point(-0.0805897, 0.996747)).len() < 0.0001);
+    EXPECT_NEAR(42.1928, testshot.getAngle().toDegrees(), 1e-4);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_no_obstacles)
@@ -286,8 +286,8 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_no_obstacles)
     std::vector<Shot> result = angleSweepCirclesAll({0, 0}, {1, 1}, {-1, 1}, {}, 0.1);
 
     ASSERT_EQ(1, result.size());
-    EXPECT_EQ(Point(0, 1), result[0].point);
-    EXPECT_EQ(90, result[0].angle.toDegrees());
+    EXPECT_EQ(Point(0, 1), result[0].getPoint());
+    EXPECT_EQ(90, result[0].getAngle().toDegrees());
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_pos_y_to_neg_y)
@@ -301,12 +301,12 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_pos_y_to_neg_y)
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.angle < shot2.angle; });
+              [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
 
-    EXPECT_EQ(1, result[0].point.x());
-    EXPECT_NEAR(-0.40, result[0].point.y(), 0.05);
-    EXPECT_EQ(1, result[1].point.x());
-    EXPECT_NEAR(0.40, result[1].point.y(), 0.05);
+    EXPECT_EQ(1, result[0].getPoint().x());
+    EXPECT_NEAR(-0.40, result[0].getPoint().y(), 0.05);
+    EXPECT_EQ(1, result[1].getPoint().x());
+    EXPECT_NEAR(0.40, result[1].getPoint().y(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_neg_y_to_pos_y)
@@ -320,12 +320,12 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_neg_y_to_pos_y)
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.angle < shot2.angle; });
+              [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
 
-    EXPECT_EQ(1, result[0].point.x());
-    EXPECT_NEAR(-0.40, result[0].point.y(), 0.05);
-    EXPECT_EQ(1, result[1].point.x());
-    EXPECT_NEAR(0.40, result[1].point.y(), 0.05);
+    EXPECT_EQ(1, result[0].getPoint().x());
+    EXPECT_NEAR(-0.40, result[0].getPoint().y(), 0.05);
+    EXPECT_EQ(1, result[1].getPoint().x());
+    EXPECT_NEAR(0.40, result[1].getPoint().y(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_x_axis)
@@ -339,12 +339,12 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_x
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.angle < shot2.angle; });
+              [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
 
-    EXPECT_EQ(-1, result[0].point.x());
-    EXPECT_NEAR(0.40, result[0].point.y(), 0.05);
-    EXPECT_EQ(-1, result[1].point.x());
-    EXPECT_NEAR(-0.40, result[1].point.y(), 0.05);
+    EXPECT_EQ(-1, result[0].getPoint().x());
+    EXPECT_NEAR(0.40, result[0].getPoint().y(), 0.05);
+    EXPECT_EQ(-1, result[1].getPoint().x());
+    EXPECT_NEAR(-0.40, result[1].getPoint().y(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_pos_y_axis)
@@ -358,12 +358,12 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_pos_y
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.angle < shot2.angle; });
+              [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
 
-    EXPECT_EQ(1, result[0].point.y());
-    EXPECT_NEAR(0.40, result[0].point.x(), 0.05);
-    EXPECT_EQ(1, result[1].point.y());
-    EXPECT_NEAR(-0.40, result[1].point.x(), 0.05);
+    EXPECT_EQ(1, result[0].getPoint().y());
+    EXPECT_NEAR(0.40, result[0].getPoint().x(), 0.05);
+    EXPECT_EQ(1, result[1].getPoint().y());
+    EXPECT_NEAR(-0.40, result[1].getPoint().x(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_y_axis)
@@ -377,12 +377,12 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_y
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.angle < shot2.angle; });
+              [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
 
-    EXPECT_EQ(-1, result[0].point.y());
-    EXPECT_NEAR(-0.40, result[0].point.x(), 0.05);
-    EXPECT_EQ(-1, result[1].point.y());
-    EXPECT_NEAR(0.40, result[1].point.x(), 0.05);
+    EXPECT_EQ(-1, result[0].getPoint().y());
+    EXPECT_NEAR(-0.40, result[0].getPoint().x(), 0.05);
+    EXPECT_EQ(-1, result[1].getPoint().y());
+    EXPECT_NEAR(0.40, result[1].getPoint().x(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacle_blocks_whole_range)

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -144,7 +144,7 @@ TEST(GeomUtilTest, test_proj_len)
 
 TEST(GeomUtilTest, test_contains_triangle_point)
 {
-    // this triangle lies in the point quatren of the field, we can rota
+    // this triangle lies in the first quatren of the field, we can rota
     Point p1(0, 0);
     Point p2((std::rand() % 100) / 100, 0);
     Point p3((std::rand() % 100) / 100, (std::rand() % 100) / 100);

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -261,8 +261,8 @@ TEST(GeomUtilTest, test_angle_sweep_circles)
 
     Shot testshot = *testshot_opt;
 
-    EXPECT_TRUE((testshot.getPoint().norm() - Point(0, 1)).len() < 0.0001);
-    EXPECT_NEAR(75.449, testshot.getAngle().toDegrees(), 1e-4);
+    EXPECT_TRUE((testshot.getPointToShootAt().norm() - Point(0, 1)).len() < 0.0001);
+    EXPECT_NEAR(75.449, testshot.getOpenAngle().toDegrees(), 1e-4);
 
     obs.clear();
     obs.push_back(Point(-4, 6));
@@ -277,9 +277,10 @@ TEST(GeomUtilTest, test_angle_sweep_circles)
 
     testshot = *testshot_opt;
 
-    EXPECT_TRUE((testshot.getPoint().norm() - Point(-0.0805897, 0.996747)).len() <
-                0.0001);
-    EXPECT_NEAR(42.1928, testshot.getAngle().toDegrees(), 1e-4);
+    EXPECT_TRUE(
+        (testshot.getPointToShootAt().norm() - Point(-0.0805897, 0.996747)).len() <
+        0.0001);
+    EXPECT_NEAR(42.1928, testshot.getOpenAngle().toDegrees(), 1e-4);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_no_obstacles)
@@ -287,8 +288,8 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_no_obstacles)
     std::vector<Shot> result = angleSweepCirclesAll({0, 0}, {1, 1}, {-1, 1}, {}, 0.1);
 
     ASSERT_EQ(1, result.size());
-    EXPECT_EQ(Point(0, 1), result[0].getPoint());
-    EXPECT_EQ(90, result[0].getAngle().toDegrees());
+    EXPECT_EQ(Point(0, 1), result[0].getPointToShootAt());
+    EXPECT_EQ(90, result[0].getOpenAngle().toDegrees());
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_pos_y_to_neg_y)
@@ -304,10 +305,10 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_pos_y_to_neg_y)
     std::sort(result.begin(), result.end(),
               [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
 
-    EXPECT_EQ(1, result[0].getPoint().x());
-    EXPECT_NEAR(-0.40, result[0].getPoint().y(), 0.05);
-    EXPECT_EQ(1, result[1].getPoint().x());
-    EXPECT_NEAR(0.40, result[1].getPoint().y(), 0.05);
+    EXPECT_EQ(1, result[0].getPointToShootAt().x());
+    EXPECT_NEAR(-0.40, result[0].getPointToShootAt().y(), 0.05);
+    EXPECT_EQ(1, result[1].getPointToShootAt().x());
+    EXPECT_NEAR(0.40, result[1].getPointToShootAt().y(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_neg_y_to_pos_y)
@@ -323,10 +324,10 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_neg_y_to_pos_y)
     std::sort(result.begin(), result.end(),
               [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
 
-    EXPECT_EQ(1, result[0].getPoint().x());
-    EXPECT_NEAR(-0.40, result[0].getPoint().y(), 0.05);
-    EXPECT_EQ(1, result[1].getPoint().x());
-    EXPECT_NEAR(0.40, result[1].getPoint().y(), 0.05);
+    EXPECT_EQ(1, result[0].getPointToShootAt().x());
+    EXPECT_NEAR(-0.40, result[0].getPointToShootAt().y(), 0.05);
+    EXPECT_EQ(1, result[1].getPointToShootAt().x());
+    EXPECT_NEAR(0.40, result[1].getPointToShootAt().y(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_x_axis)
@@ -342,10 +343,10 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_x
     std::sort(result.begin(), result.end(),
               [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
 
-    EXPECT_EQ(-1, result[0].getPoint().x());
-    EXPECT_NEAR(0.40, result[0].getPoint().y(), 0.05);
-    EXPECT_EQ(-1, result[1].getPoint().x());
-    EXPECT_NEAR(-0.40, result[1].getPoint().y(), 0.05);
+    EXPECT_EQ(-1, result[0].getPointToShootAt().x());
+    EXPECT_NEAR(0.40, result[0].getPointToShootAt().y(), 0.05);
+    EXPECT_EQ(-1, result[1].getPointToShootAt().x());
+    EXPECT_NEAR(-0.40, result[1].getPointToShootAt().y(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_pos_y_axis)
@@ -361,10 +362,10 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_pos_y
     std::sort(result.begin(), result.end(),
               [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
 
-    EXPECT_EQ(1, result[0].getPoint().y());
-    EXPECT_NEAR(0.40, result[0].getPoint().x(), 0.05);
-    EXPECT_EQ(1, result[1].getPoint().y());
-    EXPECT_NEAR(-0.40, result[1].getPoint().x(), 0.05);
+    EXPECT_EQ(1, result[0].getPointToShootAt().y());
+    EXPECT_NEAR(0.40, result[0].getPointToShootAt().x(), 0.05);
+    EXPECT_EQ(1, result[1].getPointToShootAt().y());
+    EXPECT_NEAR(-0.40, result[1].getPointToShootAt().x(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_y_axis)
@@ -380,10 +381,10 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_y
     std::sort(result.begin(), result.end(),
               [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
 
-    EXPECT_EQ(-1, result[0].getPoint().y());
-    EXPECT_NEAR(-0.40, result[0].getPoint().x(), 0.05);
-    EXPECT_EQ(-1, result[1].getPoint().y());
-    EXPECT_NEAR(0.40, result[1].getPoint().x(), 0.05);
+    EXPECT_EQ(-1, result[0].getPointToShootAt().y());
+    EXPECT_NEAR(-0.40, result[0].getPointToShootAt().x(), 0.05);
+    EXPECT_EQ(-1, result[1].getPointToShootAt().y());
+    EXPECT_NEAR(0.40, result[1].getPointToShootAt().x(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacle_blocks_whole_range)

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -277,7 +277,8 @@ TEST(GeomUtilTest, test_angle_sweep_circles)
 
     testshot = *testshot_opt;
 
-    EXPECT_TRUE((testshot.getPoint().norm() - Point(-0.0805897, 0.996747)).len() < 0.0001);
+    EXPECT_TRUE((testshot.getPoint().norm() - Point(-0.0805897, 0.996747)).len() <
+                0.0001);
     EXPECT_NEAR(42.1928, testshot.getAngle().toDegrees(), 1e-4);
 }
 

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -303,7 +303,7 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_pos_y_to_neg_y)
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
+              [](auto shot1, auto shot2) { return shot1.getOpenAngle() < shot2.getOpenAngle(); });
 
     EXPECT_EQ(1, result[0].getPointToShootAt().x());
     EXPECT_NEAR(-0.40, result[0].getPointToShootAt().y(), 0.05);
@@ -322,7 +322,7 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_neg_y_to_pos_y)
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
+              [](auto shot1, auto shot2) { return shot1.getOpenAngle() < shot2.getOpenAngle(); });
 
     EXPECT_EQ(1, result[0].getPointToShootAt().x());
     EXPECT_NEAR(-0.40, result[0].getPointToShootAt().y(), 0.05);
@@ -341,7 +341,7 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_x
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
+              [](auto shot1, auto shot2) { return shot1.getOpenAngle() < shot2.getOpenAngle(); });
 
     EXPECT_EQ(-1, result[0].getPointToShootAt().x());
     EXPECT_NEAR(0.40, result[0].getPointToShootAt().y(), 0.05);
@@ -360,7 +360,7 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_pos_y
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
+              [](auto shot1, auto shot2) { return shot1.getOpenAngle() < shot2.getOpenAngle(); });
 
     EXPECT_EQ(1, result[0].getPointToShootAt().y());
     EXPECT_NEAR(0.40, result[0].getPointToShootAt().x(), 0.05);
@@ -379,7 +379,7 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_y
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.getAngle() < shot2.getAngle(); });
+              [](auto shot1, auto shot2) { return shot1.getOpenAngle() < shot2.getOpenAngle(); });
 
     EXPECT_EQ(-1, result[0].getPointToShootAt().y());
     EXPECT_NEAR(-0.40, result[0].getPointToShootAt().x(), 0.05);

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -144,7 +144,7 @@ TEST(GeomUtilTest, test_proj_len)
 
 TEST(GeomUtilTest, test_contains_triangle_point)
 {
-    // this triangle lies in the first quatren of the field, we can rota
+    // this triangle lies in the point quatren of the field, we can rota
     Point p1(0, 0);
     Point p2((std::rand() % 100) / 100, 0);
     Point p3((std::rand() % 100) / 100, (std::rand() % 100) / 100);
@@ -253,42 +253,41 @@ TEST(GeomUtilTest, test_angle_sweep_circles)
     obs.push_back(Point(-9, 10));
     obs.push_back(Point(9, 10));
 
-    std::optional<std::pair<Point, Angle>> testpair_opt =
+    std::optional<Shot> testshot_opt =
         angleSweepCircles(Point(0, 0), Point(10, 10), Point(-10, 10), obs, 1.0);
 
     // We expect to get a result
-    ASSERT_TRUE(testpair_opt);
+    ASSERT_TRUE(testshot_opt);
 
-    std::pair<Point, Angle> testpair = *testpair_opt;
+    Shot testshot = *testshot_opt;
 
-    EXPECT_TRUE((testpair.first.norm() - Point(0, 1)).len() < 0.0001);
-    EXPECT_NEAR(75.449, testpair.second.toDegrees(), 1e-4);
+    EXPECT_TRUE((testshot.point.norm() - Point(0, 1)).len() < 0.0001);
+    EXPECT_NEAR(75.449, testshot.angle.toDegrees(), 1e-4);
 
     obs.clear();
     obs.push_back(Point(-4, 6));
     obs.push_back(Point(6, 8));
     obs.push_back(Point(4, 10));
 
-    testpair_opt =
+    testshot_opt =
         angleSweepCircles(Point(0, 0), Point(10, 10), Point(-10, 10), obs, 1.0);
 
     // We expect to get a result
-    ASSERT_TRUE(testpair_opt);
+    ASSERT_TRUE(testshot_opt);
 
-    testpair = *testpair_opt;
+    testshot = *testshot_opt;
 
-    EXPECT_TRUE((testpair.first.norm() - Point(-0.0805897, 0.996747)).len() < 0.0001);
-    EXPECT_NEAR(42.1928, testpair.second.toDegrees(), 1e-4);
+    EXPECT_TRUE((testshot.point.norm() - Point(-0.0805897, 0.996747)).len() < 0.0001);
+    EXPECT_NEAR(42.1928, testshot.angle.toDegrees(), 1e-4);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_no_obstacles)
 {
-    std::vector<std::pair<Point, Angle>> result =
-        angleSweepCirclesAll({0, 0}, {1, 1}, {-1, 1}, {}, 0.1);
+    std::vector<Shot> result = angleSweepCirclesAll({0, 0}, {1, 1}, {-1, 1}, {}, 0.1);
 
     ASSERT_EQ(1, result.size());
-    EXPECT_EQ(Point(0, 1), result[0].first);
-    EXPECT_EQ(90, result[0].second.toDegrees());
+    EXPECT_EQ(Point(0, 1), result[0].point);
+    EXPECT_EQ(90, result[0].angle.toDegrees());
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_pos_y_to_neg_y)
@@ -296,18 +295,18 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_pos_y_to_neg_y)
     // Test with a single obstacle the is centered on the line segment that we are
     // sweeping over
 
-    std::vector<std::pair<Point, Angle>> result =
+    std::vector<Shot> result =
         angleSweepCirclesAll({0, 0}, {1, -1}, {1, 1}, {{1, 0}}, 0.01);
 
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto pair1, auto pair2) { return pair1.second < pair2.second; });
+              [](auto shot1, auto shot2) { return shot1.angle < shot2.angle; });
 
-    EXPECT_EQ(1, result[0].first.x());
-    EXPECT_NEAR(-0.40, result[0].first.y(), 0.05);
-    EXPECT_EQ(1, result[1].first.x());
-    EXPECT_NEAR(0.40, result[1].first.y(), 0.05);
+    EXPECT_EQ(1, result[0].point.x());
+    EXPECT_NEAR(-0.40, result[0].point.y(), 0.05);
+    EXPECT_EQ(1, result[1].point.x());
+    EXPECT_NEAR(0.40, result[1].point.y(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_neg_y_to_pos_y)
@@ -315,18 +314,18 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_neg_y_to_pos_y)
     // Test with a single obstacle the is centered on the line segment that we are
     // sweeping over
 
-    std::vector<std::pair<Point, Angle>> result =
+    std::vector<Shot> result =
         angleSweepCirclesAll({0, 0}, {1, 1}, {1, -1}, {{1, 0}}, 0.01);
 
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto pair1, auto pair2) { return pair1.second < pair2.second; });
+              [](auto shot1, auto shot2) { return shot1.angle < shot2.angle; });
 
-    EXPECT_EQ(1, result[0].first.x());
-    EXPECT_NEAR(-0.40, result[0].first.y(), 0.05);
-    EXPECT_EQ(1, result[1].first.x());
-    EXPECT_NEAR(0.40, result[1].first.y(), 0.05);
+    EXPECT_EQ(1, result[0].point.x());
+    EXPECT_NEAR(-0.40, result[0].point.y(), 0.05);
+    EXPECT_EQ(1, result[1].point.x());
+    EXPECT_NEAR(0.40, result[1].point.y(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_x_axis)
@@ -334,18 +333,18 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_x
     // Test with a single obstacle the is centered on the line segment that we are
     // sweeping over
 
-    std::vector<std::pair<Point, Angle>> result =
+    std::vector<Shot> result =
         angleSweepCirclesAll({0, 0}, {-1, 1}, {-1, -1}, {{-1, 0}}, 0.01);
 
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto pair1, auto pair2) { return pair1.second < pair2.second; });
+              [](auto shot1, auto shot2) { return shot1.angle < shot2.angle; });
 
-    EXPECT_EQ(-1, result[0].first.x());
-    EXPECT_NEAR(0.40, result[0].first.y(), 0.05);
-    EXPECT_EQ(-1, result[1].first.x());
-    EXPECT_NEAR(-0.40, result[1].first.y(), 0.05);
+    EXPECT_EQ(-1, result[0].point.x());
+    EXPECT_NEAR(0.40, result[0].point.y(), 0.05);
+    EXPECT_EQ(-1, result[1].point.x());
+    EXPECT_NEAR(-0.40, result[1].point.y(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_pos_y_axis)
@@ -353,18 +352,18 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_pos_y
     // Test with a single obstacle the is centered on the line segment that we are
     // sweeping over
 
-    std::vector<std::pair<Point, Angle>> result =
+    std::vector<Shot> result =
         angleSweepCirclesAll({0, 0}, {-1, 1}, {1, 1}, {{0, 1}}, 0.01);
 
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto pair1, auto pair2) { return pair1.second < pair2.second; });
+              [](auto shot1, auto shot2) { return shot1.angle < shot2.angle; });
 
-    EXPECT_EQ(1, result[0].first.y());
-    EXPECT_NEAR(0.40, result[0].first.x(), 0.05);
-    EXPECT_EQ(1, result[1].first.y());
-    EXPECT_NEAR(-0.40, result[1].first.x(), 0.05);
+    EXPECT_EQ(1, result[0].point.y());
+    EXPECT_NEAR(0.40, result[0].point.x(), 0.05);
+    EXPECT_EQ(1, result[1].point.y());
+    EXPECT_NEAR(-0.40, result[1].point.x(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_y_axis)
@@ -372,18 +371,18 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_y
     // Test with a single obstacle the is centered on the line segment that we are
     // sweeping over
 
-    std::vector<std::pair<Point, Angle>> result =
+    std::vector<Shot> result =
         angleSweepCirclesAll({0, 0}, {-1, -1}, {1, -1}, {{0, -1}}, 0.01);
 
     ASSERT_EQ(2, result.size());
 
     std::sort(result.begin(), result.end(),
-              [](auto pair1, auto pair2) { return pair1.second < pair2.second; });
+              [](auto shot1, auto shot2) { return shot1.angle < shot2.angle; });
 
-    EXPECT_EQ(-1, result[0].first.y());
-    EXPECT_NEAR(-0.40, result[0].first.x(), 0.05);
-    EXPECT_EQ(-1, result[1].first.y());
-    EXPECT_NEAR(0.40, result[1].first.x(), 0.05);
+    EXPECT_EQ(-1, result[0].point.y());
+    EXPECT_NEAR(-0.40, result[0].point.x(), 0.05);
+    EXPECT_EQ(-1, result[1].point.y());
+    EXPECT_NEAR(0.40, result[1].point.x(), 0.05);
 }
 
 TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacle_blocks_whole_range)
@@ -391,7 +390,7 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacle_blocks_whole_ran
     // Test where there is no way to draw a line from the start point to the
     // target line segment that we are sweeping over because there is one obstacle in the
     // way
-    std::vector<std::pair<Point, Angle>> result =
+    std::vector<Shot> result =
         angleSweepCirclesAll({-1, -0.5}, {-4.5, 0.5}, {-4.5, -0.5}, {{-1.2, -0.5}}, 0.09);
 
     ASSERT_EQ(0, result.size());
@@ -404,7 +403,7 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all)
     obs.push_back(Point(-9, 10));
     obs.push_back(Point(9, 10));
 
-    std::vector<std::pair<Point, Angle>> testpairs =
+    std::vector<Shot> testshots =
         angleSweepCirclesAll(Point(0, 0), Point(10, 10), Point(-10, 10), obs, 1.0);
 
     obs.clear();
@@ -412,7 +411,7 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all)
     obs.push_back(Point(6, 8));
     obs.push_back(Point(4, 10));
 
-    testpairs =
+    testshots =
         angleSweepCirclesAll(Point(0, 0), Point(10, 10), Point(-10, 10), obs, 1.0);
 
     // TODO: Add assert statement

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -302,8 +302,9 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_pos_y_to_neg_y)
 
     ASSERT_EQ(2, result.size());
 
-    std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.getOpenAngle() < shot2.getOpenAngle(); });
+    std::sort(result.begin(), result.end(), [](auto shot1, auto shot2) {
+        return shot1.getOpenAngle() < shot2.getOpenAngle();
+    });
 
     EXPECT_EQ(1, result[0].getPointToShootAt().x());
     EXPECT_NEAR(-0.40, result[0].getPointToShootAt().y(), 0.05);
@@ -321,8 +322,9 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_neg_y_to_pos_y)
 
     ASSERT_EQ(2, result.size());
 
-    std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.getOpenAngle() < shot2.getOpenAngle(); });
+    std::sort(result.begin(), result.end(), [](auto shot1, auto shot2) {
+        return shot1.getOpenAngle() < shot2.getOpenAngle();
+    });
 
     EXPECT_EQ(1, result[0].getPointToShootAt().x());
     EXPECT_NEAR(-0.40, result[0].getPointToShootAt().y(), 0.05);
@@ -340,8 +342,9 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_x
 
     ASSERT_EQ(2, result.size());
 
-    std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.getOpenAngle() < shot2.getOpenAngle(); });
+    std::sort(result.begin(), result.end(), [](auto shot1, auto shot2) {
+        return shot1.getOpenAngle() < shot2.getOpenAngle();
+    });
 
     EXPECT_EQ(-1, result[0].getPointToShootAt().x());
     EXPECT_NEAR(0.40, result[0].getPointToShootAt().y(), 0.05);
@@ -359,8 +362,9 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_pos_y
 
     ASSERT_EQ(2, result.size());
 
-    std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.getOpenAngle() < shot2.getOpenAngle(); });
+    std::sort(result.begin(), result.end(), [](auto shot1, auto shot2) {
+        return shot1.getOpenAngle() < shot2.getOpenAngle();
+    });
 
     EXPECT_EQ(1, result[0].getPointToShootAt().y());
     EXPECT_NEAR(0.40, result[0].getPointToShootAt().x(), 0.05);
@@ -378,8 +382,9 @@ TEST(GeomUtilTest, test_angle_sweep_circles_all_single_obstacles_line_over_neg_y
 
     ASSERT_EQ(2, result.size());
 
-    std::sort(result.begin(), result.end(),
-              [](auto shot1, auto shot2) { return shot1.getOpenAngle() < shot2.getOpenAngle(); });
+    std::sort(result.begin(), result.end(), [](auto shot1, auto shot2) {
+        return shot1.getOpenAngle() < shot2.getOpenAngle();
+    });
 
     EXPECT_EQ(-1, result[0].getPointToShootAt().y());
     EXPECT_NEAR(-0.40, result[0].getPointToShootAt().x(), 0.05);


### PR DESCRIPTION
### Description
Added ```Shot``` class encapsulating a ```Point``` representing the target of the shot and an ```Angle``` which is the angle representing the obstacles on either side of the shot vector.

### Testing Done
Old unit tests still pass.

### Resolved Issues
resolves #771 

### Review Checklist

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

### Misc

There was some discussion about class v struct in the issue. I opted to use class since it would be easier to add functionality to it if we wanted to later on. Also to remove default constructor and ensure any Shot always has a Point and Angle associated with it. 