### PR TITLE
Remove control of ball collision avoidance from plays

### DIFF
--- a/src/software/ai/hl/stp/play/corner_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/corner_kick_play.cpp
@@ -122,12 +122,10 @@ void CornerKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     auto bait_move_tactic_2 = std::make_shared<MoveTactic>(true);
     bait_move_tactic_1->updateControlParams(
         bait_move_tactic_1_pos,
-        (world.field().enemyGoal() - bait_move_tactic_1_pos).orientation(), 0.0,
-        BallCollisionType::AVOID);
+        (world.field().enemyGoal() - bait_move_tactic_1_pos).orientation(), 0.0);
     bait_move_tactic_2->updateControlParams(
         bait_move_tactic_2_pos,
-        (world.field().enemyGoal() - bait_move_tactic_2_pos).orientation(), 0.0,
-        BallCollisionType::AVOID);
+        (world.field().enemyGoal() - bait_move_tactic_2_pos).orientation(), 0.0);
 
     PassGenerator pass_generator(world, world.ball().position(),
                                  PassType::ONE_TOUCH_SHOT);
@@ -143,7 +141,7 @@ void CornerKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     while (!align_to_ball_tactic->getAssignedRobot())
     {
         LOG(DEBUG) << "Nothing assigned to align to ball yet";
-        updateAlignToBallTactic(align_to_ball_tactic, BallCollisionType::AVOID);
+        updateAlignToBallTactic(align_to_ball_tactic);
         updateCherryPickTactics({cherry_pick_tactic_pos_y, cherry_pick_tactic_neg_y});
         updatePassGenerator(pass_generator);
         goalie_tactic->updateWorldParams(world.ball(), world.field(),
@@ -163,7 +161,7 @@ void CornerKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     LOG(DEBUG) << "Aligning to ball";
     do
     {
-        updateAlignToBallTactic(align_to_ball_tactic, BallCollisionType::AVOID);
+        updateAlignToBallTactic(align_to_ball_tactic);
         updateCherryPickTactics({cherry_pick_tactic_pos_y, cherry_pick_tactic_neg_y});
         updatePassGenerator(pass_generator);
         goalie_tactic->updateWorldParams(world.ball(), world.field(),
@@ -182,7 +180,7 @@ void CornerKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     Timestamp commit_stage_start_time = world.getMostRecentTimestamp();
     do
     {
-        updateAlignToBallTactic(align_to_ball_tactic, BallCollisionType::AVOID);
+        updateAlignToBallTactic(align_to_ball_tactic);
         updateCherryPickTactics({cherry_pick_tactic_pos_y, cherry_pick_tactic_neg_y});
         updatePassGenerator(pass_generator);
         goalie_tactic->updateWorldParams(world.ball(), world.field(),
@@ -242,8 +240,7 @@ void CornerKickPlay::updateCherryPickTactics(
 }
 
 void CornerKickPlay::updateAlignToBallTactic(
-    std::shared_ptr<MoveTactic> align_to_ball_tactic,
-    BallCollisionType ball_collision_type)
+    std::shared_ptr<MoveTactic> align_to_ball_tactic)
 {
     Vector ball_to_center_vec = Vector(0, 0) - world.ball().position().toVector();
     // We want the kicker to get into position behind the ball facing the center
@@ -251,7 +248,7 @@ void CornerKickPlay::updateAlignToBallTactic(
     align_to_ball_tactic->updateControlParams(
         world.ball().position() -
             (ball_to_center_vec.normalize(ROBOT_MAX_RADIUS_METERS * 2)),
-        ball_to_center_vec.orientation(), 0, ball_collision_type);
+        ball_to_center_vec.orientation(), 0);
 }
 
 void CornerKickPlay::updatePassGenerator(PassGenerator &pass_generator)

--- a/src/software/ai/hl/stp/play/corner_kick_play.h
+++ b/src/software/ai/hl/stp/play/corner_kick_play.h
@@ -40,10 +40,8 @@ class CornerKickPlay : public Play
      * Update the tactic that aligns the robot to the ball in preperation to pass
      *
      * @param align_to_ball_tactic
-     * @param ball_collision_type controls how robot navigates around abll
      */
-    void updateAlignToBallTactic(std::shared_ptr<MoveTactic> align_to_ball_tactic,
-                                 BallCollisionType ball_collision_type);
+    void updateAlignToBallTactic(std::shared_ptr<MoveTactic> align_to_ball_tactic);
 
     /**
      * Updates the pass generator

--- a/src/software/ai/hl/stp/play/defense_play.cpp
+++ b/src/software/ai/hl/stp/play/defense_play.cpp
@@ -144,8 +144,7 @@ void DefensePlay::getNextTactics(TacticCoroutine::push_type &yield)
                     Vector::createFromAngle(nearest_enemy_robot->orientation()) *
                         ROBOT_MAX_RADIUS_METERS * 3;
                 move_tactics[1]->updateControlParams(
-                    block_point, nearest_enemy_robot->orientation() + Angle::half(), 0.0,
-                    BallCollisionType::AVOID);
+                    block_point, nearest_enemy_robot->orientation() + Angle::half(), 0.0);
                 result.emplace_back(move_tactics[1]);
             }
             else
@@ -171,11 +170,9 @@ std::vector<std::shared_ptr<MoveTactic>> DefensePlay::moveRobotsToSwarmEnemyWith
                             Vector::createFromAngle(nearest_enemy_robot->orientation()) *
                                 ROBOT_MAX_RADIUS_METERS * 3;
         move_tactics[0]->updateControlParams(
-            block_point, nearest_enemy_robot->orientation() + Angle::half(), 0.0,
-            BallCollisionType::AVOID);
+            block_point, nearest_enemy_robot->orientation() + Angle::half(), 0.0);
         move_tactics[1]->updateControlParams(
-            block_point, nearest_enemy_robot->orientation() + Angle::half(), 0.0,
-            BallCollisionType::AVOID);
+            block_point, nearest_enemy_robot->orientation() + Angle::half(), 0.0);
         return move_tactics;
     }
     else

--- a/src/software/ai/hl/stp/play/enemy_freekick_play.cpp
+++ b/src/software/ai/hl/stp/play/enemy_freekick_play.cpp
@@ -105,12 +105,12 @@ void EnemyFreekickPlay::getNextTactics(TacticCoroutine::push_type &yield)
         {
             move_tactic_main->updateControlParams(
                 world.field().friendlyGoal() + Vector(0, 2 * ROBOT_MAX_RADIUS_METERS),
-                (world.ball().position() - world.field().friendlyGoal()).orientation(), 0,
-                BallCollisionType::AVOID);
+                (world.ball().position() - world.field().friendlyGoal()).orientation(),
+                0);
             move_tactic_main->updateControlParams(
                 world.field().friendlyGoal() + Vector(0, -2 * ROBOT_MAX_RADIUS_METERS),
-                (world.ball().position() - world.field().friendlyGoal()).orientation(), 0,
-                BallCollisionType::AVOID);
+                (world.ball().position() - world.field().friendlyGoal()).orientation(),
+                0);
 
             tactics_to_run.emplace_back(move_tactic_main);
             tactics_to_run.emplace_back(move_tactic_secondary);
@@ -123,8 +123,8 @@ void EnemyFreekickPlay::getNextTactics(TacticCoroutine::push_type &yield)
                                                     ROBOT_MAX_RADIUS_METERS * 3);
             move_tactic_main->updateControlParams(
                 world.field().friendlyGoal() + Vector(0, 2 * ROBOT_MAX_RADIUS_METERS),
-                (world.ball().position() - world.field().friendlyGoal()).orientation(), 0,
-                BallCollisionType::AVOID);
+                (world.ball().position() - world.field().friendlyGoal()).orientation(),
+                0);
 
             tactics_to_run.emplace_back(shadow_tactic_main);
             tactics_to_run.emplace_back(move_tactic_main);

--- a/src/software/ai/hl/stp/play/example_play.cpp
+++ b/src/software/ai/hl/stp/play/example_play.cpp
@@ -41,22 +41,22 @@ void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield)
         // Move the robots in a circle around the ball, facing the ball
         move_tactic_1->updateControlParams(
             world.ball().position() + Vector::createFromAngle(angle_between_robots * 1),
-            (angle_between_robots * 1) + Angle::half(), 0, BallCollisionType::AVOID);
+            (angle_between_robots * 1) + Angle::half(), 0);
         move_tactic_2->updateControlParams(
             world.ball().position() + Vector::createFromAngle(angle_between_robots * 2),
-            (angle_between_robots * 2) + Angle::half(), 0, BallCollisionType::AVOID);
+            (angle_between_robots * 2) + Angle::half(), 0);
         move_tactic_3->updateControlParams(
             world.ball().position() + Vector::createFromAngle(angle_between_robots * 3),
-            (angle_between_robots * 3) + Angle::half(), 0, BallCollisionType::AVOID);
+            (angle_between_robots * 3) + Angle::half(), 0);
         move_tactic_4->updateControlParams(
             world.ball().position() + Vector::createFromAngle(angle_between_robots * 4),
-            (angle_between_robots * 4) + Angle::half(), 0, BallCollisionType::AVOID);
+            (angle_between_robots * 4) + Angle::half(), 0);
         move_tactic_5->updateControlParams(
             world.ball().position() + Vector::createFromAngle(angle_between_robots * 5),
-            (angle_between_robots * 5) + Angle::half(), 0, BallCollisionType::AVOID);
+            (angle_between_robots * 5) + Angle::half(), 0);
         move_tactic_6->updateControlParams(
             world.ball().position() + Vector::createFromAngle(angle_between_robots * 6),
-            (angle_between_robots * 6) + Angle::half(), 0, BallCollisionType::AVOID);
+            (angle_between_robots * 6) + Angle::half(), 0);
 
         // yield the Tactics this Play wants to run, in order of priority
         // If there are fewer robots in play, robots at the end of the list will not be

--- a/src/software/ai/hl/stp/play/indirect_free_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/indirect_free_kick_play.cpp
@@ -109,7 +109,7 @@ void IndirectFreeKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     while (!align_to_ball_tactic->getAssignedRobot())
     {
         LOG(DEBUG) << "Nothing assigned to align to ball yet";
-        updateAlignToBallTactic(align_to_ball_tactic, BallCollisionType::AVOID);
+        updateAlignToBallTactic(align_to_ball_tactic);
         updateCherryPickTactics({cherry_pick_tactic_1, cherry_pick_tactic_2});
         updatePassGenerator(pass_generator);
         updateCreaseDefenderTactics(crease_defender_tactics);
@@ -131,7 +131,7 @@ void IndirectFreeKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     LOG(DEBUG) << "Aligning to ball";
     do
     {
-        updateAlignToBallTactic(align_to_ball_tactic, BallCollisionType::AVOID);
+        updateAlignToBallTactic(align_to_ball_tactic);
         updateCherryPickTactics({cherry_pick_tactic_1, cherry_pick_tactic_2});
         updatePassGenerator(pass_generator);
         updateCreaseDefenderTactics(crease_defender_tactics);
@@ -178,8 +178,7 @@ void IndirectFreeKickPlay::updateCherryPickTactics(
 }
 
 void IndirectFreeKickPlay::updateAlignToBallTactic(
-    std::shared_ptr<MoveTactic> align_to_ball_tactic,
-    BallCollisionType ball_collision_type)
+    std::shared_ptr<MoveTactic> align_to_ball_tactic)
 {
     Vector ball_to_center_vec = Vector(0, 0) - world.ball().position().toVector();
     // We want the kicker to get into position behind the ball facing the center
@@ -187,7 +186,7 @@ void IndirectFreeKickPlay::updateAlignToBallTactic(
     align_to_ball_tactic->updateControlParams(
         world.ball().position() -
             ball_to_center_vec.normalize(ROBOT_MAX_RADIUS_METERS * 2),
-        ball_to_center_vec.orientation(), 0, ball_collision_type);
+        ball_to_center_vec.orientation(), 0);
 }
 
 void IndirectFreeKickPlay::updatePassGenerator(PassGenerator &pass_generator)
@@ -288,7 +287,7 @@ void IndirectFreeKickPlay::findPassStage(
     Timestamp commit_stage_start_time = world.getMostRecentTimestamp();
     do
     {
-        updateAlignToBallTactic(align_to_ball_tactic, BallCollisionType::AVOID);
+        updateAlignToBallTactic(align_to_ball_tactic);
         updateCherryPickTactics({cherry_pick_tactic_1, cherry_pick_tactic_2});
         updatePassGenerator(pass_generator);
         updateCreaseDefenderTactics(crease_defender_tactics);

--- a/src/software/ai/hl/stp/play/indirect_free_kick_play.h
+++ b/src/software/ai/hl/stp/play/indirect_free_kick_play.h
@@ -91,10 +91,8 @@ class IndirectFreeKickPlay : public Play
      * Update the tactic that aligns the robot to the ball in preperation to pass
      *
      * @param align_to_ball_tactic
-     * @param ball_collision_type controls how robot navigates around abll
      */
-    void updateAlignToBallTactic(std::shared_ptr<MoveTactic> align_to_ball_tactic,
-                                 BallCollisionType ball_collision_type);
+    void updateAlignToBallTactic(std::shared_ptr<MoveTactic> align_to_ball_tactic);
 
     /**
      * Updates the pass generator

--- a/src/software/ai/hl/stp/play/kickoff_enemy_play.cpp
+++ b/src/software/ai/hl/stp/play/kickoff_enemy_play.cpp
@@ -142,7 +142,7 @@ void KickoffEnemyPlay::getNextTactics(TacticCoroutine::push_type &yield)
                 // listed above
                 move_tactics.at(defense_position_index)
                     ->updateControlParams(defense_positions.at(defense_position_index),
-                                          Angle::zero(), 0, BallCollisionType::AVOID);
+                                          Angle::zero(), 0);
                 result.emplace_back(move_tactics.at(defense_position_index));
                 defense_position_index++;
             }

--- a/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
+++ b/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
@@ -109,8 +109,7 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         for (unsigned i = 0; i < kickoff_setup_positions.size(); i++)
         {
             move_tactics.at(i)->updateControlParams(kickoff_setup_positions.at(i),
-                                                    Angle::zero(), 0,
-                                                    BallCollisionType::AVOID);
+                                                    Angle::zero(), 0);
             result.emplace_back(move_tactics.at(i));
         }
 
@@ -142,8 +141,7 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         for (unsigned i = 1; i < kickoff_setup_positions.size(); i++)
         {
             move_tactics.at(i)->updateControlParams(kickoff_setup_positions.at(i),
-                                                    Angle::zero(), 0,
-                                                    BallCollisionType::AVOID);
+                                                    Angle::zero(), 0);
             result.emplace_back(move_tactics.at(i));
         }
 

--- a/src/software/ai/hl/stp/play/penalty_kick_enemy_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_enemy_play.cpp
@@ -44,24 +44,19 @@ void PenaltyKickEnemyPlay::getNextTactics(TacticCoroutine::push_type &yield)
 
         // Move all non-shooter robots to the center of the field
         move_tactic_2->updateControlParams(
-            Point(0, 0), world.field().enemyGoal().toVector().orientation(), 0,
-            BallCollisionType::AVOID);
+            Point(0, 0), world.field().enemyGoal().toVector().orientation(), 0);
         move_tactic_3->updateControlParams(
             Point(0, 4 * ROBOT_MAX_RADIUS_METERS),
-            world.field().enemyGoal().toVector().orientation(), 0,
-            BallCollisionType::AVOID);
+            world.field().enemyGoal().toVector().orientation(), 0);
         move_tactic_4->updateControlParams(
             Point(0, -4 * ROBOT_MAX_RADIUS_METERS),
-            world.field().enemyGoal().toVector().orientation(), 0,
-            BallCollisionType::AVOID);
+            world.field().enemyGoal().toVector().orientation(), 0);
         move_tactic_5->updateControlParams(
             Point(0, 8 * ROBOT_MAX_RADIUS_METERS),
-            world.field().enemyGoal().toVector().orientation(), 0,
-            BallCollisionType::AVOID);
+            world.field().enemyGoal().toVector().orientation(), 0);
         move_tactic_6->updateControlParams(
             Point(0, -8 * ROBOT_MAX_RADIUS_METERS),
-            world.field().enemyGoal().toVector().orientation(), 0,
-            BallCollisionType::AVOID);
+            world.field().enemyGoal().toVector().orientation(), 0);
 
         // yield the Tactics this Play wants to run, in order of priority
         yield({goalie_tactic, move_tactic_2, move_tactic_3, move_tactic_4, move_tactic_5,

--- a/src/software/ai/hl/stp/play/penalty_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play.cpp
@@ -53,29 +53,23 @@ void PenaltyKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
 
         // Move all non-shooter robots to the center of the field
         move_tactic_2->updateControlParams(
-            Point(0, 0), world.field().enemyGoal().toVector().orientation(), 0,
-            BallCollisionType::AVOID);
+            Point(0, 0), world.field().enemyGoal().toVector().orientation(), 0);
         move_tactic_3->updateControlParams(
             Point(0, 4 * ROBOT_MAX_RADIUS_METERS),
-            world.field().enemyGoal().toVector().orientation(), 0,
-            BallCollisionType::AVOID);
+            world.field().enemyGoal().toVector().orientation(), 0);
         move_tactic_4->updateControlParams(
             Point(0, -4 * ROBOT_MAX_RADIUS_METERS),
-            world.field().enemyGoal().toVector().orientation(), 0,
-            BallCollisionType::AVOID);
+            world.field().enemyGoal().toVector().orientation(), 0);
         move_tactic_5->updateControlParams(
             Point(0, 8 * ROBOT_MAX_RADIUS_METERS),
-            world.field().enemyGoal().toVector().orientation(), 0,
-            BallCollisionType::AVOID);
+            world.field().enemyGoal().toVector().orientation(), 0);
         move_tactic_6->updateControlParams(
             Point(0, -8 * ROBOT_MAX_RADIUS_METERS),
-            world.field().enemyGoal().toVector().orientation(), 0,
-            BallCollisionType::AVOID);
+            world.field().enemyGoal().toVector().orientation(), 0);
 
         penalty_shot_tactic->updateWorldParams(world.ball(), world.enemyTeam().goalie(),
                                                world.field());
-        shooter_setup_move->updateControlParams(behind_ball, shoot_angle, 0.0,
-                                                BallCollisionType::AVOID);
+        shooter_setup_move->updateControlParams(behind_ball, shoot_angle, 0.0);
 
         // If we are setting up for penalty kick, move our robots to position
         if (world.gameState().isSetupState())

--- a/src/software/ai/hl/stp/play/shoot_or_chip_play.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_chip_play.cpp
@@ -124,8 +124,7 @@ void ShootOrChipPlay::getNextTactics(TacticCoroutine::push_type &yield)
                 chip_targets[i].getOrigin() -
                 Vector::createFromAngle(orientation).normalize(ROBOT_MAX_RADIUS_METERS);
             ;
-            move_to_open_area_tactics[i]->updateControlParams(position, orientation, 0.0,
-                                                              BallCollisionType::AVOID);
+            move_to_open_area_tactics[i]->updateControlParams(position, orientation, 0.0);
             result.emplace_back(move_to_open_area_tactics[i]);
         }
 

--- a/src/software/ai/hl/stp/play/stop_play.cpp
+++ b/src/software/ai/hl/stp/play/stop_play.cpp
@@ -99,12 +99,10 @@ void StopPlay::getNextTactics(TacticCoroutine::push_type &yield)
 
         move_tactics.at(0)->updateControlParams(
             goal_defense_point_left,
-            (world.ball().position() - goal_defense_point_left).orientation(), 0,
-            BallCollisionType::AVOID);
+            (world.ball().position() - goal_defense_point_left).orientation(), 0);
         move_tactics.at(1)->updateControlParams(
             goal_defense_point_right,
-            (world.ball().position() - goal_defense_point_right).orientation(), 0,
-            BallCollisionType::AVOID);
+            (world.ball().position() - goal_defense_point_right).orientation(), 0);
 
         // ball_defense_point_center is a point on the circle around the ball that the
         // line from the center of the goal to the ball intersects. A robot will be placed
@@ -123,16 +121,13 @@ void StopPlay::getNextTactics(TacticCoroutine::push_type &yield)
 
         move_tactics.at(2)->updateControlParams(
             ball_defense_point_center,
-            (world.ball().position() - ball_defense_point_center).orientation(), 0,
-            BallCollisionType::AVOID);
+            (world.ball().position() - ball_defense_point_center).orientation(), 0);
         move_tactics.at(3)->updateControlParams(
             ball_defense_point_left,
-            (world.ball().position() - ball_defense_point_left).orientation(), 0,
-            BallCollisionType::AVOID);
+            (world.ball().position() - ball_defense_point_left).orientation(), 0);
         move_tactics.at(4)->updateControlParams(
             ball_defense_point_right,
-            (world.ball().position() - ball_defense_point_right).orientation(), 0,
-            BallCollisionType::AVOID);
+            (world.ball().position() - ball_defense_point_right).orientation(), 0);
 
         // insert all the move tactics to the result
         result.insert(result.end(), move_tactics.begin(), move_tactics.end());

--- a/src/software/ai/hl/stp/tactic/move_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/move_tactic.cpp
@@ -12,14 +12,12 @@ std::string MoveTactic::getName() const
 }
 
 void MoveTactic::updateControlParams(Point destination, Angle final_orientation,
-                                     double final_speed,
-                                     BallCollisionType ball_collision_type)
+                                     double final_speed)
 {
     // Update the control parameters stored by this Tactic
     this->destination       = destination;
     this->final_orientation = final_orientation;
     this->final_speed       = final_speed;
-    this->ball_collision_type = ball_collision_type;
 }
 
 double MoveTactic::calculateRobotCost(const Robot &robot, const World &world)
@@ -39,7 +37,7 @@ void MoveTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
     {
         move_action.updateControlParams(
             *robot, destination, final_orientation, final_speed, DribblerEnable::OFF,
-            MoveType::NORMAL, AutokickType::NONE, ball_collision_type);
+            MoveType::NORMAL, AutokickType::NONE, BallCollisionType::AVOID);
         yield(move_action.getNextIntent());
     } while (!move_action.done());
 }

--- a/src/software/ai/hl/stp/tactic/move_tactic.h
+++ b/src/software/ai/hl/stp/tactic/move_tactic.h
@@ -27,10 +27,9 @@ class MoveTactic : public Tactic
      * @param final_orientation The final orientation the robot should have at
      * the destination
      * @param final_speed The final speed the robot should have at the destination
-     * @param ball_collision_type how the robot should navigate around ball
      */
     void updateControlParams(Point destination, Angle final_orientation,
-                             double final_speed, BallCollisionType ball_collision_type);
+                             double final_speed);
 
     /**
      * Calculates the cost of assigning the given robot to this Tactic. Prefers robots
@@ -60,6 +59,4 @@ class MoveTactic : public Tactic
     Angle final_orientation;
     // The speed the robot should have when it arrives at its destination
     double final_speed;
-    // How the robot should navigate around the ball
-    BallCollisionType ball_collision_type;
 };

--- a/src/software/ai/hl/stp/tactic/move_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/move_tactic_test.cpp
@@ -12,8 +12,7 @@ TEST(MoveTacticTest, robot_far_from_destination)
 
     MoveTactic tactic = MoveTactic();
     tactic.updateRobot(robot);
-    tactic.updateControlParams(Point(1, 0), Angle::quarter(), 1.0,
-                               BallCollisionType::AVOID);
+    tactic.updateControlParams(Point(1, 0), Angle::quarter(), 1.0);
     auto intent_ptr = tactic.getNextIntent();
 
     // Check an intent was returned (the pointer is not null)
@@ -33,7 +32,7 @@ TEST(MoveTacticTest, robot_at_destination)
 
     MoveTactic tactic = MoveTactic();
     tactic.updateRobot(robot);
-    tactic.updateControlParams(Point(0, 0), Angle::zero(), 0.0, BallCollisionType::AVOID);
+    tactic.updateControlParams(Point(0, 0), Angle::zero(), 0.0);
 
     // We call the Tactic twice. The first time the Intent will always be returned to
     // ensure the Robot is doing the right thing. In all future calls, the action will be
@@ -53,8 +52,7 @@ TEST(MoveTacticTest, test_calculate_robot_cost)
                         Timestamp::fromSeconds(0));
 
     MoveTactic tactic = MoveTactic();
-    tactic.updateControlParams(Point(3, -4), Angle::zero(), 0.0,
-                               BallCollisionType::AVOID);
+    tactic.updateControlParams(Point(3, -4), Angle::zero(), 0.0);
 
     EXPECT_EQ(5 / world.field().totalXLength(), tactic.calculateRobotCost(robot, world));
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Remove control of ball collision avoidance from plays. As per offline discussion, we don't want plays to be able to control whether or not a robot navigates around a ball to avoid collision. We should be able to do this sort of control at the tactic level, via updating the moveaction. 
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Regression testing
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
