### PR TITLE
RoboCup Changes: Port ShadowFreekickerTactic and add unit tests

### DIFF
--- a/src/software/ai/hl/stp/play/enemy_freekick_play.cpp
+++ b/src/software/ai/hl/stp/play/enemy_freekick_play.cpp
@@ -44,10 +44,10 @@ void EnemyFreekickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     // Init FreeKickShadower tactics (these robots will both block the enemy robot taking
     // a free kick (at most we will have 2
     auto shadow_freekicker_1 = std::make_shared<ShadowFreekickerTactic>(
-        ShadowFreekickerTactic::First, world.enemyTeam(), world.ball(), world.field(),
+        ShadowFreekickerTactic::LEFT, world.enemyTeam(), world.ball(), world.field(),
         true);
     auto shadow_freekicker_2 = std::make_shared<ShadowFreekickerTactic>(
-        ShadowFreekickerTactic::Second, world.enemyTeam(), world.ball(), world.field(),
+        ShadowFreekickerTactic::RIGHT, world.enemyTeam(), world.ball(), world.field(),
         true);
 
     // Init Shadow Enemy Tactics for extra robots

--- a/src/software/ai/hl/stp/tactic/BUILD
+++ b/src/software/ai/hl/stp/tactic/BUILD
@@ -242,6 +242,7 @@ cc_library(
         "//software/ai/hl/stp/action:move_action",
         "//software/ai/hl/stp/evaluation:possession",
         "//software/geom",
+        "//software/util/parameter:dynamic_parameters",
         "@g3log",
     ],
 )

--- a/src/software/ai/hl/stp/tactic/BUILD
+++ b/src/software/ai/hl/stp/tactic/BUILD
@@ -246,6 +246,17 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "shadow_freekicker_tactic_test",
+    srcs = ["shadow_freekicker_tactic_test.cpp"],
+    deps = [
+        ":shadow_freekicker_tactic",
+        "//software/geom",
+        "//software/test_util",
+        "@gtest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "shoot_goal_tactic",
     srcs = ["shoot_goal_tactic.cpp"],

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
@@ -52,9 +52,9 @@ void ShadowFreekickerTactic::calculateNextIntent(IntentCoroutine::push_type &yie
                     .norm(FREE_KICK_MAX_PROXIMITY + ROBOT_MAX_RADIUS_METERS);
 
             Vector perpendicular_to_enemy_direction =
-                enemy_pointing_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * 1.2);
+                enemy_pointing_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * 1.1);
 
-            defend_position = free_kick_shadower == FreekickShadower::First
+            defend_position = free_kick_shadower == FreekickShadower::LEFT
                                   ? ball.position() + enemy_pointing_direction +
                                         perpendicular_to_enemy_direction
                                   : ball.position() + enemy_pointing_direction -
@@ -69,7 +69,7 @@ void ShadowFreekickerTactic::calculateNextIntent(IntentCoroutine::push_type &yie
             Vector perpendicular_to_ball_direction =
                 ball_to_net_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * 1.1);
 
