### PR TITLE
Fixed segfault during stop play

### DIFF
--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -96,7 +96,8 @@ std::vector<std::unique_ptr<Intent>> STP::getIntents(const World& world)
             if (intent && !tactic->done())
             {
                 // Set Motion Constraints
-                auto motion_constraints = motion_constraint_manager.getMotionConstraints(world.gameState(), *tactic);
+                auto motion_constraints = motion_constraint_manager.getMotionConstraints(
+                    world.gameState(), *tactic);
                 intent->setMotionConstraints(motion_constraints);
 
                 intents.emplace_back(std::move(intent));

--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -89,16 +89,16 @@ std::vector<std::unique_ptr<Intent>> STP::getIntents(const World& world)
         {
             // Get the Intent the tactic wants to run
             auto intent = tactic->getNextIntent();
-            // Set Motion Constraints
-            auto motion_constraints = motion_constraint_manager.getMotionConstraints(
-                world.gameState(), *tactic);
-            intent->setMotionConstraints(motion_constraints);
 
             // If the tactic is not done and a valid intent was returned, the intent will
             // be run by the robot. Otherwise, the robot will default to running a
             // StopIntent so it doesn't do anything crazy.
             if (intent && !tactic->done())
             {
+                // Set Motion Constraints
+                auto motion_constraints = motion_constraint_manager.getMotionConstraints(world.gameState(), *tactic);
+                intent->setMotionConstraints(motion_constraints);
+
                 intents.emplace_back(std::move(intent));
             }
             else if (tactic->getAssignedRobot())

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -131,7 +131,7 @@ std::optional<Point> GoalieTactic::restrainGoalieInRectangle(
 
 void GoalieTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
 {
-    MoveAction move_action = MoveAction();
+    MoveAction move_action = MoveAction(MoveAction::ROBOT_CLOSE_TO_DEST_THRESHOLD, MoveAction::ROBOT_CLOSE_TO_ORIENTATION_THRESHOLD, true);
     ChipAction chip_action = ChipAction();
     StopAction stop_action = StopAction();
 

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -131,7 +131,9 @@ std::optional<Point> GoalieTactic::restrainGoalieInRectangle(
 
 void GoalieTactic::calculateNextIntent(IntentCoroutine::push_type &yield)
 {
-    MoveAction move_action = MoveAction(MoveAction::ROBOT_CLOSE_TO_DEST_THRESHOLD, MoveAction::ROBOT_CLOSE_TO_ORIENTATION_THRESHOLD, true);
+    MoveAction move_action =
+        MoveAction(MoveAction::ROBOT_CLOSE_TO_DEST_THRESHOLD,
+                   MoveAction::ROBOT_CLOSE_TO_ORIENTATION_THRESHOLD, true);
     ChipAction chip_action = ChipAction();
     StopAction stop_action = StopAction();
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
When running the `StopPlay` once all the robots were more or less at their final destinations, the AI would segfault. It turns out this was because the `MoveAction` in the `GoalieTactic` did not have `loop_forever` set to true, so the `GoalieTactic` would sometimes return a nullptr in certain cases. Furthermore, we were setting MotionConstraints before checking if the returned intent was actually valid, which is what triggered this error.

MotionConstraints are now set _after_ the null check, and the `MoveAction` now has `loop_forever = true`

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Lots of manual testing. STP should be tested better once it's refactored (see #783 ).

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
