### PR TITLE
RoboCup Changes: Port PenaltyKickPlay

### DIFF
--- a/src/software/ai/hl/stp/play/penalty_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play.cpp
@@ -15,7 +15,7 @@ std::string PenaltyKickPlay::getName() const
 bool PenaltyKickPlay::isApplicable(const World &world) const
 {
     return (world.gameState().isReadyState() || world.gameState().isSetupState()) &&
-           world.gameState().isOurPenalty();
+            (world.gameState().isOurPenalty());
 }
 
 bool PenaltyKickPlay::invariantHolds(const World &world) const

--- a/src/software/ai/hl/stp/play/penalty_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play.cpp
@@ -43,18 +43,23 @@ void PenaltyKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
 
     auto move_tactic_2 = std::make_shared<MoveTactic>(true);
     move_tactic_2->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    // TODO: Remove the FRIENDLY_HALF whitelist once ticket #980 is complete
     move_tactic_2->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
     auto move_tactic_3 = std::make_shared<MoveTactic>(true);
     move_tactic_3->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    // TODO: Remove the FRIENDLY_HALF whitelist once ticket #980 is complete
     move_tactic_3->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
     auto move_tactic_4 = std::make_shared<MoveTactic>(true);
     move_tactic_4->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    // TODO: Remove the FRIENDLY_HALF whitelist once ticket #980 is complete
     move_tactic_4->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
     auto move_tactic_5 = std::make_shared<MoveTactic>(true);
     move_tactic_5->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    // TODO: Remove the FRIENDLY_HALF whitelist once ticket #980 is complete
     move_tactic_5->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
     auto move_tactic_6 = std::make_shared<MoveTactic>(true);
     move_tactic_6->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    // TODO: Remove the FRIENDLY_HALF whitelist once ticket #980 is complete
     move_tactic_6->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
 
     do

--- a/src/software/ai/hl/stp/play/penalty_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play.cpp
@@ -14,12 +14,14 @@ std::string PenaltyKickPlay::getName() const
 
 bool PenaltyKickPlay::isApplicable(const World &world) const
 {
-    return (world.gameState().isReadyState() || world.gameState().isSetupState()) && world.gameState().isOurPenalty();
+    return (world.gameState().isReadyState() || world.gameState().isSetupState()) &&
+           world.gameState().isOurPenalty();
 }
 
 bool PenaltyKickPlay::invariantHolds(const World &world) const
 {
-    return world.gameState().isOurPenalty() && !world.gameState().isStopped() && !world.gameState().isHalted();
+    return world.gameState().isOurPenalty() && !world.gameState().isStopped() &&
+           !world.gameState().isHalted();
 }
 
 void PenaltyKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
