### PR TITLE
RoboCup 2019: Port geometry util

### DIFF
--- a/src/software/geom/util.cpp
+++ b/src/software/geom/util.cpp
@@ -849,16 +849,16 @@ std::pair<std::optional<Point>, std::optional<Point>> raySegmentIntersection(
 }
 
 std::pair<std::optional<Point>, std::optional<Point>> rayRectangleIntersection(
-        const Ray &ray, const Rectangle &rectangle)
+    const Ray &ray, const Rectangle &rectangle)
 {
     std::vector<Segment> rectangle_segments = {
-            Segment(rectangle.posXPosYCorner(), rectangle.negXPosYCorner()),
-            Segment(rectangle.negXPosYCorner(), rectangle.negXNegYCorner()),
-            Segment(rectangle.negXNegYCorner(), rectangle.posXNegYCorner()),
-            Segment(rectangle.posXNegYCorner(), rectangle.posXPosYCorner()),
+        Segment(rectangle.posXPosYCorner(), rectangle.negXPosYCorner()),
+        Segment(rectangle.negXPosYCorner(), rectangle.negXNegYCorner()),
+        Segment(rectangle.negXNegYCorner(), rectangle.posXNegYCorner()),
+        Segment(rectangle.posXNegYCorner(), rectangle.posXPosYCorner()),
     };
     std::pair<std::optional<Point>, std::optional<Point>> result =
-            std::make_pair(std::nullopt, std::nullopt);
+        std::make_pair(std::nullopt, std::nullopt);
     for (const auto &seg : rectangle_segments)
     {
         auto intersection = raySegmentIntersection(ray, seg);

--- a/src/software/geom/util.cpp
+++ b/src/software/geom/util.cpp
@@ -848,6 +848,31 @@ std::pair<std::optional<Point>, std::optional<Point>> raySegmentIntersection(
     }
 }
 
+std::pair<std::optional<Point>, std::optional<Point>> rayRectangleIntersection(
+        const Ray &ray, const Rectangle &rectangle)
+{
+    std::vector<Segment> rectangle_segments = {
+            Segment(rectangle.posXPosYCorner(), rectangle.negXPosYCorner()),
+            Segment(rectangle.negXPosYCorner(), rectangle.negXNegYCorner()),
+            Segment(rectangle.negXNegYCorner(), rectangle.posXNegYCorner()),
+            Segment(rectangle.posXNegYCorner(), rectangle.posXPosYCorner()),
+    };
+    std::pair<std::optional<Point>, std::optional<Point>> result =
+            std::make_pair(std::nullopt, std::nullopt);
+    for (const auto &seg : rectangle_segments)
+    {
+        auto intersection = raySegmentIntersection(ray, seg);
+        // Always take the result with more non-nullopt values
+        if ((intersection.first && !result.first) ||
+            (intersection.second && !result.second))
+        {
+            result = intersection;
+        }
+    }
+
+    return result;
+}
+
 std::optional<Point> getRayIntersection(Ray ray1, Ray ray2)
 {
     // Calculate if the intersecion exists along segments of infinite length

--- a/src/software/geom/util.h
+++ b/src/software/geom/util.h
@@ -375,6 +375,19 @@ std::pair<std::optional<Point>, std::optional<Point>> raySegmentIntersection(
     const Ray &ray, const Segment &segment);
 
 /**
+ * Calculates the intersection of a Ray and Rectangle
+ *
+ * @param ray The ray
+ * @param rectangle The rectangle
+ * @return Returns {std::nullopt, std::nullopt} if no intersections exist.
+ * Returns {Point, std::nullopt} if a single intersection exists.
+ * Returns {Point, Point} if the ray overlaps a segment of the rectangle are overlapping,
+ * where the points define the line segment of overlap.
+ */
+std::pair<std::optional<Point>, std::optional<Point>> rayRectangleIntersection(
+        const Ray &ray, const Rectangle &rectangle);
+
+/**
  * Calculates the intersection of two Rays
  *
  * @param ray1: First Ray

--- a/src/software/geom/util.h
+++ b/src/software/geom/util.h
@@ -381,7 +381,7 @@ std::pair<std::optional<Point>, std::optional<Point>> raySegmentIntersection(
  * @param rectangle The rectangle
  * @return Returns {std::nullopt, std::nullopt} if no intersections exist.
  * Returns {Point, std::nullopt} if a single intersection exists.
- * Returns {Point, Point} if the ray overlaps a segment of the rectangle are overlapping,
+ * Returns {Point, Point} if the ray overlaps a segment of the rectangle,
  * where the points define the line segment of overlap.
  */
 std::pair<std::optional<Point>, std::optional<Point>> rayRectangleIntersection(

--- a/src/software/geom/util.h
+++ b/src/software/geom/util.h
@@ -385,7 +385,7 @@ std::pair<std::optional<Point>, std::optional<Point>> raySegmentIntersection(
  * where the points define the line segment of overlap.
  */
 std::pair<std::optional<Point>, std::optional<Point>> rayRectangleIntersection(
-        const Ray &ray, const Rectangle &rectangle);
+    const Ray &ray, const Rectangle &rectangle);
 
 /**
  * Calculates the intersection of two Rays

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -1355,3 +1355,51 @@ TEST(GeomUtilTest, test_point_polygon_dist_point_far_from_polygon)
 
     EXPECT_DOUBLE_EQ(std::hypot(-5, -5), result);
 }
+
+TEST(GeomUtilTest, test_ray_rectangle_intersection_no_intersection)
+{
+    Ray ray(Point(5, 5), Vector(1, 1));
+    Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
+
+    std::pair<std::optional<Point>, std::optional<Point>> expected_result =
+            std::make_pair(std::nullopt, std::nullopt);
+    auto result = rayRectangleIntersection(ray, rectangle);
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GeomUtilTest, test_ray_rectangle_intersection_ray_start_inside_rectangle_intersects_side)
+{
+    Ray ray(Point(0, 0), Vector(1, 0));
+    Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
+
+    std::pair<std::optional<Point>, std::optional<Point>> expected_result =
+            std::make_pair(Point(1, 0), std::nullopt);
+    auto result = rayRectangleIntersection(ray, rectangle);
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GeomUtilTest, test_ray_rectangle_intersection_ray_start_inside_rectangle_intersects_corner)
+{
+    Ray ray(Point(0, 0), Vector(1, 1));
+    Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
+
+    std::pair<std::optional<Point>, std::optional<Point>> expected_result =
+            std::make_pair(Point(1, 1), std::nullopt);
+    auto result = rayRectangleIntersection(ray, rectangle);
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GeomUtilTest, test_ray_rectangle_intersection_ray_overlaps_rectangle_segment)
+{
+    Ray ray(Point(-2, -1), Vector(1, 0));
+    Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
+
+    std::pair<std::optional<Point>, std::optional<Point>> expected_result =
+            std::make_pair(Point(-1, -1), Point(1, -1));
+    auto result = rayRectangleIntersection(ray, rectangle);
+
+    EXPECT_EQ(result, expected_result);
+}

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -1362,31 +1362,33 @@ TEST(GeomUtilTest, test_ray_rectangle_intersection_no_intersection)
     Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
 
     std::pair<std::optional<Point>, std::optional<Point>> expected_result =
-            std::make_pair(std::nullopt, std::nullopt);
+        std::make_pair(std::nullopt, std::nullopt);
     auto result = rayRectangleIntersection(ray, rectangle);
 
     EXPECT_EQ(result, expected_result);
 }
 
-TEST(GeomUtilTest, test_ray_rectangle_intersection_ray_start_inside_rectangle_intersects_side)
+TEST(GeomUtilTest,
+     test_ray_rectangle_intersection_ray_start_inside_rectangle_intersects_side)
 {
     Ray ray(Point(0, 0), Vector(1, 0));
     Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
 
     std::pair<std::optional<Point>, std::optional<Point>> expected_result =
-            std::make_pair(Point(1, 0), std::nullopt);
+        std::make_pair(Point(1, 0), std::nullopt);
     auto result = rayRectangleIntersection(ray, rectangle);
 
     EXPECT_EQ(result, expected_result);
 }
 
-TEST(GeomUtilTest, test_ray_rectangle_intersection_ray_start_inside_rectangle_intersects_corner)
+TEST(GeomUtilTest,
+     test_ray_rectangle_intersection_ray_start_inside_rectangle_intersects_corner)
 {
     Ray ray(Point(0, 0), Vector(1, 1));
     Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
 
     std::pair<std::optional<Point>, std::optional<Point>> expected_result =
-            std::make_pair(Point(1, 1), std::nullopt);
+        std::make_pair(Point(1, 1), std::nullopt);
     auto result = rayRectangleIntersection(ray, rectangle);
 
     EXPECT_EQ(result, expected_result);
@@ -1398,7 +1400,7 @@ TEST(GeomUtilTest, test_ray_rectangle_intersection_ray_overlaps_rectangle_segmen
     Rectangle rectangle = Rectangle(Point(-1, -1), Point(1, 1));
 
     std::pair<std::optional<Point>, std::optional<Point>> expected_result =
-            std::make_pair(Point(-1, -1), Point(1, -1));
+        std::make_pair(Point(-1, -1), Point(1, -1));
     auto result = rayRectangleIntersection(ray, rectangle);
 
     EXPECT_EQ(result, expected_result);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Added a new geom util function needed for other robocup changes.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Added unit tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #949 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->Mathew/robocup 2019 geom util

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
