### PR TITLE
Remove dependency on Boost system headers, modified libusb build

### DIFF
--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -32,8 +32,8 @@ rules_proto_toolchains()
 
 git_repository(
     name = "com_github_nelhage_rules_boost",
-    commit = "a1dd05e7e9178f8aad86e39f3a5b377902eae5b2",
     remote = "https://github.com/nelhage/rules_boost",
+    branch = "master",
 )
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
@@ -48,17 +48,9 @@ http_archive(
     url = "https://bitbucket.org/eigen/eigen/get/c5e90d9.tar.gz",
 )
 
-http_archive(
+new_local_repository(
     name = "libusb",
     build_file = "@//external:libusb.BUILD",
-    sha256 = "a5fc7c3c8ecfaca3e149ffb5a422f358fc5276fe56d851f46a4023d1e061bc00",
-    strip_prefix = "libusb-1.0.23",
-    url = "https://github.com/libusb/libusb/archive/v1.0.23.zip",
-)
-
-new_local_repository(
-    name = "libudev",
-    build_file = "@//external:libudev.BUILD",
     path = "/",
 )
 

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -33,7 +33,7 @@ rules_proto_toolchains()
 git_repository(
     name = "com_github_nelhage_rules_boost",
     remote = "https://github.com/nelhage/rules_boost",
-    branch = "master",
+    commit = "9f9fb8b2f0213989247c9d5c0e814a8451d18d7f",
 )
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")

--- a/src/external/libudev.BUILD
+++ b/src/external/libudev.BUILD
@@ -1,7 +1,0 @@
-# We require that libudev already be installed on the system
-cc_library(
-    name = "libudev",
-    srcs = ["lib/x86_64-linux-gnu/libudev.so"],
-    hdrs = ["usr/include/libudev.h"],
-    visibility = ["//visibility:public"],
-)

--- a/src/external/libusb.BUILD
+++ b/src/external/libusb.BUILD
@@ -3,8 +3,8 @@
 
 cc_library(
     name = "libusb",
-    srcs = glob(["usr/lib/libusb*.so",
-                 "usr/lib/x86_64-linux-gnu/libusb*.so",
+    srcs = glob(["usr/lib/libusb*.so", # Arch Linux
+                 "usr/lib/x86_64-linux-gnu/libusb*.so", # Ubuntu
                 ]),
     hdrs = glob(["usr/include/libusb-1.0/*"]),
     includes = ["usr/include/libusb-1.0"],

--- a/src/external/libusb.BUILD
+++ b/src/external/libusb.BUILD
@@ -3,7 +3,9 @@
 
 cc_library(
     name = "libusb",
-    srcs = glob(["usr/lib/libusb*.so"]),
+    srcs = glob(["usr/lib/libusb*.so",
+                 "usr/lib/x86_64-linux-gnu/libusb*.so",
+                ]),
     hdrs = glob(["usr/include/libusb-1.0/*"]),
     includes = ["usr/include/libusb-1.0"],
     visibility = ["//visibility:public"],

--- a/src/external/libusb.BUILD
+++ b/src/external/libusb.BUILD
@@ -3,7 +3,7 @@
 
 cc_library(
     name = "libusb",
-    srcs = ["usr/lib/libusb-1.0.so"],
+    srcs = glob(["usr/lib/libusb*.so"]),
     hdrs = glob(["usr/include/libusb-1.0/*"]),
     includes = ["usr/include/libusb-1.0"],
     visibility = ["//visibility:public"],

--- a/src/external/libusb.BUILD
+++ b/src/external/libusb.BUILD
@@ -3,25 +3,8 @@
 
 cc_library(
     name = "libusb",
-    srcs = glob([
-        "libusb/*.c",
-        "libusb/os/linux_*.c",
-        "libusb/os/*_posix.c",
-    ]),
-    hdrs = glob([
-        "libusb/*.h",
-        "libusb/os/linux_*.h",
-        "libusb/os/*_posix.h",
-        "Xcode/config.h",
-    ]),
-    includes = [
-        ".",
-        "Xcode",
-        "libusb",
-        "libusb/os",
-    ],
-    deps = [
-        "@libudev",
-    ],
+    srcs = ["usr/lib/libusb-1.0.so"],
+    hdrs = glob(["usr/include/libusb-1.0/*"]),
+    includes = ["usr/include/libusb-1.0"],
     visibility = ["//visibility:public"],
 )

--- a/src/software/backend/input/network/networking/BUILD
+++ b/src/software/backend/input/network/networking/BUILD
@@ -8,6 +8,7 @@ cc_library(
     deps = [
         "//software/proto:ssl_cc_proto",
         "@g3log",
+        "@boost//:asio",  
     ],
 )
 
@@ -19,7 +20,8 @@ cc_library(
     deps = [
         "//software/proto:ssl_cc_proto",
         "@g3log",
-    ],
+        "@boost//:asio",  
+    ]
 )
 
 cc_library(

--- a/src/software/backend/input/network/networking/BUILD
+++ b/src/software/backend/input/network/networking/BUILD
@@ -21,7 +21,7 @@ cc_library(
         "//software/proto:ssl_cc_proto",
         "@g3log",
         "@boost//:asio",  
-    ]
+    ],
 )
 
 cc_library(

--- a/src/software/backend/output/grsim/BUILD
+++ b/src/software/backend/output/grsim/BUILD
@@ -10,6 +10,7 @@ cc_library(
         "//software/backend/output/grsim/command_primitive_visitor:grsim_command_primitive_visitor",
         "//software/proto:grsim_cc_proto",
         "//software/util/parameter:dynamic_parameters",
+        "@boost//:asio"
     ],
 )
 

--- a/src/software/backend/output/radio/mrf/usb/device.h
+++ b/src/software/backend/output/radio/mrf/usb/device.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <libusb/libusb.h>
+#include <libusb.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/software/backend/output/radio/mrf/usb/devicehandle.h
+++ b/src/software/backend/output/radio/mrf/usb/devicehandle.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <libusb/libusb.h>
+#include <libusb.h>
 
 #include <cassert>
 #include <cstddef>

--- a/src/software/backend/output/radio/mrf/usb/libusb.h
+++ b/src/software/backend/output/radio/mrf/usb/libusb.h
@@ -1,7 +1,7 @@
 #ifndef UTIL_LIBUSB_H
 #define UTIL_LIBUSB_H
 
-#include <libusb/libusb.h>
+#include <libusb.h>
 
 #include <cassert>
 #include <cstddef>

--- a/src/software/backend/output/radio/mrf/usb/transfer.h
+++ b/src/software/backend/output/radio/mrf/usb/transfer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <libusb/libusb.h>
+#include <libusb.h>
 
 #include "software/backend/output/radio/mrf/usb/devicehandle.h"
 #include "software/backend/output/radio/mrf/util/async_operation.h"

--- a/src/software/backend/output/radio/mrf/util/BUILD
+++ b/src/software/backend/output/radio/mrf/util/BUILD
@@ -6,5 +6,5 @@ cc_library(
         "async_operation.h",
         "noncopyable.h",
     ],
-    deps = [],
+    deps = ["@boost//:signals2"],
 )

--- a/src/software/geom/BUILD
+++ b/src/software/geom/BUILD
@@ -24,6 +24,7 @@ cc_library(
     deps = [
         "@boost//:geometry",
         "@g3log",
+        "@boost//:polygon",
     ],
 )
 

--- a/src/software/multithreading/BUILD
+++ b/src/software/multithreading/BUILD
@@ -17,7 +17,10 @@ cc_library(
 cc_library(
     name = "thread_safe_buffer",
     hdrs = ["thread_safe_buffer.h"],
-    deps = ["//software/util/time:duration"],
+    deps = [
+        "//software/util/time:duration",
+        "@boost//:circular_buffer",
+    ],
 )
 
 cc_library(
@@ -27,6 +30,7 @@ cc_library(
         ":observer",
         ":thread_safe_buffer",
         "//software/util/time:duration",
+        "@boost//:bind",
     ],
 )
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
- Properly added boost dependencies
- Modified libusb.BUILD to directly include prebuilt system libraries (also removed libudev.BUILD)
- TODO: working on including qt5 source for true cross-platform building (at least on Unix systems)

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Built on Arch Linux system (excluding qt). Relying on Travis to test Ubuntu :/

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
