### PR TITLE
Formatting Workflow Change

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -84,10 +84,9 @@ If you do rebase or merge and get conflicts, you'll need to resolve them manuall
 ### Formatting Your Code
 We use [clang-format](https://electronjs.org/docs/development/clang-format) to automatically format our code. Using an automatic tool helps keep things consistent across the codebase without developers having to change their personal style as they write. See the [code style guide](code-style-guide.md) for more information on exactly what it does.
 
-To format the code, from the `Software` directory run `./clang_format/fix_formatting.sh -b master`. This will take the difference between your current branch and your local `master` branch, and run `clang-format` on those changes. The only reason we use the `-b master` option is because it's faster and only formats code you have modified. There is also a `-a` option that will try format the entire codebase, but it is slow and not recommended.
+To format the code, from the `Software` directory run `./clang_format/fix_formatting.sh -b upstream/master`. This will take the difference between your current branch and the `upstream/master` branch, and run `clang-format` on those changes. The only reason we use the `-b upstream/master` option is because it's faster and only formats code you have modified. There is also a `-a` option that will try format the entire codebase, but it is slow and not recommended.
 
-We recommend committing all your changes and then running the formatting script. This keeps the formatting changes separate from your actual changes. For the formatting changes, a simple commit message like "fixed formatting" is fine.
-
+We recommend running the formatting script and then committing all your changes, so that your commits can more easily pass CI.
 ### Pull Requests
 
 Pull Requests give us a chance to run our automated tests and review the code before it gets merged. This helps us make sure our code on `upstream/master` always compiles and is as bug-free as possible.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -84,7 +84,7 @@ If you do rebase or merge and get conflicts, you'll need to resolve them manuall
 ### Formatting Your Code
 We use [clang-format](https://electronjs.org/docs/development/clang-format) to automatically format our code. Using an automatic tool helps keep things consistent across the codebase without developers having to change their personal style as they write. See the [code style guide](code-style-guide.md) for more information on exactly what it does.
 
-To format the code, from the `Software` directory run `./clang_format/fix_formatting.sh -b upstream/master`. This will take the difference between your current branch and the `upstream/master` branch, and run `clang-format` on those changes. The only reason we use the `-b upstream/master` option is because it's faster and only formats code you have modified. There is also a `-a` option that will try format the entire codebase, but it is slow and not recommended.
+To format the code, from the `Software` directory run `./formatting_scripts/fix_formatting.sh`.
 
 We recommend running the formatting script and then committing all your changes, so that your commits can more easily pass CI.
 ### Pull Requests


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Updating workflow based on my own experience. My `origin/master` isn't always kept up to date as I branch off of `upstream/master` so I've been formatting against `upstream/master`.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
