### PR TITLE
Added Boost to some BUILD files and stddef.h to Fix Compiler Errors

### DIFF
--- a/src/firmware/main/math/polynomial_1d.c
+++ b/src/firmware/main/math/polynomial_1d.c
@@ -1,7 +1,6 @@
 #include "firmware/main/math/polynomial_1d.h"
 
 #include <math.h>
-#include <stddef.h>
 
 /**
  * Compute the value at the given point for the polynomial formed by the given coeffs

--- a/src/firmware/main/math/polynomial_1d.c
+++ b/src/firmware/main/math/polynomial_1d.c
@@ -1,6 +1,7 @@
 #include "firmware/main/math/polynomial_1d.h"
 
 #include <math.h>
+#include <stddef.h>
 
 /**
  * Compute the value at the given point for the polynomial formed by the given coeffs

--- a/src/firmware/main/math/polynomial_1d.h
+++ b/src/firmware/main/math/polynomial_1d.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stddef.h>
 
 /**
  * A polynomial with a list of coefficients, with the highest order coefficients at

--- a/src/firmware/main/math/polynomial_2d_test.cpp
+++ b/src/firmware/main/math/polynomial_2d_test.cpp
@@ -5,9 +5,9 @@ extern "C"
 
 #include <gtest/gtest.h>
 
+#include "math.h"
 #include "polynomial_1d.h"
 #include "polynomial_2d.h"
-#include "math.h"
 
 class Polynomial2dTest : public testing::Test
 {

--- a/src/firmware/main/math/polynomial_2d_test.cpp
+++ b/src/firmware/main/math/polynomial_2d_test.cpp
@@ -7,6 +7,7 @@ extern "C"
 
 #include "polynomial_1d.h"
 #include "polynomial_2d.h"
+#include "math.h"
 
 class Polynomial2dTest : public testing::Test
 {

--- a/src/firmware_new/tools/communication/BUILD
+++ b/src/firmware_new/tools/communication/BUILD
@@ -10,6 +10,6 @@ cc_library(
         "//firmware_new/tools/communication/transfer_media:network_medium",
         "//firmware_new/tools/communication/transfer_media:transfer_medium",
         "//software/multithreading:thread_safe_buffer",
-    	"@boost//:asio",
-	],
+        "@boost//:asio",
+    ],
 )

--- a/src/firmware_new/tools/communication/BUILD
+++ b/src/firmware_new/tools/communication/BUILD
@@ -10,5 +10,6 @@ cc_library(
         "//firmware_new/tools/communication/transfer_media:network_medium",
         "//firmware_new/tools/communication/transfer_media:transfer_medium",
         "//software/multithreading:thread_safe_buffer",
-    ],
+    	"@boost//:asio",
+	],
 )

--- a/src/firmware_new/tools/communication/transfer_media/BUILD
+++ b/src/firmware_new/tools/communication/transfer_media/BUILD
@@ -14,5 +14,7 @@ cc_library(
         ":transfer_medium",
         "//software/multithreading:thread_safe_buffer",
         "@g3log",
+        "@boost//:array",
+	"@boost//:asio",
     ],
 )

--- a/src/firmware_new/tools/communication/transfer_media/BUILD
+++ b/src/firmware_new/tools/communication/transfer_media/BUILD
@@ -13,8 +13,8 @@ cc_library(
     deps = [
         ":transfer_medium",
         "//software/multithreading:thread_safe_buffer",
-        "@g3log",
         "@boost//:array",
-	"@boost//:asio",
+        "@boost//:asio",
+        "@g3log",
     ],
 )


### PR DESCRIPTION
For whatever reason I could not get master to build after the most recent changes.

Adding these libraries fixed it.

### Review Checklist

- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [X] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.
