### PR TITLE
Geom: Move `distance` functions from util

### DIFF
--- a/src/software/new_geom/util/BUILD
+++ b/src/software/new_geom/util/BUILD
@@ -50,10 +50,13 @@ cc_library(
         "distance.h",
     ],
     deps = [
+        "//software/geom",
         "//software/new_geom:angle",
         "//software/new_geom:geom_constants",
         "//software/new_geom:line",
         "//software/new_geom:point",
+        "//software/new_geom:polygon",
+        "//software/new_geom:segment",
         "//software/new_geom:vector",
     ],
 )

--- a/src/software/new_geom/util/distance.cpp
+++ b/src/software/new_geom/util/distance.cpp
@@ -23,10 +23,13 @@ double distance(const Segment &first, const Segment &second)
     {
         return 0.0;
     }
-    return std::sqrt(std::min(std::min(distanceSquared(first, second.getSegStart()),
-                                       distanceSquared(first, second.getEnd())),
-                              std::min(distanceSquared(second, first.getSegStart()),
-                                       distanceSquared(second, first.getEnd()))));
+    double first_to_second_start_distsq = distanceSquared(first, second.getSegStart());
+    double first_to_second_end_distsq   = distanceSquared(first, second.getEnd());
+    double second_to_first_start_distsq = distanceSquared(second, first.getSegStart());
+    double second_to_first_end_distsq   = distanceSquared(second, first.getEnd());
+    return std::sqrt(
+        std::min({first_to_second_start_distsq, first_to_second_end_distsq,
+                  second_to_first_start_distsq, second_to_first_end_distsq}));
 }
 
 double distance(const Point &first, const Segment &second)
@@ -84,10 +87,10 @@ double distanceSquared(const Point &first, const Segment &second)
         return std::fabs(cross * cross / seg_lensq);
     }
 
-    double seg_start_to_point_lensq = distanceSquared(second.getSegStart(), first),
-           seg_end_to_point_lensq   = distanceSquared(second.getEnd(), first);
+    double seg_start_to_point_distsq = distanceSquared(second.getSegStart(), first);
+    double seg_end_to_point_distsq   = distanceSquared(second.getEnd(), first);
 
-    return std::min(seg_start_to_point_lensq, seg_end_to_point_lensq);
+    return std::min(seg_start_to_point_distsq, seg_end_to_point_distsq);
 }
 
 double distanceSquared(const Segment &first, const Point &second)

--- a/src/software/new_geom/util/distance.cpp
+++ b/src/software/new_geom/util/distance.cpp
@@ -11,3 +11,91 @@ double distance(const Point &first, const Line &second)
 {
     return distance(second, first);
 }
+
+double distance(const Point &first, const Point &second)
+{
+    return (first - second).length();
+}
+
+double distance(const Segment &first, const Segment &second)
+{
+    if (intersects(first, second))
+    {
+        return 0.0;
+    }
+    return std::sqrt(std::min(std::min(distanceSquared(first, second.getSegStart()),
+                                       distanceSquared(first, second.getEnd())),
+                              std::min(distanceSquared(second, first.getSegStart()),
+                                       distanceSquared(second, first.getEnd()))));
+}
+
+double distance(const Point &first, const Segment &second)
+{
+    return std::sqrt(distanceSquared(first, second));
+}
+
+double distance(const Segment &first, const Point &second)
+{
+    return distance(second, first);
+}
+
+double distance(const Point &first, const Polygon &second)
+{
+    if (second.contains(first))
+    {
+        return 0;
+    }
+
+    double min_dist = std::numeric_limits<double>::max();
+
+    // Calculate the distance from the point to each edge
+    for (auto &segment : second.getSegments())
+    {
+        double current_dist = distance(first, segment);
+        if (current_dist < min_dist)
+        {
+            min_dist = current_dist;
+        }
+    }
+    return min_dist;
+}
+
+double distance(const Polygon &first, const Point &second)
+{
+    return distance(second, first);
+}
+
+double distanceSquared(const Point &first, const Segment &second)
+{
+    double seg_lensq          = lengthSquared(second);
+    Vector seg_start_to_point = first - second.getSegStart();
+    Vector seg_end_to_point   = first - second.getEnd();
+
+    Vector seg_vec = second.toVector();
+
+    if (seg_vec.dot(seg_start_to_point) > 0 &&
+        second.reverse().toVector().dot(seg_end_to_point) > 0)
+    {
+        if (isDegenerate(second))
+        {
+            return seg_start_to_point.length();
+        }
+        double cross = seg_start_to_point.cross(seg_vec);
+        return std::fabs(cross * cross / seg_lensq);
+    }
+
+    double seg_start_to_point_lensq = distanceSquared(second.getSegStart(), first),
+           seg_end_to_point_lensq   = distanceSquared(second.getEnd(), first);
+
+    return std::min(seg_start_to_point_lensq, seg_end_to_point_lensq);
+}
+
+double distanceSquared(const Segment &first, const Point &second)
+{
+    return distanceSquared(second, first);
+}
+
+double distanceSquared(const Point &first, const Point &second)
+{
+    return (first - second).lengthSquared();
+}

