### PR TITLE
RoboCup Changes: Port ShootOrChipPlay

### DIFF
--- a/src/software/ai/hl/stp/play/shoot_or_chip_play.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_chip_play.cpp
@@ -67,9 +67,16 @@ void ShootOrChipPlay::getNextTactics(TacticCoroutine::push_type &yield)
     std::array<std::shared_ptr<MoveTactic>, 2> move_to_open_area_tactics = {
         std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true)};
 
+    // Figure out where the fallback chip target is
+    double fallback_chip_target_x_offset =
+            Util::DynamicParameters::ShootOrChipPlay::fallback_chip_target_enemy_goal_offset.value();
+
+    Point fallback_chip_target =
+            world.field().enemyGoal() - Vector(fallback_chip_target_x_offset, 0);
+
     auto shoot_or_chip_tactic = std::make_shared<ShootGoalTactic>(
         world.field(), world.friendlyTeam(), world.enemyTeam(), world.ball(),
-        MIN_OPEN_ANGLE_FOR_SHOT, std::nullopt, false);
+        MIN_OPEN_ANGLE_FOR_SHOT, fallback_chip_target, false);
 
     do
     {
@@ -128,6 +135,9 @@ void ShootOrChipPlay::getNextTactics(TacticCoroutine::push_type &yield)
         shoot_or_chip_tactic->updateWorldParams(world.field(), world.friendlyTeam(),
                                                 world.enemyTeam(), world.ball());
         shoot_or_chip_tactic->updateControlParams(chip_target);
+
+        shoot_or_chip_tactic->addWhitelistedAvoidArea(AvoidArea::BALL);
+        shoot_or_chip_tactic->addWhitelistedAvoidArea(AvoidArea::HALF_METER_AROUND_BALL);
 
         // We want this second in priority only to the goalie
         result.insert(result.begin() + 1, shoot_or_chip_tactic);

--- a/src/software/ai/hl/stp/play/shoot_or_chip_play.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_chip_play.cpp
@@ -69,10 +69,11 @@ void ShootOrChipPlay::getNextTactics(TacticCoroutine::push_type &yield)
 
     // Figure out where the fallback chip target is
     double fallback_chip_target_x_offset =
-            Util::DynamicParameters::ShootOrChipPlay::fallback_chip_target_enemy_goal_offset.value();
+        Util::DynamicParameters::ShootOrChipPlay::fallback_chip_target_enemy_goal_offset
+            .value();
 
     Point fallback_chip_target =
-            world.field().enemyGoal() - Vector(fallback_chip_target_x_offset, 0);
+        world.field().enemyGoal() - Vector(fallback_chip_target_x_offset, 0);
 
     auto shoot_or_chip_tactic = std::make_shared<ShootGoalTactic>(
         world.field(), world.friendlyTeam(), world.enemyTeam(), world.ball(),


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Ported the changes made to the ShootOrChipPlay from RoboCup 2019

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
None. All Plays will be tested with the new simulator

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->
resolves #897 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
