### PR TITLE
capabilities blacklist

### DIFF
--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -158,7 +158,8 @@ std::vector<std::shared_ptr<Tactic>> STP::assignRobotsToTactics(
         for (unsigned col = 0; col < num_cols; col++)
         {
             if (friendly_team_robots.at(row).getCapabiltiesBlacklist().size() > 0 &&
-                friendly_team_robots.at(row).getCapabiltiesBlacklist() <= tactics.at(col)->robotCapabilityRequirements())
+                friendly_team_robots.at(row).getCapabiltiesBlacklist() <=
+                    tactics.at(col)->robotCapabilityRequirements())
             {
                 // if the blacklist contains any subset of the required capabilties,
                 // set the cost to 10.0f

--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -157,11 +157,11 @@ std::vector<std::shared_ptr<Tactic>> STP::assignRobotsToTactics(
     {
         for (unsigned col = 0; col < num_cols; col++)
         {
-            if (!(tactics.at(col)->robotCapabilityRequirements() <=
-                  friendly_team_robots.at(row).getRobotCapabilities()))
+            if (friendly_team_robots.at(row).getCapabiltiesBlacklist().size() > 0 &&
+                friendly_team_robots.at(row).getCapabiltiesBlacklist() <= tactics.at(col)->robotCapabilityRequirements())
             {
-                // hardware requirements of tactic are not satisfied by the current robot
-                // set cost to 10.0f
+                // if the blacklist contains any subset of the required capabilties,
+                // set the cost to 10.0f
                 matrix(row, col) = 10.0f;
             }
             else

--- a/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
+++ b/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
@@ -360,9 +360,7 @@ TEST_F(STPTacticAssignmentTest,
     // this robot has no capabilities
     using RobotCapabilities::Capability;
     Robot robot_0(0, Point(0.1, 0.1), Vector(), Angle::zero(), AngularVelocity::zero(),
-                  Timestamp::fromSeconds(0), 10,
-                  std::set<RobotCapabilities::Capability>{Capability::Move, Capability::Kick,
-                                                                                Capability::Chip, Capability::Dribble});
+                  Timestamp::fromSeconds(0), 10, RobotCapabilities::allCapabilities());
     // default is all capabilities, if not specified otherwise
     Robot robot_1(1, Point(-10, -10), Vector(), Angle::zero(), AngularVelocity::zero(),
                   Timestamp::fromSeconds(0));

--- a/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
+++ b/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
@@ -358,9 +358,11 @@ TEST_F(STPTacticAssignmentTest,
     // that doesn't even though the former has lower cost
     Team friendly_team(Duration::fromSeconds(0));
     // this robot has no capabilities
+    using RobotCapabilities::Capability;
     Robot robot_0(0, Point(0.1, 0.1), Vector(), Angle::zero(), AngularVelocity::zero(),
                   Timestamp::fromSeconds(0), 10,
-                  std::set<RobotCapabilities::Capability>{});
+                  std::set<RobotCapabilities::Capability>{Capability::Move, Capability::Kick,
+                                                                                Capability::Chip, Capability::Dribble});
     // default is all capabilities, if not specified otherwise
     Robot robot_1(1, Point(-10, -10), Vector(), Angle::zero(), AngularVelocity::zero(),
                   Timestamp::fromSeconds(0));

--- a/src/software/world/robot.cpp
+++ b/src/software/world/robot.cpp
@@ -7,14 +7,14 @@
 Robot::Robot(RobotId id, const Point &position, const Vector &velocity,
              const Angle &orientation, const AngularVelocity &angular_velocity,
              const Timestamp &timestamp, unsigned int history_duration,
-             const std::set<RobotCapabilities::Capability> &capabilities)
+             const std::set<RobotCapabilities::Capability> &unavailable_capabilities)
     : id_(id),
       positions_(history_duration),
       velocities_(history_duration),
       orientations_(history_duration),
       angularVelocities_(history_duration),
       last_update_timestamps(history_duration),
-      capabilities_(capabilities)
+      unavailable_capabilities_(unavailable_capabilities)
 {
     addStateToRobotHistory(position, velocity, orientation, angular_velocity, timestamp);
 }
@@ -253,12 +253,12 @@ bool Robot::operator!=(const Robot &other) const
     return !(*this == other);
 }
 
-const std::set<RobotCapabilities::Capability> &Robot::getRobotCapabilities() const
+const std::set<RobotCapabilities::Capability> &Robot::getCapabiltiesBlacklist() const
 {
-    return capabilities_;
+    return unavailable_capabilities_;
 }
 
 std::set<RobotCapabilities::Capability> &Robot::getMutableRobotCapabilities()
 {
-    return capabilities_;
+    return unavailable_capabilities_;
 }

--- a/src/software/world/robot.h
+++ b/src/software/world/robot.h
@@ -30,11 +30,12 @@ class Robot
      * state
      * @param history_duration The number of previous robot states that should be stored.
      */
-    explicit Robot(RobotId id, const Point &position, const Vector &velocity,
-                   const Angle &orientation, const AngularVelocity &angular_velocity,
-                   const Timestamp &timestamp, unsigned int history_duration = 20,
-                   const std::set<RobotCapabilities::Capability> &unavailable_capabilities =
-                           std::set<RobotCapabilities::Capability>());
+    explicit Robot(
+        RobotId id, const Point &position, const Vector &velocity,
+        const Angle &orientation, const AngularVelocity &angular_velocity,
+        const Timestamp &timestamp, unsigned int history_duration = 20,
+        const std::set<RobotCapabilities::Capability> &unavailable_capabilities =
+            std::set<RobotCapabilities::Capability>());
 
     /**
      * Updates the state of the robot.

--- a/src/software/world/robot.h
+++ b/src/software/world/robot.h
@@ -33,8 +33,8 @@ class Robot
     explicit Robot(RobotId id, const Point &position, const Vector &velocity,
                    const Angle &orientation, const AngularVelocity &angular_velocity,
                    const Timestamp &timestamp, unsigned int history_duration = 20,
-                   const std::set<RobotCapabilities::Capability> &capabilities =
-                       RobotCapabilities::allCapabilities());
+                   const std::set<RobotCapabilities::Capability> &unavailable_capabilities =
+                           std::set<RobotCapabilities::Capability>());
 
     /**
      * Updates the state of the robot.
@@ -251,7 +251,7 @@ class Robot
      *
      * @return the hardware capabilities of the robot
      */
-    const std::set<RobotCapabilities::Capability> &getRobotCapabilities() const;
+    const std::set<RobotCapabilities::Capability> &getCapabiltiesBlacklist() const;
 
     /**
      * Returns the mutable hardware capabilities of the robot
@@ -333,5 +333,5 @@ class Robot
     boost::circular_buffer<Timestamp> last_update_timestamps;
     // The hardware capabilities of the robot, generated from
     // RobotCapabilityFlags::broken_dribblers/chippers/kickers dynamic parameters
-    std::set<RobotCapabilities::Capability> capabilities_;
+    std::set<RobotCapabilities::Capability> unavailable_capabilities_;
 };


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

make robotcapabilities use a blacklist instead of a whitelist, to improve performance

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

existing robot capabiltiies tests pass, tests modified to use blacklist

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

resolves #1074 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
