### PR TITLE
Simulator: Add basic PhysicsRobot class

### DIFF
--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -13,9 +13,9 @@ const double ROBOT_MAX_RADIUS_METERS = 0.09;
 // The distance from the center of the robot to the front face (the flat part), in meters
 const double DIST_TO_FRONT_OF_ROBOT_METERS = 0.07;
 // The total width of the entire flat face on the front of the robot
-const double FRONT_OF_ROBOT_WIDTH = 0.11;
+const double FRONT_OF_ROBOT_WIDTH_METERS = 0.11;
 // The distance from one end of the dribbler to the other
-const double DRIBBLER_WIDTH = 0.088;
+const double DRIBBLER_WIDTH_METERS = 0.088;
 // The approximate radius of the ball according to the SSL rulebook
 const double BALL_MAX_RADIUS_METERS = 0.0215;
 // The maximum number of robots we can communicate with over radio.

--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -12,6 +12,8 @@ const double BALL_MAX_SPEED_METERS_PER_SECOND = 6.5;
 const double ROBOT_MAX_RADIUS_METERS = 0.09;
 // The distance from the center of the robot to the front face (the flat part), in meters
 const double DIST_TO_FRONT_OF_ROBOT_METERS = 0.07;
+// The total width of the entire flat face on the front of the robot
+const double FRONT_OF_ROBOT_WIDTH = 0.11;
 // The distance from one end of the dribbler to the other
 const double DRIBBLER_WIDTH = 0.088;
 // The approximate radius of the ball according to the SSL rulebook

--- a/src/software/backend/simulation/physics/BUILD
+++ b/src/software/backend/simulation/physics/BUILD
@@ -85,6 +85,19 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "physics_robot_test",
+    srcs = ["physics_robot_test.cpp"],
+    deps = [
+        ":physics_ball",
+        ":physics_robot",
+        "//software/test_util",
+        "//software/world:robot",
+        "@box2d",
+        "@gtest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "physics_simulator",
     srcs = ["physics_simulator.cpp"],

--- a/src/software/backend/simulation/physics/BUILD
+++ b/src/software/backend/simulation/physics/BUILD
@@ -72,6 +72,20 @@ cc_test(
 )
 
 cc_library(
+    name = "physics_robot",
+    srcs = ["physics_robot.cpp"],
+    hdrs = ["physics_robot.h"],
+    deps = [
+        ":box2d_util",
+        "//shared:constants",
+        "//software/geom",
+        "//software/util/time:timestamp",
+        "//software/world:robot",
+        "@box2d",
+    ],
+)
+
+cc_library(
     name = "physics_simulator",
     srcs = ["physics_simulator.cpp"],
     hdrs = ["physics_simulator.h"],

--- a/src/software/backend/simulation/physics/box2d_util.cpp
+++ b/src/software/backend/simulation/physics/box2d_util.cpp
@@ -25,3 +25,10 @@ b2Vec2 createVec2(const Point& point)
     ret.Set(point.x(), point.y());
     return ret;
 }
+
+b2Vec2 createVec2(const Vector& vector)
+{
+    b2Vec2 ret;
+    ret.Set(vector.x(), vector.y());
+    return ret;
+}

--- a/src/software/backend/simulation/physics/box2d_util.h
+++ b/src/software/backend/simulation/physics/box2d_util.h
@@ -3,6 +3,7 @@
 #include <Box2D/Box2D.h>
 
 #include "software/new_geom/point.h"
+#include "software/new_geom/vector.h"
 
 /**
  * These functions are utilities and convenience functions to make certain operations
@@ -31,3 +32,12 @@ bool bodyExistsInWorld(b2Body* body, b2World* world);
  * @return A b2Vec2 equivalent to the given Point
  */
 b2Vec2 createVec2(const Point& point);
+
+/**
+ * Converts the given Vector into a b2Vec2, a 2D vector used in Box2D.
+ *
+ * @param vector The Vector to convert to a b2Vec2
+ *
+ * @return A b2Vec2 equivalent to the given Vector
+ */
+b2Vec2 createVec2(const Vector& vector);

--- a/src/software/backend/simulation/physics/box2d_util_test.cpp
+++ b/src/software/backend/simulation/physics/box2d_util_test.cpp
@@ -108,3 +108,12 @@ TEST(Box2DUtilTest, test_create_b2Vec2_from_point)
     expected = {0.0, 100.100};
     EXPECT_EQ(expected, createVec2(Point(0.0, 100.100)));
 }
