### PR TITLE
Simple Simulator: Created PhysicsBall abstraction

### DIFF
--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -32,8 +32,8 @@ rules_proto_toolchains()
 
 git_repository(
     name = "com_github_nelhage_rules_boost",
-    remote = "https://github.com/nelhage/rules_boost",
     commit = "9f9fb8b2f0213989247c9d5c0e814a8451d18d7f",
+    remote = "https://github.com/nelhage/rules_boost",
 )
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
@@ -76,10 +76,12 @@ new_local_repository(
     path = "external/qt", # This directory is symlinked in the setup script
 )
 
+# We use our own fork of Box2D as we have made a few small modifications
+# See the repository readme for details
 new_git_repository(
     name = "box2d",
     build_file = "@//external:box2d.BUILD",
-    commit = "ef96a4f17f1c5527d20993b586b400c2617d6ae1",
-    remote = "https://github.com/erincatto/Box2D.git",
-    shallow_since = "1561963347 +0200",
+    commit = "9d71bf40b9bea0f0d9ef36ea9c35c3df2d067e79",
+    remote = "https://github.com/UBC-Thunderbots/Box2D",
+    shallow_since = "1570941579 -0700",
 )

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -73,7 +73,7 @@ git_repository(
 new_local_repository(
     name = "qt",
     build_file = "@bazel_rules_qt//:qt.BUILD",
-    path = "external/qt", # This directory is symlinked in the setup script
+    path = "external/qt",  # This directory is symlinked in the setup script
 )
 
 # We use our own fork of Box2D as we have made a few small modifications
@@ -81,7 +81,7 @@ new_local_repository(
 new_git_repository(
     name = "box2d",
     build_file = "@//external:box2d.BUILD",
-    commit = "9d71bf40b9bea0f0d9ef36ea9c35c3df2d067e79",
+    commit = "bddb4ec7efc8a6630fcbe7ef913017d88fb9b4b1",
     remote = "https://github.com/UBC-Thunderbots/Box2D",
-    shallow_since = "1570941579 -0700",
+    shallow_since = "1571445859 -0700",
 )

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -75,3 +75,11 @@ new_local_repository(
     build_file = "@bazel_rules_qt//:qt.BUILD",
     path = "external/qt", # This directory is symlinked in the setup script
 )
+
+new_git_repository(
+    name = "box2d",
+    build_file = "@//external:box2d.BUILD",
+    commit = "ef96a4f17f1c5527d20993b586b400c2617d6ae1",
+    remote = "https://github.com/erincatto/Box2D.git",
+    shallow_since = "1561963347 +0200",
+)

--- a/src/external/box2d.BUILD
+++ b/src/external/box2d.BUILD
@@ -1,0 +1,14 @@
+# Description:
+#   This library provides us with a 2D physics engine
+#   https://github.com/erincatto/Box2D
+#   https://box2d.org/
+
+cc_library(
+    name = "box2d",
+    srcs = glob(["Box2D/**/*.cpp"]),
+    hdrs = glob(["Box2D/**/*.h"]),
+    includes = [
+        ".",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/src/external/box2d.BUILD
+++ b/src/external/box2d.BUILD
@@ -14,7 +14,7 @@ cc_library(
         # Slightly increase the max vertices to better represent robot shapes
         "b2_maxPolygonVertices=10",
         # Decrease the linear stop to 0.001 (1mm) for more accuracy
-        "b2_linearSlop=0.005f",
+        "b2_linearSlop=0.001f",
         # Decrease the linear stop to for more accuracy. This value is in radians
         # and is equal to 0.1 degrees
         "b2_angularSlop=0.00174532f",

--- a/src/external/box2d.BUILD
+++ b/src/external/box2d.BUILD
@@ -10,5 +10,18 @@ cc_library(
     includes = [
         ".",
     ],
+    defines = [
+        # Slightly increase the max vertices to better represent robot shapes
+        "b2_maxPolygonVertices=10",
+        # Decrease the linear stop to 0.001 (1mm) for more accuracy
+        "b2_linearSlop=0.005f",
+        # Decrease the linear stop to for more accuracy. This value is in radians
+        # and is equal to 0.1 degrees
+        "b2_angularSlop=0.00174532f",
+        # Decrease the velocity threshold so that have normal collisions at or above
+        # this speed (1mm/s). Collisions below this speed will "stick", but we can
+        # tolerate those since we don't care about anything that slow
+        "b2_velocityThreshold=0.001f",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/src/software/backend/simulation/BUILD
+++ b/src/software/backend/simulation/BUILD
@@ -18,3 +18,28 @@ cc_test(
         "@gtest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "ball",
+    srcs = ["physics_ball.cpp"],
+    hdrs = ["physics_ball.h"],
+    deps = [
+        ":box2d_util",
+        "//shared:constants",
+        "//software/geom",
+        "//software/util/time:timestamp",
+        "//software/world:ball",
+        "@box2d",
+    ],
+)
+
+cc_test(
+    name = "ball_test",
+    srcs = ["physics_ball_test.cpp"],
+    deps = [
+        ":ball",
+        "//software/world:ball",
+        "@box2d",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/src/software/backend/simulation/BUILD
+++ b/src/software/backend/simulation/BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "box2d_util",
+    srcs = ["box2d_util.cpp"],
+    hdrs = ["box2d_util.h"],
+    deps = [
+        "@box2d",
+    ],
+)
+
+cc_test(
+    name = "box2d_util_test",
+    srcs = ["box2d_util_test.cpp"],
+    deps = [
+        ":box2d_util",
+        "@box2d",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/src/software/backend/simulation/box2d_util.cpp
+++ b/src/software/backend/simulation/box2d_util.cpp
@@ -1,0 +1,20 @@
+#include "software/backend/simulation/box2d_util.h"
+
+bool bodyExistsInWorld(b2Body* body, std::shared_ptr<b2World> world)
+{
+    if (body == nullptr || !world)
+    {
+        return false;
+    }
+
+    b2Body* current_body = world->GetBodyList();
+    while (current_body != nullptr)
+    {
+        if (current_body == body)
+        {
+            return true;
+        }
+        current_body = current_body->GetNext();
+    }
+    return false;
+}

--- a/src/software/backend/simulation/box2d_util.h
+++ b/src/software/backend/simulation/box2d_util.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Box2D/Box2D.h>
+
+/**
+ * These functions are utilities and convenience functions to make certain operations
+ * with Box2D easier
+ */
+
+/**
+ * Returns true if the b2Body exists in the world, and false otherwise.
+ * If either body or world are null, false is returned
+ *
+ * @param body The Box2D body to search for in the world
+ * @param world The world to search for the Box2D boxy
+ *
+ * @return true if the body exists in the world, and false otherwise. If either the
+ * body or the world are null, false is returned.
+ */
+bool bodyExistsInWorld(b2Body* body, std::shared_ptr<b2World> world);

--- a/src/software/backend/simulation/box2d_util_test.cpp
+++ b/src/software/backend/simulation/box2d_util_test.cpp
@@ -1,0 +1,99 @@
+#include "software/backend/simulation/box2d_util.h"
+
+#include <Box2D/Box2D.h>
+#include <gtest/gtest.h>
+
+TEST(Box2DUtilTest, test_existence_of_null_body_in_null_world)
+{
+    std::shared_ptr<b2World> world;
+
+    b2Body* body = nullptr;
+
+    auto result = bodyExistsInWorld(body, world);
+    EXPECT_FALSE(result);
+}
+
+TEST(Box2DUtilTest, test_existence_of_null_body)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    b2Body* body = nullptr;
+
+    auto result = bodyExistsInWorld(body, world);
+    EXPECT_FALSE(result);
+}
+
+TEST(Box2DUtilTest, test_existence_of_random_body_in_empty_world)
+{
+    b2Vec2 gravity(0, 0);
+    auto world       = std::make_shared<b2World>(gravity);
+    auto other_world = std::make_shared<b2World>(gravity);
+
+    b2BodyDef body_def;
+    body_def.type = b2_dynamicBody;
+    body_def.position.Set(0, 0);
+    body_def.linearVelocity.Set(0, 0);
+    auto body = other_world->CreateBody(&body_def);
+
+    auto result = bodyExistsInWorld(body, world);
+    EXPECT_FALSE(result);
+}
+
+
+TEST(Box2DUtilTest, test_existence_of_body_in_world_with_one_body)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    b2BodyDef body_def;
+    body_def.type = b2_dynamicBody;
+    body_def.position.Set(0, 0);
+    body_def.linearVelocity.Set(0, 0);
+    auto body = world->CreateBody(&body_def);
+
+    auto result = bodyExistsInWorld(body, world);
+    EXPECT_TRUE(result);
+}
+
+TEST(Box2DUtilTest, test_existence_of_body_in_world_with_multiple_bodies)
+{
+    b2Vec2 gravity(0, 0);
+    auto world       = std::make_shared<b2World>(gravity);
+    auto other_world = std::make_shared<b2World>(gravity);
+
+    b2BodyDef body_def_1;
+    body_def_1.type = b2_dynamicBody;
+    body_def_1.position.Set(0, 0);
+    body_def_1.linearVelocity.Set(0, 0);
+    auto body_1 = world->CreateBody(&body_def_1);
+
+    b2BodyDef body_def_2;
+    body_def_2.type = b2_dynamicBody;
+    body_def_2.position.Set(1, 0.8);
+    body_def_2.linearVelocity.Set(0, 0);
+    auto body_2 = world->CreateBody(&body_def_2);
+
+    b2BodyDef body_def_3;
+    body_def_3.type = b2_staticBody;
+    body_def_3.position.Set(1, 0.8);
+    auto body_3 = world->CreateBody(&body_def_3);
+
+    b2BodyDef body_def_4;
+    body_def_4.type = b2_dynamicBody;
+    body_def_4.position.Set(1, 0.8);
+    body_def_4.linearVelocity.Set(0, 0);
+    auto body_4 = other_world->CreateBody(&body_def_4);
+
+    auto result_1 = bodyExistsInWorld(body_1, world);
+    EXPECT_TRUE(result_1);
+
+    auto result_2 = bodyExistsInWorld(body_2, world);
+    EXPECT_TRUE(result_2);
+
+    auto result_3 = bodyExistsInWorld(body_3, world);
+    EXPECT_TRUE(result_3);
+
+    auto result_4 = bodyExistsInWorld(body_4, world);
+    EXPECT_FALSE(result_4);
+}

--- a/src/software/backend/simulation/physics_ball.cpp
+++ b/src/software/backend/simulation/physics_ball.cpp
@@ -12,12 +12,18 @@ PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const Ball &ball)
     ball_body_def.linearVelocity.Set(ball.velocity().x(), ball.velocity().y());
     // The ball can potentially move relatively quickly, so treating it as a "bullet"
     // helps prevent tunneling and other collision problems
+    // See the "Breakdown of a collision" section of:
+    // https://www.iforce2d.net/b2dtut/collision-anatomy
     ball_body_def.bullet = true;
     ball_body            = world->CreateBody(&ball_body_def);
 
     ball_shape.m_radius = BALL_MAX_RADIUS_METERS;
 
     ball_fixture_def.shape       = &ball_shape;
+    // These values do not reflect the ball in real life and may still need some tuning.
+    // For now, they are "ideal" values that give the ball perfectly elastic collision
+    // and no friction
+    // TODO: tune values if necessary (#768)
     ball_fixture_def.density     = 1.0;
     ball_fixture_def.restitution = 1.0;
     ball_fixture_def.friction    = 0.0;

--- a/src/software/backend/simulation/physics_ball.cpp
+++ b/src/software/backend/simulation/physics_ball.cpp
@@ -9,13 +9,15 @@ PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const Ball &ball)
     // Changes made after aren't reflected
     ball_body_def.type = b2_dynamicBody;
     ball_body_def.position.Set(ball.position().x(), ball.position().y());
-    ball_body_def.linearVelocity.Set(ball.velocity().x(), ball.velocity().y());
+//    ball_body_def.linearVelocity.Set(ball.velocity().x(), ball.velocity().y());
     // The ball can potentially move relatively quickly, so treating it as a "bullet"
     // helps prevent tunneling and other collision problems
     // See the "Breakdown of a collision" section of:
     // https://www.iforce2d.net/b2dtut/collision-anatomy
-    ball_body_def.bullet = true;
+//    ball_body_def.bullet = true;
     ball_body            = world->CreateBody(&ball_body_def);
+    b2Vec2 velocity_impulse_direction(ball.velocity().x(), ball.velocity().y());
+    ball_body->ApplyLinearImpulse(velocity_impulse_direction, ball_body->GetWorldCenter(), true);
 
     ball_shape.m_radius = BALL_MAX_RADIUS_METERS;
 

--- a/src/software/backend/simulation/physics_ball.cpp
+++ b/src/software/backend/simulation/physics_ball.cpp
@@ -9,19 +9,20 @@ PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const Ball &ball)
     // Changes made after aren't reflected
     ball_body_def.type = b2_dynamicBody;
     ball_body_def.position.Set(ball.position().x(), ball.position().y());
-//    ball_body_def.linearVelocity.Set(ball.velocity().x(), ball.velocity().y());
+    //    ball_body_def.linearVelocity.Set(ball.velocity().x(), ball.velocity().y());
     // The ball can potentially move relatively quickly, so treating it as a "bullet"
     // helps prevent tunneling and other collision problems
     // See the "Breakdown of a collision" section of:
     // https://www.iforce2d.net/b2dtut/collision-anatomy
-//    ball_body_def.bullet = true;
-    ball_body            = world->CreateBody(&ball_body_def);
+    //    ball_body_def.bullet = true;
+    ball_body = world->CreateBody(&ball_body_def);
     b2Vec2 velocity_impulse_direction(ball.velocity().x(), ball.velocity().y());
-    ball_body->ApplyLinearImpulse(velocity_impulse_direction, ball_body->GetWorldCenter(), true);
+    ball_body->ApplyLinearImpulse(velocity_impulse_direction, ball_body->GetWorldCenter(),
+                                  true);
 
     ball_shape.m_radius = BALL_MAX_RADIUS_METERS;
 
-    ball_fixture_def.shape       = &ball_shape;
+    ball_fixture_def.shape = &ball_shape;
     // These values do not reflect the ball in real life and may still need some tuning.
     // For now, they are "ideal" values that give the ball perfectly elastic collision
     // and no friction

--- a/src/software/backend/simulation/physics_ball.cpp
+++ b/src/software/backend/simulation/physics_ball.cpp
@@ -1,0 +1,42 @@
+#include "software/backend/simulation/physics_ball.h"
+
+#include "shared/constants.h"
+#include "software/backend/simulation/box2d_util.h"
+
+PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const Ball &ball)
+{
+    // All the BodyDef must be defined before the body is created.
+    // Changes made after aren't reflected
+    ball_body_def.type = b2_dynamicBody;
+    ball_body_def.position.Set(ball.position().x(), ball.position().y());
+    ball_body_def.linearVelocity.Set(ball.velocity().x(), ball.velocity().y());
+    // The ball can potentially move relatively quickly, so treating it as a "bullet"
+    // helps prevent tunneling and other collision problems
+    ball_body_def.bullet = true;
+    ball_body            = world->CreateBody(&ball_body_def);
+
+    ball_shape.m_radius = BALL_MAX_RADIUS_METERS;
+
+    ball_fixture_def.shape       = &ball_shape;
+    ball_fixture_def.density     = 1.0;
+    ball_fixture_def.restitution = 1.0;
+    ball_fixture_def.friction    = 0.0;
+
+    ball_body->CreateFixture(&ball_fixture_def);
+}
+
+Ball PhysicsBall::getBallWithTimestamp(const Timestamp &timestamp) const
+{
+    auto position = Point(ball_body->GetPosition().x, ball_body->GetPosition().y);
+    auto velocity =
+        Vector(ball_body->GetLinearVelocity().x, ball_body->GetLinearVelocity().y);
+    return Ball(position, velocity, timestamp);
+}
+
+void PhysicsBall::removeFromWorld(std::shared_ptr<b2World> world)
+{
+    if (bodyExistsInWorld(ball_body, world))
+    {
+        world->DestroyBody(ball_body);
+    }
+}

--- a/src/software/backend/simulation/physics_ball.h
+++ b/src/software/backend/simulation/physics_ball.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <Box2D/Box2D.h>
+
+#include "software/geom/point.h"
+#include "software/util/time/timestamp.h"
+#include "software/world/ball.h"
+
+/**
+ * This class represents a ball in a Box2D physics simulation. It provides a convenient
+ * way for us to abstract the ball and convert to our own Ball class when data is needed
+ */
+class PhysicsBall
+{
+   public:
+    /**
+     * Creates a new PhysicsBall given a Box2D world and a Ball object. A Box2D body
+     * representing the ball will be automatically added to the Box2D world and updated
+     * during world update steps.
+     *
+     * @param world A shared_ptr to a Box2D World
+     * @param ball The Ball to be created in the Box2D world
+     */
+    explicit PhysicsBall(std::shared_ptr<b2World> world, const Ball& ball);
+
+    PhysicsBall() = delete;
+
+    /**
+     * Removes the corresponding ball body from the Box2D world. If this function
+     * is called on a world that does not contain the ball, nothing happens.
+     *
+     * @param world The Box2D world to remove the ball from
+     */
+    void removeFromWorld(std::shared_ptr<b2World> world);
+
+    /**
+     * Returns a Ball object representing the current state of the ball object in the
+     * simulated Box2D world the ball was created in. The timestamp is provided as a
+     * parameter so that the caller can control the timestamp of the data being returned,
+     * since the caller will have context about the Box2D world and simulation time step,
+     * and can synchronize the Ball timestamp with other objects.
+     *
+     * @param timestamp The timestamp for the returned Ball to have
+     *
+     * @return A Ball object representing the current state of the ball object in the
+     * simulated Box2D world the ball was originally created in. The returned Ball object
+     * will have the same timestamp as the one provided in the parameter
+     */
+    Ball getBallWithTimestamp(const Timestamp& timestamp) const;
+
+   private:
+    // See https://box2d.org/manual.pdf chapters 6 and 7 more information on Shapes,
+    // Bodies, and Fixtures
+    b2CircleShape ball_shape;
+    b2BodyDef ball_body_def;
+    b2FixtureDef ball_fixture_def;
+    b2Body* ball_body;
+};

--- a/src/software/backend/simulation/physics_ball_test.cpp
+++ b/src/software/backend/simulation/physics_ball_test.cpp
@@ -127,7 +127,7 @@ TEST(PhysicsBallTest, test_ball_changes_reverses_direction_after_object_collisio
     wall_body_def.type = b2_staticBody;
     wall_body_def.position.Set(1.5, 0.0);
     wall_body_def.angle = 0.0;
-    b2Body* wall_body = world->CreateBody(&wall_body_def);
+    b2Body* wall_body   = world->CreateBody(&wall_body_def);
 
     b2PolygonShape wall_shape;
     wall_shape.SetAsBox(1, 1);
@@ -136,7 +136,7 @@ TEST(PhysicsBallTest, test_ball_changes_reverses_direction_after_object_collisio
     wall_fixture_def.shape = &wall_shape;
     // Perfectly elastic collisions and no friction
     wall_fixture_def.restitution = 1.0;
-    wall_fixture_def.friction = 0.0;
+    wall_fixture_def.friction    = 0.0;
     wall_body->CreateFixture(&wall_fixture_def);
 
     Ball ball_parameter(Point(0, 0), Vector(0.5, 0), Timestamp::fromSeconds(0));
@@ -146,8 +146,9 @@ TEST(PhysicsBallTest, test_ball_changes_reverses_direction_after_object_collisio
     // is lost if we take a single step of 1 second
     for (unsigned int i = 0; i < 120; i++)
     {
-        // 5 and 8 here are somewhat arbitrary values for the velocity and position iterations but are generally
-        // the recommended defaults from https://www.iforce2d.net/b2dtut/worlds
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are generally the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
         world->Step(1.0 / 60.0, 5, 8);
     }
 
@@ -168,7 +169,7 @@ TEST(PhysicsBallTest, test_ball_changes_changes_direction_after_object_deflectio
     wall_body_def.type = b2_staticBody;
     wall_body_def.position.Set(2.0, 0.5);
     wall_body_def.angle = M_PI_4;
-    b2Body* wall_body = world->CreateBody(&wall_body_def);
+    b2Body* wall_body   = world->CreateBody(&wall_body_def);
 
     b2PolygonShape wall_shape;
     wall_shape.SetAsBox(1, 1);
@@ -177,7 +178,7 @@ TEST(PhysicsBallTest, test_ball_changes_changes_direction_after_object_deflectio
     wall_fixture_def.shape = &wall_shape;
     // Perfectly elastic collisions and no friction
     wall_fixture_def.restitution = 1.0;
-    wall_fixture_def.friction = 0.0;
+    wall_fixture_def.friction    = 0.0;
     wall_body->CreateFixture(&wall_fixture_def);
 
     Ball ball_parameter(Point(0, 0), Vector(1.0, 0), Timestamp::fromSeconds(0));
@@ -187,8 +188,9 @@ TEST(PhysicsBallTest, test_ball_changes_changes_direction_after_object_deflectio
     // is lost if we take a single step of 1 second
     for (unsigned int i = 0; i < 120; i++)
     {
-        // 5 and 8 here are somewhat arbitrary values for the velocity and position iterations but are generally
-        // the recommended defaults from https://www.iforce2d.net/b2dtut/worlds
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are generally the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
         world->Step(1.0 / 60.0, 5, 8);
     }
 

--- a/src/software/backend/simulation/physics_ball_test.cpp
+++ b/src/software/backend/simulation/physics_ball_test.cpp
@@ -87,6 +87,9 @@ TEST(PhysicsBallTest, test_ball_velocity_and_position_updates_during_simulation_
     // is lost if we take a single step of 1 second
     for (unsigned int i = 0; i < 60; i++)
     {
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
         world->Step(1.0 / 60.0, 5, 8);
     }
 
@@ -109,6 +112,9 @@ TEST(PhysicsBallTest, test_ball_acceleration_and_velocity_updates_during_simulat
     // is lost if we take a single step of 1 second
     for (unsigned int i = 0; i < 60; i++)
     {
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
         world->Step(1.0 / 60.0, 5, 8);
     }
 
@@ -147,7 +153,7 @@ TEST(PhysicsBallTest, test_ball_changes_reverses_direction_after_object_collisio
     for (unsigned int i = 0; i < 120; i++)
     {
         // 5 and 8 here are somewhat arbitrary values for the velocity and position
-        // iterations but are generally the recommended defaults from
+        // iterations but are the recommended defaults from
         // https://www.iforce2d.net/b2dtut/worlds
         world->Step(1.0 / 60.0, 5, 8);
     }
@@ -189,7 +195,7 @@ TEST(PhysicsBallTest, test_ball_changes_changes_direction_after_object_deflectio
     for (unsigned int i = 0; i < 120; i++)
     {
         // 5 and 8 here are somewhat arbitrary values for the velocity and position
-        // iterations but are generally the recommended defaults from
+        // iterations but are the recommended defaults from
         // https://www.iforce2d.net/b2dtut/worlds
         world->Step(1.0 / 60.0, 5, 8);
     }

--- a/src/software/backend/simulation/physics_ball_test.cpp
+++ b/src/software/backend/simulation/physics_ball_test.cpp
@@ -2,6 +2,7 @@
 
 #include <Box2D/Box2D.h>
 #include <gtest/gtest.h>
+#include <math.h>
 
 #include "software/world/ball.h"
 
@@ -115,4 +116,43 @@ TEST(PhysicsBallTest, test_ball_acceleration_and_velocity_updates_during_simulat
 
     EXPECT_TRUE(Vector(3, -0.5).isClose(ball.velocity(), 1e-5));
     EXPECT_EQ(Timestamp::fromSeconds(1.1), ball.lastUpdateTimestamp());
+}
+
+TEST(PhysicsBallTest, test_ball_changes_direction_after_object_collision)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    b2BodyDef wall_body_def;
+    wall_body_def.type = b2_staticBody;
+    wall_body_def.position.Set(2, 0.0);
+    wall_body_def.angle = M_PI;
+    b2Body* wall_body = world->CreateBody(&wall_body_def);
+
+    b2PolygonShape wall_shape;
+    wall_shape.SetAsBox(1, 1);
+
+    b2FixtureDef wall_fixture_def;
+    wall_fixture_def.shape = &wall_shape;
+    // Perfectly elasitc collisions and no friction
+    wall_fixture_def.restitution = 1.0;
+    wall_fixture_def.friction = 0.0;
+    wall_body->CreateFixture(&wall_fixture_def);
+
+    Ball ball_parameter(Point(0, 0), Vector(1, 0), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 120; i++)
+    {
+        world->Step(1.0 / 60.0, 5, 8);
+        std::cout << physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(0)).velocity() << std::endl;
+        std::cout << wall_body->GetPosition().x << std::endl;
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(1.1));
+
+//    EXPECT_TRUE(Vector(3, -0.5).isClose(ball.velocity(), 1e-5));
+//    EXPECT_EQ(Timestamp::fromSeconds(1.1), ball.lastUpdateTimestamp());
 }

--- a/src/software/backend/simulation/physics_ball_test.cpp
+++ b/src/software/backend/simulation/physics_ball_test.cpp
@@ -1,0 +1,118 @@
+#include "software/backend/simulation/physics_ball.h"
+
+#include <Box2D/Box2D.h>
+#include <gtest/gtest.h>
+
+#include "software/world/ball.h"
+
+TEST(PhysicsBallTest, test_get_ball_with_timestamp)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Ball ball_parameter(Point(0.1, -0.04), Vector(1, -2), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+    auto ball         = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(1.1));
+
+    EXPECT_TRUE(ball_parameter.position().isClose(ball.position(), 1e-7));
+    EXPECT_TRUE(ball_parameter.velocity().isClose(ball.velocity(), 1e-7));
+    EXPECT_EQ(Timestamp::fromSeconds(1.1), ball.lastUpdateTimestamp());
+}
+
+TEST(PhysicsBallTest, test_ball_added_to_physics_world_on_creation)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Ball ball_parameter(Point(0.1, -0.04), Vector(1, -2), Timestamp::fromSeconds(0));
+
+    EXPECT_EQ(0, world->GetBodyCount());
+
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    EXPECT_EQ(1, world->GetBodyCount());
+}
+
+TEST(PhysicsBallTest, test_remove_physics_ball_from_world)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Ball ball_parameter(Point(0.1, -0.04), Vector(1, -2), Timestamp::fromSeconds(0));
+
+    EXPECT_EQ(0, world->GetBodyCount());
+
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    EXPECT_EQ(1, world->GetBodyCount());
+
+    physics_ball.removeFromWorld(world);
+
+    EXPECT_EQ(0, world->GetBodyCount());
+}
+
+TEST(PhysicsBallTest, test_remove_physics_ball_from_world_multiple_times)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Ball ball_parameter(Point(0.1, -0.04), Vector(1, -2), Timestamp::fromSeconds(0));
+
+    EXPECT_EQ(0, world->GetBodyCount());
+
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    EXPECT_EQ(1, world->GetBodyCount());
+
+    physics_ball.removeFromWorld(world);
+
+    EXPECT_EQ(0, world->GetBodyCount());
+
+    physics_ball.removeFromWorld(world);
+
+    EXPECT_EQ(0, world->GetBodyCount());
+}
+
+
+TEST(PhysicsBallTest, test_ball_velocity_and_position_updates_during_simulation_step)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Ball ball_parameter(Point(1, -1), Vector(1, -2), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        world->Step(1.0 / 60.0, 5, 8);
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(1.1));
+
+    EXPECT_TRUE(Point(2, -3).isClose(ball.position(), 1e-5));
+    EXPECT_TRUE(Vector(1, -2).isClose(ball.velocity(), 1e-5));
+    EXPECT_EQ(Timestamp::fromSeconds(1.1), ball.lastUpdateTimestamp());
+}
+
+TEST(PhysicsBallTest, test_ball_acceleration_and_velocity_updates_during_simulation_step)
+{
+    b2Vec2 gravity(3, -0.5);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Ball ball_parameter(Point(0, 0), Vector(0, 0), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        world->Step(1.0 / 60.0, 5, 8);
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(1.1));
+
+    EXPECT_TRUE(Vector(3, -0.5).isClose(ball.velocity(), 1e-5));
+    EXPECT_EQ(Timestamp::fromSeconds(1.1), ball.lastUpdateTimestamp());
+}

--- a/src/software/backend/simulator_backend.h
+++ b/src/software/backend/simulator_backend.h
@@ -5,9 +5,17 @@
 #include "software/backend/backend.h"
 #include "software/world/world.h"
 
-// Box2D tutorials and documentation used as reference
-// TODO: Move these somewhere more appropriate
-// https://github.com/libgdx/libgdx/wiki/Box2d
+/**
+ * This class implements the Backend interface using a physics simulation to
+ * execute received commands and provide new data to the system.
+ *
+ * The simulation uses Box2D as the physics engine, and the abstractions can be found
+ * in the `simulation` folder. For more information and examples of how to use Box2D
+ * see the following:
+ * - https://box2d.org/documentation/
+ * - https://github.com/libgdx/libgdx/wiki/Box2d
+ * - https://www.iforce2d.net/b2dtut/
+ */
 class SimulatorBackend : public Backend
 {
    public:

--- a/src/software/backend/simulator_backend.h
+++ b/src/software/backend/simulator_backend.h
@@ -5,6 +5,9 @@
 #include "software/backend/backend.h"
 #include "software/world/world.h"
 
+// Box2D tutorials and documentation used as reference
+// TODO: Move these somewhere more appropriate
+// https://github.com/libgdx/libgdx/wiki/Box2d
 class SimulatorBackend : public Backend
 {
    public:


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
This PR adds a `PhysicsBall` abstraction for the simulation, making it easy to add a Ball into the physics world as well as get a `Ball` object with the current ball state.

Box2D was chosen as the physics engine / library to use because of it's good documentation and overall simplicity.

Some utility functions for working with Box2D were added as well.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
unit tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #881 
resolves #869 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
