### PR TITLE
RoboCup Changes: Port KickoffFriendlyPlay

### DIFF
--- a/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
+++ b/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
@@ -16,12 +16,14 @@ std::string KickoffFriendlyPlay::getName() const
 bool KickoffFriendlyPlay::isApplicable(const World &world) const
 {
     return ((world.gameState().isReadyState() || world.gameState().isSetupState()) &&
-           world.gameState().isOurKickoff()) && !world.gameState().isHalted() && !world.gameState().isStopped();
+            world.gameState().isOurKickoff()) &&
+           !world.gameState().isHalted() && !world.gameState().isStopped();
 }
 
 bool KickoffFriendlyPlay::invariantHolds(const World &world) const
 {
-    return (!world.gameState().isPlaying() || world.gameState().isHalted() || world.gameState().isStopped());
+    return (!world.gameState().isPlaying() || world.gameState().isHalted() ||
+            world.gameState().isStopped());
 }
 
 void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)

--- a/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
+++ b/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
@@ -15,13 +15,13 @@ std::string KickoffFriendlyPlay::getName() const
 
 bool KickoffFriendlyPlay::isApplicable(const World &world) const
 {
-    return (world.gameState().isReadyState() || world.gameState().isSetupState()) &&
-           world.gameState().isOurKickoff();
+    return ((world.gameState().isReadyState() || world.gameState().isSetupState()) &&
+           world.gameState().isOurKickoff()) && !world.gameState().isHalted() && !world.gameState().isStopped();
 }
 
 bool KickoffFriendlyPlay::invariantHolds(const World &world) const
 {
-    return !world.gameState().isPlaying();
+    return (!world.gameState().isPlaying() || world.gameState().isHalted() || world.gameState().isStopped());
 }
 
 void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
@@ -89,6 +89,10 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         world.ball(), world.field(), world.friendlyTeam(), world.enemyTeam());
     auto chip_tactic = std::make_shared<ChipTactic>(world.ball(), true);
 
+    // the chipper is allowed to go into the centre circle and touch the ball
+    chip_tactic->addWhitelistedAvoidArea(AvoidArea::CENTER_CIRCLE);
+    chip_tactic->addWhitelistedAvoidArea(AvoidArea::HALF_METER_AROUND_BALL);
+
     // Part 1: setup state (move to key positions)
     while (world.gameState().isSetupState())
     {
@@ -107,7 +111,7 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         for (unsigned i = 0; i < kickoff_setup_positions.size(); i++)
         {
             move_tactics.at(i)->updateControlParams(kickoff_setup_positions.at(i),
-                                                    Angle::half(), 0);
+                                                    Angle::zero(), 0);
             result.emplace_back(move_tactics.at(i));
         }
 
@@ -129,8 +133,8 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         // in the middle of the enemy field
         chip_tactic->updateWorldParams(world.ball());
         chip_tactic->updateControlParams(
-            world.field().centerPoint(),
-            world.field().centerPoint() + Point(world.field().xLength() / 4, 0),
+            world.ball().position(),
+            world.field().centerPoint() + Point(world.field().xLength() / 6, 0),
             world.field().xLength() / 2);
         result.emplace_back(chip_tactic);
 
@@ -139,7 +143,7 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         for (unsigned i = 1; i < kickoff_setup_positions.size(); i++)
         {
             move_tactics.at(i)->updateControlParams(kickoff_setup_positions.at(i),
-                                                    Angle::half(), 0);
+                                                    Angle::zero(), 0);
             result.emplace_back(move_tactics.at(i));
         }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Ported changes to the KickoffFriendlyPlay made at RoboCup 2019

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
None. All plays will be tested when the new simulator is done.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #894 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
