### PR TITLE
Symlink Qt include dir during setup, added Arch Linux setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,16 +9,8 @@
 *.pb.cc
 *.pb.h
 
-# ROS and catkin
-/src/CMakeLists.txt
-/build
-/devel
-/install
-/logs
-
-# rosbag
-*.bag
-*.bag.active
+# Symlinked qt directory
+src/external/qt
 
 # Pycache
 *.pyc

--- a/environment_setup/setup_grsim_arch.sh
+++ b/environment_setup/setup_grsim_arch.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# UBC Thunderbots Arch Linux grSim Setup
+#
+# This script will install all the required libraries and dependencies to run
+# grSim. This only includes the simulator (grSim), and not anything related to
+# our AI. See the setup_software.sh script for that.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+
+# Save the parent dir of this script since we want to return here
+# so that commands are run relative to the location of this script. This
+# helps prevent bugs and odd behaviour if this script is run through a symlink
+# or from a different directory.
+CURR_DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+cd $CURR_DIR
+
+
+# Install required packages
+echo "================================================================"
+echo "Downloading and installing required packages."
+echo "================================================================"
+
+# The list of packages required to build and run grSim
+# See the github repo for the list of dependencies
+# https://github.com/RoboCup-SSL/grSim/blob/master/INSTALL.md
+
+host_software_packages=(
+    git
+    cmake
+    protobuf
+    qt5-base
+    protobuf
+    ode
+    boost
+)
+
+sudo pacman -Sy
+sudo pacman -S ${host_software_packages[@]} --noconfirm
+
+if [ $? -ne 0 ]; then
+    echo "##############################################################"
+    echo "Error: Installing grsim dependencies failed"
+    echo "##############################################################"
+    exit 1
+fi
+
+# Install grSim
+echo "================================================================"
+echo "Installing grSim"
+echo "================================================================"
+
+# Clone and install grSim.
+# grsim will be install in the /opt directory
+# Since /opt is owned by the system commands that operate on it
+# (adding and removing files) require sudo
+
+# Remove old grsim if it exists
+grSim_location="/opt"
+grSim_path="$grSim_location/grSim"
+
+if [ -d $grSim_path ]; then
+    echo "Removing old grSim..."
+    sudo rm -r $grSim_path
+fi
+
+cd $grSim_location
+sudo git clone https://github.com/RoboCup-SSL/grSim
+cd ./grSim
+sudo mkdir build
+cd build
+sudo cmake ..
+sudo make
+
+# Create a symlink so that the grsim executable will be in the PATH
+# /usr/local/bin is one of the default locations included by the PATH
+sudo ln -sf $grSim_path/bin/grSim /usr/local/bin/grsim
+
+
+# Report done
+echo "================================================================"
+echo "Done grSim Setup"
+echo "================================================================"
+

--- a/environment_setup/setup_grsim_arch.sh
+++ b/environment_setup/setup_grsim_arch.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+#########################################################################################
+# WARNING: THIS SCRIPT IS ONLY FOR ARCH LINUX SYSTEMS, AND IS NOT OFFICIALLY SUPPORTED. #
+# IT IS HAS NO GUARANTEE OF WORKING!                                                    #
+# (but you are free to fix it if it doesn't :) )                                        #
+######################################################################################### 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 # UBC Thunderbots Arch Linux grSim Setup
-#
 # This script will install all the required libraries and dependencies to run
 # grSim. This only includes the simulator (grSim), and not anything related to
 # our AI. See the setup_software.sh script for that.

--- a/environment_setup/setup_software.sh
+++ b/environment_setup/setup_software.sh
@@ -76,7 +76,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Symlink qt include directory
-ln -sf /usr/include/x86_64-linux-gnu/qt5 ../src/external/qt
+ln -snf /usr/include/x86_64-linux-gnu/qt5 $GIT_ROOT/src/external/qt
 
 # Done
 echo "================================================================"

