### PR TITLE
Added Newer Version Of Valgrind To Software Setup Script

### DIFF
--- a/environment_setup/setup_software.sh
+++ b/environment_setup/setup_software.sh
@@ -56,6 +56,19 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+echo "================================================================"
+echo "Installing Newer Valgrind Version"
+echo "================================================================"
+# The default version of valgrind on Ubuntu 18.04 via `apt` is '3.13', but
+# the version of clang we use requires at least '3.15'. To get around this, we
+# remove the version installed by `apt` and get the version from `snap` instead
+sudo apt remove valgrind
+sudo snap install valgrind --channel=stable --classic
+
+echo "================================================================"
+echo "Done Installing Newer Valgrind Version"
+echo "================================================================"
+
 # Install Bazel
 echo "================================================================" 
 echo "Installing Bazel"


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Tested out the commands added.

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #1035 

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
