### PR TITLE
Fix visualizer not drawing world

### DIFF
--- a/src/software/backend/input/network/networking/network_filter.cpp
+++ b/src/software/backend/input/network/networking/network_filter.cpp
@@ -164,7 +164,7 @@ Team NetworkFilter::getFilteredFriendlyTeamData(
     for (const auto &detection : detections)
     {
         auto ssl_robots = detection.robots_yellow();
-        if (refbox_config->FriendlyColorYellow()->value())
+        if (!refbox_config->FriendlyColorYellow()->value())
         {
             ssl_robots = detection.robots_blue();
         }

--- a/src/software/visualizer/visualizer_wrapper.h
+++ b/src/software/visualizer/visualizer_wrapper.h
@@ -80,15 +80,15 @@ class VisualizerWrapper : public ThreadedObserver<World>,
     // smooth if the stream of data isn't perfectly consistent, so we use a very small
     // buffer of 2 values to be responsive while also giving a small buffer for
     // smoothness
-    const std::size_t world_draw_functions_buffer_size = 2;
-    const std::size_t ai_draw_functions_buffer_size    = 2;
+    static constexpr std::size_t world_draw_functions_buffer_size = 2;
+    static constexpr std::size_t ai_draw_functions_buffer_size    = 2;
     // We only care about the most recent PlayInfo, so the buffer is of size 1
-    const std::size_t play_info_buffer_size = 1;
+    static constexpr std::size_t play_info_buffer_size = 1;
     // We don't want to miss any robot status updates so we make the buffer larger
-    const std::size_t robot_status_buffer_size = 60;
+    static constexpr std::size_t robot_status_buffer_size = 60;
     // We only care about the most recent view area that was requested, so the
     // buffer is of size 1
-    const std::size_t view_area_buffer_size = 1;
+    static constexpr std::size_t view_area_buffer_size = 1;
 
     std::atomic_bool application_shutting_down;
     bool initial_view_area_set;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
This PR fixes the long-standing issue of the Visualizer not drawing the World at all. The issue was with the buffers we use to pass data between our `VisualizerWrapper` and `Visualizer`, which run on different threads.

The buffer sizes were `const` member variables of the class, and initialized directly in the header where they were declared. Because the buffers are created in the initializer list of the class constructor, those buffer size values were not actually initialized by the time the buffers were getting created (since the class didn't exist yet), and so the buffers all were created with a size of 0. This resulted in no data getting passed to the Visualizer so it didn't draw anything.

It seems like the change in compilers was still what exposed this issue, because this technically shouldn't have worked before. I solved the issue by making the buffer size variables `static constexpr` so they are initialized well before the class is created.

This pattern of assigning values to private const member variables in classes in used elsewhere in the code and should be fixed as well. We need to decide what solution we prefer, and should see if we can add compiler flags to prevent this again.

**Solution 1**
Declare variables as `static constexpr` in the class

**Solution 2**
Initialize the variables in the initializer list (before they are used)

Please leave feedback as to which is preferred. I think solution 1 is slightly more correct since the variables are the same for all instances of the class and don't belong to a particular instance.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Manually verified drawing works as expected

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
None

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