--- a/environment_setup/setup_software.sh
+++ b/environment_setup/setup_software.sh
@@ -76,6 +76,9 @@ if [ $? -ne 0 ]; then
 fi
 
 # Symlink qt include directory
+# As the Qt Bazel rules depend on an include directory which varies between Linux
+# platforms, we symlink this directory to one place in our source tree
+# and platform-dependent properties stay in the setup script
 ln -snf /usr/include/x86_64-linux-gnu/qt5 $GIT_ROOT/src/external/qt
 
 # Done

--- a/environment_setup/setup_software_arch.sh
+++ b/environment_setup/setup_software_arch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-# UBC Thunderbots Archlinux Software Setup
+# UBC Thunderbots Arch Linux Software Setup
 #
 # This script must be run with sudo! root permissions are required to install
 # packages and copy files to the /etc/udev/rules.d directory. The reason that the script
@@ -34,11 +34,10 @@ sudo pacman -Sy
 host_software_packages=(
     curl
     cmake
-    protobuf-compiler
-    libprotobuf-dev
+    protobuf
     libusb
-    qt5 # The GUI library for our visualizer
-    libeigen3-dev # A math / numerical library used for things like linear regression
+    qt5-base # The GUI library for our visualizer
+    eigen # A math / numerical library used for things like linear regression
     python-yaml # yaml for cfg generation (Dynamic Parameters)
 )
 sudo pacman -S ${host_software_packages[@]} --noconfirm
@@ -50,30 +49,10 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Install Bazel
-echo "================================================================" 
-echo "Installing Bazel"
-echo "================================================================"
-
-# Adapted from https://docs.bazel.build/versions/master/install-ubuntu.html#install-on-ubuntu
-sudo apt-get update
-sudo apt-get install openjdk-11-jdk -y
-echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-sudo apt-get update
-sudo apt-get install bazel -y
-if [ $? -ne 0 ]; then
-    echo "##############################################################"
-    echo "Error: Installing Bazel failed"
-    echo "##############################################################"
-    exit 1
-fi
-
 # Symlink qt include directory
-ln -sf /usr/include/x86_64-linux-gnu/qt5 ../src/external/qt
+ln -snf /usr/include/qt $GIT_ROOT/src/external/qt
 
 # Done
 echo "================================================================"
 echo "Done Software Setup"
 echo "================================================================"
-

--- a/environment_setup/setup_software_arch.sh
+++ b/environment_setup/setup_software_arch.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
+#########################################################################################
+# WARNING: THIS SCRIPT IS ONLY FOR ARCH LINUX SYSTEMS, AND IS NOT OFFICIALLY SUPPORTED. #
+# IT IS NOT RUN IN CI AND HAS NO GUARANTEE OF WORKING!                                  #
+# (but you are free to fix it if it doesn't :) )                                        #
+######################################################################################### 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 # UBC Thunderbots Arch Linux Software Setup
-#
-# This script must be run with sudo! root permissions are required to install
-# packages and copy files to the /etc/udev/rules.d directory. The reason that the script
-# must be run with sudo rather than the individual commands using sudo, is that
-# when running CI within Docker, the sudo command does not exist since
-# everything is automatically run as root.
 #
 # This script will install all the required libraries and dependencies to build
 # and run the Thunderbots codebase. This includes being able to run the ai and
@@ -29,9 +28,8 @@ echo "================================================================"
 echo "Installing Utilities and Dependencies"
 echo "================================================================"
 