--- a/src/software/new_geom/util/distance.h
+++ b/src/software/new_geom/util/distance.h
@@ -11,8 +11,8 @@
 /**
  * Finds the shortest distance between a Line and a Point
  *
- * @param first the Line
- * @param second the Point
+ * @param first
+ * @param second
  * @return the shortest distance between first and second
  */
 double distance(const Line &first, const Point &second);
@@ -21,8 +21,8 @@ double distance(const Point &first, const Line &second);
 /**
  * Finds the shortest distance between two Points
  *
- * @param first Point
- * @param second Point
+ * @param first
+ * @param second
  * @return the shortest distance between first and second
  */
 double distance(const Point &first, const Point &second);
@@ -30,8 +30,8 @@ double distance(const Point &first, const Point &second);
 /**
  * Finds the shortest distance between two Segments
  *
- * @param first Segment
- * @param second Segment
+ * @param first
+ * @param second
  * @return the shortest distance between first and second
  */
 double distance(const Segment &first, const Segment &second);
@@ -39,8 +39,8 @@ double distance(const Segment &first, const Segment &second);
 /**
  * Finds the shortest distance between a Point and a Segment
  *
- * @param first the Point
- * @param second the Segment
+ * @param first
+ * @param second
  * @return the shortest distance between first and second
  */
 double distance(const Point &first, const Segment &second);
@@ -49,8 +49,8 @@ double distance(const Segment &first, const Point &second);
 /**
  * Finds the shortest distance between a Point and a Polygon
  *
- * @param first the Point
- * @param second the Polygon
+ * @param first
+ * @param second
  * @return the shortest distance between first and second
  */
 double distance(const Point &first, const Polygon &second);
@@ -59,8 +59,8 @@ double distance(const Polygon &first, const Point &second);
 /**
  * Finds the squared shortest distance between a Point and a Segment
  *
- * @param first the Point
- * @param second the Segment
+ * @param first
+ * @param second
  * @return the squared shortest distance between first and second
  */
 double distanceSquared(const Point &first, const Segment &second);
@@ -69,8 +69,8 @@ double distanceSquared(const Segment &first, const Point &second);
 /**
  * Finds the squared shortest distance between two Points
  *
- * @param first Point
- * @param second Point
+ * @param first
+ * @param second
  * @return the squared shortest distance between first and second
  */
 double distanceSquared(const Point &first, const Point &second);

--- a/src/software/new_geom/util/distance.h
+++ b/src/software/new_geom/util/distance.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <limits>
+
+#include "software/geom/util.h"
 #include "software/new_geom/line.h"
 #include "software/new_geom/point.h"
+#include "software/new_geom/polygon.h"
+#include "software/new_geom/segment.h"
 
 /**
  * Finds the shortest distance between a Line and a Point
@@ -12,3 +17,60 @@
  */
 double distance(const Line &first, const Point &second);
 double distance(const Point &first, const Line &second);
