### PR TITLE
Added Minimum Bounds On Max Navigable Coords In ThetaStarPathPlanner

### DIFF
--- a/src/software/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/software/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -7,6 +7,14 @@
 
 #include <g3log/g3log.hpp>
 
+ThetaStarPathPlanner::ThetaStarPathPlanner()
+    : num_grid_rows(0),
+      num_grid_cols(0),
+      max_navigable_x_coord(0),
+      max_navigable_y_coord(0)
+{
+}
+
 bool ThetaStarPathPlanner::isCoordValid(Coordinate test_coord)
 {
     // Returns true if row number and column number
@@ -486,8 +494,10 @@ void ThetaStarPathPlanner::resetAndInitializeMemberVariables(
 {
     // Initialize member variables
     this->obstacles       = obstacles;
-    max_navigable_x_coord = navigable_area.xLength() / 2.0 - ROBOT_MAX_RADIUS_METERS;
-    max_navigable_y_coord = navigable_area.yLength() / 2.0 - ROBOT_MAX_RADIUS_METERS;
+    max_navigable_x_coord =
+        std::max(navigable_area.xLength() / 2.0 - ROBOT_MAX_RADIUS_METERS, 0.0);
+    max_navigable_y_coord =
+        std::max(navigable_area.yLength() / 2.0 - ROBOT_MAX_RADIUS_METERS, 0.0);
     num_grid_rows =
         static_cast<int>((max_navigable_x_coord * 2.0 + ROBOT_MAX_RADIUS_METERS) /
                          SIZE_OF_GRID_CELL_IN_METERS);

--- a/src/software/ai/navigator/path_planner/theta_star_path_planner.h
+++ b/src/software/ai/navigator/path_planner/theta_star_path_planner.h
@@ -13,6 +13,8 @@
 class ThetaStarPathPlanner : public PathPlanner
 {
    public:
+    ThetaStarPathPlanner();
+
     /**
      * Returns a path that is an optimized path between start and destination.
      *

--- a/src/software/ai/navigator/path_planner/theta_star_path_planner_test.cpp
+++ b/src/software/ai/navigator/path_planner/theta_star_path_planner_test.cpp
@@ -226,6 +226,18 @@ TEST(TestThetaStarPathPlanner, test_theta_star_path_planner_same_cell_dest)
     EXPECT_EQ(dest, path->endPoint());
 }
 
+TEST(TestThetaStarPathPlanner, no_navigable_area)
+{
+    // Test running theta star with no area to navigate in
+    Point start{-1.0, -1.0}, dest{1.0, 1.0};
+
+    std::vector<Obstacle> obstacles = std::vector<Obstacle>();
+    Rectangle navigable_area({0, 0}, {0, 0});
+    auto path = ThetaStarPathPlanner().findPath(start, dest, navigable_area, obstacles);
+
+    EXPECT_EQ(std::nullopt, path);
+}
+
 TEST(TestThetaStarPathPlanner, performance)
 {
     // This test can be used to guage performance, and profiled to find areas for


### PR DESCRIPTION
Added a lower bound on `max_navigable_x_coord` and
`max_navigable_y_coord` in the `ThetaStarPathPlanner` class to prevent
initialization of the cell heuristic 2D grid with negative sizes.

<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Added a unit test for this specific case.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