+
+TEST(Box2DUtilTest, test_create_b2Vec2_from_vector)
+{
+    b2Vec2 expected = {-1.02, 5.4};
+    EXPECT_EQ(expected, createVec2(Vector(-1.02, 5.4)));
+
+    expected = {0.0, 100.100};
+    EXPECT_EQ(expected, createVec2(Vector(0.0, 100.100)));
+}

--- a/src/software/backend/simulation/physics/physics_robot.cpp
+++ b/src/software/backend/simulation/physics/physics_robot.cpp
@@ -1,0 +1,120 @@
+#include "software/backend/simulation/physics/physics_robot.h"
+
+#include "shared/constants.h"
+#include "software/backend/simulation/physics/box2d_util.h"
+
+PhysicsRobot::PhysicsRobot(std::shared_ptr<b2World> world, const Robot& robot)
+    : robot_id(robot.id())
+{
+    // All the BodyDef must be defined before the body is created.
+    // Changes made after aren't reflected
+    createRobotPhysicsBody(world, robot);
+    setupRobotPhysicsBody(robot);
+    setupChickerPhysicsBody(robot);
+}
+
+PhysicsRobot::~PhysicsRobot()
+{
+    // Examples for removing bodies safely from
+    // https://www.iforce2d.net/b2dtut/removing-bodies
+    b2World* robot_body_world = robot_body->GetWorld();
+    if (bodyExistsInWorld(robot_body, robot_body_world))
+    {
+        robot_body_world->DestroyBody(robot_body);
+    }
+}
+
+void PhysicsRobot::createRobotPhysicsBody(std::shared_ptr<b2World> world,
+                                          const Robot& robot)
+{
+    robot_body_def.type = b2_dynamicBody;
+    robot_body_def.position.Set(robot.position().x(), robot.position().y());
+    robot_body_def.linearVelocity.Set(robot.position().x(), robot.position().y());
+    robot_body_def.angle           = robot.orientation().toRadians();
+    robot_body_def.angularVelocity = robot.angularVelocity().toRadians();
+
+    robot_body = world->CreateBody(&robot_body_def);
+}
+
+void PhysicsRobot::setupRobotPhysicsBody(const Robot& robot)
+{
+    // To create a polygon that approximates the shape of a robot, we find
+    // one of the points at the edge of the flat face at the front of the robot,
+    // and sweep around the back of the robot evenly distributing vertices until
+    // we reach the other edge of the flat face.
+
+    const unsigned int num_robot_body_vertices = b2_maxPolygonVertices;
+    b2Vec2 robot_body_vertices[num_robot_body_vertices];
+
+    Angle angle_to_edge_of_flat_face_relative_to_robot_orientation =
+        Vector(DIST_TO_FRONT_OF_ROBOT_METERS, FRONT_OF_ROBOT_WIDTH / 2.0).orientation();
+    Angle global_angle_to_edge_of_flat_face =
+        angle_to_edge_of_flat_face_relative_to_robot_orientation + robot.orientation();
+
+    Angle angle_to_sweep_across =
+        Angle::full() - (2 * angle_to_edge_of_flat_face_relative_to_robot_orientation);
+    Angle angle_increment = angle_to_sweep_across / (num_robot_body_vertices - 1);
+
+    for (unsigned int i = 0; i < num_robot_body_vertices; i++)
+    {
+        Angle angle_to_vertex = global_angle_to_edge_of_flat_face + (i * angle_increment);
+        // Shapes are defined relative to the body they are added to, so we do everything
+        // relative to the centre of the robot body, which is treated as (0, 0)
+        Vector vector_from_body_to_vertex =
+            Vector::createFromAngle(angle_to_vertex).normalize(ROBOT_MAX_RADIUS_METERS);
+        Point vertex           = Point(0, 0) + vector_from_body_to_vertex;
+        robot_body_vertices[i] = createVec2(vertex);
+    }
+
+    robot_body_shape.Set(robot_body_vertices, num_robot_body_vertices);
+    robot_fixture_def.shape = &robot_body_shape;
+
+    robot_fixture_def.density = 1.0;
+    // This is a somewhat arbitrary value. Collisions with robots are not perfectly
+    // elastic. However because this is an "ideal" simulation and we generally don't care
+    // about the exact behaviour of collisions, getting this value to perfectly match
+    // reality isn't too important.
+    robot_fixture_def.restitution = 0.5;
+    robot_fixture_def.friction    = 0.0;
+
+    robot_body->CreateFixture(&robot_fixture_def);
+}
+
+void PhysicsRobot::setupChickerPhysicsBody(const Robot& robot)
+{
+    // Create a very thin rectangle where the dribbler and chicker are on the
+    // flat face of the robot
+    robot_chicker_shape.SetAsBox(
+        0.001, DRIBBLER_WIDTH / 2.0,
+        createVec2(Vector::createFromAngle(robot.orientation())
+                       .normalize(DIST_TO_FRONT_OF_ROBOT_METERS)),
+        robot.orientation().toRadians());
+    robot_chicker_def.shape = &robot_chicker_shape;
+
+    // We don't want this shape to contribute to the mass of the overall robot, so density
+    // is 0
+    robot_chicker_def.density = 0.0;
+    // restitution and friction are somewhat arbitrary values. Collisions with the chicker
+    // are generally very damped, and friction along the dribbler is high since the
+    // dribbler is designed to have high friction with the ball. However because this is
+    // an "ideal" simulation and we generally don't care about the exact behaviour of the
+    // ball colliding or rolling along the chicker / dribbler, getting these values to
+    // perfectly match reality isn't too important.
+    robot_fixture_def.restitution = 0.1;
+    robot_fixture_def.friction    = 1.0;
+
+    robot_body->CreateFixture(&robot_chicker_def);
+}
+
+Robot PhysicsRobot::getRobotWithTimestamp(const Timestamp& timestamp) const
+{
+    Point position(robot_body->GetPosition().x, robot_body->GetPosition().y);
+    Vector velocity(robot_body->GetLinearVelocity().x, robot_body->GetLinearVelocity().y);
+    Angle orientation = Angle::fromRadians(robot_body->GetAngle());
+    Angle angular_velocity =
+        AngularVelocity::fromRadians(robot_body->GetAngularVelocity());
+
+    Robot robot =
+        Robot(robot_id, position, velocity, orientation, angular_velocity, timestamp);
+    return robot;
+}