+
+/**
+ * Finds the shortest distance between two Points
+ *
+ * @param first Point
+ * @param second Point
+ * @return the shortest distance between first and second
+ */
+double distance(const Point &first, const Point &second);
+
+/**
+ * Finds the shortest distance between two Segments
+ *
+ * @param first Segment
+ * @param second Segment
+ * @return the shortest distance between first and second
+ */
+double distance(const Segment &first, const Segment &second);
+
+/**
+ * Finds the shortest distance between a Point and a Segment
+ *
+ * @param first the Point
+ * @param second the Segment
+ * @return the shortest distance between first and second
+ */
+double distance(const Point &first, const Segment &second);
+double distance(const Segment &first, const Point &second);
+
+/**
+ * Finds the shortest distance between a Point and a Polygon
+ *
+ * @param first the Point
+ * @param second the Polygon
+ * @return the shortest distance between first and second
+ */
+double distance(const Point &first, const Polygon &second);
+double distance(const Polygon &first, const Point &second);
+
+/**
+ * Finds the squared shortest distance between a Point and a Segment
+ *
+ * @param first the Point
+ * @param second the Segment
+ * @return the squared shortest distance between first and second
+ */
+double distanceSquared(const Point &first, const Segment &second);
+double distanceSquared(const Segment &first, const Point &second);
+
+/**
+ * Finds the squared shortest distance between two Points
+ *
+ * @param first Point
+ * @param second Point
+ * @return the squared shortest distance between first and second
+ */
+double distanceSquared(const Point &first, const Point &second);

