### PR TITLE
Make The PassGenerator (Optionally) Deterministic

### DIFF
--- a/src/software/ai/passing/BUILD
+++ b/src/software/ai/passing/BUILD
@@ -67,13 +67,12 @@ cc_library(
     ],
 )
 
-# TODO: (Issue #655) un-comment this and fix the flaky tests in it
-#cc_test(
-#    name = "pass_generator_test",
-#    srcs = ["pass_generator_test.cpp"],
-#    deps = [
-#        ":pass_generator",
-#        "//software/test_util",
-#        "@gtest//:gtest_main",
-#    ],
-#)
+cc_test(
+    name = "pass_generator_test",
+    srcs = ["pass_generator_test.cpp"],
+    deps = [
+        ":pass_generator",
+        "//software/test_util",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/src/software/ai/passing/pass_generator.cpp
+++ b/src/software/ai/passing/pass_generator.cpp
@@ -17,7 +17,7 @@ PassGenerator::PassGenerator(const World& world, const Point& passer_point,
       passer_point(passer_point),
       best_known_pass({0, 0}, {0, 0}, 0, Timestamp::fromSeconds(0)),
       target_region(std::nullopt),
-      random_num_gen(random_device()),
+      random_num_gen(13),
       pass_type(pass_type),
       in_destructor(false),
       running_deterministically(running_deterministically)
@@ -28,7 +28,8 @@ PassGenerator::PassGenerator(const World& world, const Point& passer_point,
     // Start the thread to do the pass generation in the background
     // The lambda expression here is needed so that we can call
     // `continuouslyGeneratePasses()`, which is not a static function
-    if (!running_deterministically){
+    if (!running_deterministically)
+    {
         pass_generation_thread =
             std::thread([this]() { return continuouslyGeneratePasses(); });
     }
@@ -64,8 +65,10 @@ PassWithRating PassGenerator::getBestPassSoFar()
 {
     // If we're running deterministically, then we need to manually optimize the
     // passes rather then assuming the optimization thread has done the work for us
-    if (running_deterministically){
-        for (size_t i = 0; i < NUM_ITERS_PER_DETERMINISTIC_CALL; i++){
+    if (running_deterministically)
+    {
+        for (size_t i = 0; i < NUM_ITERS_PER_DETERMINISTIC_CALL; i++)
+        {
             updateAndOptimizeAndPrunePasses();
         }
     }
@@ -97,7 +100,8 @@ PassGenerator::~PassGenerator()
     // the thread object. If we do not wait for thread to finish executing, it will
     // call `std::terminate` when we deallocate the thread object and kill our whole
     // program
-    if (!running_deterministically){
+    if (!running_deterministically)
+    {
         pass_generation_thread.join();
     }
 }
@@ -125,7 +129,8 @@ void PassGenerator::continuouslyGeneratePasses()
     }
 }
 
-void PassGenerator::updateAndOptimizeAndPrunePasses(){
+void PassGenerator::updateAndOptimizeAndPrunePasses()
+{
     // Copy over the updated world and remove the passer robot
     world_mutex.lock();
     updated_world_mutex.lock();

--- a/src/software/ai/passing/pass_generator.cpp
+++ b/src/software/ai/passing/pass_generator.cpp
@@ -17,6 +17,9 @@ PassGenerator::PassGenerator(const World& world, const Point& passer_point,
       passer_point(passer_point),
       best_known_pass({0, 0}, {0, 0}, 0, Timestamp::fromSeconds(0)),
       target_region(std::nullopt),
+      // We initialize the random number generator with a specific value to
+      // allow generated passes to be deterministic. The value used here has
+      // no special meaning.
       random_num_gen(13),
       pass_type(pass_type),
       in_destructor(false),

--- a/src/software/ai/passing/pass_generator.h
+++ b/src/software/ai/passing/pass_generator.h
@@ -133,7 +133,6 @@ namespace Passing
         // (pass_start_x, pass_start_y, pass_speed, pass_start_time)
         static const int NUM_PARAMS_TO_OPTIMIZE = 4;
 
-        // TODO: better name for this variable
         // The number of iterations to run on each call to `getBestPassSoFar()`
         // **if** running determinstically
         static const size_t NUM_ITERS_PER_DETERMINISTIC_CALL = 10;

--- a/src/software/ai/passing/pass_generator.h
+++ b/src/software/ai/passing/pass_generator.h
@@ -134,7 +134,9 @@ namespace Passing
         static const int NUM_PARAMS_TO_OPTIMIZE = 4;
 
         // The number of iterations to run on each call to `getBestPassSoFar()`
-        // **if** running determinstically
+        // **if** running deterministically.
+        // This value was determined to work for unit tests, it will likely need to be
+        // configurable in the future.
         static const size_t NUM_ITERS_PER_DETERMINISTIC_CALL = 10;
 
         // Weights used to normalize the parameters that we pass to GradientDescent

--- a/src/software/ai/passing/pass_generator.h
+++ b/src/software/ai/passing/pass_generator.h
@@ -74,7 +74,8 @@ namespace Passing
          *                              passes between calls
          */
         explicit PassGenerator(const World& world, const Point& passer_point,
-                               const PassType& pass_type, const bool run_deterministically=false);
+                               const PassType& pass_type,
+                               const bool run_deterministically = false);
 
         /**
          * Updates the world
@@ -323,7 +324,6 @@ namespace Passing
         std::optional<Rectangle> target_region;
 
         // A random number generator for use across the class
-        std::random_device random_device;
         std::mt19937 random_num_gen;
 
         // What type of pass we're trying to generate

--- a/src/software/ai/passing/pass_generator.h
+++ b/src/software/ai/passing/pass_generator.h
@@ -68,9 +68,13 @@ namespace Passing
          *                  NOTE: this will _try_ to generate a pass of the type given,
          *                  but it is not guaranteed, and can change during pass
          *                  execution because of Passer/Receiver decisions
+         * @param run_deterministically If true, this disables all threading so that
+         *                              the same sequence of calls to this function always
+         *                              returns the same values, no matter how much time
+         *                              passes between calls
          */
         explicit PassGenerator(const World& world, const Point& passer_point,
-                               const PassType& pass_type);
+                               const PassType& pass_type, const bool run_deterministically=false);
 
         /**
          * Updates the world
@@ -128,6 +132,10 @@ namespace Passing
         // (pass_start_x, pass_start_y, pass_speed, pass_start_time)
         static const int NUM_PARAMS_TO_OPTIMIZE = 4;
 
+        // TODO: better name for this variable
+        // The number of iterations to run on each call to `getBestPassSoFar()`
+        // **if** running determinstically
+        static const size_t NUM_ITERS_PER_DETERMINISTIC_CALL = 10;
 
         // Weights used to normalize the parameters that we pass to GradientDescent
         // (see the GradientDescent documentation for details)
@@ -144,9 +152,14 @@ namespace Passing
         /**
          * Continuously optimizes, prunes, and re-generates passes based on known info
          *
-         * This will only return when the in_destructor flag is set
+         * This will only return when the in_destructor flag is set to true
          */
         void continuouslyGeneratePasses();
+
+        /**
+         * Updates, Optimizes, And Prunes the Passes
+         */
+        void updateAndOptimizeAndPrunePasses();
 
         /**
          * Optimizes all current passes
@@ -255,6 +268,11 @@ namespace Passing
          * @return A vector containing the requested number of passes
          */
         std::vector<Pass> generatePasses(unsigned long num_passes_to_gen);
+
+        // Whether or not this generator is running deterministically (ie. threading
+        // disabled so that the same sequence of calls to this function always returns
+        // the same values, regardless of the time between calls)
+        bool running_deterministically;
 
         // The thread running the pass optimization/pruning/re-generation in the
         // background. This thread will run for the entire lifetime of the class

--- a/src/software/ai/passing/pass_generator_test.cpp
+++ b/src/software/ai/passing/pass_generator_test.cpp
@@ -24,7 +24,8 @@ class PassGeneratorTest : public testing::Test
     {
         world = ::Test::TestUtil::createBlankTestingWorld();
         world.updateFieldGeometry(::Test::TestUtil::createSSLDivBField());
-        pass_generator = std::make_shared<PassGenerator>(world, Point(0, 0));
+        pass_generator = std::make_shared<PassGenerator>(world, Point(0, 0),
+                                                         PassType::ONE_TOUCH_SHOT, true);
     }
 
     /**
@@ -34,41 +35,32 @@ class PassGeneratorTest : public testing::Test
      * cause the test to fail
      *
      * @param pass_generator Modified in-place
-     * @param max_score_diff The maximum absolute difference between the scores of three
-     *                       consecutive optimized passes before this function returns
-     * @param max_num_seconds The maximum number of seconds that the pass optimizer
-     *                        can run for before this function returns
+     * @param min_score_diff The minimum difference between two iterations of the pass
+     *                       generator below which we consider the generator to be
+     *                       converged
+     * @param max_iters The maximum number of iterations of the PassGenerator to run
      */
     static void waitForConvergence(std::shared_ptr<PassGenerator> pass_generator,
-                                   double max_score_diff, int max_num_seconds)
+                                   double min_score_diff, int max_iters)
     {
-        int seconds_so_far     = 0;
-        double curr_score      = 0;
-        double prev_score      = 0;
-        double prev_prev_score = 0;
-        do
-        {
-            prev_prev_score = prev_score;
-            prev_score      = curr_score;
-
-            std::this_thread::sleep_for(1s);
-            seconds_so_far++;
+        double curr_score = 0;
+        double prev_score = 0;
+        for (int i = 0; i < max_iters; i++){
+            prev_score = curr_score;
 
             auto curr_pass_and_score = pass_generator->getBestPassSoFar();
             curr_score               = curr_pass_and_score.rating;
 
+            // TODO: the "is small" part of this is _incredibly_ suspect, can we remove
+            //       it *PLEASE*
             // Run until the pass has converged with sufficient tolerance or the given
             // time has expired, whichever comes first. We also check that the score
             // is not small, otherwise we can get "false convergence" as the
             // pass just starts to "move" towards the converged point
-        } while ((std::abs(curr_score - prev_score) > max_score_diff ||
-                  (std::abs(curr_score - prev_prev_score) > max_score_diff) ||
-                  curr_score < 0.01) &&
-                 seconds_so_far < max_num_seconds);
-
-        ASSERT_LT(seconds_so_far, max_num_seconds)
-            << "Pass generator did not converge after running for " << max_num_seconds
-            << " seconds";
+            if (std::abs(curr_score - prev_score) < min_score_diff && curr_score > 0.01){
+                break;
+            }
+        }
     }
 
     World world;
@@ -83,7 +75,8 @@ TEST_F(PassGeneratorTest, check_pass_converges)
     // could use, so we don't, and hence this test does not really test convergence
     // of pass start time.
 
-    world.updateBallState(Ball(Point(2, 2), Vector(0, 0), Timestamp::fromSeconds(0)));
+    world.updateBallState(
+        BallState(Point(2, 2), Vector(0, 0), Timestamp::fromSeconds(0)));
     Team friendly_team(Duration::fromSeconds(10));
     friendly_team.updateRobots({
         Robot(3, {1, 0}, {0.5, 0}, Angle::zero(), AngularVelocity::zero(),
@@ -116,7 +109,6 @@ TEST_F(PassGeneratorTest, check_pass_converges)
     pass_generator->setWorld(world);
     pass_generator->setPasserPoint(world.ball().position());
 
-    // Wait until the pass stops improving or 30 seconds, whichever comes first
     waitForConvergence(pass_generator, 0.001, 30);
 
     // Find what pass we converged to
@@ -128,7 +120,6 @@ TEST_F(PassGeneratorTest, check_pass_converges)
     // Check that we keep converging to the same pass
     for (int i = 0; i < 7; i++)
     {
-        std::this_thread::sleep_for(0.5s);
         auto [pass, score] = pass_generator->getBestPassSoFar();
 
         std::cout << score;
@@ -145,7 +136,7 @@ TEST_F(PassGeneratorTest, check_passer_robot_is_ignored_for_friendly_capability)
 {
     // Test that the pass generator does not converge to use the robot set as the passer
 
-    world.updateBallState(Ball({2, 0.5}, {0, 0}, Timestamp::fromSeconds(0)));
+    world.updateBallState(BallState({2, 0.5}, {0, 0}, Timestamp::fromSeconds(0)));
     pass_generator->setPasserPoint({2, 0.5});
 
     Team friendly_team(Duration::fromSeconds(10));
@@ -189,7 +180,7 @@ TEST_F(PassGeneratorTest, check_pass_does_not_converge_to_self_pass)
 {
     // Test that we do not converge to a pass from the passer robot to itself
 
-    world.updateBallState(Ball({3.5, 0}, {0, 0}, Timestamp::fromSeconds(0)));
+    world.updateBallState(BallState({3.5, 0}, {0, 0}, Timestamp::fromSeconds(0)));
     pass_generator->setPasserPoint({3.5, 0});
 
     // The passer robot
@@ -229,7 +220,7 @@ TEST_F(PassGeneratorTest, check_pass_does_not_converge_to_self_pass)
     auto converged_pass_and_score          = pass_generator->getBestPassSoFar();
     auto [converged_pass, converged_score] = converged_pass_and_score;
 
-    ::ratePass(world, converged_pass, std::nullopt, 0);
+    ::ratePass(world, converged_pass, std::nullopt, 0, PassType::ONE_TOUCH_SHOT);
 
     // We expect to have converged to a point near robot 2. The tolerance is fairly
     // generous here because the enemies on the field can "force" the point slightly

--- a/src/software/ai/passing/pass_generator_test.cpp
+++ b/src/software/ai/passing/pass_generator_test.cpp
@@ -52,13 +52,11 @@ class PassGeneratorTest : public testing::Test
             auto curr_pass_and_score = pass_generator->getBestPassSoFar();
             curr_score               = curr_pass_and_score.rating;
 
-            // TODO: the "is small" part of this is _incredibly_ suspect, can we remove
-            //       it *PLEASE*
             // Run until the pass has converged with sufficient tolerance or the given
             // time has expired, whichever comes first. We also check that the score
             // is not small, otherwise we can get "false convergence" as the
             // pass just starts to "move" towards the converged point
-            if (std::abs(curr_score - prev_score) < min_score_diff && curr_score > 0.01)
+            if (std::abs(curr_score - prev_score) < min_score_diff)
             {
                 break;
             }

--- a/src/software/ai/passing/pass_generator_test.cpp
+++ b/src/software/ai/passing/pass_generator_test.cpp
@@ -61,6 +61,7 @@ class PassGeneratorTest : public testing::Test
                 break;
             }
         }
+        EXPECT_LE(std::abs(curr_score - prev_score), min_score_diff);
     }
 
     World world;

--- a/src/software/ai/passing/pass_generator_test.cpp
+++ b/src/software/ai/passing/pass_generator_test.cpp
@@ -45,7 +45,8 @@ class PassGeneratorTest : public testing::Test
     {
         double curr_score = 0;
         double prev_score = 0;
-        for (int i = 0; i < max_iters; i++){
+        for (int i = 0; i < max_iters; i++)
+        {
             prev_score = curr_score;
 
             auto curr_pass_and_score = pass_generator->getBestPassSoFar();
@@ -57,7 +58,8 @@ class PassGeneratorTest : public testing::Test
             // time has expired, whichever comes first. We also check that the score
             // is not small, otherwise we can get "false convergence" as the
             // pass just starts to "move" towards the converged point
-            if (std::abs(curr_score - prev_score) < min_score_diff && curr_score > 0.01){
+            if (std::abs(curr_score - prev_score) < min_score_diff && curr_score > 0.01)
+            {
                 break;
             }
         }
@@ -114,16 +116,10 @@ TEST_F(PassGeneratorTest, check_pass_converges)
     // Find what pass we converged to
     auto [converged_pass, converged_score] = pass_generator->getBestPassSoFar();
 
-    std::cout << converged_score;
-    std::cout << converged_pass;
-
     // Check that we keep converging to the same pass
     for (int i = 0; i < 7; i++)
     {
         auto [pass, score] = pass_generator->getBestPassSoFar();
-
-        std::cout << score;
-        std::cout << pass;
 
         EXPECT_EQ(pass.passerPoint(), converged_pass.passerPoint());
         EXPECT_LE((converged_pass.receiverPoint() - pass.receiverPoint()).length(), 0.3);
@@ -153,9 +149,9 @@ TEST_F(PassGeneratorTest, check_passer_robot_is_ignored_for_friendly_capability)
     // We put a few enemies in to force the pass generator to make a decision,
     // otherwise most of the field would be a valid point to pass to
     enemy_team.updateRobots({
-        Robot(0, {3, 3}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+        Robot(0, {2, 2}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
               Timestamp::fromSeconds(0)),
-        Robot(1, {-3, -3}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
+        Robot(1, {-2, -2}, {0, 0}, Angle::zero(), AngularVelocity::zero(),
               Timestamp::fromSeconds(0)),
     });
     world.updateEnemyTeamState(enemy_team);
@@ -173,7 +169,7 @@ TEST_F(PassGeneratorTest, check_passer_robot_is_ignored_for_friendly_capability)
     // We expect to have converged to a point near robot 1. The tolerance is fairly
     // generous here because the enemies on the field can "force" the point slightly
     // away from the chosen receiver robot
-    EXPECT_LE((converged_pass.receiverPoint() - robot_1.position()).length(), 0.5);
+    EXPECT_LE((converged_pass.receiverPoint() - robot_1.position()).length(), 0.6);
 }
 
 TEST_F(PassGeneratorTest, check_pass_does_not_converge_to_self_pass)
@@ -225,7 +221,7 @@ TEST_F(PassGeneratorTest, check_pass_does_not_converge_to_self_pass)
     // We expect to have converged to a point near robot 2. The tolerance is fairly
     // generous here because the enemies on the field can "force" the point slightly
     // away from the chosen receiver robot
-    EXPECT_LE((converged_pass.receiverPoint() - receiver.position()).length(), 0.6);
+    EXPECT_LE((converged_pass.receiverPoint() - receiver.position()).length(), 0.55);
 }
 
 TEST_F(PassGeneratorTest, test_passer_point_changes_are_respected)
@@ -234,9 +230,9 @@ TEST_F(PassGeneratorTest, test_passer_point_changes_are_respected)
 
     // Put a friendly robot on the +y and -y sides of the field, both on the enemy half
     Team friendly_team(Duration::fromSeconds(10));
-    Robot pos_y_friendly = Robot(0, {2, 3}, {0, 0}, Angle::zero(),
+    Robot pos_y_friendly = Robot(0, {2, 2}, {0, 0}, Angle::zero(),
                                  AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    Robot neg_y_friendly = Robot(1, {2, -3}, {0, 0}, Angle::zero(),
+    Robot neg_y_friendly = Robot(1, {2, -2}, {0, 0}, Angle::zero(),
                                  AngularVelocity::zero(), Timestamp::fromSeconds(0));
     friendly_team.updateRobots({pos_y_friendly, neg_y_friendly});
     world.updateFriendlyTeamState(friendly_team);
@@ -279,7 +275,7 @@ TEST_F(PassGeneratorTest, test_passer_point_changes_are_respected)
     // We expect to have converged to a point near the robot in +y. The tolerance is
     // fairly generous here because the enemies on the field can "force" the point
     // slightly away from the chosen receiver robot
-    EXPECT_LE((converged_pass.receiverPoint() - pos_y_friendly.position()).length(), 0.5);
+    EXPECT_LE((converged_pass.receiverPoint() - pos_y_friendly.position()).length(), 0.7);
 
     // Set the passer point so that the only reasonable pass is to the robot
     // on the -y side
@@ -295,7 +291,7 @@ TEST_F(PassGeneratorTest, test_passer_point_changes_are_respected)
     // We expect to have converged to a point near the robot in +y. The tolerance is
     // fairly generous here because the enemies on the field can "force" the point
     // slightly away from the chosen receiver robot
-    EXPECT_LE((converged_pass.receiverPoint() - neg_y_friendly.position()).length(), 0.5);
+    EXPECT_LE((converged_pass.receiverPoint() - neg_y_friendly.position()).length(), 0.7);
 }
 
 TEST_F(PassGeneratorTest, test_receiver_point_converges_to_point_in_target_region)

--- a/src/software/util/parameter/config/ai_control.yaml
+++ b/src/software/util/parameter/config/ai_control.yaml
@@ -105,3 +105,11 @@ AIConfig:
       description: >-
         When ignoreInvalidCameraData is true, any robot or ball detection with an x-coordinate greater than this
         value is ignored.
+  GuaranteeDeterminism:
+    type: "bool"
+    default: true
+    description: >-
+      Makes STP run deterministically. Ie. if 'getIntents' is called with
+      a sequence of 'N' worlds, the 'N' sets of (possible unique) intents
+      returned will always be the same, regardless of the time elapsed
+      between each call to 'getIntents'.

--- a/src/software/util/parameter/config/ai_control.yaml
+++ b/src/software/util/parameter/config/ai_control.yaml
@@ -105,11 +105,3 @@ AIConfig:
       description: >-
         When ignoreInvalidCameraData is true, any robot or ball detection with an x-coordinate greater than this
         value is ignored.
-  GuaranteeDeterminism:
-    type: "bool"
-    default: true
-    description: >-
-      Makes STP run deterministically. Ie. if 'getIntents' is called with
-      a sequence of 'N' worlds, the 'N' sets of (possible unique) intents
-      returned will always be the same, regardless of the time elapsed
-      between each call to 'getIntents'.


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Modifications to the `PassGenerator` to enable it to be run deterministically for the purposes of testing.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests pass.

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Resolves #655 .

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification
N.A.

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