@@ -59,10 +61,14 @@ void PenaltyKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     {
         std::vector<std::shared_ptr<Tactic>> tactics_to_run;
 
-        Vector behind_ball_direction = (world.ball().position() - world.field().enemyGoalpostPos()).norm();
-        Angle shoot_angle = (world.field().enemyGoalpostPos() -  world.ball().position()).orientation();
+        Vector behind_ball_direction =
+            (world.ball().position() - world.field().enemyGoalpostPos()).norm();
+        Angle shoot_angle =
+            (world.field().enemyGoalpostPos() - world.ball().position()).orientation();
 
-        Point behind_ball = world.ball().position() + behind_ball_direction.norm(DIST_TO_FRONT_OF_ROBOT_METERS + BALL_MAX_RADIUS_METERS + 0.1);
+        Point behind_ball = world.ball().position() +
+                            behind_ball_direction.norm(DIST_TO_FRONT_OF_ROBOT_METERS +
+                                                       BALL_MAX_RADIUS_METERS + 0.1);
 
         // Move all non-shooter robots to the center of the field
         move_tactic_2->updateControlParams(Point(0, 0),
@@ -76,14 +82,17 @@ void PenaltyKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
         move_tactic_6->updateControlParams(Point(0, -8 * ROBOT_MAX_RADIUS_METERS),
                                            world.field().enemyGoal().orientation(), 0);
 
-        penalty_shot_tactic->updateWorldParams(world.ball(), world.enemyTeam().goalie(), world.field());
+        penalty_shot_tactic->updateWorldParams(world.ball(), world.enemyTeam().goalie(),
+                                               world.field());
         shooter_setup_move->updateControlParams(behind_ball, shoot_angle, 0.0);
 
         // If we are setting up for penalty kick, move our robots to position
-        if(world.gameState().isSetupState()) {
+        if (world.gameState().isSetupState())
+        {
             tactics_to_run.emplace_back(shooter_setup_move);
         }
-        else if(world.gameState().isOurPenalty() ) {
+        else if (world.gameState().isOurPenalty())
+        {
             tactics_to_run.emplace_back(penalty_shot_tactic);
         }
         // Move all non-shooter robots to the center of the field

--- a/src/software/ai/hl/stp/play/penalty_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play.cpp
@@ -15,7 +15,7 @@ std::string PenaltyKickPlay::getName() const
 bool PenaltyKickPlay::isApplicable(const World &world) const
 {
     return (world.gameState().isReadyState() || world.gameState().isSetupState()) &&
-            (world.gameState().isOurPenalty());
+           world.gameState().isOurPenalty();
 }
 
 bool PenaltyKickPlay::invariantHolds(const World &world) const

--- a/src/software/ai/hl/stp/play/penalty_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play.cpp
@@ -14,26 +14,12 @@ std::string PenaltyKickPlay::getName() const
 
 bool PenaltyKickPlay::isApplicable(const World &world) const
 {
-    if (world.gameState().isOurPenalty())
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return (world.gameState().isReadyState() || world.gameState().isSetupState()) && world.gameState().isOurPenalty();
 }
 
 bool PenaltyKickPlay::invariantHolds(const World &world) const
 {
-    if (world.gameState().isOurPenalty())
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return world.gameState().isOurPenalty() && !world.gameState().isStopped() && !world.gameState().isHalted();
 }
 
 void PenaltyKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
@@ -41,17 +27,42 @@ void PenaltyKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     auto penalty_shot_tactic = std::make_shared<PenaltyKickTactic>(
         world.ball(), world.field(), world.enemyTeam().goalie(), true);
 
+    penalty_shot_tactic->addWhitelistedAvoidArea(AvoidArea::BALL);
+    penalty_shot_tactic->addWhitelistedAvoidArea(AvoidArea::HALF_METER_AROUND_BALL);
+    penalty_shot_tactic->addWhitelistedAvoidArea(AvoidArea::ENEMY_DEFENSE_AREA);
+    penalty_shot_tactic->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+
+    auto shooter_setup_move = std::make_shared<MoveTactic>(true);
+
+    shooter_setup_move->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    shooter_setup_move->addWhitelistedAvoidArea(AvoidArea::ENEMY_DEFENSE_AREA);
+    shooter_setup_move->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    shooter_setup_move->addWhitelistedAvoidArea(AvoidArea::HALF_METER_AROUND_BALL);
+
     auto move_tactic_2 = std::make_shared<MoveTactic>(true);
+    move_tactic_2->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    move_tactic_2->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
     auto move_tactic_3 = std::make_shared<MoveTactic>(true);
+    move_tactic_3->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    move_tactic_3->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
     auto move_tactic_4 = std::make_shared<MoveTactic>(true);
+    move_tactic_4->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    move_tactic_4->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
     auto move_tactic_5 = std::make_shared<MoveTactic>(true);
+    move_tactic_5->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    move_tactic_5->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
     auto move_tactic_6 = std::make_shared<MoveTactic>(true);
+    move_tactic_6->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
+    move_tactic_6->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
 
     do
     {
-        // Assign one robot to be the penalty shooter
-        penalty_shot_tactic->updateWorldParams(world.ball(), world.enemyTeam().goalie(),
-                                               world.field());
+        std::vector<std::shared_ptr<Tactic>> tactics_to_run;
+
+        Vector behind_ball_direction = (world.ball().position() - world.field().enemyGoalpostPos()).norm();
+        Angle shoot_angle = (world.field().enemyGoalpostPos() -  world.ball().position()).orientation();
+
+        Point behind_ball = world.ball().position() + behind_ball_direction.norm(DIST_TO_FRONT_OF_ROBOT_METERS + BALL_MAX_RADIUS_METERS + 0.1);
 
         // Move all non-shooter robots to the center of the field
         move_tactic_2->updateControlParams(Point(0, 0),
@@ -65,9 +76,26 @@ void PenaltyKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
         move_tactic_6->updateControlParams(Point(0, -8 * ROBOT_MAX_RADIUS_METERS),
                                            world.field().enemyGoal().orientation(), 0);
 
+        penalty_shot_tactic->updateWorldParams(world.ball(), world.enemyTeam().goalie(), world.field());
+        shooter_setup_move->updateControlParams(behind_ball, shoot_angle, 0.0);
+
+        // If we are setting up for penalty kick, move our robots to position
+        if(world.gameState().isSetupState()) {
+            tactics_to_run.emplace_back(shooter_setup_move);
+        }
+        else if(world.gameState().isOurPenalty() ) {
+            tactics_to_run.emplace_back(penalty_shot_tactic);
+        }
+        // Move all non-shooter robots to the center of the field
+
+        tactics_to_run.emplace_back(move_tactic_2);
+        tactics_to_run.emplace_back(move_tactic_3);
+        tactics_to_run.emplace_back(move_tactic_4);
+        tactics_to_run.emplace_back(move_tactic_5);
+        tactics_to_run.emplace_back(move_tactic_6);
+
         // yield the Tactics this Play wants to run, in order of priority
-        yield({penalty_shot_tactic, move_tactic_2, move_tactic_3, move_tactic_4,
-               move_tactic_5, move_tactic_6});
+        yield(tactics_to_run);
     } while (true);
 }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Ported the changes made to the PenaltyKickPlay from RoboCup 2019

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
None. Plays will be tested when the new simulator is done.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #895 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
