### PR TITLE
Properly Default Initialized game_state In GameState

### DIFF
--- a/src/software/backend/input/network/networking/network_client.cpp
+++ b/src/software/backend/input/network/networking/network_client.cpp
@@ -13,13 +13,11 @@ NetworkClient::NetworkClient(std::string vision_multicast_address,
                              int gamecontroller_multicast_port,
                              std::function<void(World)> received_world_callback)
     : network_filter(),
-      world(),
       io_service(),
       last_valid_t_capture(std::numeric_limits<double>::max()),
       initial_packet_count(0),
       received_world_callback(received_world_callback)
 {
-    world.updateRefboxGameState(RefboxGameState::HALT);
     setupVisionClient(vision_multicast_address, vision_multicast_port);
 
     setupGameControllerClient(gamecontroller_multicast_address,

--- a/src/software/backend/input/network/networking/network_client.cpp
+++ b/src/software/backend/input/network/networking/network_client.cpp
@@ -13,11 +13,13 @@ NetworkClient::NetworkClient(std::string vision_multicast_address,
                              int gamecontroller_multicast_port,
                              std::function<void(World)> received_world_callback)
     : network_filter(),
+      world(),
       io_service(),
       last_valid_t_capture(std::numeric_limits<double>::max()),
       initial_packet_count(0),
       received_world_callback(received_world_callback)
 {
+    world.updateRefboxGameState(RefboxGameState::HALT);
     setupVisionClient(vision_multicast_address, vision_multicast_port);
 
     setupGameControllerClient(gamecontroller_multicast_address,

--- a/src/software/world/game_state.cpp
+++ b/src/software/world/game_state.cpp
@@ -155,7 +155,8 @@ void GameState::setBallPlacementPoint(Point placementPoint)
 std::optional<Point> GameState::getBallPlacementPoint() const
 {
     std::optional<Point> opt_ball_placement_point = std::nullopt;
-    if (isSetupRestart()){
+    if (isSetupRestart())
+    {
         opt_ball_placement_point = ball_placement_point;
     }
     return opt_ball_placement_point;

--- a/src/software/world/game_state.cpp
+++ b/src/software/world/game_state.cpp
@@ -73,7 +73,7 @@ bool GameState::isOurFreeKick() const
     return isOurDirectFree() || isOurIndirectFree();
 }
 
-bool GameState::isOurPlacement() const
+bool GameState::isOurBallPlacement() const
 {
     return isBallPlacement() && our_restart;
 }
@@ -93,14 +93,14 @@ bool GameState::isTheirDirectFree() const
     return isDirectFree() && !our_restart;
 }
 
-bool GameState::isTheirIndirect() const
+bool GameState::isTheirIndirectFree() const
 {
     return isIndirectFree() && !our_restart;
 }
 
 bool GameState::isTheirFreeKick() const
 {
-    return isTheirDirectFree() || isTheirIndirect();
+    return isTheirDirectFree() || isTheirIndirectFree();
 }
 
 bool GameState::isTheirBallPlacement() const
@@ -152,9 +152,13 @@ void GameState::setBallPlacementPoint(Point placementPoint)
     ball_placement_point = placementPoint;
 }
 
-Point GameState::getBallPlacementPoint() const
+std::optional<Point> GameState::getBallPlacementPoint() const
 {
-    return ball_placement_point;
+    std::optional<Point> opt_ball_placement_point = std::nullopt;
+    if (isSetupRestart()){
+        opt_ball_placement_point = ball_placement_point;
+    }
+    return opt_ball_placement_point;
 }
 
 // apologies for this monster switch statement

--- a/src/software/world/game_state.h
+++ b/src/software/world/game_state.h
@@ -51,7 +51,7 @@ class GameState
     // Robocup SSL Rules 9.2.
     Point ball_placement_point;
 
-    GameState() : state(HALT), restart_reason(NONE), our_restart(false) {}
+    GameState() : state(HALT), restart_reason(NONE), game_state(RefboxGameState::HALT), our_restart(false) {}
 
     /**
      * Updates the game state with a value from backend_input
@@ -216,7 +216,7 @@ class GameState
      *
      * @return true if we are doing ball placement.
      */
-    bool isOurPlacement() const;
+    bool isOurBallPlacement() const;
 
     /**
      * Returns true if opposing side is doing kickoff.
@@ -246,7 +246,7 @@ class GameState
      *
      * @return true if opposing side is taking an indirect free kick.
      */
-    bool isTheirIndirect() const;
+    bool isTheirIndirectFree() const;
 
     /**
      * Returns true if opposing side is taking any type of free kick.
@@ -326,9 +326,10 @@ class GameState
     void setBallPlacementPoint(Point placementPoint);
 
     /**
-     * Returns the point where the ball should be placed.
+     * Returns the point where the ball should be placed
      *
-     * @return the point where the ball should be placed.
+     * @return the point where the ball should be placed, or std::nullopt if we are not
+     *         in a state of play where the ball needs to be placed
      */
-    Point getBallPlacementPoint() const;
+    std::optional<Point> getBallPlacementPoint() const;
 };

--- a/src/software/world/game_state.h
+++ b/src/software/world/game_state.h
@@ -51,7 +51,13 @@ class GameState
     // Robocup SSL Rules 9.2.
     Point ball_placement_point;
 
-    GameState() : state(HALT), restart_reason(NONE), game_state(RefboxGameState::HALT), our_restart(false) {}
+    GameState()
+        : state(HALT),
+          restart_reason(NONE),
+          game_state(RefboxGameState::HALT),
+          our_restart(false)
+    {
+    }
 
     /**
      * Updates the game state with a value from backend_input

--- a/src/software/world/game_state_test.cpp
+++ b/src/software/world/game_state_test.cpp
@@ -3,6 +3,42 @@
 #include "software/test_util/test_util.h"
 #include "software/world/refbox_constants.h"
 
+TEST(GameStateTest, default_constructor){
+    GameState game_state;
+
+    EXPECT_EQ(RefboxGameState::HALT, game_state.getRefboxGameState());
+    EXPECT_EQ(GameState::RestartReason::NONE, game_state.getRestartReason());
+    EXPECT_FALSE(game_state.isOurRestart());
+
+    EXPECT_TRUE(game_state.isHalted());
+    EXPECT_FALSE(game_state.isStopped());
+    EXPECT_FALSE(game_state.isPlaying());
+    EXPECT_FALSE(game_state.isKickoff());
+    EXPECT_FALSE(game_state.isPenalty());
+    EXPECT_FALSE(game_state.isBallPlacement());
+    EXPECT_FALSE(game_state.isOurRestart());
+    EXPECT_FALSE(game_state.isDirectFree());
+    EXPECT_FALSE(game_state.isIndirectFree());
+    EXPECT_FALSE(game_state.isOurKickoff());
+    EXPECT_FALSE(game_state.isOurPenalty());
+    EXPECT_FALSE(game_state.isOurDirectFree());
+    EXPECT_FALSE(game_state.isOurIndirectFree());
+    EXPECT_FALSE(game_state.isOurFreeKick());
+    EXPECT_FALSE(game_state.isOurBallPlacement());
+    EXPECT_FALSE(game_state.isTheirKickoff());
+    EXPECT_FALSE(game_state.isTheirPenalty());
+    EXPECT_FALSE(game_state.isTheirDirectFree());
+    EXPECT_FALSE(game_state.isTheirIndirectFree());
+    EXPECT_FALSE(game_state.isTheirFreeKick());
+    EXPECT_FALSE(game_state.isTheirBallPlacement());
+    EXPECT_FALSE(game_state.isSetupRestart());
+    EXPECT_FALSE(game_state.isReadyState());
+    EXPECT_FALSE(game_state.canKick());
+    EXPECT_TRUE(game_state.stayAwayFromBall());
+    EXPECT_FALSE(game_state.stayOnSide());
+    EXPECT_FALSE(game_state.stayBehindPenaltyLine());
+}
+
 // tuple of start state, update state, end state, our_restart, restart reason
 typedef std::tuple<RefboxGameState, RefboxGameState, RefboxGameState, bool,
                    GameState::RestartReason>
@@ -186,7 +222,7 @@ PREDICATE_TEST(isOurKickoff, RefboxGameState::PREPARE_KICKOFF_US)
 PREDICATE_TEST(isOurPenalty, RefboxGameState::PREPARE_PENALTY_US)
 PREDICATE_TEST(isOurDirectFree, RefboxGameState::DIRECT_FREE_US)
 PREDICATE_TEST(isOurIndirectFree, RefboxGameState::INDIRECT_FREE_US)
-PREDICATE_TEST(isOurPlacement, RefboxGameState::BALL_PLACEMENT_US)
+PREDICATE_TEST(isOurBallPlacement, RefboxGameState::BALL_PLACEMENT_US)
 PREDICATE_TEST(isOurFreeKick, RefboxGameState::DIRECT_FREE_US,
                RefboxGameState::INDIRECT_FREE_US)
 PREDICATE_TEST(isTheirKickoff, RefboxGameState::PREPARE_KICKOFF_THEM)

--- a/src/software/world/game_state_test.cpp
+++ b/src/software/world/game_state_test.cpp
@@ -3,7 +3,8 @@
 #include "software/test_util/test_util.h"
 #include "software/world/refbox_constants.h"
 
-TEST(GameStateTest, default_constructor){
+TEST(GameStateTest, default_constructor)
+{
     GameState game_state;
 
     EXPECT_EQ(RefboxGameState::HALT, game_state.getRefboxGameState());


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
- properly initialized `game_state` in `GameState` so that we don't get garbage values if we try to read it before calling `updateRefboxGameState`
- added a test for default construction of the `GameState` class
- tweaked some naming to be a bit more consistent

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Added unit test, confirmed #951 is resolved.

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #951

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
