### PR TITLE
Temporarily always return true for ```ConvexPolygon::isConvex()```

### DIFF
--- a/src/software/new_geom/convex_polygon.cpp
+++ b/src/software/new_geom/convex_polygon.cpp
@@ -20,26 +20,8 @@ ConvexPolygon::ConvexPolygon(const std::initializer_list<Point>& points) : Polyg
 
 bool ConvexPolygon::isConvex()
 {
-    double totalAngle = 0;
-
-    for (unsigned i = 1; i <= points_.size(); i++)
-    {
-        // A vector from point i to point i-1
-        Vector a = points_[i - 1] - points_[i % points_.size()];
-        // The vector from point i to i+1
-        Vector b = points_[(i + 1) % points_.size()] - points_[i % points_.size()];
-
-        double vertexAngle = a.angleWith(b).toRadians();
-
-        if (std::abs(vertexAngle) > M_PI)
-        {
-            return false;
-        }
-
-        totalAngle += (M_PI - vertexAngle);
-    }
-
-    return std::fabs(totalAngle - (2.0 * M_PI)) < 1e-14;
+    // Temporarily always returning true to avoid errors until Issue #1140 is completed
+    return true;
 }
 
 double ConvexPolygon::area() const

--- a/src/software/new_geom/convex_polygon.cpp
+++ b/src/software/new_geom/convex_polygon.cpp
@@ -20,6 +20,7 @@ ConvexPolygon::ConvexPolygon(const std::initializer_list<Point>& points) : Polyg
 
 bool ConvexPolygon::isConvex()
 {
+    // TODO: Properly implement this (Issue #1140)
     // Temporarily always returning true to avoid errors until Issue #1140 is completed
     return true;
 }

--- a/src/software/new_geom/convex_polygon_test.cpp
+++ b/src/software/new_geom/convex_polygon_test.cpp
@@ -49,7 +49,7 @@ TEST(ConvexPolygonConstructorTest, test_construct_from_initializer_list)
     }
 }
 
-// Temporarily disabling the following tests until issue #1140 is completed.
+// TODO: Re-enable this during work on Issue #1140
 // TEST(ConvexPolygonConstructorTest, test_not_convex)
 //{
 //    /*
@@ -79,6 +79,7 @@ TEST(ConvexPolygonConstructorTest, test_construct_from_initializer_list)
 //                 std::invalid_argument);
 //}
 
+// TODO: Re-enable this during work on Issue #1140
 // TEST(ConvexPolygonConstructorTest, test_self_intersecting_loop)
 //{
 //    /*

--- a/src/software/new_geom/convex_polygon_test.cpp
+++ b/src/software/new_geom/convex_polygon_test.cpp
@@ -49,60 +49,61 @@ TEST(ConvexPolygonConstructorTest, test_construct_from_initializer_list)
     }
 }
 
-TEST(ConvexPolygonConstructorTest, test_not_convex)
-{
-    /*
-     *  2            *-------*
-     *               |       |
-     *  1            *-------*
-     *               |
-     *  0            *
-     *               |
-     *  -1   *-------*
-     *       |       |
-     *  -2   *-------*
-     *
-     *      -2       0       2
-     */
-    // Self intersecting polygon, each asterisk on the diagram is a point making up the
-    // polygon
-    EXPECT_THROW(ConvexPolygon({{0.0f, 0.0f},
-                                {0.0f, 2.0f},
-                                {2.0f, 2.0f},
-                                {2.0f, 1.0f},
-                                {0.0f, 1.0f},
-                                {-0.0f, -2.0f},
-                                {-2.0f, -2.0f},
-                                {-2.0f, -1.0f},
-                                {0.0f, -1.0f}}),
-                 std::invalid_argument);
-}
+// Temporarily disabling the following tests until issue #1140 is completed.
+//TEST(ConvexPolygonConstructorTest, test_not_convex)
+//{
+//    /*
+//     *  2            *-------*
+//     *               |       |
+//     *  1            *-------*
+//     *               |
+//     *  0            *
+//     *               |
+//     *  -1   *-------*
+//     *       |       |
+//     *  -2   *-------*
+//     *
+//     *      -2       0       2
+//     */
+//    // Self intersecting polygon, each asterisk on the diagram is a point making up the
+//    // polygon
+//    EXPECT_THROW(ConvexPolygon({{0.0f, 0.0f},
+//                                {0.0f, 2.0f},
+//                                {2.0f, 2.0f},
+//                                {2.0f, 1.0f},
+//                                {0.0f, 1.0f},
+//                                {-0.0f, -2.0f},
+//                                {-2.0f, -2.0f},
+//                                {-2.0f, -1.0f},
+//                                {0.0f, -1.0f}}),
+//                 std::invalid_argument);
+//}
 
