### PR TITLE
Remove bazel remote cache from the bazelrc

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -1,17 +1,3 @@
-# Use Our Remote Cache To Avoid Rebuilding Files Already Built By CI
-build --remote_http_cache=https://storage.googleapis.com/thunderbots_bazel_cache_us_multi_region
-
-# Disable sandboxing, since using the remote cache with it enabled is still 
-# considered "experimental"
---spawn_strategy=standalone
-
-# Don't Try to Upload Results (since CI does not currently have required credentials)
-# See https://github.com/UBC-Thunderbots/Software/issues/829 for more info
-build --remote_upload_local_results=false 
-
-# Credentials for Uploading Build Results To Our Remote Cache
-#build --google_credentials="/home/gareth/Downloads/tbots-bazel-cache-key.json"
-
 # We rely on all symbols being included when linking for our implementation of
 # the "factory" design pattern.
 build --incompatible_remove_legacy_whole_archive=False


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
The bazel remote cache hasn't been providing much value, and in some cases seems to slow down builds if the network is slow since bazel doesn't seem to know when to "stop trying" to use the remote cache.

So for simplicity and possible speed we are removing it.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
