### PR TITLE
RoboCup Changes: CreaseDefenderTactic whitelist and tests

### DIFF
--- a/src/software/ai/hl/stp/tactic/BUILD
+++ b/src/software/ai/hl/stp/tactic/BUILD
@@ -80,6 +80,18 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "crease_defender_tactic_test",
+    srcs = ["crease_defender_tactic_test.cpp"],
+    deps = [
+        ":crease_defender_tactic",
+        "//shared:constants",
+        "//software/ai/intent:move_intent",
+        "//software/test_util",
+        "@gtest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "goalie_tactic",
     srcs = ["goalie_tactic.cpp"],

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
@@ -23,6 +23,7 @@ CreaseDefenderTactic::CreaseDefenderTactic(
       enemy_team(enemy_team),
       left_or_right(left_or_right)
 {
+    addWhitelistedAvoidArea(AvoidArea::BALL);
 }
 
 std::string CreaseDefenderTactic::getName() const

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic_test.cpp
@@ -6,7 +6,7 @@
 #include "software/ai/intent/move_intent.h"
 #include "software/test_util/test_util.h"
 
-TEST(BlockShotPathTacticTest, single_defender_blocks_shot_without_goalie)
+TEST(CreaseDefenderTacticTest, single_defender_blocks_shot_without_goalie)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
     ::Test::TestUtil::setBallPosition(world, Point(0, 0), Timestamp::fromSeconds(0));
@@ -42,7 +42,7 @@ TEST(BlockShotPathTacticTest, single_defender_blocks_shot_without_goalie)
     }
 }
 
-TEST(BlockShotPathTacticTest, single_defender_blocks_shot_with_goalie_left_side)
+TEST(CreaseDefenderTacticTest, single_defender_blocks_shot_with_goalie_left_side)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
     ::Test::TestUtil::setBallPosition(world, Point(0, 0), Timestamp::fromSeconds(0));
