### PR TITLE
Moved Updating Of Tactic & Action World Params To Main STP Loop Via Visitors

### DIFF
--- a/src/software/ai/hl/stp/BUILD
+++ b/src/software/ai/hl/stp/BUILD
@@ -10,6 +10,7 @@ cc_library(
         "//software/ai/hl/stp/play",
         "//software/ai/hl/stp/play:play_factory",
         "//software/ai/hl/stp/tactic",
+        "//software/ai/hl/stp/tactic:tactic_world_params_update_visitor",
         "//software/ai/intent:stop_intent",
         "//software/ai/motion_constraint:motion_constraint_manager",
         "//software/parameter:dynamic_parameters",

--- a/src/software/ai/hl/stp/BUILD
+++ b/src/software/ai/hl/stp/BUILD
@@ -6,6 +6,7 @@ cc_library(
     hdrs = ["stp.h"],
     deps = [
         "//software/ai/hl",
+        "//software/ai/hl/stp/action:action_world_params_update_visitor",
         "//software/ai/hl/stp/play",
         "//software/ai/hl/stp/play:play_factory",
         "//software/ai/hl/stp/tactic",

--- a/src/software/ai/hl/stp/action/BUILD
+++ b/src/software/ai/hl/stp/action/BUILD
@@ -221,7 +221,7 @@ cc_test(
 
 cc_library(
     name = "action_visitor",
-    hdrs = ["action_visitor.h"],
+    hdrs = ["mutable_action_visitor.h"],
     deps = [":action"],
 )
 

--- a/src/software/ai/hl/stp/action/BUILD
+++ b/src/software/ai/hl/stp/action/BUILD
@@ -224,3 +224,14 @@ cc_library(
     hdrs = ["action_visitor.h"],
     deps = [":action"],
 )
+
+cc_library(
+    name = "action_world_params_update_visitor",
+    srcs = ["action_world_params_update_visitor.cpp"],
+    hdrs = ["action_world_params_update_visitor.h"],
+    deps = [
+        ":action_visitor",
+        ":all_actions",
+        "//software/world",
+    ],
+)

--- a/src/software/ai/hl/stp/action/action.h
+++ b/src/software/ai/hl/stp/action/action.h
@@ -61,7 +61,7 @@ class Action
      *
      * @param visitor A Action Visitor
      */
-    virtual void accept(ActionVisitor &visitor) const = 0;
+    virtual void accept(ActionVisitor &visitor) = 0;
 
     virtual ~Action() = default;
 

--- a/src/software/ai/hl/stp/action/action.h
+++ b/src/software/ai/hl/stp/action/action.h
@@ -6,12 +6,12 @@
 #include "software/ai/intent/intent.h"
 #include "software/world/robot.h"
 
-// We forward-declare the ActionVisitor interface (pure virtual class) because we need
-// to know about the existence of this class in order to accept visitors with the
+// We forward-declare the MutableActionVisitor interface (pure virtual class) because we
+// need to know about the existence of this class in order to accept visitors with the
 // accept() function. We cannot use an #include statement because this creates a cyclic
 // dependency
 //
-class ActionVisitor;
+class MutableActionVisitor;
 
 // We typedef the coroutine return type to make it shorter, more descriptive,
 // and easier to work with
@@ -61,7 +61,7 @@ class Action
      *
      * @param visitor A Action Visitor
      */
-    virtual void accept(ActionVisitor &visitor) = 0;
+    virtual void accept(MutableActionVisitor &visitor) = 0;
 
     virtual ~Action() = default;
 

--- a/src/software/ai/hl/stp/action/action_visitor.h
+++ b/src/software/ai/hl/stp/action/action_visitor.h
@@ -29,12 +29,12 @@ class ActionVisitor
      * @param action The action to visit
      */
 
-    virtual void visit(const ChipAction& action)          = 0;
-    virtual void visit(const DribbleAction& action)       = 0;
-    virtual void visit(const InterceptBallAction& action) = 0;
-    virtual void visit(const KickAction& action)          = 0;
-    virtual void visit(const MoveAction& action)          = 0;
-    virtual void visit(const MoveSpinAction& action)      = 0;
-    virtual void visit(const PivotAction& action)         = 0;
-    virtual void visit(const StopAction& action)          = 0;
+    virtual void visit(ChipAction& action)          = 0;
+    virtual void visit(DribbleAction& action)       = 0;
+    virtual void visit(InterceptBallAction& action) = 0;
+    virtual void visit(KickAction& action)          = 0;
+    virtual void visit(MoveAction& action)          = 0;
+    virtual void visit(MoveSpinAction& action)      = 0;
+    virtual void visit(PivotAction& action)         = 0;
+    virtual void visit(StopAction& action)          = 0;
 };

--- a/src/software/ai/hl/stp/action/action_world_params_update_visitor.cpp
+++ b/src/software/ai/hl/stp/action/action_world_params_update_visitor.cpp
@@ -1,0 +1,31 @@
+#include "software/ai/hl/stp/action/action_world_params_update_visitor.h"
+
+ActionWorldParamsUpdateVisitor::ActionWorldParamsUpdateVisitor(const World& world)
+    : world(world)
+{
+}
+
+void ActionWorldParamsUpdateVisitor::visit(ChipAction& action)
+{
+    action.updateWorldParams(world.ball());
+}
+
+void ActionWorldParamsUpdateVisitor::visit(DribbleAction& action) {}
+
+void ActionWorldParamsUpdateVisitor::visit(InterceptBallAction& action)
+{
+    action.updateWorldParams(world.field(), world.ball());
+}
+
+void ActionWorldParamsUpdateVisitor::visit(KickAction& action)
+{
+    action.updateWorldParams(world.ball());
+}
+
+void ActionWorldParamsUpdateVisitor::visit(MoveAction& action) {}
+
+void ActionWorldParamsUpdateVisitor::visit(MoveSpinAction& action) {}
+
+void ActionWorldParamsUpdateVisitor::visit(PivotAction& action) {}
+
+void ActionWorldParamsUpdateVisitor::visit(StopAction& action) {}

--- a/src/software/ai/hl/stp/action/action_world_params_update_visitor.h
+++ b/src/software/ai/hl/stp/action/action_world_params_update_visitor.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "software/ai/hl/stp/action/action_visitor.h"
+#include "software/ai/hl/stp/action/all_actions.h"
+#include "software/world/world.h"
+
+/**
+ * This class can be used to generically update the world parameters of any action,
+ * without knowing the type of the action
+ */
+class ActionWorldParamsUpdateVisitor : public ActionVisitor
+{
+   public:
+    /**
+     * Creates a new ActionWorldParamsUpdateVisitor
+     *
+     * @param world The world that will be used to update any visited actions
+     */
+    ActionWorldParamsUpdateVisitor(const World& world);
+
+    /**
+     * Visit and update the world parameters for a given action
+     */
+    void visit(ChipAction& action) override;
+    void visit(DribbleAction& action) override;
+    void visit(InterceptBallAction& action) override;
+    void visit(KickAction& action) override;
+    void visit(MoveAction& action) override;
+    void visit(MoveSpinAction& action) override;
+    void visit(PivotAction& action) override;
+    void visit(StopAction& action) override;
+
+   private:
+    const World world;
+};

--- a/src/software/ai/hl/stp/action/action_world_params_update_visitor.h
+++ b/src/software/ai/hl/stp/action/action_world_params_update_visitor.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "software/ai/hl/stp/action/action_visitor.h"
 #include "software/ai/hl/stp/action/all_actions.h"
+#include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/world/world.h"
 
 /**
  * This class can be used to generically update the world parameters of any action,
  * without knowing the type of the action
  */
-class ActionWorldParamsUpdateVisitor : public ActionVisitor
+class ActionWorldParamsUpdateVisitor : public MutableActionVisitor
 {
    public:
     /**

--- a/src/software/ai/hl/stp/action/all_actions.h
+++ b/src/software/ai/hl/stp/action/all_actions.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "software/ai/hl/stp/actions/chip_action.h"
-#include "software/ai/hl/stp/actions/dribble_action.h"
-#include "software/ai/hl/stp/actions/intercept_ball_action.h"
-#include "software/ai/hl/stp/actions/kick_action.h"
-#include "software/ai/hl/stp/actions/move_action.h"
-#include "software/ai/hl/stp/actions/movespin_action.h"
-#include "software/ai/hl/stp/actions/pivot_action.h"
-#include "software/ai/hl/stp/actions/stop_action.h"
+#include "software/ai/hl/stp/action/chip_action.h"
+#include "software/ai/hl/stp/action/dribble_action.h"
+#include "software/ai/hl/stp/action/intercept_ball_action.h"
+#include "software/ai/hl/stp/action/kick_action.h"
+#include "software/ai/hl/stp/action/move_action.h"
+#include "software/ai/hl/stp/action/movespin_action.h"
+#include "software/ai/hl/stp/action/pivot_action.h"
+#include "software/ai/hl/stp/action/stop_action.h"

--- a/src/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/software/ai/hl/stp/action/chip_action.cpp
@@ -29,7 +29,7 @@ void ChipAction::updateControlParams(const Robot& robot, Point chip_origin,
                         chip_distance_meters);
 }
 
-void ChipAction::accept(ActionVisitor& visitor)
+void ChipAction::accept(MutableActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/software/ai/hl/stp/action/chip_action.cpp
@@ -29,7 +29,7 @@ void ChipAction::updateControlParams(const Robot& robot, Point chip_origin,
                         chip_distance_meters);
 }
 
-void ChipAction::accept(ActionVisitor& visitor) const
+void ChipAction::accept(ActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/chip_action.h
+++ b/src/software/ai/hl/stp/action/chip_action.h
@@ -56,7 +56,7 @@ class ChipAction : public Action
     void updateControlParams(const Robot& robot, Point chip_origin, Point chip_target,
                              double chip_distance_meters);
 
-    void accept(ActionVisitor& visitor) const override;
+    void accept(ActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/chip_action.h
+++ b/src/software/ai/hl/stp/action/chip_action.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "software/ai/hl/stp/action/action.h"
-#include "software/ai/hl/stp/action/action_visitor.h"
+#include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/new_geom/angle.h"
 #include "software/new_geom/point.h"
 #include "software/world/ball.h"
@@ -56,7 +56,7 @@ class ChipAction : public Action
     void updateControlParams(const Robot& robot, Point chip_origin, Point chip_target,
                              double chip_distance_meters);
 
-    void accept(ActionVisitor& visitor) override;
+    void accept(MutableActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/dribble_action.cpp
+++ b/src/software/ai/hl/stp/action/dribble_action.cpp
@@ -18,7 +18,7 @@ void DribbleAction::updateControlParams(const Robot& robot, const Point& dest,
     this->small_kick_allowed = small_kick_allowed;
 }
 
-void DribbleAction::accept(ActionVisitor& visitor) const
+void DribbleAction::accept(ActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/dribble_action.cpp
+++ b/src/software/ai/hl/stp/action/dribble_action.cpp
@@ -18,7 +18,7 @@ void DribbleAction::updateControlParams(const Robot& robot, const Point& dest,
     this->small_kick_allowed = small_kick_allowed;
 }
 
-void DribbleAction::accept(ActionVisitor& visitor)
+void DribbleAction::accept(MutableActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/dribble_action.h
+++ b/src/software/ai/hl/stp/action/dribble_action.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "software/ai/hl/stp/action/action.h"
-#include "software/ai/hl/stp/action/action_visitor.h"
+#include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/new_geom/angle.h"
 #include "software/new_geom/point.h"
 
@@ -37,7 +37,7 @@ class DribbleAction : public Action
                              const Angle& final_angle, double rpm,
                              bool small_kick_allowed);
 
-    void accept(ActionVisitor& visitor) override;
+    void accept(MutableActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/dribble_action.h
+++ b/src/software/ai/hl/stp/action/dribble_action.h
@@ -37,7 +37,7 @@ class DribbleAction : public Action
                              const Angle& final_angle, double rpm,
                              bool small_kick_allowed);
 
-    void accept(ActionVisitor& visitor) const override;
+    void accept(ActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/intercept_ball_action.cpp
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.cpp
@@ -28,7 +28,7 @@ void InterceptBallAction::updateControlParams(const Robot& robot)
     this->robot = robot;
 }
 
-void InterceptBallAction::accept(ActionVisitor& visitor)
+void InterceptBallAction::accept(MutableActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/intercept_ball_action.cpp
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.cpp
@@ -28,7 +28,7 @@ void InterceptBallAction::updateControlParams(const Robot& robot)
     this->robot = robot;
 }
 
-void InterceptBallAction::accept(ActionVisitor& visitor) const
+void InterceptBallAction::accept(ActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/intercept_ball_action.h
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.h
@@ -34,7 +34,7 @@ class InterceptBallAction : public Action
      */
     void updateControlParams(const Robot& robot);
 
-    void accept(ActionVisitor& visitor) const override;
+    void accept(ActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/intercept_ball_action.h
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "software/ai/hl/stp/action/action.h"
-#include "software/ai/hl/stp/action/action_visitor.h"
+#include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/ai/primitive/move_primitive.h"
 #include "software/new_geom/angle.h"
 #include "software/new_geom/point.h"
@@ -34,7 +34,7 @@ class InterceptBallAction : public Action
      */
     void updateControlParams(const Robot& robot);
 
-    void accept(ActionVisitor& visitor) override;
+    void accept(MutableActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/software/ai/hl/stp/action/kick_action.cpp
@@ -47,7 +47,7 @@ double KickAction::getKickSpeed()
     return kick_speed_meters_per_second;
 }
 
-void KickAction::accept(ActionVisitor &visitor)
+void KickAction::accept(MutableActionVisitor &visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/software/ai/hl/stp/action/kick_action.cpp
@@ -47,7 +47,7 @@ double KickAction::getKickSpeed()
     return kick_speed_meters_per_second;
 }
 
-void KickAction::accept(ActionVisitor &visitor) const
+void KickAction::accept(ActionVisitor &visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/kick_action.h
+++ b/src/software/ai/hl/stp/action/kick_action.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "software/ai/hl/stp/action/action.h"
-#include "software/ai/hl/stp/action/action_visitor.h"
+#include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/new_geom/angle.h"
 #include "software/new_geom/point.h"
 #include "software/world/ball.h"
@@ -70,7 +70,7 @@ class KickAction : public Action
      */
     double getKickSpeed();
 
-    void accept(ActionVisitor &visitor) override;
+    void accept(MutableActionVisitor &visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type &yield) override;

--- a/src/software/ai/hl/stp/action/kick_action.h
+++ b/src/software/ai/hl/stp/action/kick_action.h
@@ -70,7 +70,7 @@ class KickAction : public Action
      */
     double getKickSpeed();
 
-    void accept(ActionVisitor &visitor) const override;
+    void accept(ActionVisitor &visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type &yield) override;

--- a/src/software/ai/hl/stp/action/move_action.cpp
+++ b/src/software/ai/hl/stp/action/move_action.cpp
@@ -57,7 +57,7 @@ DribblerEnable MoveAction::getDribblerEnabled()
     return enable_dribbler;
 }
 
-void MoveAction::accept(ActionVisitor& visitor) const
+void MoveAction::accept(ActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/move_action.cpp
+++ b/src/software/ai/hl/stp/action/move_action.cpp
@@ -57,7 +57,7 @@ DribblerEnable MoveAction::getDribblerEnabled()
     return enable_dribbler;
 }
 
-void MoveAction::accept(ActionVisitor& visitor)
+void MoveAction::accept(MutableActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/move_action.h
+++ b/src/software/ai/hl/stp/action/move_action.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "software/ai/hl/stp/action/action.h"
-#include "software/ai/hl/stp/action/action_visitor.h"
+#include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/ai/intent/move_intent.h"
 #include "software/ai/primitive/move_primitive.h"
 #include "software/new_geom/angle.h"
@@ -84,7 +84,7 @@ class MoveAction : public Action
      */
     DribblerEnable getDribblerEnabled();
 
-    void accept(ActionVisitor& visitor) override;
+    void accept(MutableActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/move_action.h
+++ b/src/software/ai/hl/stp/action/move_action.h
@@ -84,7 +84,7 @@ class MoveAction : public Action
      */
     DribblerEnable getDribblerEnabled();
 
-    void accept(ActionVisitor& visitor) const override;
+    void accept(ActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/movespin_action.cpp
+++ b/src/software/ai/hl/stp/action/movespin_action.cpp
@@ -22,7 +22,7 @@ Point MoveSpinAction::getDestination()
     return destination;
 }
 
-void MoveSpinAction::accept(ActionVisitor& visitor) const
+void MoveSpinAction::accept(ActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/movespin_action.cpp
+++ b/src/software/ai/hl/stp/action/movespin_action.cpp
@@ -22,7 +22,7 @@ Point MoveSpinAction::getDestination()
     return destination;
 }
 
-void MoveSpinAction::accept(ActionVisitor& visitor)
+void MoveSpinAction::accept(MutableActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/movespin_action.h
+++ b/src/software/ai/hl/stp/action/movespin_action.h
@@ -46,7 +46,7 @@ class MoveSpinAction : public Action
      */
     Point getDestination();
 
-    void accept(ActionVisitor& visitor) const override;
+    void accept(ActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/movespin_action.h
+++ b/src/software/ai/hl/stp/action/movespin_action.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "software/ai/hl/stp/action/action.h"
-#include "software/ai/hl/stp/action/action_visitor.h"
+#include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/new_geom/angle.h"
 #include "software/new_geom/point.h"
 
@@ -46,7 +46,7 @@ class MoveSpinAction : public Action
      */
     Point getDestination();
 
-    void accept(ActionVisitor& visitor) override;
+    void accept(MutableActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/mutable_action_visitor.h
+++ b/src/software/ai/hl/stp/action/mutable_action_visitor.h
@@ -2,7 +2,7 @@
 
 // We forward-declare all the actions because if we include them we induce a
 // circular dependency between the individual library for each action and this
-// visitor. Ex. `MoveAction` includes `ActionVisitor`, but `ActionVisitor`
+// visitor. Ex. `MoveAction` includes `MutableActionVisitor`, but `MutableActionVisitor`
 // also includes `MoveAction`
 class ChipAction;
 class DribbleAction;
@@ -17,10 +17,10 @@ class StopAction;
  * This class provides an interface for all Action visitors.
  * (ie. the "Visitor" design pattern)
  */
-class ActionVisitor
+class MutableActionVisitor
 {
    public:
-    virtual ~ActionVisitor() = default;
+    virtual ~MutableActionVisitor() = default;
 
     // The javadoc comment for all methods here can be read as:
     /**

--- a/src/software/ai/hl/stp/action/pivot_action.cpp
+++ b/src/software/ai/hl/stp/action/pivot_action.cpp
@@ -22,7 +22,7 @@ void PivotAction::updateControlParams(const Robot& robot, Point pivot_point,
     this->enable_dribbler = enable_dribbler;
 }
 
-void PivotAction::accept(ActionVisitor& visitor)
+void PivotAction::accept(MutableActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/pivot_action.cpp
+++ b/src/software/ai/hl/stp/action/pivot_action.cpp
@@ -22,7 +22,7 @@ void PivotAction::updateControlParams(const Robot& robot, Point pivot_point,
     this->enable_dribbler = enable_dribbler;
 }
 
-void PivotAction::accept(ActionVisitor& visitor) const
+void PivotAction::accept(ActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/pivot_action.h
+++ b/src/software/ai/hl/stp/action/pivot_action.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "software/ai/hl/stp/action/action.h"
-#include "software/ai/hl/stp/action/action_visitor.h"
+#include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/ai/intent/move_intent.h"
 #include "software/new_geom/angle.h"
 #include "software/new_geom/point.h"
@@ -29,7 +29,7 @@ class PivotAction : public Action
     void updateControlParams(const Robot& robot, Point pivot_point, Angle final_angle,
                              Angle pivot_speed, DribblerEnable enable_dribbler);
 
-    void accept(ActionVisitor& visitor) override;
+    void accept(MutableActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/pivot_action.h
+++ b/src/software/ai/hl/stp/action/pivot_action.h
@@ -29,7 +29,7 @@ class PivotAction : public Action
     void updateControlParams(const Robot& robot, Point pivot_point, Angle final_angle,
                              Angle pivot_speed, DribblerEnable enable_dribbler);
 
-    void accept(ActionVisitor& visitor) const override;
+    void accept(ActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/stop_action.cpp
+++ b/src/software/ai/hl/stp/action/stop_action.cpp
@@ -16,7 +16,7 @@ void StopAction::updateControlParams(const Robot& robot, bool coast)
     this->coast = coast;
 }
 
-void StopAction::accept(ActionVisitor& visitor) const
+void StopAction::accept(ActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/stop_action.cpp
+++ b/src/software/ai/hl/stp/action/stop_action.cpp
@@ -16,7 +16,7 @@ void StopAction::updateControlParams(const Robot& robot, bool coast)
     this->coast = coast;
 }
 
-void StopAction::accept(ActionVisitor& visitor)
+void StopAction::accept(MutableActionVisitor& visitor)
 {
     visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/action/stop_action.h
+++ b/src/software/ai/hl/stp/action/stop_action.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "software/ai/hl/stp/action/action.h"
-#include "software/ai/hl/stp/action/action_visitor.h"
+#include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/new_geom/angle.h"
 #include "software/new_geom/point.h"
 
@@ -34,7 +34,7 @@ class StopAction : public Action
      */
     void updateControlParams(const Robot& robot, bool coast);
 
-    void accept(ActionVisitor& visitor) override;
+    void accept(MutableActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/stop_action.h
+++ b/src/software/ai/hl/stp/action/stop_action.h
@@ -34,7 +34,7 @@ class StopAction : public Action
      */
     void updateControlParams(const Robot& robot, bool coast);
 
-    void accept(ActionVisitor& visitor) const override;
+    void accept(ActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
+++ b/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
@@ -1,6 +1,6 @@
 #include "software/ai/hl/stp/action/test_actions/move_test_action.h"
 
-#include "software/ai/hl/stp/action/action_visitor.h"
+#include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/ai/intent/move_intent.h"
 
 MoveTestAction::MoveTestAction(double close_to_dest_threshold)
@@ -29,10 +29,10 @@ void MoveTestAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     } while ((robot->position() - destination).length() > close_to_dest_threshold);
 }
 
-void MoveTestAction::accept(ActionVisitor& visitor) const
+void MoveTestAction::accept(MutableActionVisitor& visitor) const
 {
     // We don't call "visitor.visit" here because this class is just intended
     // for testing and shouldn't be part of the visitor
     throw std::logic_error(
-        "accept(ActionVisitor) is not implemented for MoveTestAction!");
+        "accept(MutableActionVisitor) is not implemented for MoveTestAction!");
 }

--- a/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
+++ b/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
@@ -29,7 +29,7 @@ void MoveTestAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     } while ((robot->position() - destination).length() > close_to_dest_threshold);
 }
 
-void MoveTestAction::accept(MutableActionVisitor& visitor) const
+void MoveTestAction::accept(MutableActionVisitor& visitor)
 {
     // We don't call "visitor.visit" here because this class is just intended
     // for testing and shouldn't be part of the visitor

--- a/src/software/ai/hl/stp/action/test_actions/move_test_action.h
+++ b/src/software/ai/hl/stp/action/test_actions/move_test_action.h
@@ -25,7 +25,7 @@ class MoveTestAction : public Action
      */
     void updateControlParams(const Robot& robot, Point destination);
 
-    void accept(MutableActionVisitor& visitor) const override;
+    void accept(MutableActionVisitor& visitor) override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/action/test_actions/move_test_action.h
+++ b/src/software/ai/hl/stp/action/test_actions/move_test_action.h
@@ -25,7 +25,7 @@ class MoveTestAction : public Action
      */
     void updateControlParams(const Robot& robot, Point destination);
 
-    void accept(ActionVisitor& visitor) const override;
+    void accept(MutableActionVisitor& visitor) const override;
 
    private:
     void calculateNextIntent(IntentCoroutine::push_type& yield) override;

--- a/src/software/ai/hl/stp/play/corner_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/corner_kick_play.cpp
@@ -143,10 +143,7 @@ void CornerKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     {
         LOG(DEBUG) << "Nothing assigned to align to ball yet";
         updateAlignToBallTactic(align_to_ball_tactic);
-        updateCherryPickTactics({cherry_pick_tactic_pos_y, cherry_pick_tactic_neg_y});
         updatePassGenerator(pass_generator);
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
 
         yield({goalie_tactic, align_to_ball_tactic, cherry_pick_tactic_pos_y,
                cherry_pick_tactic_neg_y, bait_move_tactic_1, bait_move_tactic_2});
@@ -163,10 +160,7 @@ void CornerKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     do
     {
         updateAlignToBallTactic(align_to_ball_tactic);
-        updateCherryPickTactics({cherry_pick_tactic_pos_y, cherry_pick_tactic_neg_y});
         updatePassGenerator(pass_generator);
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
 
         yield({goalie_tactic, align_to_ball_tactic, cherry_pick_tactic_pos_y,
                cherry_pick_tactic_neg_y, bait_move_tactic_1, bait_move_tactic_2});
@@ -182,10 +176,7 @@ void CornerKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     do
     {
         updateAlignToBallTactic(align_to_ball_tactic);
-        updateCherryPickTactics({cherry_pick_tactic_pos_y, cherry_pick_tactic_neg_y});
         updatePassGenerator(pass_generator);
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
 
         yield({goalie_tactic, align_to_ball_tactic, cherry_pick_tactic_pos_y,
                cherry_pick_tactic_neg_y, bait_move_tactic_1, bait_move_tactic_2});
@@ -217,27 +208,13 @@ void CornerKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
                                          world.enemyTeam(), pass, world.ball(), false);
     do
     {
-        passer->updateWorldParams(world.ball());
         passer->updateControlParams(pass);
-        receiver->updateWorldParams(world.friendlyTeam(), world.enemyTeam(),
-                                    world.ball());
         receiver->updateControlParams(pass);
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
 
         yield({goalie_tactic, passer, receiver, bait_move_tactic_1, bait_move_tactic_2});
     } while (!receiver->done());
 
     LOG(DEBUG) << "Finished";
-}
-
-void CornerKickPlay::updateCherryPickTactics(
-    std::vector<std::shared_ptr<CherryPickTactic>> tactics)
-{
-    for (auto &tactic : tactics)
-    {
-        tactic->updateWorldParams(world);
-    }
 }
 
 void CornerKickPlay::updateAlignToBallTactic(

--- a/src/software/ai/hl/stp/play/corner_kick_play.h
+++ b/src/software/ai/hl/stp/play/corner_kick_play.h
@@ -31,12 +31,6 @@ class CornerKickPlay : public Play
     const Duration MAX_TIME_TO_COMMIT_TO_PASS;
 
     /**
-     * Updates the given cherry-pick tactics
-     * @param tactics
-     */
-    void updateCherryPickTactics(std::vector<std::shared_ptr<CherryPickTactic>> tactics);
-
-    /**
      * Update the tactic that aligns the robot to the ball in preperation to pass
      *
      * @param align_to_ball_tactic

--- a/src/software/ai/hl/stp/play/defense_play.cpp
+++ b/src/software/ai/hl/stp/play/defense_play.cpp
@@ -88,10 +88,6 @@ void DefensePlay::getNextTactics(TacticCoroutine::push_type &yield)
                     crease_defender_tactic->getAssignedRobot()->id());
             }
         }
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         friendly_team_for_goalie, world.enemyTeam());
-        shoot_goal_tactic->updateWorldParams(world.field(), world.friendlyTeam(),
-                                             world.enemyTeam(), world.ball());
         shoot_goal_tactic->updateControlParams(std::nullopt);
 
         std::vector<std::shared_ptr<Tactic>> result = {goalie_tactic, shoot_goal_tactic};
@@ -99,8 +95,6 @@ void DefensePlay::getNextTactics(TacticCoroutine::push_type &yield)
         // Update crease defenders
         for (auto crease_defender_tactic : crease_defender_tactics)
         {
-            crease_defender_tactic->updateWorldParams(
-                world.ball(), world.field(), world.friendlyTeam(), world.enemyTeam());
             result.emplace_back(crease_defender_tactic);
         }
 
@@ -108,8 +102,6 @@ void DefensePlay::getNextTactics(TacticCoroutine::push_type &yield)
         // extra friendly robots, have them perform a reasonable default defensive tactic
         if (enemy_threats.size() > 0)
         {
-            defense_shadow_enemy_tactic->updateWorldParams(
-                world.field(), world.friendlyTeam(), world.enemyTeam(), world.ball());
             defense_shadow_enemy_tactic->updateControlParams(enemy_threats.at(1));
             result.emplace_back(defense_shadow_enemy_tactic);
         }
@@ -122,8 +114,6 @@ void DefensePlay::getNextTactics(TacticCoroutine::push_type &yield)
 
         if (enemy_threats.size() > 1)
         {
-            shadow_enemy_tactic->updateWorldParams(world.field(), world.friendlyTeam(),
-                                                   world.enemyTeam(), world.ball());
             shadow_enemy_tactic->updateControlParams(enemy_threats.at(0),
                                                      ROBOT_MAX_RADIUS_METERS * 3);
             result.emplace_back(shadow_enemy_tactic);

--- a/src/software/ai/hl/stp/play/enemy_freekick_play.cpp
+++ b/src/software/ai/hl/stp/play/enemy_freekick_play.cpp
@@ -81,18 +81,6 @@ void EnemyFreekickPlay::getNextTactics(TacticCoroutine::push_type &yield)
         auto enemy_threats = Evaluation::getAllEnemyThreats(
             world.field(), world.friendlyTeam(), world.enemyTeam(), world.ball(), false);
 
-        // Update goalie tactic
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
-
-        // Update free kicke shadowers
-        shadow_freekicker_1->updateWorldParams(world.enemyTeam(), world.ball());
-        shadow_freekicker_2->updateWorldParams(world.enemyTeam(), world.ball());
-
-        // Update crease defenders
-        crease_defender_tactic->updateWorldParams(
-            world.ball(), world.field(), world.friendlyTeam(), world.enemyTeam());
-
         // Add Freekick shadower tactics
         tactics_to_run.emplace_back(shadow_freekicker_1);
         tactics_to_run.emplace_back(shadow_freekicker_2);
@@ -118,8 +106,6 @@ void EnemyFreekickPlay::getNextTactics(TacticCoroutine::push_type &yield)
         }
         if (enemy_threats.size() == 1)
         {
-            shadow_tactic_main->updateWorldParams(world.field(), world.friendlyTeam(),
-                                                  world.enemyTeam(), world.ball());
             shadow_tactic_main->updateControlParams(enemy_threats.at(1),
                                                     ROBOT_MAX_RADIUS_METERS * 3);
             move_tactic_main->updateControlParams(
@@ -132,12 +118,8 @@ void EnemyFreekickPlay::getNextTactics(TacticCoroutine::push_type &yield)
         }
         if (enemy_threats.size() >= 2)
         {
-            shadow_tactic_main->updateWorldParams(world.field(), world.friendlyTeam(),
-                                                  world.enemyTeam(), world.ball());
             shadow_tactic_main->updateControlParams(enemy_threats.at(1),
                                                     ROBOT_MAX_RADIUS_METERS * 3);
-            shadow_tactic_secondary->updateWorldParams(
-                world.field(), world.friendlyTeam(), world.enemyTeam(), world.ball());
             shadow_tactic_secondary->updateControlParams(enemy_threats.at(2),
                                                          ROBOT_MAX_RADIUS_METERS * 3);
 

--- a/src/software/ai/hl/stp/play/free_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/free_kick_play.cpp
@@ -108,11 +108,7 @@ void FreeKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     {
         LOG(DEBUG) << "Nothing assigned to align to ball yet";
         updateAlignToBallTactic(align_to_ball_tactic);
-        updateCherryPickTactics({cherry_pick_tactic_1, cherry_pick_tactic_2});
         updatePassGenerator(pass_generator);
-        updateCreaseDefenderTactics(crease_defender_tactics);
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
 
         yield({goalie_tactic, align_to_ball_tactic, cherry_pick_tactic_1,
                cherry_pick_tactic_2, std::get<0>(crease_defender_tactics),
@@ -130,11 +126,7 @@ void FreeKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     do
     {
         updateAlignToBallTactic(align_to_ball_tactic);
-        updateCherryPickTactics({cherry_pick_tactic_1, cherry_pick_tactic_2});
         updatePassGenerator(pass_generator);
-        updateCreaseDefenderTactics(crease_defender_tactics);
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
 
         yield({goalie_tactic, align_to_ball_tactic, cherry_pick_tactic_1,
                cherry_pick_tactic_2, std::get<0>(crease_defender_tactics),
@@ -180,15 +172,6 @@ void FreeKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
     LOG(DEBUG) << "Finished";
 }
 
-void FreeKickPlay::updateCherryPickTactics(
-    std::vector<std::shared_ptr<CherryPickTactic>> tactics)
-{
-    for (auto &tactic : tactics)
-    {
-        tactic->updateWorldParams(world);
-    }
-}
-
 void FreeKickPlay::updateAlignToBallTactic(
     std::shared_ptr<MoveTactic> align_to_ball_tactic)
 {
@@ -205,22 +188,6 @@ void FreeKickPlay::updatePassGenerator(PassGenerator &pass_generator)
 {
     pass_generator.setWorld(world);
     pass_generator.setPasserPoint(world.ball().position());
-}
-
-void FreeKickPlay::updateShootGoalTactic(std::shared_ptr<ShootGoalTactic> shoot_tactic)
-{
-    shoot_tactic->updateWorldParams(world.field(), world.friendlyTeam(),
-                                    world.enemyTeam(), world.ball());
-}
-
-void FreeKickPlay::updateCreaseDefenderTactics(
-    std::array<std::shared_ptr<CreaseDefenderTactic>, 2> crease_defenders)
-{
-    for (auto &crease_defender : crease_defenders)
-    {
-        crease_defender->updateWorldParams(world.ball(), world.field(),
-                                           world.friendlyTeam(), world.enemyTeam());
-    }
 }
 
 void FreeKickPlay::chipAtGoalStage(
@@ -242,11 +209,7 @@ void FreeKickPlay::chipAtGoalStage(
     {
         double chip_dist = (chip_target - world.ball().position()).length();
 
-        updateCreaseDefenderTactics(crease_defender_tactics);
-        chip_tactic->updateWorldParams(world.ball());
         chip_tactic->updateControlParams(world.ball().position(), chip_target, chip_dist);
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
 
         yield({goalie_tactic, chip_tactic, std::get<0>(crease_defender_tactics),
                std::get<1>(crease_defender_tactics)});
@@ -276,14 +239,8 @@ void FreeKickPlay::performPassStage(
                                          world.enemyTeam(), pass, world.ball(), false);
     do
     {
-        updateCreaseDefenderTactics(crease_defender_tactics);
-        passer->updateWorldParams(world.ball());
         passer->updateControlParams(pass);
-        receiver->updateWorldParams(world.friendlyTeam(), world.enemyTeam(),
-                                    world.ball());
         receiver->updateControlParams(pass);
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
 
         yield({goalie_tactic, passer, receiver, std::get<0>(crease_defender_tactics),
                std::get<1>(crease_defender_tactics)});
@@ -307,12 +264,7 @@ void FreeKickPlay::shootOrFindPassStage(
     do
     {
         updateAlignToBallTactic(align_to_ball_tactic);
-        updateCherryPickTactics({cherry_pick_tactic_1, cherry_pick_tactic_2});
         updatePassGenerator(pass_generator);
-        updateShootGoalTactic(shoot_tactic);
-        updateCreaseDefenderTactics(crease_defender_tactics);
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
 
         yield({goalie_tactic, align_to_ball_tactic, shoot_tactic, cherry_pick_tactic_1,
                cherry_pick_tactic_2, std::get<0>(crease_defender_tactics),

--- a/src/software/ai/hl/stp/play/free_kick_play.h
+++ b/src/software/ai/hl/stp/play/free_kick_play.h
@@ -84,12 +84,6 @@ class FreeKickPlay : public Play
         PassWithRating &best_pass_and_score_so_far);
 
     /**
-     * Updates the given cherry-pick tactics
-     * @param tactics
-     */
-    void updateCherryPickTactics(std::vector<std::shared_ptr<CherryPickTactic>> tactics);
-
-    /**
      * Update the tactic that aligns the robot to the ball in preperation to pass
      *
      * @param align_to_ball_tactic
@@ -102,19 +96,4 @@ class FreeKickPlay : public Play
      * @param pass_generator
      */
     void updatePassGenerator(Passing::PassGenerator &pass_generator);
-
-    /**
-     * Update the given shoot goal tactic
-     *
-     * @param shoot_tactic
-     */
-    void updateShootGoalTactic(std::shared_ptr<ShootGoalTactic> shoot_tactic);
-
-    /**
-     * Updates the given crease defender tactics
-     *
-     * @param crease_defenders The defenders to update
-     */
-    void updateCreaseDefenderTactics(
-        std::array<std::shared_ptr<CreaseDefenderTactic>, 2> crease_defenders);
 };

--- a/src/software/ai/hl/stp/play/kickoff_enemy_play.cpp
+++ b/src/software/ai/hl/stp/play/kickoff_enemy_play.cpp
@@ -112,8 +112,6 @@ void KickoffEnemyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         auto enemy_threats = Evaluation::getAllEnemyThreats(
             world.field(), world.friendlyTeam(), world.enemyTeam(), world.ball(), false);
 
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
         std::vector<std::shared_ptr<Tactic>> result = {goalie_tactic};
 
         // keeps track of the next defense position to assign
@@ -132,8 +130,6 @@ void KickoffEnemyPlay::getNextTactics(TacticCoroutine::push_type &yield)
                 // We shadow assuming the robots do not pass so we do not try block passes
                 // while shadowing, since we can't go on the enemy side to block the pass
                 // anyway
-                shadow_enemy_tactics.at(i)->updateWorldParams(
-                    world.field(), world.friendlyTeam(), world.enemyTeam(), world.ball());
                 shadow_enemy_tactics.at(i)->updateControlParams(enemy_threat,
                                                                 shadow_dist);
                 result.emplace_back(shadow_enemy_tactics.at(i));

--- a/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
+++ b/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
@@ -97,8 +97,6 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         auto enemy_threats = Evaluation::getAllEnemyThreats(
             world.field(), world.friendlyTeam(), world.enemyTeam(), world.ball(), false);
 
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
         std::vector<std::shared_ptr<Tactic>> result = {goalie_tactic};
 
         // set the requirement that Robot 1 must be able to kick and chip
@@ -123,13 +121,10 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield)
         auto enemy_threats = Evaluation::getAllEnemyThreats(
             world.field(), world.friendlyTeam(), world.enemyTeam(), world.ball(), false);
 
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
         std::vector<std::shared_ptr<Tactic>> result = {goalie_tactic};
 
         // TODO This needs to be adjusted post field testing, ball needs to land exactly
         // in the middle of the enemy field
-        kickoff_chip_tactic->updateWorldParams(world.ball());
         kickoff_chip_tactic->updateControlParams(
             world.ball().position(),
             world.field().centerPoint() + Vector(world.field().xLength() / 6, 0),

--- a/src/software/ai/hl/stp/play/penalty_kick_enemy_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_enemy_play.cpp
@@ -37,9 +37,6 @@ void PenaltyKickEnemyPlay::getNextTactics(TacticCoroutine::push_type &yield)
     do
     {
         // goalie
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
-
         std::vector<std::shared_ptr<Tactic>> result = {goalie_tactic};
 
         // Move all non-shooter robots to the center of the field

--- a/src/software/ai/hl/stp/play/penalty_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play.cpp
@@ -67,8 +67,6 @@ void PenaltyKickPlay::getNextTactics(TacticCoroutine::push_type &yield)
             Point(0, -8 * ROBOT_MAX_RADIUS_METERS),
             world.field().enemyGoal().toVector().orientation(), 0);
 
-        penalty_shot_tactic->updateWorldParams(world.ball(), world.enemyTeam().goalie(),
-                                               world.field());
         shooter_setup_move->updateControlParams(behind_ball, shoot_angle, 0.0);
 
         // If we are setting up for penalty kick, move our robots to position

--- a/src/software/ai/hl/stp/play/shoot_or_chip_play.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_chip_play.cpp
@@ -113,14 +113,10 @@ void ShootOrChipPlay::getNextTactics(TacticCoroutine::push_type &yield)
                     crease_defender_tactic->getAssignedRobot()->id());
             }
         }
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         friendly_team_for_goalie, world.enemyTeam());
 
         // Update crease defenders
         for (auto &crease_defender_tactic : crease_defender_tactics)
         {
-            crease_defender_tactic->updateWorldParams(
-                world.ball(), world.field(), world.friendlyTeam(), world.enemyTeam());
             result.emplace_back(crease_defender_tactic);
         }
 
@@ -152,8 +148,6 @@ void ShootOrChipPlay::getNextTactics(TacticCoroutine::push_type &yield)
         {
             chip_target = chip_targets[0].getOrigin();
         }
-        shoot_or_chip_tactic->updateWorldParams(world.field(), world.friendlyTeam(),
-                                                world.enemyTeam(), world.ball());
         shoot_or_chip_tactic->updateControlParams(chip_target);
 
         // We want this second in priority only to the goalie

--- a/src/software/ai/hl/stp/play/shoot_or_pass_play.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_pass_play.cpp
@@ -135,10 +135,6 @@ void ShootOrPassPlay::getNextTactics(TacticCoroutine::push_type &yield)
                                                ->value();
     do
     {
-        updateCreaseDefenderTactics(crease_defender_tactics);
-        updateGoalie(goalie_tactic);
-        updateShootGoalTactic(shoot_tactic);
-        updateCherryPickTactics(cherry_pick_tactics);
         updatePassGenerator(pass_generator);
 
         LOG(DEBUG) << "Best pass so far is: " << best_pass_and_score_so_far.pass;
@@ -198,12 +194,7 @@ void ShootOrPassPlay::getNextTactics(TacticCoroutine::push_type &yield)
             false);
         do
         {
-            updateCreaseDefenderTactics(crease_defender_tactics);
-            updateGoalie(goalie_tactic);
-            passer->updateWorldParams(world.ball());
             passer->updateControlParams(pass);
-            receiver->updateWorldParams(world.friendlyTeam(), world.enemyTeam(),
-                                        world.ball());
             receiver->updateControlParams(pass);
             yield({goalie_tactic, passer, receiver, std::get<0>(crease_defender_tactics),
                    std::get<1>(crease_defender_tactics)});
@@ -217,41 +208,10 @@ void ShootOrPassPlay::getNextTactics(TacticCoroutine::push_type &yield)
     LOG(DEBUG) << "Finished";
 }
 
-void ShootOrPassPlay::updateCherryPickTactics(
-    std::array<std::shared_ptr<CherryPickTactic>, 2> tactics)
-{
-    for (auto &tactic : tactics)
-    {
-        tactic->updateWorldParams(world);
-    }
-}
-
-void ShootOrPassPlay::updateShootGoalTactic(std::shared_ptr<ShootGoalTactic> shoot_tactic)
-{
-    shoot_tactic->updateWorldParams(world.field(), world.friendlyTeam(),
-                                    world.enemyTeam(), world.ball());
-}
-
 void ShootOrPassPlay::updatePassGenerator(PassGenerator &pass_generator)
 {
     pass_generator.setWorld(world);
     pass_generator.setPasserPoint(world.ball().position());
-}
-
-void ShootOrPassPlay::updateCreaseDefenderTactics(
-    std::array<std::shared_ptr<CreaseDefenderTactic>, 2> crease_defenders)
-{
-    for (auto &crease_defender : crease_defenders)
-    {
-        crease_defender->updateWorldParams(world.ball(), world.field(),
-                                           world.friendlyTeam(), world.enemyTeam());
-    }
-}
-
-void ShootOrPassPlay::updateGoalie(std::shared_ptr<GoalieTactic> goalie)
-{
-    goalie->updateWorldParams(world.ball(), world.field(), world.friendlyTeam(),
-                              world.enemyTeam());
 }
 
 // Register this play in the PlayFactory

--- a/src/software/ai/hl/stp/play/shoot_or_pass_play.h
+++ b/src/software/ai/hl/stp/play/shoot_or_pass_play.h
@@ -35,38 +35,9 @@ class ShootOrPassPlay : public Play
     static constexpr double SPEED_AT_PATROL_POINTS = 0.0;
 
     /**
-     * Updates the given cherry-pick tactics
-     * @param tactics
-     */
-    void updateCherryPickTactics(
-        std::array<std::shared_ptr<CherryPickTactic>, 2> tactics);
-
-    /**
-     * Update the given shoot goal tactic
-     *
-     * @param shoot_tactic
-     */
-    void updateShootGoalTactic(std::shared_ptr<ShootGoalTactic> shoot_tactic);
-
-    /**
      * Updates the pass generator
      *
      * @param pass_generator
      */
     void updatePassGenerator(Passing::PassGenerator &pass_generator);
-
-    /**
-     * Updates the given crease defender tactics
-     *
-     * @param crease_defenders The defenders to update
-     */
-    void updateCreaseDefenderTactics(
-        std::array<std::shared_ptr<CreaseDefenderTactic>, 2> crease_defenders);
-
-    /**
-     * Updates the given goalie tactics
-     *
-     * @param goalie
-     */
-    void updateGoalie(std::shared_ptr<GoalieTactic> goalie);
 };

--- a/src/software/ai/hl/stp/play/stop_play.cpp
+++ b/src/software/ai/hl/stp/play/stop_play.cpp
@@ -73,8 +73,6 @@ void StopPlay::getNextTactics(TacticCoroutine::push_type &yield)
         auto enemy_threats = Evaluation::getAllEnemyThreats(
             world.field(), world.friendlyTeam(), world.enemyTeam(), world.ball(), false);
 
-        goalie_tactic->updateWorldParams(world.ball(), world.field(),
-                                         world.friendlyTeam(), world.enemyTeam());
         std::vector<std::shared_ptr<Tactic>> result = {goalie_tactic};
 
         // a unit vector from the center of the goal to the ball, this vector will be used

--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -8,6 +8,7 @@
 #include <g3log/g3log.hpp>
 #include <random>
 
+#include "software/ai/hl/stp/action/action_world_params_update_visitor.h"
 #include "software/ai/hl/stp/play/play.h"
 #include "software/ai/hl/stp/play/play_factory.h"
 #include "software/ai/hl/stp/play_info.h"
@@ -88,6 +89,8 @@ std::vector<std::unique_ptr<Intent>> STP::getIntentsFromCurrentPlay(const World&
     {
         assignRobotsToTactics(world, *current_tactics);
 
+        ActionWorldParamsUpdateVisitor action_update_visitor(world);
+
         for (const std::shared_ptr<Tactic>& tactic : *current_tactics)
         {
             // Try to get an intent from the tactic
@@ -95,6 +98,7 @@ std::vector<std::unique_ptr<Intent>> STP::getIntentsFromCurrentPlay(const World&
             std::unique_ptr<Intent> intent;
             if (action)
             {
+                action->accept(action_update_visitor);
                 intent = action->getNextIntent();
             }
 

--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -89,7 +89,7 @@ std::vector<std::unique_ptr<Intent>> STP::getIntentsFromCurrentPlay(const World&
     {
         assignRobotsToTactics(world, *current_tactics);
 
-        ActionWorldParamsUpdateVisitor action_update_visitor(world);
+        ActionWorldParamsUpdateVisitor action_world_params_update_visitor(world);
 
         for (const std::shared_ptr<Tactic>& tactic : *current_tactics)
         {
@@ -98,7 +98,7 @@ std::vector<std::unique_ptr<Intent>> STP::getIntentsFromCurrentPlay(const World&
             std::unique_ptr<Intent> intent;
             if (action)
             {
-                action->accept(action_update_visitor);
+                action->accept(action_world_params_update_visitor);
                 intent = action->getNextIntent();
             }
 

--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -13,6 +13,7 @@
 #include "software/ai/hl/stp/play/play_factory.h"
 #include "software/ai/hl/stp/play_info.h"
 #include "software/ai/hl/stp/tactic/tactic.h"
+#include "software/ai/hl/stp/tactic/tactic_world_params_update_visitor.h"
 #include "software/ai/intent/stop_intent.h"
 #include "software/parameter/dynamic_parameters.h"
 
@@ -90,9 +91,12 @@ std::vector<std::unique_ptr<Intent>> STP::getIntentsFromCurrentPlay(const World&
         assignRobotsToTactics(world, *current_tactics);
 
         ActionWorldParamsUpdateVisitor action_world_params_update_visitor(world);
+        TacticWorldParamsUpdateVisitor tactic_world_params_update_visitor(world);
 
         for (const std::shared_ptr<Tactic>& tactic : *current_tactics)
         {
+            tactic->accept(tactic_world_params_update_visitor);
+
             // Try to get an intent from the tactic
             std::shared_ptr<Action> action = tactic->getNextAction();
             std::unique_ptr<Intent> intent;

--- a/src/software/ai/hl/stp/tactic/chip_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/chip_tactic.cpp
@@ -44,7 +44,6 @@ void ChipTactic::calculateNextAction(ActionCoroutine::push_type &yield)
     auto chip_action = std::make_shared<ChipAction>();
     do
     {
-        chip_action->updateWorldParams(ball);
         chip_action->updateControlParams(*robot, chip_origin, chip_target,
                                          chip_distance_meters);
         yield(chip_action);

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -234,7 +234,6 @@ void GoalieTactic::calculateNextAction(ActionCoroutine::push_type &yield)
             // to do so, chip it out
             else
             {
-                chip_action->updateWorldParams(ball);
                 chip_action->updateControlParams(
                     *robot, ball.position(),
                     (ball.position() - field.friendlyGoal()).orientation(), 2);

--- a/src/software/ai/hl/stp/tactic/mutable_tactic_visitor.h
+++ b/src/software/ai/hl/stp/tactic/mutable_tactic_visitor.h
@@ -22,6 +22,7 @@ class PasserTactic;
 class DefenseShadowEnemyTactic;
 class MoveTestTactic;
 class StopTestTactic;
+class GoalieTestTactic;
 
 /**
  * Refer to the docs about why we use the Visitor Design Pattern
@@ -56,4 +57,5 @@ class MutableTacticVisitor
     virtual void visit(DefenseShadowEnemyTactic &tactic) = 0;
     virtual void visit(MoveTestTactic &tactic)           = 0;
     virtual void visit(StopTestTactic &tactic)           = 0;
+    virtual void visit(GoalieTestTactic &tactic)         = 0;
 };

--- a/src/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -75,7 +75,6 @@ void PasserTactic::calculateNextAction(ActionCoroutine::push_type& yield)
     {
         // We want the robot to move to the starting position for the shot and also
         // rotate to the correct orientation to face the shot
-        kick_action->updateWorldParams(ball);
         kick_action->updateControlParams(*robot, ball.position(), pass.receiverPoint(),
                                          pass.speed());
         yield(kick_action);

--- a/src/software/ai/hl/stp/tactic/penalty_kick_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/penalty_kick_tactic.cpp
@@ -163,7 +163,6 @@ void PenaltyKickTactic::calculateNextAction(ActionCoroutine::push_type& yield)
         {
             if (evaluate_penalty_shot())
             {
-                kick_action->updateWorldParams(ball);
                 kick_action->updateControlParams(*robot, ball.position(),
                                                  robot.value().orientation(),
                                                  PENALTY_KICK_SHOT_SPEED);

--- a/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
@@ -116,7 +116,6 @@ void ShootGoalTactic::shootUntilShotBlocked(std::shared_ptr<KickAction> kick_act
     {
         if (!isEnemyAboutToStealBall())
         {
-            kick_action->updateWorldParams(ball);
             kick_action->updateControlParams(*robot, ball.position(),
                                              shot_target->getPointToShootAt(),
                                              BALL_MAX_SPEED_METERS_PER_SECOND - 0.5);
@@ -128,7 +127,6 @@ void ShootGoalTactic::shootUntilShotBlocked(std::shared_ptr<KickAction> kick_act
             // steal the ball we chip instead to just get over the enemy. We do not adjust
             // the point we are targeting since that may take more time to realign to, and
             // we need to be very quick so the enemy doesn't get the ball
-            chip_action->updateWorldParams(ball);
             chip_action->updateControlParams(*robot, ball.position(),
                                              shot_target->getPointToShootAt(), CHIP_DIST);
             yield(chip_action);
@@ -167,7 +165,6 @@ void ShootGoalTactic::calculateNextAction(ActionCoroutine::push_type &yield)
             // try recover the ball after, which is better than being stripped of the ball
             // and directly losing possession that way
             Point fallback_chip_target = chip_target ? *chip_target : field.enemyGoal();
-            chip_action->updateWorldParams(ball);
             chip_action->updateControlParams(*robot, ball.position(),
                                              fallback_chip_target, CHIP_DIST);
             yield(chip_action);

--- a/src/software/ai/hl/stp/tactic/tactic_world_params_update_visitor.cpp
+++ b/src/software/ai/hl/stp/tactic/tactic_world_params_update_visitor.cpp
@@ -74,4 +74,5 @@ void TacticWorldParamsUpdateVisitor::visit(DefenseShadowEnemyTactic &tactic)
 }
 void TacticWorldParamsUpdateVisitor::visit(MoveTestTactic &tactic) {}
 void TacticWorldParamsUpdateVisitor::visit(StopTestTactic &tactic) {}
+void TacticWorldParamsUpdateVisitor::visit(GoalieTestTactic &tactic) {}
 // clang-format on

--- a/src/software/ai/hl/stp/tactic/tactic_world_params_update_visitor.h
+++ b/src/software/ai/hl/stp/tactic/tactic_world_params_update_visitor.h
@@ -36,6 +36,7 @@ class TacticWorldParamsUpdateVisitor : public MutableTacticVisitor
     void visit(DefenseShadowEnemyTactic &tactic) override;
     void visit(MoveTestTactic &tactic) override;
     void visit(StopTestTactic &tactic) override;
+    void visit(GoalieTestTactic &tactic) override;
 
    private:
     World world;

--- a/src/software/ai/hl/stp/tactic/test_tactics/BUILD
+++ b/src/software/ai/hl/stp/tactic/test_tactics/BUILD
@@ -7,6 +7,7 @@ cc_library(
     deps = [
         "//software/ai/hl/stp/action:move_action",
         "//software/ai/hl/stp/tactic",
+        "//software/ai/hl/stp/tactic:mutable_tactic_visitor",
     ],
 )
 
@@ -17,6 +18,7 @@ cc_library(
     deps = [
         "//software/ai/hl/stp/action:stop_action",
         "//software/ai/hl/stp/tactic",
+        "//software/ai/hl/stp/tactic:mutable_tactic_visitor",
     ],
 )
 
@@ -26,5 +28,6 @@ cc_library(
     hdrs = ["goalie_test_tactic.h"],
     deps = [
         "//software/ai/hl/stp/tactic",
+        "//software/ai/hl/stp/tactic:mutable_tactic_visitor",
     ],
 )

--- a/src/software/ai/hl/stp/tactic/test_tactics/goalie_test_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/test_tactics/goalie_test_tactic.cpp
@@ -1,5 +1,7 @@
 #include "software/ai/hl/stp/tactic/test_tactics/goalie_test_tactic.h"
 
+#include "software/ai/hl/stp/tactic/mutable_tactic_visitor.h"
+
 GoalieTestTactic::GoalieTestTactic(bool loop_forever) : Tactic(loop_forever) {}
 
 std::string GoalieTestTactic::getName() const
@@ -25,8 +27,5 @@ void GoalieTestTactic::calculateNextAction(ActionCoroutine::push_type &yield)
 
 void GoalieTestTactic::accept(MutableTacticVisitor &visitor)
 {
-    // GoalieTestTactic is meant to be a simple test tactic and so
-    // we invoke YAGNI to not implement the visitor for this tactic
-    throw std::invalid_argument(
-        "Error: Tactic Visitor does not implement visiting this Tactic, so this accept function does nothing");
+    visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/tactic/test_tactics/move_test_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/test_tactics/move_test_tactic.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include "software/ai/hl/stp/action/move_action.h"
+#include "software/ai/hl/stp/tactic/mutable_tactic_visitor.h"
 
 MoveTestTactic::MoveTestTactic(bool loop_forever)
     : Tactic(loop_forever,
@@ -41,8 +42,5 @@ void MoveTestTactic::calculateNextAction(ActionCoroutine::push_type &yield)
 
 void MoveTestTactic::accept(MutableTacticVisitor &visitor)
 {
-    // MoveTestTactic is meant to be a simple test tactic and so
-    // we invoke YAGNI to not implement the visitor for this tactic
-    throw std::invalid_argument(
-        "Error: Tactic Visitor does not implement visiting this Tactic, so this accept function does nothing");
+    visitor.visit(*this);
 }

--- a/src/software/ai/hl/stp/tactic/test_tactics/stop_test_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/test_tactics/stop_test_tactic.cpp
@@ -1,6 +1,7 @@
 #include "software/ai/hl/stp/tactic/test_tactics/stop_test_tactic.h"
 
 #include "software/ai/hl/stp/action/stop_action.h"
+#include "software/ai/hl/stp/tactic/mutable_tactic_visitor.h"
 
 StopTestTactic::StopTestTactic(bool loop_forever) : Tactic(loop_forever) {}
 
@@ -25,8 +26,5 @@ void StopTestTactic::calculateNextAction(ActionCoroutine::push_type &yield)
 
 void StopTestTactic::accept(MutableTacticVisitor &visitor)
 {
-    // StopTestTactic is meant to be a simple test tactic and so
-    // we invoke YAGNI to not implement the visitor for this tactic
-    throw std::invalid_argument(
-        "Error: Tactic Visitor does not implement visiting this Tactic, so this accept function does nothing");
+    visitor.visit(*this);
 }

--- a/src/software/ai/motion_constraint/motion_constraint_manager.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_manager.cpp
@@ -98,6 +98,9 @@ void MotionConstraintManager::visit(DefenseShadowEnemyTactic &tactic) {}
 void MotionConstraintManager::visit(MoveTestTactic &tactic) {}
 
 void MotionConstraintManager::visit(StopTestTactic &tactic) {}
+
+void MotionConstraintManager::visit(GoalieTestTactic &tactic) {}
+
 // clang-format on
 
 std::set<MotionConstraint> MotionConstraintManager::getMotionConstraintsFromGameState(

--- a/src/software/ai/motion_constraint/motion_constraint_manager.h
+++ b/src/software/ai/motion_constraint/motion_constraint_manager.h
@@ -48,6 +48,7 @@ class MotionConstraintManager : public MutableTacticVisitor
     void visit(DefenseShadowEnemyTactic &tactic) override;
     void visit(MoveTestTactic &tactic) override;
     void visit(StopTestTactic &tactic) override;
+    void visit(GoalieTestTactic &tactic) override;
 
    private:
     std::set<MotionConstraint> current_whitelisted_constraints;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Previously, we were setting parameters for actions that were purely derived from the world directly in each tactic. Since we only need the world to update these parameters, this migrates that updating to the main `stp` loop, so that individual tactics only need to worry about updating the bits of actions that are actually specific to that tactic.

Similar deal for tactics, we were previously setting them for each tactic in plays, so moved all the updating to a visitor in the main STP loop.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Tested with full stack in grsim, verified that action that required this to work (`KickAction`) still functioned as expected.

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves  #773 

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
