### PR TITLE
RoboCup Changes: Port PenaltyKickEnemyChanges

### DIFF
--- a/src/software/ai/hl/stp/play/penalty_kick_enemy_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_enemy_play.cpp
@@ -33,18 +33,23 @@ void PenaltyKickEnemyPlay::getNextTactics(TacticCoroutine::push_type &yield)
 
     auto move_tactic_2 = std::make_shared<MoveTactic>(true);
     move_tactic_2->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    // TODO: Remove the ENEMY_HALF whitelist once ticket #980 is complete
     move_tactic_2->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
     auto move_tactic_3 = std::make_shared<MoveTactic>(true);
     move_tactic_3->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    // TODO: Remove the ENEMY_HALF whitelist once ticket #980 is complete
     move_tactic_3->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
     auto move_tactic_4 = std::make_shared<MoveTactic>(true);
     move_tactic_4->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    // TODO: Remove the ENEMY_HALF whitelist once ticket #980 is complete
     move_tactic_4->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
     auto move_tactic_5 = std::make_shared<MoveTactic>(true);
     move_tactic_5->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    // TODO: Remove the ENEMY_HALF whitelist once ticket #980 is complete
     move_tactic_5->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
     auto move_tactic_6 = std::make_shared<MoveTactic>(true);
     move_tactic_6->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    // TODO: Remove the ENEMY_HALF whitelist once ticket #980 is complete
     move_tactic_6->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
 
     do

--- a/src/software/ai/hl/stp/play/penalty_kick_enemy_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_enemy_play.cpp
@@ -19,7 +19,8 @@ bool PenaltyKickEnemyPlay::isApplicable(const World &world) const
 
 bool PenaltyKickEnemyPlay::invariantHolds(const World &world) const
 {
-    return world.gameState().isTheirPenalty() && !world.gameState().isStopped() && !world.gameState().isHalted();
+    return world.gameState().isTheirPenalty() && !world.gameState().isStopped() &&
+           !world.gameState().isHalted();
 }
 
 void PenaltyKickEnemyPlay::getNextTactics(TacticCoroutine::push_type &yield)

--- a/src/software/ai/hl/stp/play/penalty_kick_enemy_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_enemy_play.cpp
@@ -19,19 +19,32 @@ bool PenaltyKickEnemyPlay::isApplicable(const World &world) const
 
 bool PenaltyKickEnemyPlay::invariantHolds(const World &world) const
 {
-    return world.gameState().isTheirPenalty();
+    return world.gameState().isTheirPenalty() && !world.gameState().isStopped() && !world.gameState().isHalted();
 }
 
 void PenaltyKickEnemyPlay::getNextTactics(TacticCoroutine::push_type &yield)
 {
     auto goalie_tactic = std::make_shared<GoalieTactic>(
         world.ball(), world.field(), world.friendlyTeam(), world.enemyTeam());
+    goalie_tactic->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    goalie_tactic->addWhitelistedAvoidArea(AvoidArea::BALL);
+    goalie_tactic->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_DEFENSE_AREA);
 
     auto move_tactic_2 = std::make_shared<MoveTactic>(true);
+    move_tactic_2->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    move_tactic_2->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
     auto move_tactic_3 = std::make_shared<MoveTactic>(true);
+    move_tactic_3->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    move_tactic_3->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
     auto move_tactic_4 = std::make_shared<MoveTactic>(true);
+    move_tactic_4->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    move_tactic_4->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
     auto move_tactic_5 = std::make_shared<MoveTactic>(true);
+    move_tactic_5->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    move_tactic_5->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
     auto move_tactic_6 = std::make_shared<MoveTactic>(true);
+    move_tactic_6->addWhitelistedAvoidArea(AvoidArea::FRIENDLY_HALF);
+    move_tactic_6->addWhitelistedAvoidArea(AvoidArea::ENEMY_HALF);
 
     do
     {


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Ported the changes made to the PenaltyKickEnemyPlay at RoboCup 2019

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
None. All Plays will be tested when the new simulator is done.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #975 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