@@ -69,6 +69,9 @@ TEST(BlockShotPathTacticTest, single_defender_blocks_shot_with_goalie_left_side)
 
     try
     {
+        // The robot's position should be one full robot diameter to the left, perpendicular to the shot vector,
+        // so that the goalie is allowed to block the shot in the middle and the crease defender isn't
+        // overlapping with the goalie
         MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
         EXPECT_TRUE(move_intent.getDestination().isClose(
             Point(world.field().friendlyDefenseArea().posXPosYCorner().x() +
@@ -82,7 +85,7 @@ TEST(BlockShotPathTacticTest, single_defender_blocks_shot_with_goalie_left_side)
     }
 }
 
-TEST(BlockShotPathTacticTest, single_defender_blocks_shot_with_goalie_right_side)
+TEST(CreaseDefenderTacticTest, single_defender_blocks_shot_with_goalie_right_side)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
     ::Test::TestUtil::setBallPosition(world, Point(0, 0), Timestamp::fromSeconds(0));
@@ -109,6 +112,9 @@ TEST(BlockShotPathTacticTest, single_defender_blocks_shot_with_goalie_right_side
 
     try
     {
+        // The robot's position should be one full robot diameter to the right, perpendicular to the shot vector,
+        // so that the goalie is allowed to block the shot in the middle and the crease defender isn't
+        // overlapping with the goalie
         MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
         EXPECT_TRUE(move_intent.getDestination().isClose(
             Point(world.field().friendlyDefenseArea().posXPosYCorner().x() +

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic_test.cpp
@@ -76,7 +76,7 @@ TEST(CreaseDefenderTacticTest, single_defender_blocks_shot_with_goalie_left_side
         EXPECT_TRUE(move_intent.getDestination().isClose(
             Point(world.field().friendlyDefenseArea().posXPosYCorner().x() +
                       ROBOT_MAX_RADIUS_METERS,
-                  0.18),
+                  2 * ROBOT_MAX_RADIUS_METERS),
             0.05));
     }
     catch (...)
@@ -119,7 +119,7 @@ TEST(CreaseDefenderTacticTest, single_defender_blocks_shot_with_goalie_right_sid
         EXPECT_TRUE(move_intent.getDestination().isClose(
             Point(world.field().friendlyDefenseArea().posXPosYCorner().x() +
                       ROBOT_MAX_RADIUS_METERS,
-                  -0.18),
+                  -2 * ROBOT_MAX_RADIUS_METERS),
             0.05));
     }
     catch (...)

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic_test.cpp
@@ -1,0 +1,94 @@
+#include "software/ai/hl/stp/tactic/crease_defender_tactic.h"
+
+#include <gtest/gtest.h>
+
+#include "software/ai/intent/move_intent.h"
+#include "software/test_util/test_util.h"
+#include "shared/constants.h"
+
+TEST(BlockShotPathTacticTest, single_defender_blocks_shot_without_goalie)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    ::Test::TestUtil::setBallPosition(world, Point(0, 0), Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setEnemyRobotPositions(world, {Point(0.09, 0)}, Timestamp::fromSeconds(0));
+
+    Robot friendly_robot = Robot(0, Point(-2, 0), Vector(0, 0), Angle::zero(),
+                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().updateRobots({friendly_robot});
+
+    CreaseDefenderTactic tactic = CreaseDefenderTactic(world.field(), world.ball(), world.friendlyTeam(), world.enemyTeam(), CreaseDefenderTactic::LEFT);
+    tactic.updateRobot(friendly_robot);
+    auto intent_ptr = tactic.getNextIntent();
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+
+    try {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(world.field().friendlyDefenseArea().posXPosYCorner().x() + ROBOT_MAX_RADIUS_METERS, 0.0), 0.05));
+    }
+    catch (...) {
+        ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
+    }
+}
+
+TEST(BlockShotPathTacticTest, single_defender_blocks_shot_with_goalie_left_side)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    ::Test::TestUtil::setBallPosition(world, Point(0, 0), Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setEnemyRobotPositions(world, {Point(0.09, 0)}, Timestamp::fromSeconds(0));
+
+    Robot friendly_robot = Robot(0, Point(-2, 0), Vector(0, 0), Angle::zero(),
+                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_goalie = Robot(1, world.field().friendlyGoal(), Vector(0, 0), Angle::zero(),
+                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().updateRobots({friendly_robot, friendly_goalie});
+    world.mutableFriendlyTeam().assignGoalie(1);
+
+    CreaseDefenderTactic tactic = CreaseDefenderTactic(world.field(), world.ball(), world.friendlyTeam(), world.enemyTeam(), CreaseDefenderTactic::LEFT);
+    tactic.updateRobot(friendly_robot);
+    auto intent_ptr = tactic.getNextIntent();
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+
+    try {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(world.field().friendlyDefenseArea().posXPosYCorner().x() + ROBOT_MAX_RADIUS_METERS, 0.18), 0.05));
+    }
+    catch (...) {
+        ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
+    }
+}
+
+TEST(BlockShotPathTacticTest, single_defender_blocks_shot_with_goalie_right_side)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    ::Test::TestUtil::setBallPosition(world, Point(0, 0), Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setEnemyRobotPositions(world, {Point(0.09, 0)}, Timestamp::fromSeconds(0));
+
+    Robot friendly_robot = Robot(0, Point(-2, 0), Vector(0, 0), Angle::zero(),
+                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_goalie = Robot(1, world.field().friendlyGoal(), Vector(0, 0), Angle::zero(),
+                                  AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().updateRobots({friendly_robot, friendly_goalie});
+    world.mutableFriendlyTeam().assignGoalie(1);
+
+    CreaseDefenderTactic tactic = CreaseDefenderTactic(world.field(), world.ball(), world.friendlyTeam(), world.enemyTeam(), CreaseDefenderTactic::RIGHT);
+    tactic.updateRobot(friendly_robot);
+    auto intent_ptr = tactic.getNextIntent();
+
+    // Check an intent was returned (the pointer is not null)
+    EXPECT_TRUE(intent_ptr);
+
+    try {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        EXPECT_TRUE(move_intent.getDestination().isClose(Point(world.field().friendlyDefenseArea().posXPosYCorner().x() + ROBOT_MAX_RADIUS_METERS, -0.18), 0.05));
+    }
+    catch (...) {
+        ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
+    }
+}

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic_test.cpp
@@ -69,9 +69,9 @@ TEST(CreaseDefenderTacticTest, single_defender_blocks_shot_with_goalie_left_side
 
     try
     {
-        // The robot's position should be one full robot diameter to the left, perpendicular to the shot vector,
-        // so that the goalie is allowed to block the shot in the middle and the crease defender isn't
-        // overlapping with the goalie
+        // The robot's position should be one full robot diameter to the left,
+        // perpendicular to the shot vector, so that the goalie is allowed to block the
+        // shot in the middle and the crease defender isn't overlapping with the goalie
         MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
         EXPECT_TRUE(move_intent.getDestination().isClose(
             Point(world.field().friendlyDefenseArea().posXPosYCorner().x() +
@@ -112,9 +112,9 @@ TEST(CreaseDefenderTacticTest, single_defender_blocks_shot_with_goalie_right_sid
 
     try
     {
-        // The robot's position should be one full robot diameter to the right, perpendicular to the shot vector,
-        // so that the goalie is allowed to block the shot in the middle and the crease defender isn't
-        // overlapping with the goalie
+        // The robot's position should be one full robot diameter to the right,
+        // perpendicular to the shot vector, so that the goalie is allowed to block the
+        // shot in the middle and the crease defender isn't overlapping with the goalie
         MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
         EXPECT_TRUE(move_intent.getDestination().isClose(
             Point(world.field().friendlyDefenseArea().posXPosYCorner().x() +

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic_test.cpp
@@ -2,33 +2,42 @@
 
 #include <gtest/gtest.h>
 
+#include "shared/constants.h"
 #include "software/ai/intent/move_intent.h"
 #include "software/test_util/test_util.h"
-#include "shared/constants.h"
 
 TEST(BlockShotPathTacticTest, single_defender_blocks_shot_without_goalie)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
     ::Test::TestUtil::setBallPosition(world, Point(0, 0), Timestamp::fromSeconds(0));
     ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
-    ::Test::TestUtil::setEnemyRobotPositions(world, {Point(0.09, 0)}, Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setEnemyRobotPositions(world, {Point(0.09, 0)},
+                                             Timestamp::fromSeconds(0));
 
     Robot friendly_robot = Robot(0, Point(-2, 0), Vector(0, 0), Angle::zero(),
                                  AngularVelocity::zero(), Timestamp::fromSeconds(0));
     world.mutableFriendlyTeam().updateRobots({friendly_robot});
 
-    CreaseDefenderTactic tactic = CreaseDefenderTactic(world.field(), world.ball(), world.friendlyTeam(), world.enemyTeam(), CreaseDefenderTactic::LEFT);
+    CreaseDefenderTactic tactic =
+        CreaseDefenderTactic(world.field(), world.ball(), world.friendlyTeam(),
+                             world.enemyTeam(), CreaseDefenderTactic::LEFT);
     tactic.updateRobot(friendly_robot);
     auto intent_ptr = tactic.getNextIntent();
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
 
-    try {
+    try
+    {
         MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-        EXPECT_TRUE(move_intent.getDestination().isClose(Point(world.field().friendlyDefenseArea().posXPosYCorner().x() + ROBOT_MAX_RADIUS_METERS, 0.0), 0.05));
+        EXPECT_TRUE(move_intent.getDestination().isClose(
+            Point(world.field().friendlyDefenseArea().posXPosYCorner().x() +
+                      ROBOT_MAX_RADIUS_METERS,
+                  0.0),
+            0.05));
     }
-    catch (...) {
+    catch (...)
+    {
         ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
     }
 }
@@ -38,27 +47,37 @@ TEST(BlockShotPathTacticTest, single_defender_blocks_shot_with_goalie_left_side)
     World world = ::Test::TestUtil::createBlankTestingWorld();
     ::Test::TestUtil::setBallPosition(world, Point(0, 0), Timestamp::fromSeconds(0));
     ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
-    ::Test::TestUtil::setEnemyRobotPositions(world, {Point(0.09, 0)}, Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setEnemyRobotPositions(world, {Point(0.09, 0)},
+                                             Timestamp::fromSeconds(0));
 
     Robot friendly_robot = Robot(0, Point(-2, 0), Vector(0, 0), Angle::zero(),
                                  AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Robot friendly_goalie = Robot(1, world.field().friendlyGoal(), Vector(0, 0), Angle::zero(),
-                                 AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_goalie =
+        Robot(1, world.field().friendlyGoal(), Vector(0, 0), Angle::zero(),
+              AngularVelocity::zero(), Timestamp::fromSeconds(0));
     world.mutableFriendlyTeam().updateRobots({friendly_robot, friendly_goalie});
     world.mutableFriendlyTeam().assignGoalie(1);
 
-    CreaseDefenderTactic tactic = CreaseDefenderTactic(world.field(), world.ball(), world.friendlyTeam(), world.enemyTeam(), CreaseDefenderTactic::LEFT);
+    CreaseDefenderTactic tactic =
+        CreaseDefenderTactic(world.field(), world.ball(), world.friendlyTeam(),
+                             world.enemyTeam(), CreaseDefenderTactic::LEFT);
     tactic.updateRobot(friendly_robot);
     auto intent_ptr = tactic.getNextIntent();
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
 
-    try {
+    try
+    {
         MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-        EXPECT_TRUE(move_intent.getDestination().isClose(Point(world.field().friendlyDefenseArea().posXPosYCorner().x() + ROBOT_MAX_RADIUS_METERS, 0.18), 0.05));
+        EXPECT_TRUE(move_intent.getDestination().isClose(
+            Point(world.field().friendlyDefenseArea().posXPosYCorner().x() +
+                      ROBOT_MAX_RADIUS_METERS,
+                  0.18),
+            0.05));
     }
-    catch (...) {
+    catch (...)
+    {
         ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
     }
 }
@@ -68,27 +87,37 @@ TEST(BlockShotPathTacticTest, single_defender_blocks_shot_with_goalie_right_side
     World world = ::Test::TestUtil::createBlankTestingWorld();
     ::Test::TestUtil::setBallPosition(world, Point(0, 0), Timestamp::fromSeconds(0));
     ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
-    ::Test::TestUtil::setEnemyRobotPositions(world, {Point(0.09, 0)}, Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setEnemyRobotPositions(world, {Point(0.09, 0)},
+                                             Timestamp::fromSeconds(0));
 
     Robot friendly_robot = Robot(0, Point(-2, 0), Vector(0, 0), Angle::zero(),
                                  AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Robot friendly_goalie = Robot(1, world.field().friendlyGoal(), Vector(0, 0), Angle::zero(),
-                                  AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    Robot friendly_goalie =
+        Robot(1, world.field().friendlyGoal(), Vector(0, 0), Angle::zero(),
+              AngularVelocity::zero(), Timestamp::fromSeconds(0));
     world.mutableFriendlyTeam().updateRobots({friendly_robot, friendly_goalie});
     world.mutableFriendlyTeam().assignGoalie(1);
 
-    CreaseDefenderTactic tactic = CreaseDefenderTactic(world.field(), world.ball(), world.friendlyTeam(), world.enemyTeam(), CreaseDefenderTactic::RIGHT);
+    CreaseDefenderTactic tactic =
+        CreaseDefenderTactic(world.field(), world.ball(), world.friendlyTeam(),
+                             world.enemyTeam(), CreaseDefenderTactic::RIGHT);
     tactic.updateRobot(friendly_robot);
     auto intent_ptr = tactic.getNextIntent();
 
     // Check an intent was returned (the pointer is not null)
     EXPECT_TRUE(intent_ptr);
 
-    try {
+    try
+    {
         MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
-        EXPECT_TRUE(move_intent.getDestination().isClose(Point(world.field().friendlyDefenseArea().posXPosYCorner().x() + ROBOT_MAX_RADIUS_METERS, -0.18), 0.05));
+        EXPECT_TRUE(move_intent.getDestination().isClose(
+            Point(world.field().friendlyDefenseArea().posXPosYCorner().x() +
+                      ROBOT_MAX_RADIUS_METERS,
+                  -0.18),
+            0.05));
     }
-    catch (...) {
+    catch (...)
+    {
         ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
     }
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Minor whitelist change from RoboCup 2019

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Added a few unit tests. By no means are these a complete test suite but they are something to verify very basic behavior. Tactics will be fully tested once all RoboCup changes are merged.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #901 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
