### PR TITLE
Simulator: Misc improvements

### DIFF
--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -16,6 +16,8 @@ const double DIST_TO_FRONT_OF_ROBOT_METERS = 0.07;
 const double DRIBBLER_WIDTH = 0.088;
 // The approximate radius of the ball according to the SSL rulebook
 const double BALL_MAX_RADIUS_METERS = 0.0215;
+// The mass of a standard golf ball, as defined by https://en.wikipedia.org/wiki/Golf_ball
+const double BALL_MASS_KG = 0.004593;
 // The maximum number of robots we can communicate with over radio.
 const unsigned MAX_ROBOTS_OVER_RADIO = 8;
 // TODO: Determine a more realistic value. See Issue #178.

--- a/src/software/backend/simulation/physics/physics_ball.cpp
+++ b/src/software/backend/simulation/physics/physics_ball.cpp
@@ -23,8 +23,8 @@ PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const Ball &ball)
 
     ball_fixture_def.shape = &ball_shape;
 
-    // Calculate the density the fixture / ball must have in order for it to have the desired mass.
-    // The density is uniform across the shape.
+    // Calculate the density the fixture / ball must have in order for it to have the
+    // desired mass. The density is uniform across the shape.
     float ball_area          = M_PI * ball_shape.m_radius * ball_shape.m_radius;
     ball_fixture_def.density = BALL_MASS_KG / ball_area;
     // These restitution and friction values are somewhat arbitrary. Because this is an

--- a/src/software/backend/simulation/physics/physics_ball.cpp
+++ b/src/software/backend/simulation/physics/physics_ball.cpp
@@ -1,6 +1,7 @@
 #include "software/backend/simulation/physics/physics_ball.h"
 
 #include "shared/constants.h"
+#include <cmath>
 #include "software/backend/simulation/physics/box2d_util.h"
 
 PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const Ball &ball)
@@ -20,11 +21,14 @@ PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const Ball &ball)
     ball_shape.m_radius = BALL_MAX_RADIUS_METERS;
 
     ball_fixture_def.shape = &ball_shape;
-    // These values do not reflect the ball in real life and may still need some tuning.
-    // For now, they are "ideal" values that give the ball perfectly elastic collision
-    // and no friction
-    // TODO: tune values if necessary (#768)
-    ball_fixture_def.density     = 1.0;
+
+    float ball_area = M_PI * ball_shape.m_radius * ball_shape.m_radius;
+    ball_fixture_def.density     = BALL_MASS_KG / ball_area;
+    // These restitution and friction values are somewhat arbitrary. Because this is an
+    // "ideal" simulation, we can approximate the ball as having perfectly elastic
+    // collisions and no friction. Because we also do not generally depend on specific
+    // behaviour when the ball collides with something, getting these values to perfectly
+    // match reality isn't too important.
     ball_fixture_def.restitution = 1.0;
     ball_fixture_def.friction    = 0.0;
 

--- a/src/software/backend/simulation/physics/physics_ball.cpp
+++ b/src/software/backend/simulation/physics/physics_ball.cpp
@@ -23,6 +23,8 @@ PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const Ball &ball)
 
     ball_fixture_def.shape = &ball_shape;
 
+    // Calculate the density the fixture / ball must have in order for it to have the desired mass.
+    // The density is uniform across the shape.
     float ball_area          = M_PI * ball_shape.m_radius * ball_shape.m_radius;
     ball_fixture_def.density = BALL_MASS_KG / ball_area;
     // These restitution and friction values are somewhat arbitrary. Because this is an

--- a/src/software/backend/simulation/physics/physics_ball.cpp
+++ b/src/software/backend/simulation/physics/physics_ball.cpp
@@ -1,7 +1,8 @@
 #include "software/backend/simulation/physics/physics_ball.h"
 
-#include "shared/constants.h"
 #include <cmath>
+
+#include "shared/constants.h"
 #include "software/backend/simulation/physics/box2d_util.h"
 
 PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const Ball &ball)
@@ -22,8 +23,8 @@ PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const Ball &ball)
 
     ball_fixture_def.shape = &ball_shape;
 
-    float ball_area = M_PI * ball_shape.m_radius * ball_shape.m_radius;
-    ball_fixture_def.density     = BALL_MASS_KG / ball_area;
+    float ball_area          = M_PI * ball_shape.m_radius * ball_shape.m_radius;
+    ball_fixture_def.density = BALL_MASS_KG / ball_area;
     // These restitution and friction values are somewhat arbitrary. Because this is an
     // "ideal" simulation, we can approximate the ball as having perfectly elastic
     // collisions and no friction. Because we also do not generally depend on specific

--- a/src/software/backend/simulation/physics/physics_ball_test.cpp
+++ b/src/software/backend/simulation/physics/physics_ball_test.cpp
@@ -54,6 +54,14 @@ TEST(PhysicsBallTest, test_physics_ball_is_removed_from_world_when_destroyed)
     EXPECT_EQ(0, world->GetBodyCount());
 }
 
