### PR TITLE
Fix cmdline for stm32 and add entry in readme

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,6 +156,6 @@ Debugging in CLion is as simple as running the above instructions for building C
 
 ## Working with CubeMX to regenerate code
 1. Make sure you've followed [Installing Firmware Dependencies](#installing-firmware-dependencies)
-2. To regenerate code from the `.ioc` file, run `bazel run //firmware_new/tools:cubemx_regen firmware_new/boards/frankie_v1`. The directory that is passed in as an argument must only contain 1 ioc file, which will be used to generate code into the same directory.
+2. To regenerate code from the `.ioc` file, run `bazel run //firmware_new/tools:cubemx_regen path/to/directory/with/.ioc`. The directory that is passed in as an argument must only contain 1 ioc file, which will be used to generate code into the same directory.
 
 To make sure we are all using the same cube version, run `STM32CubeMX` when editing the `.ioc` file.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -153,3 +153,9 @@ Debugging in CLion is as simple as running the above instructions for building C
 2. From the `src` folder, run `bazel run --cpu=stm32h7 --compilation_mode=dbg //firmware_new/tools:debug_firmware_on_arm_board`. We specify `--cpu=stm32h7` because we want to compile code for the stm32h7 MCU (rather then a `x86_64` processor like you have in your computer), and `--compilation_mode=dbg` in order to build in the debug symbols required so you can step through the code and see what's going on. You'll be given a list of elf files to choose from.
 3. Assuming you choose 0 from the list in step (2), run `bazel run --cpu=stm32h7 --compilation_mode=dbg //firmware_new/tools:debug_firmware_on_arm_board 0`. This will load the `.elf` file associated with (0) to the the nucleo and put you into a gdb prompt.
 4. At this point you should be in a gdb window. Take a look at [this tutorial](https://www.cprogramming.com/gdb.html) for some basics.
+
+## Working with CubeMX to regenerate code
+1. Make sure you've followed [Installing Firmware Dependencies](#installing-firmware-dependencies)
+2. To regenerate code from the `.ioc` file, run `bazel run //firmware_new/tools:cubemx_regen firmware_new/boards/frankie_v1`. The directory that is passed in as an argument must only contain 1 ioc file, which will be used to generate code into the same directory.
+
+To make sure we are all using the same cube version, run `STM32CubeMX` when editing the `.ioc` file.

--- a/environment_setup/install_cubemx.sh
+++ b/environment_setup/install_cubemx.sh
@@ -41,7 +41,7 @@ else
     echo -n $AUTO_INSTALL_XML > auto-install.xml
 
     # create script to cd and run STM32CubeMX
-    STM32_SCRIPT="pushd $CUBEMX_TMP_DIR && cd /opt/STM32CubeMX_$CUBE_VERSION && ./STM32CubeMX && popd"
+    STM32_SCRIPT="pushd . && cd /opt/STM32CubeMX_$CUBE_VERSION && ./STM32CubeMX && popd"
 
     echo -n $STM32_SCRIPT > cuberunner.sh
     

--- a/environment_setup/install_cubemx.sh
+++ b/environment_setup/install_cubemx.sh
@@ -41,7 +41,7 @@ else
     echo -n $AUTO_INSTALL_XML > auto-install.xml
 
     # create script to cd and run STM32CubeMX
-    STM32_SCRIPT="cd /opt/STM32CubeMX_$CUBE_VERSION && ./STM32CubeMX && cd -"
+    STM32_SCRIPT="pushd $CUBEMX_TMP_DIR && cd /opt/STM32CubeMX_$CUBE_VERSION && ./STM32CubeMX && popd"
 
     echo -n $STM32_SCRIPT > cuberunner.sh
     

--- a/environment_setup/install_cubemx.sh
+++ b/environment_setup/install_cubemx.sh
@@ -41,7 +41,7 @@ else
     echo -n $AUTO_INSTALL_XML > auto-install.xml
 
     # create script to cd and run STM32CubeMX
-    STM32_SCRIPT="pushd . && cd /opt/STM32CubeMX_$CUBE_VERSION && ./STM32CubeMX && popd"
+    STM32_SCRIPT="pushd /opt/STM32CubeMX_$CUBE_VERSION && ./STM32CubeMX && popd"
 
     echo -n $STM32_SCRIPT > cuberunner.sh
     

--- a/environment_setup/install_cubemx.sh
+++ b/environment_setup/install_cubemx.sh
@@ -39,12 +39,22 @@ else
         </AutomatedInstallation>"
     
     echo -n $AUTO_INSTALL_XML > auto-install.xml
+
+    # create script to cd and run STM32CubeMX
+    STM32_SCRIPT="cd /opt/STM32CubeMX_$CUBE_VERSION && ./STM32CubeMX && cd -"
+
+    echo -n $STM32_SCRIPT > cuberunner.sh
     
     curl -O $CUBE_LINK
     unzip en.stm32cubemx_v5.4.0.zip
     
     sudo java -jar ./SetupSTM32CubeMX-5.4.0.exe auto-install.xml
-    sudo ln -sfn /opt/STM32CubeMX_$CUBE_VERSION/STM32CubeMX /usr/local/bin/STM32CubeMX 
+    sudo cp ./cuberunner.sh /opt/STM32CubeMX_$CUBE_VERSION/cuberunner.sh
+
+    cd $CUBEMX_INSTALL_DIR
+
+    sudo chmod +x cuberunner.sh
+    sudo ln -sfn /opt/STM32CubeMX_$CUBE_VERSION/cuberunner.sh /usr/local/bin/STM32CubeMX 
 
     echo "================================================================"
     echo "Done Installing CubeMX"

--- a/src/firmware_new/tools/cubemx_regen.sh
+++ b/src/firmware_new/tools/cubemx_regen.sh
@@ -12,7 +12,7 @@ WORKSPACE_DIR="$CURR_DIR/../../"
 THIS_SCRIPT_FILENAME=$(basename "$0")
 
 TEMP_DIR="/tmp/tbots_autogen"
-CUBE_EXECUTABLE="/usr/local/bin/STM32CubeMX"
+CUBE_EXECUTABLE="/opt/STM32CubeMX_5.4.0/STM32CubeMX"
 
 # cleanup temp dir and create Src/Inc folder, the way Cube expects this output
 mkdir -p $TEMP_DIR/Src


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

The executable requires cwd to be the folder w/ the xml and jar files, so running `STM32CubeMX` from the cmd line now cd's and then executes there, and when finished, cds back to the previous dir. 

Also added an entry in `getting-started.md` w/ the command to regen cube code.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Ran the installer and made sure I can run cube from command line
### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification
N/A
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