-            defend_position = free_kick_shadower == FreekickShadower::First
+            defend_position = free_kick_shadower == FreekickShadower::LEFT
                                   ? ball.position() + ball_to_net_direction +
                                         perpendicular_to_ball_direction
                                   : ball.position() + ball_to_net_direction -

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
@@ -44,7 +44,9 @@ void ShadowFreekickerTactic::calculateNextIntent(IntentCoroutine::push_type &yie
     {
         std::optional<Robot> enemy_with_ball =
             Evaluation::getRobotWithEffectiveBallPossession(enemy_team, ball, field);
-        double robot_separation_scaling_factor = Util::DynamicParameters::ShadowFreekickerTactic::robot_separation_scaling_factor.value();
+        double robot_separation_scaling_factor =
+            Util::DynamicParameters::ShadowFreekickerTactic::
+                robot_separation_scaling_factor.value();
 
         if (enemy_with_ball.has_value())
         {
@@ -53,7 +55,8 @@ void ShadowFreekickerTactic::calculateNextIntent(IntentCoroutine::push_type &yie
                     .norm(FREE_KICK_MAX_PROXIMITY + ROBOT_MAX_RADIUS_METERS);
 
             Vector perpendicular_to_enemy_direction =
-                enemy_pointing_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * robot_separation_scaling_factor);
+                enemy_pointing_direction.perp().norm(ROBOT_MAX_RADIUS_METERS *
+                                                     robot_separation_scaling_factor);
 
             defend_position = free_kick_shadower == FreekickShadower::RIGHT
                                   ? ball.position() + enemy_pointing_direction +
@@ -67,8 +70,8 @@ void ShadowFreekickerTactic::calculateNextIntent(IntentCoroutine::push_type &yie
                 (field.friendlyGoal() - ball.position())
                     .norm(FREE_KICK_MAX_PROXIMITY + ROBOT_MAX_RADIUS_METERS);
 
-            Vector perpendicular_to_ball_direction =
-                ball_to_net_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * robot_separation_scaling_factor);
+            Vector perpendicular_to_ball_direction = ball_to_net_direction.perp().norm(
+                ROBOT_MAX_RADIUS_METERS * robot_separation_scaling_factor);
 
             defend_position = free_kick_shadower == FreekickShadower::RIGHT
                                   ? ball.position() + ball_to_net_direction +

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
@@ -54,7 +54,7 @@ void ShadowFreekickerTactic::calculateNextIntent(IntentCoroutine::push_type &yie
             Vector perpendicular_to_enemy_direction =
                 enemy_pointing_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * 1.1);
 
-            defend_position = free_kick_shadower == FreekickShadower::LEFT
+            defend_position = free_kick_shadower == FreekickShadower::RIGHT
                                   ? ball.position() + enemy_pointing_direction +
                                         perpendicular_to_enemy_direction
                                   : ball.position() + enemy_pointing_direction -
@@ -69,7 +69,7 @@ void ShadowFreekickerTactic::calculateNextIntent(IntentCoroutine::push_type &yie
             Vector perpendicular_to_ball_direction =
                 ball_to_net_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * 1.1);
 
-            defend_position = free_kick_shadower == FreekickShadower::LEFT
+            defend_position = free_kick_shadower == FreekickShadower::RIGHT
                                   ? ball.position() + ball_to_net_direction +
                                         perpendicular_to_ball_direction
                                   : ball.position() + ball_to_net_direction -

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
@@ -5,7 +5,7 @@
 #include "shared/constants.h"
 #include "software/ai/hl/stp/evaluation/possession.h"
 #include "software/ai/hl/stp/tactic/tactic_visitor.h"
-
+#include "software/util/parameter/dynamic_parameters.h"
 
 ShadowFreekickerTactic::ShadowFreekickerTactic(FreekickShadower free_kick_shadower,
                                                Team enemy_team, Ball ball, Field field,
@@ -44,6 +44,7 @@ void ShadowFreekickerTactic::calculateNextIntent(IntentCoroutine::push_type &yie
     {
         std::optional<Robot> enemy_with_ball =
             Evaluation::getRobotWithEffectiveBallPossession(enemy_team, ball, field);
+        double robot_separation_scaling_factor = Util::DynamicParameters::ShadowFreekickerTactic::robot_separation_scaling_factor.value();
 
         if (enemy_with_ball.has_value())
         {
@@ -52,7 +53,7 @@ void ShadowFreekickerTactic::calculateNextIntent(IntentCoroutine::push_type &yie
                     .norm(FREE_KICK_MAX_PROXIMITY + ROBOT_MAX_RADIUS_METERS);
 
             Vector perpendicular_to_enemy_direction =
-                enemy_pointing_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * 1.1);
+                enemy_pointing_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * robot_separation_scaling_factor);
 
             defend_position = free_kick_shadower == FreekickShadower::RIGHT
                                   ? ball.position() + enemy_pointing_direction +
@@ -67,7 +68,7 @@ void ShadowFreekickerTactic::calculateNextIntent(IntentCoroutine::push_type &yie
                     .norm(FREE_KICK_MAX_PROXIMITY + ROBOT_MAX_RADIUS_METERS);
 
             Vector perpendicular_to_ball_direction =
-                ball_to_net_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * 1.1);
+                ball_to_net_direction.perp().norm(ROBOT_MAX_RADIUS_METERS * robot_separation_scaling_factor);
 
             defend_position = free_kick_shadower == FreekickShadower::RIGHT
                                   ? ball.position() + ball_to_net_direction +

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.h
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.h
@@ -66,5 +66,6 @@ class ShadowFreekickerTactic : public Tactic
     Field field;
 
     const double FREE_KICK_MAX_PROXIMITY =
-        0.50 * 1.05;  // Robots cannot be closer than 50cm from the ball during a freekick (with a buffer factor)
+        0.50 * 1.05;  // Robots cannot be closer than 50cm from the ball during a freekick
+                      // (with a buffer factor)
 };

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.h
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.h
@@ -12,8 +12,8 @@ class ShadowFreekickerTactic : public Tactic
    public:
     enum FreekickShadower
     {
-        First  = 0,
-        Second = 1,
+        LEFT  = 0,
+        RIGHT = 1,
     };
 
     /**
@@ -66,5 +66,5 @@ class ShadowFreekickerTactic : public Tactic
     Field field;
 
     const double FREE_KICK_MAX_PROXIMITY =
-        0.50;  // Robots cannot be closer than 50cm from the ball during a freekick
+        0.50 * 1.05;  // Robots cannot be closer than 50cm from the ball during a freekick (with a buffer factor)
 };

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.h
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.h
@@ -10,6 +10,12 @@
 class ShadowFreekickerTactic : public Tactic
 {
    public:
+    /*
+     * This enum indicates the side the robot running this tactic should shadow on. "Left" and "Right" are
+     * from the POV of a robot in the friendly goal looking at the enemy taking the free kick. For example,
+     * the tactic using the LEFT enum would shadow slightly to the left of the vector from the enemy freekicker
+     * to the friendly goal
+     */
     enum FreekickShadower
     {
         LEFT  = 0,

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.h
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.h
@@ -11,10 +11,10 @@ class ShadowFreekickerTactic : public Tactic
 {
    public:
     /*
-     * This enum indicates the side the robot running this tactic should shadow on. "Left" and "Right" are
-     * from the POV of a robot in the friendly goal looking at the enemy taking the free kick. For example,
-     * the tactic using the LEFT enum would shadow slightly to the left of the vector from the enemy freekicker
-     * to the friendly goal
+     * This enum indicates the side the robot running this tactic should shadow on. "Left"
+     * and "Right" are from the POV of a robot in the friendly goal looking at the enemy
+     * taking the free kick. For example, the tactic using the LEFT enum would shadow
+     * slightly to the left of the vector from the enemy freekicker to the friendly goal
      */
     enum FreekickShadower
     {

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic_test.cpp
@@ -51,7 +51,7 @@ TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_left_side)
             (move_intent.getDestination() - world.field().friendlyGoal()).orientation();
         EXPECT_GT(goal_to_dest_angle, goal_to_ball_angle);
     }
-    catch (...)
+    catch (std::bad_cast&)
     {
         ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
     }
@@ -100,7 +100,7 @@ TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_right_side)
             (move_intent.getDestination() - world.field().friendlyGoal()).orientation();
         EXPECT_LT(goal_to_dest_angle, goal_to_ball_angle);
     }
-    catch (...)
+    catch (std::bad_cast&)
     {
         ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
     }

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic_test.cpp
@@ -4,22 +4,29 @@
 
 #include "shared/constants.h"
 #include "software/ai/intent/move_intent.h"
-#include "software/test_util/test_util.h"
 #include "software/geom/line.h"
 #include "software/geom/util.h"
+#include "software/test_util/test_util.h"
 
 TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_left_side)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
-    world = ::Test::TestUtil::setEnemyRobotPositions(world, {0, Point(world.field().friendlyCornerPos().y(), 0)}, Timestamp::fromSeconds(0));
-    world = ::Test::TestUtil::setBallPosition(world, Point(-0.09, world.field().friendlyCornerPos().y() - 0.09), Timestamp::fromSeconds(0));
-    world = ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
+    world       = ::Test::TestUtil::setEnemyRobotPositions(
+        world, {0, Point(world.field().friendlyCornerPos().y(), 0)},
+        Timestamp::fromSeconds(0));
+    world = ::Test::TestUtil::setBallPosition(
+        world, Point(-0.09, world.field().friendlyCornerPos().y() - 0.09),
+        Timestamp::fromSeconds(0));
+    world =
+        ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
 
     Robot friendly_robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
     world.mutableFriendlyTeam().updateRobots({friendly_robot});
 
-    ShadowFreekickerTactic tactic = ShadowFreekickerTactic(ShadowFreekickerTactic::LEFT, world.enemyTeam(), world.ball(), world.field(), false);
+    ShadowFreekickerTactic tactic =
+        ShadowFreekickerTactic(ShadowFreekickerTactic::LEFT, world.enemyTeam(),
+                               world.ball(), world.field(), false);
     tactic.updateRobot(friendly_robot);
 
     auto intent_ptr = tactic.getNextIntent();
@@ -30,14 +37,18 @@ TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_left_side)
     {
         MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
         // The edge of the robot should be slightly more than 0.5m from the ball
-        EXPECT_NEAR((world.ball().position() - move_intent.getDestination()).len(), 0.62, 0.05);
+        EXPECT_NEAR((world.ball().position() - move_intent.getDestination()).len(), 0.62,
+                    0.05);
 
-        // The robot should be just to the left of the line between the friendly net and the ball
-        // (from the POV of the friendly net)
-        Line ball_to_net_line = Line(world.ball().position(), world.field().friendlyGoal());
+        // The robot should be just to the left of the line between the friendly net and
+        // the ball (from the POV of the friendly net)
+        Line ball_to_net_line =
+            Line(world.ball().position(), world.field().friendlyGoal());
         EXPECT_NEAR(dist(ball_to_net_line, move_intent.getDestination()), 0.09, 0.01);
-        Angle goal_to_ball_angle = (world.ball().position() - world.field().friendlyGoal()).orientation();
-        Angle goal_to_dest_angle = (move_intent.getDestination() - world.field().friendlyGoal()).orientation();
+        Angle goal_to_ball_angle =
+            (world.ball().position() - world.field().friendlyGoal()).orientation();
+        Angle goal_to_dest_angle =
+            (move_intent.getDestination() - world.field().friendlyGoal()).orientation();
         EXPECT_GT(goal_to_dest_angle, goal_to_ball_angle);
     }
     catch (...)
@@ -49,15 +60,22 @@ TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_left_side)
 TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_right_side)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