+TEST(PhysicsBallTest, test_ball_mass) {
+    b2Vec2 gravity(0, 0);
+    auto world = std::make_shared<b2World>(gravity);
+
+    Ball ball_parameter(Point(1, -1), Vector(1, -2), Timestamp::fromSeconds(0));
+    auto physics_ball = PhysicsBall(world, ball_parameter);
+}
+
 TEST(PhysicsBallTest, test_ball_velocity_and_position_updates_during_simulation_step)
 {
     b2Vec2 gravity(0, 0);

--- a/src/software/backend/simulation/physics/physics_ball_test.cpp
+++ b/src/software/backend/simulation/physics/physics_ball_test.cpp
@@ -54,7 +54,8 @@ TEST(PhysicsBallTest, test_physics_ball_is_removed_from_world_when_destroyed)
     EXPECT_EQ(0, world->GetBodyCount());
 }
 
-TEST(PhysicsBallTest, test_ball_mass) {
+TEST(PhysicsBallTest, test_ball_mass)
+{
     b2Vec2 gravity(0, 0);
     auto world = std::make_shared<b2World>(gravity);
 

--- a/src/software/backend/simulation/physics/physics_ball_test.cpp
+++ b/src/software/backend/simulation/physics/physics_ball_test.cpp
@@ -54,15 +54,6 @@ TEST(PhysicsBallTest, test_physics_ball_is_removed_from_world_when_destroyed)
     EXPECT_EQ(0, world->GetBodyCount());
 }
 
-TEST(PhysicsBallTest, test_ball_mass)
-{
-    b2Vec2 gravity(0, 0);
-    auto world = std::make_shared<b2World>(gravity);
-
-    Ball ball_parameter(Point(1, -1), Vector(1, -2), Timestamp::fromSeconds(0));
-    auto physics_ball = PhysicsBall(world, ball_parameter);
-}
-
 TEST(PhysicsBallTest, test_ball_velocity_and_position_updates_during_simulation_step)
 {
     b2Vec2 gravity(0, 0);

--- a/src/software/backend/simulation/physics/physics_field.cpp
+++ b/src/software/backend/simulation/physics/physics_field.cpp
@@ -5,8 +5,8 @@
 PhysicsField::PhysicsField(std::shared_ptr<b2World> world, const Field &field)
     : field(field)
 {
-    // The body must be created first so that subsequent changes (like adding fixtures)
-    // work correctly
+    // createFieldBody must be called before the setup functions, so that the b2Body is
+    // instantiated before fixtures are added to it.
     createFieldBody(world);
     setupFieldBoundary(field);
     setupEnemyGoal(field);
@@ -26,6 +26,8 @@ PhysicsField::~PhysicsField()
 
 void PhysicsField::createFieldBody(std::shared_ptr<b2World> world)
 {
+    // All the BodyDef must be defined before the body is created.
+    // Changes made after aren't reflected
     field_body_def.type = b2_staticBody;
     // Note that the body shape is defined relative to the body position. Setting the
     // body position to (0, 0) makes it easy to add the shape using the standard field

--- a/src/software/backend/simulation/physics/physics_field.cpp
+++ b/src/software/backend/simulation/physics/physics_field.cpp
@@ -24,7 +24,8 @@ PhysicsField::~PhysicsField()
     }
 }
 
-void PhysicsField::createFieldBody(std::shared_ptr<b2World> world) {
+void PhysicsField::createFieldBody(std::shared_ptr<b2World> world)
+{
     field_body_def.type = b2_staticBody;
     // Note that the body shape is defined relative to the body position. Setting the
     // body position to (0, 0) makes it easy to add the shape using the standard field

--- a/src/software/backend/simulation/physics/physics_field.h
+++ b/src/software/backend/simulation/physics/physics_field.h
@@ -54,8 +54,31 @@ class PhysicsField
     Field getFieldWithTimestamp(const Timestamp& timestamp) const;
 
    private:
+    /**
+     * A helper function that creates and sets up physics objects for the field
+     * boundary in the physics world
+     *
+     * @param world The physics world to setup the Field in
+     * @param field The Field being created in the physics world
+     */
     void setupFieldBoundary(std::shared_ptr<b2World> world, const Field& field);
+
+    /**
+     * A helper function that creates and sets up physics objects for the enemy
+     * goal in the physics world
+     *
+     * @param world The physics world to setup the Field in
+     * @param field The Field being created in the physics world
+     */
     void setupEnemyGoal(std::shared_ptr<b2World> world, const Field& field);
+
+    /**
+     * A helper function that creates and sets up physics objects for the friendly
+     * goal in the physics world
+     *
+     * @param world The physics world to setup the Field in
+     * @param field The Field being created in the physics world
+     */
     void setupFriendlyGoal(std::shared_ptr<b2World> world, const Field& field);
 
     // This body represents the 4 boundary walls around the edge of the field

--- a/src/software/backend/simulation/physics/physics_field.h
+++ b/src/software/backend/simulation/physics/physics_field.h
@@ -68,7 +68,7 @@ class PhysicsField
      *
      * @param field The Field being created in the physics world
      */
-    void setupFieldBoundary(const Field &field);
+    void setupFieldBoundary(const Field& field);
 
     /**
      * A helper function that creates and sets up physics objects for the enemy
@@ -76,7 +76,7 @@ class PhysicsField
      *
      * @param field The Field being created in the physics world
      */
-    void setupEnemyGoal(const Field &field);
+    void setupEnemyGoal(const Field& field);
 
     /**
      * A helper function that creates and sets up physics objects for the friendly
@@ -84,7 +84,7 @@ class PhysicsField
      *
      * @param field The Field being created in the physics world
      */
-    void setupFriendlyGoal(const Field &field);
+    void setupFriendlyGoal(const Field& field);
 
     // This body represents the entire field object. Different fixtures and shapes
     // are added to this body for the field boundary, goals, etc. The fixtures are what

--- a/src/software/backend/simulation/physics/physics_field.h
+++ b/src/software/backend/simulation/physics/physics_field.h
@@ -55,49 +55,54 @@ class PhysicsField
 
    private:
     /**
+     * A helper function that creates a physics body to represent the Field
+     * in the physics world
+     *
+     * @param world The physics world to setup the Field in
+     */
+    void createFieldBody(std::shared_ptr<b2World> world);
+
+    /**
      * A helper function that creates and sets up physics objects for the field
      * boundary in the physics world
      *
-     * @param world The physics world to setup the Field in
      * @param field The Field being created in the physics world
      */
-    void setupFieldBoundary(std::shared_ptr<b2World> world, const Field& field);
+    void setupFieldBoundary(const Field &field);
 
     /**
      * A helper function that creates and sets up physics objects for the enemy
      * goal in the physics world
      *
-     * @param world The physics world to setup the Field in
      * @param field The Field being created in the physics world
      */
-    void setupEnemyGoal(std::shared_ptr<b2World> world, const Field& field);
+    void setupEnemyGoal(const Field &field);
 
     /**
      * A helper function that creates and sets up physics objects for the friendly
      * goal in the physics world
      *
-     * @param world The physics world to setup the Field in
      * @param field The Field being created in the physics world
      */
-    void setupFriendlyGoal(std::shared_ptr<b2World> world, const Field& field);
+    void setupFriendlyGoal(const Field &field);
 
-    // This body represents the 4 boundary walls around the edge of the field
-    b2BodyDef field_boundary_body_def;
+    // This body represents the entire field object. Different fixtures and shapes
+    // are added to this body for the field boundary, goals, etc. The fixtures are what
+    // actually handle collisions, which is why we only need a single body to represent
+    // the whole field
+    b2BodyDef field_body_def;
+    b2Body* field_body;
+
     b2ChainShape field_boundary_shape;
-    b2Body* field_boundary_body;
     b2FixtureDef field_boundary_fixture_def;
 
-    // This body represents the enemy net
-    b2BodyDef enemy_goal_body_def;
     b2ChainShape enemy_goal_shape;
-    b2Body* enemy_goal_body;
     b2FixtureDef enemy_goal_fixture_def;
 
-    // This body represents the friendly goal
-    b2BodyDef friendly_goal_body_def;
     b2ChainShape friendly_goal_shape;
-    b2Body* friendly_goal_body;
     b2FixtureDef friendly_goal_fixture_def;
 
+    // Since the field never changes during simulation, we store the initial field
+    // used during construction to make it easy to return Field objects when requested
     Field field;
 };

--- a/src/software/backend/simulation/physics/physics_field_test.cpp
+++ b/src/software/backend/simulation/physics/physics_field_test.cpp
@@ -32,8 +32,8 @@ TEST(PhysicsFieldTest, test_field_added_to_physics_world_on_creation)
 
     auto physics_field = PhysicsField(world, field_parameter);
 
-    // The field adds 3 bodies: 1 for the boundary and 1 for each goal
-    EXPECT_EQ(3, world->GetBodyCount());
+    // There is only 1 body that represents the entire field
+    EXPECT_EQ(1, world->GetBodyCount());
 }
 
 TEST(PhysicsFieldTest, test_physics_field_is_removed_from_world_when_destroyed)
@@ -48,7 +48,7 @@ TEST(PhysicsFieldTest, test_physics_field_is_removed_from_world_when_destroyed)
 
         auto physics_field = PhysicsField(world, field_parameter);
 
-        EXPECT_EQ(3, world->GetBodyCount());
+        EXPECT_EQ(1, world->GetBodyCount());
     }
 
     // Once we leave the above scope the field is destroyed, so it should have been


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Misc improvements to simulation physics and abstractions:
* Added some missing javadoc comments
* Simplified how the `PhysicsField` was represented. It only needed 1 body instead of 3
* Gave the `PhysicsBall` the correct mass

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Mostly refactoring, so existing unit tests are still valid (and were updated as needed)

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
None

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
