### PR TITLE
Add Warning To fix_formatting.sh Script When Using -a Argument

### DIFF
--- a/clang_format/fix_formatting.sh
+++ b/clang_format/fix_formatting.sh
@@ -55,33 +55,32 @@ while test $# -gt 0; do
             ;;
         -a|--all)
             echo "WARNING: "-a" will format all the files and can be very slow! Please consider using "-b" instead!"
+
             echo "Are you sure you want to format all files (y/n)?"
             read continueFormat
             if [ "$continueFormat" == "n" ]; then
-                echo "exiting.."
 		exit 0
 	    elif [ "$continueFormat" == "y" ]; then
-		    echo "Formatting all files..."
+		echo "Formatting all files..."
 
-		    # Generate extension string
-		    # Formatted as -iname *.EXTENSION -o
-		    EXTENSION_STRING=""
-		    for value in "${EXTENSIONS[@]}"
-		    do
-		        EXTENSION_STRING="$EXTENSION_STRING -iname *.$value -o"
-		    done
+		# Generate extension string
+		# Formatted as -iname *.EXTENSION -o
+		EXTENSION_STRING=""
+		for value in "${EXTENSIONS[@]}"
+		do
+		    EXTENSION_STRING="$EXTENSION_STRING -iname *.$value -o"
+		done
 		    
-		    # Find all the files that we want to format, and pass them to
-		    # clang-format as arguments
-		    # We remove the last -o flag from the extension string
-		    find $CURR_DIR/../src/ ${EXTENSION_STRING::-2} \
-		        | xargs $CURR_DIR/clang-format-$CLANG_VERSION -i -style=file
+		# Find all the files that we want to format, and pass them to
+		# clang-format as arguments
+		# We remove the last -o flag from the extension string
+		find $CURR_DIR/../src/ ${EXTENSION_STRING::-2} \
+		    | xargs $CURR_DIR/clang-format-$CLANG_VERSION -i -style=file
 
-		    shift
-           else 
-		 echo "Error: input not recognized"
-		 echo "exiting.."
-                 exit 0
+		shift
+            else 
+		echo "Error: input not recognized"
+                exit 1
 	   fi
 	    ;;
         -b|--branch)

--- a/clang_format/fix_formatting.sh
+++ b/clang_format/fix_formatting.sh
@@ -54,24 +54,36 @@ while test $# -gt 0; do
             exit 0
             ;;
         -a|--all)
-            echo "Formatting all files..."
+            echo "WARNING: "-a" will format all the files and can be very slow! Please consider using "-b" instead!"
+            echo "Are you sure you want to format all files (y/n)?"
+            read continueFormat
+            if [ "$continueFormat" == "n" ]; then
+                echo "exiting.."
+		exit 0
+	    elif [ "$continueFormat" == "y" ]; then
+		    echo "Formatting all files..."
 
-            # Generate extension string
-            # Formatted as -iname *.EXTENSION -o
-            EXTENSION_STRING=""
-            for value in "${EXTENSIONS[@]}"
-            do
-                EXTENSION_STRING="$EXTENSION_STRING -iname *.$value -o"
-            done
-            
-            # Find all the files that we want to format, and pass them to
-            # clang-format as arguments
-            # We remove the last -o flag from the extension string
-            find $CURR_DIR/../src/ ${EXTENSION_STRING::-2} \
-                | xargs $CURR_DIR/clang-format-$CLANG_VERSION -i -style=file
+		    # Generate extension string
+		    # Formatted as -iname *.EXTENSION -o
+		    EXTENSION_STRING=""
+		    for value in "${EXTENSIONS[@]}"
+		    do
+		        EXTENSION_STRING="$EXTENSION_STRING -iname *.$value -o"
+		    done
+		    
+		    # Find all the files that we want to format, and pass them to
+		    # clang-format as arguments
+		    # We remove the last -o flag from the extension string
+		    find $CURR_DIR/../src/ ${EXTENSION_STRING::-2} \
+		        | xargs $CURR_DIR/clang-format-$CLANG_VERSION -i -style=file
 
-            shift
-            ;;
+		    shift
+           else 
+		 echo "Error: input not recognized"
+		 echo "exiting.."
+                 exit 0
+	   fi
+	    ;;
         -b|--branch)
             # Shift the arguents to check for the argument to this flag
             shift

--- a/clang_format/fix_formatting.sh
+++ b/clang_format/fix_formatting.sh
@@ -55,34 +55,34 @@ while test $# -gt 0; do
             ;;
         -a|--all)
             echo "WARNING: "-a" will format all the files and can be very slow! Please consider using "-b" instead!"
-
             echo "Are you sure you want to format all files (y/n)?"
             read continueFormat
+
             if [ "$continueFormat" == "n" ]; then
-		exit 0
-	    elif [ "$continueFormat" == "y" ]; then
-		echo "Formatting all files..."
+                exit 0
 
-		# Generate extension string
-		# Formatted as -iname *.EXTENSION -o
-		EXTENSION_STRING=""
-		for value in "${EXTENSIONS[@]}"
-		do
-		    EXTENSION_STRING="$EXTENSION_STRING -iname *.$value -o"
-		done
-		    
-		# Find all the files that we want to format, and pass them to
-		# clang-format as arguments
-		# We remove the last -o flag from the extension string
-		find $CURR_DIR/../src/ ${EXTENSION_STRING::-2} \
-		    | xargs $CURR_DIR/clang-format-$CLANG_VERSION -i -style=file
+            elif [ "$continueFormat" == "y" ]; then
+                echo "Formatting all files..."
 
-		shift
+                # Generate extension string
+                # Formatted as -iname *.EXTENSION -o
+                EXTENSION_STRING=""
+                for value in "${EXTENSIONS[@]}"
+                do
+                    EXTENSION_STRING="$EXTENSION_STRING -iname *.$value -o"
+                done
+    
+                # Find all the files that we want to format, and pass them to
+                # clang-format as arguments
+                # We remove the last -o flag from the extension string
+                find $CURR_DIR/../src/ ${EXTENSION_STRING::-2} \
+                    | xargs $CURR_DIR/clang-format-$CLANG_VERSION -i -style=file
+                shift
             else 
-		echo "Error: input not recognized"
+                echo "Error: input not recognized"
                 exit 1
-	   fi
-	    ;;
+            fi
+            ;;
         -b|--branch)
             # Shift the arguents to check for the argument to this flag
             shift


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Added a warning to the -a flag in the `fix_formatting.sh` script. Following the warning, the script prompts the user on whether they want to continue execution or not. If the response is 'n', script exits. 
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Tested in terminal for cases where the user inputs 'y', 'n', or something invalid. Also tested the other commands just in case. All pass.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #791 
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