-    world = ::Test::TestUtil::setEnemyRobotPositions(world, {0, Point(world.field().friendlyCornerPos().y(), 0)}, Timestamp::fromSeconds(0));
-    world = ::Test::TestUtil::setBallPosition(world, Point(-0.09, world.field().friendlyCornerPos().y() - 0.09), Timestamp::fromSeconds(0));
-    world = ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
+    world       = ::Test::TestUtil::setEnemyRobotPositions(
+        world, {0, Point(world.field().friendlyCornerPos().y(), 0)},
+        Timestamp::fromSeconds(0));
+    world = ::Test::TestUtil::setBallPosition(
+        world, Point(-0.09, world.field().friendlyCornerPos().y() - 0.09),
+        Timestamp::fromSeconds(0));
+    world =
+        ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
 
     Robot friendly_robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
     world.mutableFriendlyTeam().updateRobots({friendly_robot});
 
-    ShadowFreekickerTactic tactic = ShadowFreekickerTactic(ShadowFreekickerTactic::RIGHT, world.enemyTeam(), world.ball(), world.field(), false);
+    ShadowFreekickerTactic tactic =
+        ShadowFreekickerTactic(ShadowFreekickerTactic::RIGHT, world.enemyTeam(),
+                               world.ball(), world.field(), false);
     tactic.updateRobot(friendly_robot);
 
     auto intent_ptr = tactic.getNextIntent();