--- a/src/software/backend/simulation/physics/physics_robot.cpp
+++ b/src/software/backend/simulation/physics/physics_robot.cpp
@@ -6,8 +6,8 @@
 PhysicsRobot::PhysicsRobot(std::shared_ptr<b2World> world, const Robot& robot)
     : robot_id(robot.id())
 {
-    // createRobotPhysicsBody must be called before the setup functions, so that the b2Body is
-    // instantiated before fixtures are added to it.
+    // createRobotPhysicsBody must be called before the setup functions, so that the
+    // b2Body is instantiated before fixtures are added to it.
     createRobotPhysicsBody(world, robot);
     setupRobotPhysicsBody(robot);
     setupChickerPhysicsBody(robot);
@@ -68,10 +68,10 @@ void PhysicsRobot::setupChickerPhysicsBody(const Robot& robot)
     // Create a very thin rectangle where the dribbler and chicker are on the
     // flat face of the robot
     robot_chicker_shape.SetAsBox(
-            0.001, DRIBBLER_WIDTH_METERS / 2.0,
-            createVec2(Vector::createFromAngle(robot.orientation())
+        0.001, DRIBBLER_WIDTH_METERS / 2.0,
+        createVec2(Vector::createFromAngle(robot.orientation())
                        .normalize(DIST_TO_FRONT_OF_ROBOT_METERS)),
-            robot.orientation().toRadians());
+        robot.orientation().toRadians());
     robot_chicker_def.shape = &robot_chicker_shape;
 
     // We don't want this shape to contribute to the mass of the overall robot, so density
@@ -89,19 +89,22 @@ void PhysicsRobot::setupChickerPhysicsBody(const Robot& robot)
     robot_body->CreateFixture(&robot_chicker_def);
 }
 
