### PR TITLE
BugFix: Unsigned Negative Comparisons In For Loops

### DIFF
--- a/src/software/backend/input/network/filter/ball_filter.cpp
+++ b/src/software/backend/input/network/filter/ball_filter.cpp
@@ -104,11 +104,11 @@ std::optional<BallVelocityEstimate> BallFilter::estimateBallVelocity(
 
     std::vector<Vector> ball_velocities;
     std::vector<double> ball_velocity_magnitudes;
-    for (unsigned i = 0; i < ball_detections.size() - 1; i++)
+    for (unsigned i = 1; i < ball_detections.size(); i++)
     {
-        for (unsigned j = i + 1; j < ball_detections.size(); j++)
+        for (unsigned j = i; j < ball_detections.size(); j++)
         {
-            SSLBallDetection previous_detection = ball_detections.at(i);
+            SSLBallDetection previous_detection = ball_detections.at(i - 1);
             SSLBallDetection current_detection  = ball_detections.at(j);
 
             Duration time_diff =

--- a/src/software/geom/util.cpp
+++ b/src/software/geom/util.cpp
@@ -433,11 +433,11 @@ std::vector<Shot> angleSweepCirclesAll(const Vector &src, const Vector &p1,
     }
 
     std::vector<Shot> result;
-    for (unsigned i = 0; i < events_collapsed.size() - 1; i += 2)
+    for (unsigned i = 1; i < events_collapsed.size(); i += 2)
     {
         // Calculate the center of this range on the target line segement
-        Angle range_start = events_collapsed[i].first + start_angle;
-        Angle range_end   = events_collapsed[i + 1].first + start_angle;
+        Angle range_start = events_collapsed[i - 1].first + start_angle;
+        Angle range_end   = events_collapsed[i].first + start_angle;
         Angle mid         = (range_end - range_start) / 2 + range_start;
         Vector ray        = Vector::createFromAngle(mid) * 10.0;
         Vector inter      = lineIntersection(src, src + ray, p1, p2).value();


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Found 2 bugs that had Negative Comparisons In For Loops, and fixed them
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
regression tests
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Resolves #934
<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