-TEST(ConvexPolygonConstructorTest, test_self_intersecting_loop)
-{
-    /*
-     *  3    *------------------------------------------------*
-     *       |                                                |
-     *       |                                                |
-     *  2    |       *--------------------------------*       |
-     *       |             ------           ------            |
-     *       |                  ----      ----                |
-     *  1    |                       ------                   |
-     *       |                ------      ------              |
-     *       |         ------                   -------       |
-     *  0    *------                                   -------*
-     *      -3      -2       -1       0       1       2       3
-     */
-    // Self intersecting polygon, each asterisk on the diagram is a point making up the
-    // polygon
-    EXPECT_THROW(ConvexPolygon({{-3.0f, 0.0f},
-                                {-3.0f, 3.0f},
-                                {3.0f, 3.0f},
-                                {3.0f, 0.0f},
-                                {-2.0f, 2.0f},
-                                {2.0f, 2.0f}}),
-                 std::invalid_argument);
-}
+//TEST(ConvexPolygonConstructorTest, test_self_intersecting_loop)
+//{
+//    /*
+//     *  3    *------------------------------------------------*
+//     *       |                                                |
+//     *       |                                                |
+//     *  2    |       *--------------------------------*       |
+//     *       |             ------           ------            |
+//     *       |                  ----      ----                |
+//     *  1    |                       ------                   |
+//     *       |                ------      ------              |
+//     *       |         ------                   -------       |
+//     *  0    *------                                   -------*
+//     *      -3      -2       -1       0       1       2       3
+//     */
+//    // Self intersecting polygon, each asterisk on the diagram is a point making up the
+//    // polygon
+//    EXPECT_THROW(ConvexPolygon({{-3.0f, 0.0f},
+//                                {-3.0f, 3.0f},
+//                                {3.0f, 3.0f},
+//                                {3.0f, 0.0f},
+//                                {-2.0f, 2.0f},
+//                                {2.0f, 2.0f}}),
+//                 std::invalid_argument);
+//}
 
 TEST(ConvexPolygonAreaTest, test_trapezoid_area)
 {

--- a/src/software/new_geom/convex_polygon_test.cpp
+++ b/src/software/new_geom/convex_polygon_test.cpp
@@ -50,7 +50,7 @@ TEST(ConvexPolygonConstructorTest, test_construct_from_initializer_list)
 }
 
 // Temporarily disabling the following tests until issue #1140 is completed.
-//TEST(ConvexPolygonConstructorTest, test_not_convex)
+// TEST(ConvexPolygonConstructorTest, test_not_convex)
 //{
 //    /*
 //     *  2            *-------*
@@ -79,7 +79,7 @@ TEST(ConvexPolygonConstructorTest, test_construct_from_initializer_list)
 //                 std::invalid_argument);
 //}
 
-//TEST(ConvexPolygonConstructorTest, test_self_intersecting_loop)
+// TEST(ConvexPolygonConstructorTest, test_self_intersecting_loop)
 //{
 //    /*
 //     *  3    *------------------------------------------------*


### PR DESCRIPTION
### Description
As titled, to avoid errors until #1140 is done within the week.

### Testing Done
Manual test that running ```bazel run //software:full_system -- --backend=grsim``` no longer throws an error from ```isConvex()```