@@ -68,14 +86,18 @@ TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_right_side)
     {
         MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
         // The edge of the robot should be slightly more than 0.5m from the ball
-        EXPECT_NEAR((world.ball().position() - move_intent.getDestination()).len(), 0.62, 0.05);
+        EXPECT_NEAR((world.ball().position() - move_intent.getDestination()).len(), 0.62,
+                    0.05);
 
-        // The robot should be just to the right of the line between the friendly net and the ball
-        // (from the POV of the friendly net)
-        Line ball_to_net_line = Line(world.ball().position(), world.field().friendlyGoal());
+        // The robot should be just to the right of the line between the friendly net and
+        // the ball (from the POV of the friendly net)
+        Line ball_to_net_line =
+            Line(world.ball().position(), world.field().friendlyGoal());
         EXPECT_NEAR(dist(ball_to_net_line, move_intent.getDestination()), 0.09, 0.01);
-        Angle goal_to_ball_angle = (world.ball().position() - world.field().friendlyGoal()).orientation();
-        Angle goal_to_dest_angle = (move_intent.getDestination() - world.field().friendlyGoal()).orientation();
+        Angle goal_to_ball_angle =
+            (world.ball().position() - world.field().friendlyGoal()).orientation();
+        Angle goal_to_dest_angle =
+            (move_intent.getDestination() - world.field().friendlyGoal()).orientation();
         EXPECT_LT(goal_to_dest_angle, goal_to_ball_angle);
     }
     catch (...)

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic_test.cpp
@@ -51,7 +51,7 @@ TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_left_side)
             (move_intent.getDestination() - world.field().friendlyGoal()).orientation();
         EXPECT_GT(goal_to_dest_angle, goal_to_ball_angle);
     }