-sudo pacman -Sy
-
 host_software_packages=(
+    bazel
     curl
     cmake
     protobuf
@@ -40,6 +38,7 @@ host_software_packages=(
     eigen # A math / numerical library used for things like linear regression
     python-yaml # yaml for cfg generation (Dynamic Parameters)
 )
+sudo pacman -Sy
 sudo pacman -S ${host_software_packages[@]} --noconfirm
 
 if [ $? -ne 0 ]; then
@@ -50,6 +49,9 @@ if [ $? -ne 0 ]; then
 fi
 
 # Symlink qt include directory
+# As the Qt Bazel rules depend on an include directory which varies between Linux
+# platforms, we symlink this directory to one place in our source tree
+# and platform-dependent properties stay in the setup script
 ln -snf /usr/include/qt $GIT_ROOT/src/external/qt
 
 # Done

--- a/environment_setup/setup_software_arch.sh
+++ b/environment_setup/setup_software_arch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-# UBC Thunderbots Ubuntu Software Setup
+# UBC Thunderbots Archlinux Software Setup
 #
 # This script must be run with sudo! root permissions are required to install
 # packages and copy files to the /etc/udev/rules.d directory. The reason that the script
@@ -29,25 +29,19 @@ echo "================================================================"
 echo "Installing Utilities and Dependencies"
 echo "================================================================"
 
-sudo apt-get update
-sudo apt-get install -y software-properties-common # required for add-apt-repository
-# Required to make sure we install protobuf version 3.0.0 or greater
-sudo add-apt-repository ppa:maarten-fonville/protobuf -y
-
-sudo apt-get update
+sudo pacman -Sy
 
 host_software_packages=(
     curl
     cmake
     protobuf-compiler
     libprotobuf-dev
-    libusb-1.0-0-dev
-    qt5-default # The GUI library for our visualizer
-    libudev-dev
+    libusb
+    qt5 # The GUI library for our visualizer
     libeigen3-dev # A math / numerical library used for things like linear regression
-    python3-yaml # yaml for cfg generation (Dynamic Parameters)
+    python-yaml # yaml for cfg generation (Dynamic Parameters)
 )
-sudo apt-get install ${host_software_packages[@]} -y
+sudo pacman -S ${host_software_packages[@]} --noconfirm
 
 if [ $? -ne 0 ]; then
     echo "##############################################################"

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -73,5 +73,5 @@ git_repository(
 new_local_repository(
     name = "qt",
     build_file = "@bazel_rules_qt//:qt.BUILD",
-    path = "/usr/include/x86_64-linux-gnu/qt5/",
+    path = "external/qt", # This directory is symlinked in the setup script
 )

--- a/src/software/world/refbox_constants_test.cpp
+++ b/src/software/world/refbox_constants_test.cpp
@@ -11,12 +11,12 @@ TEST(RefboxConstants, test_get_name_of_refbox_constants)
             RefboxGameState state = static_cast<RefboxGameState>(i);
             name(state);
         }
-        catch (std::invalid_argument)
+        catch (std::invalid_argument&)
         {
             ADD_FAILURE() << "Unable to get a name for refbox gamestate " << i
                           << std::endl;
         }
-        catch (std::exception)
+        catch (std::exception&)
         {
             ADD_FAILURE() << "Unexpected exception thrown while trying to get the refbox"
                           << " gamestate name for " << i << std::endl;

--- a/src/software/world/refbox_constants_test.cpp
+++ b/src/software/world/refbox_constants_test.cpp
@@ -11,12 +11,12 @@ TEST(RefboxConstants, test_get_name_of_refbox_constants)
             RefboxGameState state = static_cast<RefboxGameState>(i);
             name(state);
         }
-        catch (std::invalid_argument&)
+        catch (std::invalid_argument &)
         {
             ADD_FAILURE() << "Unable to get a name for refbox gamestate " << i
                           << std::endl;
         }
-        catch (std::exception&)
+        catch (std::exception &)
         {
             ADD_FAILURE() << "Unexpected exception thrown while trying to get the refbox"
                           << " gamestate name for " << i << std::endl;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
To allow our code to build on other Linux platforms (like Arch), the include dir used for Qt is now turned into a symlink (`src/external/qt`) that is setup by the setup script for that platform.

I'm not sure if external/ is the best folder (also consider software/) to put the symlink in, but it should definitely be within our source tree.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Tested on Manjaro 18.1 system, letting CI test Ubuntu

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