-std::vector<Point> PhysicsRobot::getRobotBodyVertices(const Robot &robot, unsigned int num_vertices) {
+std::vector<Point> PhysicsRobot::getRobotBodyVertices(const Robot& robot,
+                                                      unsigned int num_vertices)
+{
     // To create a polygon that approximates the shape of a robot, we find
     // one of the points at the edge of the flat face at the front of the robot,
     // and sweep around the back of the robot evenly distributing vertices until
     // we reach the other edge of the flat face.
 
     Angle angle_to_edge_of_flat_face_relative_to_robot_orientation =
-            Vector(DIST_TO_FRONT_OF_ROBOT_METERS, FRONT_OF_ROBOT_WIDTH_METERS / 2.0).orientation();
+        Vector(DIST_TO_FRONT_OF_ROBOT_METERS, FRONT_OF_ROBOT_WIDTH_METERS / 2.0)
+            .orientation();
     Angle global_angle_to_edge_of_flat_face =
-            angle_to_edge_of_flat_face_relative_to_robot_orientation + robot.orientation();
+        angle_to_edge_of_flat_face_relative_to_robot_orientation + robot.orientation();
 
     Angle angle_to_sweep_across =
-            Angle::full() - (2 * angle_to_edge_of_flat_face_relative_to_robot_orientation);
+        Angle::full() - (2 * angle_to_edge_of_flat_face_relative_to_robot_orientation);
     Angle angle_increment = angle_to_sweep_across / (num_vertices - 1);
 
     std::vector<Point> robot_body_vertex_points;
@@ -111,8 +114,8 @@ std::vector<Point> PhysicsRobot::getRobotBodyVertices(const Robot &robot, unsign
         // Shapes are defined relative to the body they are added to, so we do everything
         // relative to the centre of the robot body, which is treated as (0, 0)
         Vector vector_from_body_to_vertex =
-                Vector::createFromAngle(angle_to_vertex).normalize(ROBOT_MAX_RADIUS_METERS);
-        Point vertex           = Point(0, 0) + vector_from_body_to_vertex;
+            Vector::createFromAngle(angle_to_vertex).normalize(ROBOT_MAX_RADIUS_METERS);
+        Point vertex = Point(0, 0) + vector_from_body_to_vertex;
         robot_body_vertex_points.emplace_back(vertex);
     }
 

--- a/src/software/backend/simulation/physics/physics_robot.h
+++ b/src/software/backend/simulation/physics/physics_robot.h
@@ -58,18 +58,33 @@ class PhysicsRobot
     void createRobotPhysicsBody(std::shared_ptr<b2World> world, const Robot& robot);
 
     /**
-     * A helper function that sets up the robot body physics object
+     * A helper function that defines and adds fixtures to the robot physics object
+     * that represent the robot body
      *
      * @param robot The Robot being created in the Box2D world
      */
     void setupRobotPhysicsBody(const Robot& robot);
 
     /**
-     * A helper function that sets up the robot chicker physics object
+     * A helper function that defines and adds fixtures to the robot physics object
+     * that represent the robot's chicker
      *
      * @param robot The Robot being created in the Box2D world
      */
     void setupChickerPhysicsBody(const Robot& robot);
+
+    /**
+     * Returns a list of points that represent the vertices of a polygon approximating
+     * the shape of the robot body. The points are relative to the center of the robot,
+     * which is assumed to be at (0, 0)
+     *
+     * @param robot The robot
+     * @param num_vertices How many vertices to create
+     *
+     * @return A list of vertices that make up a polygon approximating the shape of the
+     * robot body
+     */
+    std::vector<Point> getRobotBodyVertices(const Robot& robot, unsigned int num_vertices);
 
     // See https://box2d.org/manual.pdf chapters 6 and 7 more information on Shapes,
     // Bodies, and Fixtures

--- a/src/software/backend/simulation/physics/physics_robot.h
+++ b/src/software/backend/simulation/physics/physics_robot.h
@@ -84,7 +84,8 @@ class PhysicsRobot
      * @return A list of vertices that make up a polygon approximating the shape of the
      * robot body
      */
-    std::vector<Point> getRobotBodyVertices(const Robot& robot, unsigned int num_vertices);
+    std::vector<Point> getRobotBodyVertices(const Robot& robot,
+                                            unsigned int num_vertices);
 
     // See https://box2d.org/manual.pdf chapters 6 and 7 more information on Shapes,
     // Bodies, and Fixtures

--- a/src/software/backend/simulation/physics/physics_robot.h
+++ b/src/software/backend/simulation/physics/physics_robot.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <Box2D/Box2D.h>
+
+#include "software/new_geom/point.h"
+#include "software/util/time/timestamp.h"
+#include "software/world/robot.h"
+
+class PhysicsRobot
+{
+   public:
+    /**
+     * Creates a new PhysicsRobot given a Box2D world and a Robot object. A Box2D body
+     * will be automatically added to the Box2D world and updated during world update
+     * steps.
+     *
+     * @param world A shared_ptr to a Box2D World
+     * @param robot The Robot to be created in the Box2D world
+     */
+    explicit PhysicsRobot(std::shared_ptr<b2World> world, const Robot& robot);
+
+    PhysicsRobot() = delete;
+
+    // Delete the copy and assignment operators because copying this class causes
+    // issues with the b2World and how it tracks bodies in the world, because as objects
+    // are copied and destroyed, they will destroy the bodies in the b2World as well
+    PhysicsRobot& operator=(const PhysicsRobot&) = delete;
+    PhysicsRobot(const PhysicsRobot&)            = delete;
+
+    /**
+     * Destroys the PhysicsRobot object and removes any corresponding bodies
+     * from the physics world if the robot is part of one
+     */
+    ~PhysicsRobot();
+
+    /**
+     * Returns a Robot object representing the current state of the robot object in the
+     * simulated Box2D world the robot was created in. The timestamp is provided as a
+     * parameter so that the caller can control the timestamp of the data being returned,
+     * since the caller will have context about the Box2D world and simulation time step,
+     * and can synchronize the Robot timestamp with other objects.
+     *
+     * @param timestamp The timestamp for the returned Robot to have
+     *
+     * @return A Robot object representing the current state of the robot object in the
+     * simulated Box2D world the robot was originally created in. The returned Robot
+     * object will have the same timestamp as the one provided in the parameter
+     */
+    Robot getRobotWithTimestamp(const Timestamp& timestamp) const;
+
+   private:
+    /**
+     * A helper function that creates the robot body object in the physics world
+     *
+     * @param world A shared_ptr to a Box2D World
+     * @param robot The Robot being created in the Box2D world
+     */
+    void createRobotPhysicsBody(std::shared_ptr<b2World> world, const Robot& robot);
+
+    /**
+     * A helper function that sets up the robot body physics object
+     *
+     * @param robot The Robot being created in the Box2D world
+     */
+    void setupRobotPhysicsBody(const Robot& robot);
+
+    /**
+     * A helper function that sets up the robot chicker physics object
+     *
+     * @param robot The Robot being created in the Box2D world
+     */
+    void setupChickerPhysicsBody(const Robot& robot);
+
+    // See https://box2d.org/manual.pdf chapters 6 and 7 more information on Shapes,
+    // Bodies, and Fixtures
+    b2PolygonShape robot_body_shape;
+    b2FixtureDef robot_fixture_def;
+    b2PolygonShape robot_chicker_shape;
+    b2FixtureDef robot_chicker_def;
+    b2BodyDef robot_body_def;
+    b2Body* robot_body;
+
+    RobotId robot_id;
+};

--- a/src/software/backend/simulation/physics/physics_robot_test.cpp
+++ b/src/software/backend/simulation/physics/physics_robot_test.cpp
@@ -1,0 +1,312 @@
+#include "software/backend/simulation/physics/physics_robot.h"
+
+#include <Box2D/Box2D.h>
+#include <gtest/gtest.h>
+#include <math.h>
+
+#include "shared/constants.h"
+#include "software/backend/simulation/physics/physics_ball.h"
+#include "software/test_util/test_util.h"
+#include "software/world/robot.h"
+
+TEST(PhysicsRobotTest, test_get_robot_with_timestamp)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    PhysicsRobot physics_robot(world, robot_parameter);
+    auto robot = physics_robot.getRobotWithTimestamp(Timestamp::fromSeconds(3.3));
+
+    // TODO: CHECK ROBOT STATE
+    EXPECT_EQ(robot_parameter.position(), robot.position());
+    EXPECT_EQ(Timestamp::fromSeconds(3.3), robot.getMostRecentTimestamp());
+}
+
+TEST(PhysicsRobotTest, test_robot_added_to_physics_world_on_creation)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
+
+    EXPECT_EQ(0, world->GetBodyCount());
+
+    PhysicsRobot physics_robot(world, robot_parameter);
+
+    EXPECT_EQ(1, world->GetBodyCount());
+}
+
+TEST(PhysicsRobotTest, test_physics_robot_is_removed_from_world_when_destroyed)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    {
+        Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                              AngularVelocity::zero(), Timestamp::fromSeconds(0));
+
+        EXPECT_EQ(0, world->GetBodyCount());
+
+        PhysicsRobot physics_robot(world, robot_parameter);
+
+        EXPECT_EQ(1, world->GetBodyCount());
+    }
+
+    // Once we leave the above scope the robot is destroyed, so it should have been
+    // removed from the world
+    EXPECT_EQ(0, world->GetBodyCount());
+}
+
+// Roll the ball along the left side of the robot just outside of the robot radius
+// and check it does not collide
+TEST(PhysicsRobotTest, test_physics_robot_dimensions_left_side_outside_radius)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    PhysicsRobot physics_robot(world, robot_parameter);
+
+    // The ball should pass right next to the robot without colliding, so should not
+    // change direction
+    Ball ball_parameter(Point(1, ROBOT_MAX_RADIUS_METERS + BALL_MAX_RADIUS_METERS),
+                        Vector(-2, 0), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
+        world->Step(1.0 / 60.0, 5, 8);
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(0));
+    EXPECT_LT(ball.velocity().orientation().minDiff(Angle::half()).toDegrees(), 0.1);
+}
+
+// Roll the ball along the left side of the robot just inside of the robot radius
+// and check it does collide
+TEST(PhysicsRobotTest, test_physics_robot_dimensions_left_side_inside_radius)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    PhysicsRobot physics_robot(world, robot_parameter);
+
+    Ball ball_parameter(
+        Point(1, ROBOT_MAX_RADIUS_METERS + BALL_MAX_RADIUS_METERS - 0.005), Vector(-2, 0),
+        Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
+        world->Step(1.0 / 60.0, 5, 8);
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(0));
+    EXPECT_GT(ball.velocity().orientation().minDiff(Angle::half()).toDegrees(), 0.1);
+}
+
+// Roll the ball along the right side of the robot just outside of the robot radius
+// and check it does not collide
+TEST(PhysicsRobotTest, test_physics_robot_dimensions_right_side_outside_radius)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    PhysicsRobot physics_robot(world, robot_parameter);
+
+    Ball ball_parameter(Point(1, -ROBOT_MAX_RADIUS_METERS - BALL_MAX_RADIUS_METERS),
+                        Vector(-2, 0), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
+        world->Step(1.0 / 60.0, 5, 8);
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(0));
+    EXPECT_LT(ball.velocity().orientation().minDiff(Angle::half()).toDegrees(), 0.1);
+}
+
+// Roll the ball along the right side of the robot just inside of the robot radius
+// and check it does collide
+TEST(PhysicsRobotTest, test_physics_robot_dimensions_right_side_inside_radius)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    PhysicsRobot physics_robot(world, robot_parameter);
+
+    Ball ball_parameter(
+        Point(1, -ROBOT_MAX_RADIUS_METERS - BALL_MAX_RADIUS_METERS + 0.005),
+        Vector(-2, 0), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
+        world->Step(1.0 / 60.0, 5, 8);
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(0));
+    EXPECT_GT(ball.velocity().orientation().minDiff(Angle::half()).toDegrees(), 0.1);
+}
+
+// Roll the ball along the back side of the robot just outside of the robot radius
+// and check it does not collide
+TEST(PhysicsRobotTest, test_physics_robot_dimensions_back_side_outside_radius)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    PhysicsRobot physics_robot(world, robot_parameter);
+
+    // The ball should pass right next to the robot without colliding, so should not
+    // change direction
+    Ball ball_parameter(Point(-ROBOT_MAX_RADIUS_METERS - BALL_MAX_RADIUS_METERS, 1),
+                        Vector(0, -2), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
+        world->Step(1.0 / 60.0, 5, 8);
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(0));
+    EXPECT_LT(ball.velocity().orientation().minDiff(Angle::threeQuarter()).toDegrees(),
+              0.1);
+}
+
+// Roll the ball along the back side of the robot just inside of the robot radius
+// and check it does collide
+TEST(PhysicsRobotTest, test_physics_robot_dimensions_back_side_inside_radius)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    PhysicsRobot physics_robot(world, robot_parameter);
+
+    // The ball should pass right next to the robot without colliding, so should not
+    // change direction
+    Ball ball_parameter(
+        Point(-ROBOT_MAX_RADIUS_METERS - BALL_MAX_RADIUS_METERS + 0.005, 1),
+        Vector(0, -2), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
+        world->Step(1.0 / 60.0, 5, 8);
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(0));
+    EXPECT_GT(ball.velocity().orientation().minDiff(Angle::threeQuarter()).toDegrees(),
+              0.1);
+}
+
+// Roll the ball along the front side of the robot just in front of the chicker
+// and check it does not collide
+TEST(PhysicsRobotTest, test_physics_robot_dimensions_front_side_in_front_of_chicker)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    PhysicsRobot physics_robot(world, robot_parameter);
+
+    // The ball should pass right next to the robot without colliding, so should not
+    // change direction
+    Ball ball_parameter(
+        Point(DIST_TO_FRONT_OF_ROBOT_METERS + BALL_MAX_RADIUS_METERS + 0.003, 1),
+        Vector(0, -2), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
+        world->Step(1.0 / 60.0, 5, 8);
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(0));
+    EXPECT_LT(ball.velocity().orientation().minDiff(Angle::threeQuarter()).toDegrees(),
+              0.1);
+}
+
+// Roll the ball along the front side of the robot just behind the chicker
+// and check it does collide
+TEST(PhysicsRobotTest, test_physics_robot_dimensions_front_side_behind_chicker)
+{
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Robot robot_parameter(0, Point(0, 0), Vector(0, 0), Angle::zero(),
+                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    PhysicsRobot physics_robot(world, robot_parameter);
+
+    // The ball should pass right next to the robot without colliding, so should not
+    // change direction
+    Ball ball_parameter(
+        Point(DIST_TO_FRONT_OF_ROBOT_METERS + BALL_MAX_RADIUS_METERS - 0.005, 1),
+        Vector(0, -2), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+
+    // We have to take lots of small steps because a significant amount of accuracy
+    // is lost if we take a single step of 1 second
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        // 5 and 8 here are somewhat arbitrary values for the velocity and position
+        // iterations but are the recommended defaults from
+        // https://www.iforce2d.net/b2dtut/worlds
+        world->Step(1.0 / 60.0, 5, 8);
+    }
+
+    auto ball = physics_ball.getBallWithTimestamp(Timestamp::fromSeconds(0));
+    EXPECT_GT(ball.velocity().orientation().minDiff(Angle::threeQuarter()).toDegrees(),
+              0.1);
+}

--- a/src/software/backend/simulation/physics/physics_robot_test.cpp
+++ b/src/software/backend/simulation/physics/physics_robot_test.cpp
@@ -19,7 +19,6 @@ TEST(PhysicsRobotTest, test_get_robot_with_timestamp)
     PhysicsRobot physics_robot(world, robot_parameter);
     auto robot = physics_robot.getRobotWithTimestamp(Timestamp::fromSeconds(3.3));
 
-    // TODO: CHECK ROBOT STATE
     EXPECT_EQ(robot_parameter.position(), robot.position());
     EXPECT_EQ(Timestamp::fromSeconds(3.3), robot.getMostRecentTimestamp());
 }


### PR DESCRIPTION
<!---

This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Adds a `PhysicsRobot` class to represent a `Robot` in simulation. This PR just sets up the class and the basic physics bodies, it does not implement robot capabilities like kicking.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
`partially resolves #883`
(formatting this so the ticket won't auto-close)

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
Lots of unit tests, puts it just over.

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