--- a/src/software/new_geom/util/distance.h
+++ b/src/software/new_geom/util/distance.h
@@ -47,7 +47,8 @@ double distance(const Point &first, const Segment &second);
 double distance(const Segment &first, const Point &second);
 
 /**
- * Finds the shortest distance between a Point and a Polygon
+ * Finds the shortest distance between a Point and a Polygon. If the Point is inside the
+ * Polygon, the shortest distance is 0.
  *
  * @param first
  * @param second

--- a/src/software/new_geom/util/distance_test.cpp
+++ b/src/software/new_geom/util/distance_test.cpp
@@ -36,7 +36,255 @@ TEST(DistanceTest, point_far_from_line)
 {
     Line l(Point(0, -4), Point(10, 2));
     Point p(179500, -299164);
-    double expected = 348879.57175;
-    EXPECT_NEAR(expected, distance(l, p), 1e-5);
-    EXPECT_NEAR(expected, distance(p, l), 1e-5);
+    double expected =
+        std::abs(-6.0 / 10.0 * p.x() + p.y() + 4) / std::hypot(-6.0 / 10.0, 1);
+    EXPECT_NEAR(distance(l, p), expected, 1e-10);
+    EXPECT_NEAR(distance(p, l), expected, 1e-10);
+}
+
+TEST(DistanceTest, same_points)
+{
+    Point p1(3, 5);
+    Point p2(3, 5);
+    double expected = 0.0;
+    EXPECT_DOUBLE_EQ(distance(p1, p2), expected);
+}
+
+TEST(DistanceTest, different_points)
+{
+    Point p1(-1, -7);
+    Point p2(4, 5);
+    double expected = 13.0;
+    EXPECT_DOUBLE_EQ(distance(p1, p2), expected);
+}
+
+TEST(DistanceTest, same_segments)
+{
+    Segment s1(Point(-4, 7), Point(4, 2));
+    Segment s2(Point(-4, 7), Point(4, 2));
+    double expected = 0;
+    EXPECT_DOUBLE_EQ(distance(s1, s2), expected);
+}
+
+TEST(DistanceTest, different_parallel_segments)
+{
+    Segment s1(Point(-4, 7), Point(4, 2));
+    Segment s2(Point(-8, 6), Point(4, -1.5));
+    double expected = std::abs(4.5 - 1) / std::sqrt(std::pow((-5.0 / 8.0), 2) + 1);
+    EXPECT_DOUBLE_EQ(distance(s1, s2), expected);
+}
+
+TEST(DistanceTest, intersecting_segments)
+{
+    Segment s1(Point(-4, 4), Point(4, 4));
+    Segment s2(Point(-5, 8), Point(2, 0));
+    double expected = 0;
+    EXPECT_DOUBLE_EQ(distance(s1, s2), expected);
+}
+
+TEST(DistanceTest, non_intersecting_segments)
+{
+    Segment s1(Point(-4, 4), Point(4, 2));
+    Segment s2(Point(6, 8), Point(-2, 7));
+    double expected = std::abs(1.0 / 4.0 * -2 + 7 + -3) / std::hypot(1.0 / 4.0, 1);
+    EXPECT_DOUBLE_EQ(distance(s1, s2), expected);
+}
+
+TEST(DistanceTest, degenerate_segments)
+{
+    Segment s1(Point(-4, 4), Point(-4, 4));
+    Segment s2(Point(1, 9), Point(1, 9));
+    double expected = std::hypot(5, 5);
+    EXPECT_DOUBLE_EQ(distance(s1, s2), expected);
+}
+
+TEST(DistanceTest, point_on_segment_end)
+{
+    Point p(12, 5);
+    Segment s(Point(12, 5), Point(-1, -20));
+    double expected = 0;
+    EXPECT_DOUBLE_EQ(distance(p, s), expected);
+    EXPECT_DOUBLE_EQ(distance(s, p), expected);
+}
+
+TEST(DistanceTest, point_on_segment_middle)
+{
+    Point p(1, 1);
+    Segment s(Point(-3, -3), Point(2, 2));
+    double expected = 0;
+    EXPECT_DOUBLE_EQ(distance(p, s), expected);
+    EXPECT_DOUBLE_EQ(distance(s, p), expected);
+}
+
+TEST(DistanceTest, point_off_segment_in_direction)
+{
+    Point p(-8, 5);
+    Segment s(Point(-4, 4), Point(4, 2));
+    double expected = std::sqrt(17);
+    EXPECT_DOUBLE_EQ(distance(p, s), expected);
+    EXPECT_DOUBLE_EQ(distance(s, p), expected);
+}
+
+TEST(DistanceTest, point_off_segment_closest_to_segment_middle)
+{
+    Point p(-2, 7);
+    Segment s(Point(-4, 4), Point(4, 2));
+    double expected = std::abs(1.0 / 4.0 * -2 + 7 + -3) / std::hypot(1.0 / 4.0, 1);
+    EXPECT_DOUBLE_EQ(distance(p, s), expected);
+    EXPECT_DOUBLE_EQ(distance(s, p), expected);
+}
+
+TEST(DistanceTest, point_off_segment_closest_to_segment_end)
+{
+    Point p(2, 12);
+    Segment s(Point(-7, 2), Point(1, 8));
+    double expected = std::hypot(4, 1);
+    EXPECT_DOUBLE_EQ(distance(p, s), expected);
+    EXPECT_DOUBLE_EQ(distance(s, p), expected);
+}
+
+TEST(DistanceTest, point_off_degenerate_segment)
+{
+    Point p(5, 3);
+    Segment s(Point(-2, 2), Point(-2, 2));
+    double expected = std::hypot(7, 1);
+    EXPECT_DOUBLE_EQ(distance(p, s), expected);
+    EXPECT_DOUBLE_EQ(distance(s, p), expected);
+}
+
+TEST(DistanceTest, point_in_polygon)
+{
+    Polygon polygon({Point(0, 0), Point(1, 0), Point(1, 1), Point(0, 1)});
+    Point point(0.5, 0.5);
+    double expected = 0.0;
+    EXPECT_DOUBLE_EQ(distance(point, polygon), expected);
+    EXPECT_DOUBLE_EQ(distance(polygon, point), expected);
+}
+
+TEST(DistanceTest, point_on_polygon_edge)
+{
+    Polygon polygon({Point(-1, 1), Point(1, 0), Point(1, 1), Point(0.5, 2), Point(0, 1)});
+    Point point(0.25, 1.5);
+    double expected = 0.0;
+    EXPECT_DOUBLE_EQ(distance(point, polygon), expected);
+    EXPECT_DOUBLE_EQ(distance(polygon, point), expected);
+}
+
+TEST(DistanceTest, point_on_polygon_vertex)
+{
+    Polygon polygon({Point(-1, 1), Point(1, 0), Point(1, 1), Point(0.5, 2), Point(0, 1)});
+    Point point(0.5, 2);
+    double expected = 0.0;
+    EXPECT_DOUBLE_EQ(distance(point, polygon), expected);
+    EXPECT_DOUBLE_EQ(distance(polygon, point), expected);
+}
+
+TEST(DistanceTest, point_off_polygon_closest_to_vertex)
+{
+    Polygon polygon({Point(-1, 1), Point(1, 0), Point(1, 1), Point(0.5, 2), Point(0, 1)});
+    Point point(-2, 2);
+    double expected = std::sqrt(2);
+    EXPECT_DOUBLE_EQ(distance(point, polygon), expected);
+    EXPECT_DOUBLE_EQ(distance(polygon, point), expected);
+}
+
+TEST(DistanceTest, point_near_polygon_closest_to_edge)
+{
+    Polygon polygon({Point(0, 0), Point(1, 0), Point(1, 1), Point(0, 1)});
+    Point point(0.5, 1.1);
+    double expected = 0.1;
+    EXPECT_NEAR(distance(point, polygon), expected, GeomConstants::EPSILON);
+    EXPECT_NEAR(distance(polygon, point), expected, GeomConstants::EPSILON);
+}
+
+TEST(DistanceTest, point_far_from_polygon)
+{
+    Polygon polygon({Point(0, 0), Point(1, 0), Point(1, 1), Point(0, 1)});
+    Point point(-5, -5);
+    double expected = std::hypot(-5, -5);
+    EXPECT_DOUBLE_EQ(distance(point, polygon), expected);
+    EXPECT_DOUBLE_EQ(distance(polygon, point), expected);
+}
+
+TEST(DistanceTest, point_in_rectangle)
+{
+    Point p(1, 2.1);
+    Rectangle r({0, 2}, {2, 4});
+    double expected = 0;
+    EXPECT_DOUBLE_EQ(distance(p, r), expected);
+    EXPECT_DOUBLE_EQ(distance(r, p), expected);
+}
+
+
+TEST(DistanceTest, point_near_rectangle)
+{
+    Point p(1, 1);
+    Rectangle r({0, 2}, {2, 4});
+    double expected = 1.0;
+    EXPECT_DOUBLE_EQ(distance(p, r), expected);
+    EXPECT_DOUBLE_EQ(distance(r, p), expected);
+}
+
+TEST(DistanceTest, point_on_segment_end_squared)
+{
+    Point p(12, 5);
+    Segment s(Point(12, 5), Point(-1, -20));
+    double expected = 0;
+    EXPECT_DOUBLE_EQ(distanceSquared(p, s), expected);
+    EXPECT_DOUBLE_EQ(distanceSquared(s, p), expected);
+}
+
+TEST(DistanceTest, point_on_segment_middle_squared)
+{
+    Point p(1, 1);
+    Segment s(Point(-3, -3), Point(2, 2));
+    double expected = 0;
+    EXPECT_DOUBLE_EQ(distanceSquared(p, s), expected);
+    EXPECT_DOUBLE_EQ(distanceSquared(s, p), expected);
+}
+
+TEST(DistanceTest, point_off_segment_in_direction_squared)
+{
+    Point p(-8, 5);
+    Segment s(Point(-4, 4), Point(4, 2));
+    double expected = 17;
+    EXPECT_DOUBLE_EQ(distanceSquared(p, s), expected);
+    EXPECT_DOUBLE_EQ(distanceSquared(s, p), expected);
+}
+
+TEST(DistanceTest, point_off_segment_closest_to_segment_middle_squared)
+{
+    Point p(-2, 7);
+    Segment s(Point(-4, 4), Point(4, 2));
+    double expected =
+        std::pow(std::abs(1.0 / 4.0 * -2 + 7 + -3), 2) / (std::pow(1.0 / 4.0, 2) + 1);
+    EXPECT_DOUBLE_EQ(distanceSquared(p, s), expected);
+    EXPECT_DOUBLE_EQ(distanceSquared(s, p), expected);
+}
+
+TEST(DistanceTest, point_off_segment_closest_to_segment_end_squared)
+{
+    Point p(2, 12);
+    Segment s(Point(-7, 2), Point(1, 8));
+    double expected = 17;
+    EXPECT_DOUBLE_EQ(distanceSquared(p, s), expected);
+    EXPECT_DOUBLE_EQ(distanceSquared(s, p), expected);
+}
+
+TEST(DistanceTest, same_points_squared)
+{
+    Point p1(8, 4);
+    Point p2(8, 4);
+    double expected = 0;
+    EXPECT_DOUBLE_EQ(distanceSquared(p1, p2), expected);
+    EXPECT_DOUBLE_EQ(distanceSquared(p2, p1), expected);
+}
+
+TEST(DistanceTest, different_points_squared)
+{
+    Point p1(8, 4);
+    Point p2(56, 25);
+    double expected = 2745;
+    EXPECT_DOUBLE_EQ(distanceSquared(p1, p2), expected);
+    EXPECT_DOUBLE_EQ(distanceSquared(p2, p1), expected);
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
<!--
    Give a high-level description of the changes in this PR
-->

Moved over `distance` family of functions (`distance`, `distanceSquared`) to `new_geom`. Made some minor adjustments (ie. changing some variable names to make more readable, changing function name from `dist` -> `distance`), and wrote missing unit tests.

### Testing Done
Unit tests

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Part 1/2 of #1136 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
