### PR TITLE
Added a Function To Get A T-Value From Arclength In Firmware Polynomial2d

### DIFF
--- a/src/firmware/main/math/polynomial_2d.c
+++ b/src/firmware/main/math/polynomial_2d.c
@@ -118,6 +118,21 @@ GENERATE_2D_POLYNOMIAL_GET_ARC_LENGTH_PARAMETRIZATION_FUNCTION_DEFINITION(1, 0)
         Polynomial2dOrder##N##_t p, float arc_length,                                    \
         ArcLengthParametrization_t arc_length_parametrization)                           \
     {                                                                                    \
+        float t = shared_polynomial2d_getTValueAtArcLengthOrder##N(                      \
+            p, arc_length, arc_length_parametrization);                                  \
+        Vector2d_t result = {.x = shared_polynomial1d_getValueOrder##N(p.x, t),          \
+                             .y = shared_polynomial1d_getValueOrder##N(p.y, t)};         \
+        return result;                                                                   \
+    }
+GENERATE_2D_POLYNOMIAL_GET_POSITION_AT_ARC_LENGTH_FUNCTION_DEFINITION(3)
+GENERATE_2D_POLYNOMIAL_GET_POSITION_AT_ARC_LENGTH_FUNCTION_DEFINITION(2)
+GENERATE_2D_POLYNOMIAL_GET_POSITION_AT_ARC_LENGTH_FUNCTION_DEFINITION(1)
+
+#define GENERATE_2D_POLYNOMIAL_GET_T_VALUE_AT_ARC_LENGTH_FUNCTION_DEFINITION(N)          \
+    float shared_polynomial2d_getTValueAtArcLengthOrder##N(                              \
+        Polynomial2dOrder##N##_t p, float arc_length,                                    \
+        ArcLengthParametrization_t arc_length_parametrization)                           \
+    {                                                                                    \
         /* Check that we have at least one s-value in the parametrization, and the s */  \
         /* value we're looking for is within the parametrization */                      \
         assert(arc_length_parametrization.num_values > 0);                               \
@@ -174,13 +189,8 @@ GENERATE_2D_POLYNOMIAL_GET_ARC_LENGTH_PARAMETRIZATION_FUNCTION_DEFINITION(1, 0)
             (arc_length_above_pivot - arc_length_below_pivot);                           \
         const float t =                                                                  \
             t_below_pivot + (t_above_pivot - t_below_pivot) * arc_length_ratio;          \
-                                                                                         \
-        Vector2d_t result = {.x = shared_polynomial1d_getValueOrder##N(p.x, t),          \
-                             .y = shared_polynomial1d_getValueOrder##N(p.y, t)};         \
-                                                                                         \
-        return result;                                                                   \
+        return t;                                                                        \
     }
-GENERATE_2D_POLYNOMIAL_GET_POSITION_AT_ARC_LENGTH_FUNCTION_DEFINITION(3)
-GENERATE_2D_POLYNOMIAL_GET_POSITION_AT_ARC_LENGTH_FUNCTION_DEFINITION(2)
-GENERATE_2D_POLYNOMIAL_GET_POSITION_AT_ARC_LENGTH_FUNCTION_DEFINITION(1)
-GENERATE_2D_POLYNOMIAL_GET_POSITION_AT_ARC_LENGTH_FUNCTION_DEFINITION(0)
+GENERATE_2D_POLYNOMIAL_GET_T_VALUE_AT_ARC_LENGTH_FUNCTION_DEFINITION(3)
+GENERATE_2D_POLYNOMIAL_GET_T_VALUE_AT_ARC_LENGTH_FUNCTION_DEFINITION(2)
+GENERATE_2D_POLYNOMIAL_GET_T_VALUE_AT_ARC_LENGTH_FUNCTION_DEFINITION(1)

--- a/src/firmware/main/math/polynomial_2d.h
+++ b/src/firmware/main/math/polynomial_2d.h
@@ -105,9 +105,38 @@ GENERATE_2D_POLYNOMIAL_GET_ARC_LENGTH_PARAMETRIZATION_DECLARATION(2);
 GENERATE_2D_POLYNOMIAL_GET_ARC_LENGTH_PARAMETRIZATION_DECLARATION(3);
 
 /**
+ * Get an approximation of the `t` value from a given arclength
+ *
+ * This can be used to get the position at a given arclength
+ * (ie. `p(t)` = (x_at_arclength, y_at_arclength)
+ *
+ * @pre s is between the minimum and maximum s value in the given parametrization
+ * @pre arc_length_parametrization has at least one entry
+ *
+ * @param p [in] The polynomial from which to get the t-value at the given arc length
+ * @param s [in] The arc length to get the t-value at. If this is above or below the
+ *               min/max arc length in the given parametrization, it will be set to the
+ *               closest arc length in the parametrization.
+ * @param arc_length_parametrization [in] A re-parametrization of "p" in terms of arc
+ *                                        length. *THIS MUST HAVE AT LEAST ONE ENTRY*
+ *
+ * @return An approximation of the t-value at the given arc length on the given
+ *         polynomial
+ */
+#define GENERATE_2D_POLYNOMIAL_GET_T_VALUE_AT_ARC_LENGTH_FUNCTION_DECLARATION(N)         \
+    float shared_polynomial2d_getTValueAtArcLengthOrder##N(                              \
+        Polynomial2dOrder##N##_t p, float s,                                             \
+        ArcLengthParametrization_t arc_length_parametrization)
+
+GENERATE_2D_POLYNOMIAL_GET_T_VALUE_AT_ARC_LENGTH_FUNCTION_DECLARATION(1);
+GENERATE_2D_POLYNOMIAL_GET_T_VALUE_AT_ARC_LENGTH_FUNCTION_DECLARATION(2);
+GENERATE_2D_POLYNOMIAL_GET_T_VALUE_AT_ARC_LENGTH_FUNCTION_DECLARATION(3);
+
+/**
  * Get an approximation of the position along the given polynomial at the given arc length
  *
  * @pre s is between the minimum and maximum s value in the given parametrization
+ * @pre arc_length_parametrization has at least one entry
  *
  * @param p [in] The polynomial from which to get the position at the given arc length
  * @param s [in] The arc length to get the position at. If this is above or below the

--- a/src/firmware/main/math/polynomial_2d_test.cpp
+++ b/src/firmware/main/math/polynomial_2d_test.cpp
@@ -111,9 +111,9 @@ TEST_F(Polynomial2dTest, get_arc_length_parametrization_num_values_0)
 
     shared_polynomial_getArcLengthParametrizationOrder1(poly, -2, 2, parametrization);
 
-    static float expected_t_values[0]          = {};
-    static float expected_arc_length_values[0] = {};
-    ArcLengthParametrization_t expected        = {
+    float expected_t_values[0]          = {};
+    float expected_arc_length_values[0] = {};
+    ArcLengthParametrization_t expected = {
         .t_values          = expected_t_values,
         .arc_length_values = expected_arc_length_values,
         .num_values        = 0};
@@ -134,9 +134,9 @@ TEST_F(Polynomial2dTest, get_arc_length_parametrization_num_values_1)
 
     shared_polynomial_getArcLengthParametrizationOrder1(poly, -1, 2, parametrization);
 
-    static float expected_t_values[1]          = {0.5};
-    static float expected_arc_length_values[1] = {0};
-    ArcLengthParametrization_t expected        = {
+    float expected_t_values[1]          = {0.5};
+    float expected_arc_length_values[1] = {0};
+    ArcLengthParametrization_t expected = {
         .t_values          = expected_t_values,
         .arc_length_values = expected_arc_length_values,
         .num_values        = 1};
@@ -155,9 +155,9 @@ TEST_F(Polynomial2dTest, get_arc_length_parametrization_vertical_line_0_division
 
     shared_polynomial_getArcLengthParametrizationOrder1(poly, -2, 2, parametrization);
 
-    static float expected_t_values[2]          = {-2, 2};
-    static float expected_arc_length_values[2] = {0, 4};
-    ArcLengthParametrization_t expected        = {
+    float expected_t_values[2]          = {-2, 2};
+    float expected_arc_length_values[2] = {0, 4};
+    ArcLengthParametrization_t expected = {
         .t_values          = expected_t_values,
         .arc_length_values = expected_arc_length_values,
         .num_values        = 2};
@@ -176,8 +176,8 @@ TEST_F(Polynomial2dTest, get_arc_length_parametrization_diagonal_line_2_division
 
     shared_polynomial_getArcLengthParametrizationOrder1(poly, -3, 3, parametrization);
 
-    static float expected_t_values_storage[4]          = {-3, -1, 1, 3};
-    static float expected_arc_length_values_storage[4] = {
+    float expected_t_values_storage[4]          = {-3, -1, 1, 3};
+    float expected_arc_length_values_storage[4] = {
         0.0, (float)sqrt(4 + 4), (float)sqrt(16 + 16), (float)sqrt(36 + 36)};
     ArcLengthParametrization_t expected = {
         .t_values          = expected_t_values_storage,
@@ -211,10 +211,9 @@ TEST_F(Polynomial2dTest, get_arc_length_parametrization_for_complex_function)
     // end
     // ```
     // clang-format on
-    static float expected_t_values[17]          = {-6,   -5.25, -4.5, -3.75, -3.0, -2.25,
-                                          -1.5, -0.75, 0,    0.75,  1.5,  2.25,
-                                          3,    3.75,  4.5,  5.25,  6};
-    static float expected_arc_length_values[17] = {
+    float expected_t_values[17] = {-6,   -5.25, -4.5, -3.75, -3.0, -2.25, -1.5, -0.75, 0,
+                                   0.75, 1.5,   2.25, 3,     3.75, 4.5,   5.25, 6};
+    float expected_arc_length_values[17] = {
         0,      168.5,  314.3,  437.58, 538.49, 617.19, 673.86, 708.65, 721.73,
         730.46, 760.33, 811.43, 883.60, 976.68, 1090.5, 1224.9, 1379.8};
     ArcLengthParametrization_t expected = {
@@ -235,8 +234,8 @@ TEST_F(Polynomial2dTest, get_position_at_arc_length_on_straight_line_1_values)
         .y = {.coefficients = {1, 0.2}},
     };
 
-    static float t_values[1]                              = {0.5};
-    static float arc_length_values[1]                     = {99};
+    float t_values[1]                                     = {0.5};
+    float arc_length_values[1]                            = {99};
     ArcLengthParametrization_t arc_length_parametrization = {
         .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 1};
 
@@ -252,8 +251,8 @@ TEST_F(Polynomial2dTest, get_position_at_arc_length_on_straight_line_single_divi
         .y = {.coefficients = {1, 0.1}},
     };
 
-    static float t_values[2]                              = {-2, 2};
-    static float arc_length_values[2]                     = {0, 4};
+    float t_values[2]                                     = {-2, 2};
+    float arc_length_values[2]                            = {0, 4};
     ArcLengthParametrization_t arc_length_parametrization = {
         .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 2};
 
@@ -281,8 +280,8 @@ TEST_F(Polynomial2dTest, get_position_on_arc_length_above_arc_lengths_in_paramet
         .y = {.coefficients = {1, 0.1}},
     };
 
-    static float t_values[2]                              = {-2, 2};
-    static float arc_length_values[2]                     = {0, 4};
+    float t_values[2]                                     = {-2, 2};
+    float arc_length_values[2]                            = {0, 4};
     ArcLengthParametrization_t arc_length_parametrization = {
         .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 2};
 
@@ -298,8 +297,8 @@ TEST_F(Polynomial2dTest, get_position_on_arc_length_below_arc_lengths_in_paramet
         .y = {.coefficients = {1, 0.1}},
     };
 
-    static float t_values[2]                              = {-2, 2};
-    static float arc_length_values[2]                     = {0, 4};
+    float t_values[2]                                     = {-2, 2};
+    float arc_length_values[2]                            = {0, 4};
     ArcLengthParametrization_t arc_length_parametrization = {
         .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 2};
 
@@ -319,11 +318,11 @@ TEST_F(Polynomial2dTest, get_position_at_arc_length_on_complex_line_multiple_div
     // values here actually are, as long as they're both in ascending order, as this
     // function's job is merely to interpolate over the given set of values, whatever
     // those values might be.
-    static float t_values[17] = {-6,   -5.25, -4.5, -3.75, -3.0, -2.25, -1.5, -0.75, 0,
-                                 0.75, 1.5,   2.25, 3,     3.75, 4.5,   5.25, 6};
-    static float arc_length_values[17] = {0,      168.5,  314.3,  437.58, 538.49, 617.19,
-                                          673.86, 708.65, 721.73, 730.46, 760.33, 811.43,
-                                          883.60, 976.68, 1090.5, 1224.9, 1379.8};
+    float t_values[17]          = {-6,   -5.25, -4.5, -3.75, -3.0, -2.25, -1.5, -0.75, 0,
+                          0.75, 1.5,   2.25, 3,     3.75, 4.5,   5.25, 6};
+    float arc_length_values[17] = {0,      168.5,  314.3,  437.58, 538.49, 617.19,
+                                   673.86, 708.65, 721.73, 730.46, 760.33, 811.43,
+                                   883.60, 976.68, 1090.5, 1224.9, 1379.8};
     ArcLengthParametrization_t arc_length_parametrization = {
         .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 17};
 
@@ -362,8 +361,8 @@ TEST_F(Polynomial2dTest, get_t_value_at_arc_length_on_straight_line_1_values)
         .y = {.coefficients = {1, 0.2}},
     };
 
-    static float t_values[1]                              = {0.5};
-    static float arc_length_values[1]                     = {99};
+    float t_values[1]                                     = {0.5};
+    float arc_length_values[1]                            = {99};
     ArcLengthParametrization_t arc_length_parametrization = {
         .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 1};
 
@@ -378,8 +377,8 @@ TEST_F(Polynomial2dTest, get_t_value_at_arc_length_on_straight_line_single_divis
         .y = {.coefficients = {1, 0.1}},
     };
 
-    static float t_values[2]                              = {-2, 2};
-    static float arc_length_values[2]                     = {0, 4};
+    float t_values[2]                                     = {-2, 2};
+    float arc_length_values[2]                            = {0, 4};
     ArcLengthParametrization_t arc_length_parametrization = {
         .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 2};
 
@@ -402,8 +401,8 @@ TEST_F(Polynomial2dTest, get_t_value_on_arc_length_above_arc_lengths_in_parametr
         .y = {.coefficients = {1, 0.1}},
     };
 
-    static float t_values[2]                              = {-2, 2};
-    static float arc_length_values[2]                     = {0, 4};
+    float t_values[2]                                     = {-2, 2};
+    float arc_length_values[2]                            = {0, 4};
     ArcLengthParametrization_t arc_length_parametrization = {
         .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 2};
 
@@ -418,8 +417,8 @@ TEST_F(Polynomial2dTest, get_t_value_on_arc_length_below_arc_lengths_in_parametr
         .y = {.coefficients = {1, 0.1}},
     };
 
-    static float t_values[2]                              = {-2, 2};
-    static float arc_length_values[2]                     = {0, 4};
+    float t_values[2]                                     = {-2, 2};
+    float arc_length_values[2]                            = {0, 4};
     ArcLengthParametrization_t arc_length_parametrization = {
         .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 2};
 
@@ -438,11 +437,11 @@ TEST_F(Polynomial2dTest, get_t_value_at_arc_length_on_complex_line_multiple_divi
     // values here actually are, as long as they're both in ascending order, as this
     // function's job is merely to interpolate over the given set of values, whatever
     // those values might be.
-    static float t_values[17] = {-6,   -5.25, -4.5, -3.75, -3.0, -2.25, -1.5, -0.75, 0,
-                                 0.75, 1.5,   2.25, 3,     3.75, 4.5,   5.25, 6};
-    static float arc_length_values[17] = {0,      168.5,  314.3,  437.58, 538.49, 617.19,
-                                          673.86, 708.65, 721.73, 730.46, 760.33, 811.43,
-                                          883.60, 976.68, 1090.5, 1224.9, 1379.8};
+    float t_values[17]          = {-6,   -5.25, -4.5, -3.75, -3.0, -2.25, -1.5, -0.75, 0,
+                          0.75, 1.5,   2.25, 3,     3.75, 4.5,   5.25, 6};
+    float arc_length_values[17] = {0,      168.5,  314.3,  437.58, 538.49, 617.19,
+                                   673.86, 708.65, 721.73, 730.46, 760.33, 811.43,
+                                   883.60, 976.68, 1090.5, 1224.9, 1379.8};
     ArcLengthParametrization_t arc_length_parametrization = {
         .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 17};
 

--- a/src/firmware/main/math/polynomial_2d_test.cpp
+++ b/src/firmware/main/math/polynomial_2d_test.cpp
@@ -89,13 +89,13 @@ TEST_F(Polynomial2dTest, get_derivative_3rd_order_polynomial)
 
     Polynomial2dOrder2_t derivative = shared_polynomial2d_differentiateOrder3(poly);
 
-    EXPECT_DOUBLE_EQ(-6, derivative.x.coefficients[0]);
-    EXPECT_DOUBLE_EQ(1, derivative.x.coefficients[1]);
-    EXPECT_DOUBLE_EQ(6, derivative.x.coefficients[2]);
+    EXPECT_FLOAT_EQ(-6, derivative.x.coefficients[0]);
+    EXPECT_FLOAT_EQ(1, derivative.x.coefficients[1]);
+    EXPECT_FLOAT_EQ(6, derivative.x.coefficients[2]);
 
     EXPECT_NEAR(0.6, derivative.y.coefficients[0], 10e-7);
-    EXPECT_DOUBLE_EQ(14, derivative.y.coefficients[1]);
-    EXPECT_DOUBLE_EQ(2, derivative.y.coefficients[2]);
+    EXPECT_FLOAT_EQ(14, derivative.y.coefficients[1]);
+    EXPECT_FLOAT_EQ(2, derivative.y.coefficients[2]);
 }
 
 TEST_F(Polynomial2dTest, get_arc_length_parametrization_num_values_0)
@@ -225,7 +225,7 @@ TEST_F(Polynomial2dTest, get_arc_length_parametrization_for_complex_function)
     expectArcLengthParametrizationsEqual(expected, parametrization, 1);
 }
 
-TEST_F(Polynomial2dTest, get_position_at_arc_length_on_straight_1_values)
+TEST_F(Polynomial2dTest, get_position_at_arc_length_on_straight_line_1_values)
 {
     // This function should probably never be used like this, but this checks that
     // we're at least executing defined behavior
@@ -308,7 +308,6 @@ TEST_F(Polynomial2dTest, get_position_on_arc_length_below_arc_lengths_in_paramet
                             poly, -5, arc_length_parametrization));
 }
 
-
 TEST_F(Polynomial2dTest, get_position_at_arc_length_on_complex_line_multiple_divisions)
 {
     Polynomial2dOrder3_t poly = {
@@ -351,4 +350,113 @@ TEST_F(Polynomial2dTest, get_position_at_arc_length_on_complex_line_multiple_div
                         shared_polynomial2d_getPositionAtArcLengthOrder3(
                             poly, 345.12, arc_length_parametrization),
                         0.01);
+}
+
+TEST_F(Polynomial2dTest, get_t_value_at_arc_length_on_straight_line_1_values)
+{
+    // This function should probably never be used like this, but this checks that
+    // we're at least executing defined behavior
+
+    Polynomial2dOrder1_t poly = {
+        .x = {.coefficients = {1, 0.1}},
+        .y = {.coefficients = {1, 0.2}},
+    };
+
+    static float t_values[1]                              = {0.5};
+    static float arc_length_values[1]                     = {99};
+    ArcLengthParametrization_t arc_length_parametrization = {
+        .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 1};
+
+    EXPECT_FLOAT_EQ(0.5, shared_polynomial2d_getTValueAtArcLengthOrder1(
+                             poly, 99, arc_length_parametrization));
+}
+
+TEST_F(Polynomial2dTest, get_t_value_at_arc_length_on_straight_line_single_division)
+{
+    Polynomial2dOrder1_t poly = {
+        .x = {.coefficients = {1, 0.1}},
+        .y = {.coefficients = {1, 0.1}},
+    };
+
+    static float t_values[2]                              = {-2, 2};
+    static float arc_length_values[2]                     = {0, 4};
+    ArcLengthParametrization_t arc_length_parametrization = {
+        .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 2};
+
+    EXPECT_FLOAT_EQ(-2, shared_polynomial2d_getTValueAtArcLengthOrder1(
+                            poly, 0, arc_length_parametrization));
+    EXPECT_FLOAT_EQ(-1, shared_polynomial2d_getTValueAtArcLengthOrder1(
+                            poly, 1, arc_length_parametrization));
+    EXPECT_FLOAT_EQ(0, shared_polynomial2d_getTValueAtArcLengthOrder1(
+                           poly, 2, arc_length_parametrization));
+    EXPECT_FLOAT_EQ(1, shared_polynomial2d_getTValueAtArcLengthOrder1(
+                           poly, 3, arc_length_parametrization));
+    EXPECT_FLOAT_EQ(2, shared_polynomial2d_getTValueAtArcLengthOrder1(
+                           poly, 4, arc_length_parametrization));
+}
+
+TEST_F(Polynomial2dTest, get_t_value_on_arc_length_above_arc_lengths_in_parametrization)
+{
+    Polynomial2dOrder1_t poly = {
+        .x = {.coefficients = {1, 0.1}},
+        .y = {.coefficients = {1, 0.1}},
+    };
+
+    static float t_values[2]                              = {-2, 2};
+    static float arc_length_values[2]                     = {0, 4};
+    ArcLengthParametrization_t arc_length_parametrization = {
+        .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 2};
+
+    EXPECT_FLOAT_EQ(2, shared_polynomial2d_getTValueAtArcLengthOrder1(
+                           poly, 5, arc_length_parametrization));
+}
+
+TEST_F(Polynomial2dTest, get_t_value_on_arc_length_below_arc_lengths_in_parametrization)
+{
+    Polynomial2dOrder1_t poly = {
+        .x = {.coefficients = {1, 0.1}},
+        .y = {.coefficients = {1, 0.1}},
+    };
+
+    static float t_values[2]                              = {-2, 2};
+    static float arc_length_values[2]                     = {0, 4};
+    ArcLengthParametrization_t arc_length_parametrization = {
+        .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 2};
+
+    EXPECT_FLOAT_EQ(-2, shared_polynomial2d_getTValueAtArcLengthOrder1(
+                            poly, -5, arc_length_parametrization));
+}
+
+TEST_F(Polynomial2dTest, get_t_value_at_arc_length_on_complex_line_multiple_divisions)
+{
+    Polynomial2dOrder3_t poly = {
+        .x = {.coefficients = {0.1 / 3, 1.5, -0.5, 70.1}},
+        .y = {.coefficients = {-0.2 / 3, 19.1, -3, -3}},
+    };
+
+    // Note that for the purposes of this test it does not matter what the t and s
+    // values here actually are, as long as they're both in ascending order, as this
+    // function's job is merely to interpolate over the given set of values, whatever
+    // those values might be.
+    static float t_values[17] = {-6,   -5.25, -4.5, -3.75, -3.0, -2.25, -1.5, -0.75, 0,
+                                 0.75, 1.5,   2.25, 3,     3.75, 4.5,   5.25, 6};
+    static float arc_length_values[17] = {0,      168.5,  314.3,  437.58, 538.49, 617.19,
+                                          673.86, 708.65, 721.73, 730.46, 760.33, 811.43,
+                                          883.60, 976.68, 1090.5, 1224.9, 1379.8};
+    ArcLengthParametrization_t arc_length_parametrization = {
+        .t_values = t_values, .arc_length_values = arc_length_values, .num_values = 17};
+
+    // Check some arc length points that require no interpolation
+    EXPECT_FLOAT_EQ(-6, shared_polynomial2d_getTValueAtArcLengthOrder3(
+                            poly, 0, arc_length_parametrization));
+    EXPECT_FLOAT_EQ(6, shared_polynomial2d_getTValueAtArcLengthOrder3(
+                           poly, 1379.8, arc_length_parametrization));
+    EXPECT_FLOAT_EQ(0, shared_polynomial2d_getTValueAtArcLengthOrder3(
+                           poly, 721.73, arc_length_parametrization));
+
+    // Check some arc length points that should be determined via interpolation
+    EXPECT_FLOAT_EQ(-5.4374776, shared_polynomial2d_getTValueAtArcLengthOrder3(
+                                    poly, 126.38, arc_length_parametrization));
+    EXPECT_FLOAT_EQ(-4.3125, shared_polynomial2d_getTValueAtArcLengthOrder3(
+                                 poly, 345.12, arc_length_parametrization));
 }


### PR DESCRIPTION


<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Unit tests.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
N/A
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