-    catch (std::bad_cast&)
+    catch (std::bad_cast &)
     {
         ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
     }
@@ -100,7 +100,7 @@ TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_right_side)
             (move_intent.getDestination() - world.field().friendlyGoal()).orientation();
         EXPECT_LT(goal_to_dest_angle, goal_to_ball_angle);
     }
-    catch (std::bad_cast&)
+    catch (std::bad_cast &)
     {
         ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
     }

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic_test.cpp
@@ -1,0 +1,85 @@
+#include "software/ai/hl/stp/tactic/shadow_freekicker_tactic.h"
+
+#include <gtest/gtest.h>
+
+#include "shared/constants.h"
+#include "software/ai/intent/move_intent.h"
+#include "software/test_util/test_util.h"
+#include "software/geom/line.h"
+#include "software/geom/util.h"
+
+TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_left_side)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    world = ::Test::TestUtil::setEnemyRobotPositions(world, {0, Point(world.field().friendlyCornerPos().y(), 0)}, Timestamp::fromSeconds(0));
+    world = ::Test::TestUtil::setBallPosition(world, Point(-0.09, world.field().friendlyCornerPos().y() - 0.09), Timestamp::fromSeconds(0));
+    world = ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
+
+    Robot friendly_robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().updateRobots({friendly_robot});
+
+    ShadowFreekickerTactic tactic = ShadowFreekickerTactic(ShadowFreekickerTactic::LEFT, world.enemyTeam(), world.ball(), world.field(), false);
+    tactic.updateRobot(friendly_robot);
+
+    auto intent_ptr = tactic.getNextIntent();
+
+    ASSERT_TRUE(intent_ptr);
+
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        // The edge of the robot should be slightly more than 0.5m from the ball
+        EXPECT_NEAR((world.ball().position() - move_intent.getDestination()).len(), 0.62, 0.05);
+
+        // The robot should be just to the left of the line between the friendly net and the ball
+        // (from the POV of the friendly net)
+        Line ball_to_net_line = Line(world.ball().position(), world.field().friendlyGoal());
+        EXPECT_NEAR(dist(ball_to_net_line, move_intent.getDestination()), 0.09, 0.01);
+        Angle goal_to_ball_angle = (world.ball().position() - world.field().friendlyGoal()).orientation();
+        Angle goal_to_dest_angle = (move_intent.getDestination() - world.field().friendlyGoal()).orientation();
+        EXPECT_GT(goal_to_dest_angle, goal_to_ball_angle);
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
+    }
+}
+
+TEST(ShadowFreekickerTacticTest, test_shadow_free_kicker_right_side)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    world = ::Test::TestUtil::setEnemyRobotPositions(world, {0, Point(world.field().friendlyCornerPos().y(), 0)}, Timestamp::fromSeconds(0));
+    world = ::Test::TestUtil::setBallPosition(world, Point(-0.09, world.field().friendlyCornerPos().y() - 0.09), Timestamp::fromSeconds(0));
+    world = ::Test::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
+
+    Robot friendly_robot(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().updateRobots({friendly_robot});
+
+    ShadowFreekickerTactic tactic = ShadowFreekickerTactic(ShadowFreekickerTactic::RIGHT, world.enemyTeam(), world.ball(), world.field(), false);
+    tactic.updateRobot(friendly_robot);
+
+    auto intent_ptr = tactic.getNextIntent();
+
+    ASSERT_TRUE(intent_ptr);
+
+    try
+    {
+        MoveIntent move_intent = dynamic_cast<MoveIntent &>(*intent_ptr);
+        // The edge of the robot should be slightly more than 0.5m from the ball
+        EXPECT_NEAR((world.ball().position() - move_intent.getDestination()).len(), 0.62, 0.05);
+
+        // The robot should be just to the right of the line between the friendly net and the ball
+        // (from the POV of the friendly net)
+        Line ball_to_net_line = Line(world.ball().position(), world.field().friendlyGoal());
+        EXPECT_NEAR(dist(ball_to_net_line, move_intent.getDestination()), 0.09, 0.01);
+        Angle goal_to_ball_angle = (world.ball().position() - world.field().friendlyGoal()).orientation();
+        Angle goal_to_dest_angle = (move_intent.getDestination() - world.field().friendlyGoal()).orientation();
+        EXPECT_LT(goal_to_dest_angle, goal_to_ball_angle);
+    }
+    catch (...)
+    {
+        ADD_FAILURE() << "MoveIntent was not returned by the ShootGoalTactic!";
+    }
+}

--- a/src/software/util/parameter/config/ai.yaml
+++ b/src/software/util/parameter/config/ai.yaml
@@ -415,6 +415,15 @@ ShootOrPassPlay:
     default: 6
     type: double
     description: The minimum open angle to the goal that we require before taking a shot
+ShadowFreekickerTactic:
+  robot_separation_scaling_factor:
+    min: 1.0
+    max: 5.0
+    default: 1.1
+    type: double
+    description: >-
+      How much to scale the separation distance between the two robots shadowing
+      an enemy freekicker
 HighLevelStrategy:
   use_shoot_or_pass_instead_of_shoot_or_chip:
     default: true


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Minor changes to the positioning of the ShadowFreeKickerTactic. Also fixed a small bug where the "left" and "right" sides were reversed.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Added a few unit tests. By no means are these a complete test suite but they are something to validate basic behavior for now. Tactics will be fully tested once all RoboCup changes have been ported.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #911 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
