### PR TITLE
Add unit test to goalie tactic

### DIFF
--- a/src/software/ai/hl/stp/tactic/BUILD
+++ b/src/software/ai/hl/stp/tactic/BUILD
@@ -163,6 +163,9 @@ cc_test(
     srcs = ["goalie_tactic_test.cpp"],
     deps = [
         ":goalie_tactic",
+        "//software/ai/hl/stp/action:chip_action",
+        "//software/ai/hl/stp/action:move_action",
+        "//software/ai/hl/stp/action:stop_action",
         "//software/geom",
         "//software/test_util",
         "@gtest//:gtest_main",

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -278,12 +278,12 @@ void GoalieTactic::calculateNextAction(ActionCoroutine::push_type &yield)
                 if (ball.position().y() > 0)
                 {
                     goalie_pos =
-                            field.friendlyGoalpostPos() + Vector(-ROBOT_MAX_RADIUS_METERS, 0);
+                            field.friendlyGoalpostPos() + Vector(0, -ROBOT_MAX_RADIUS_METERS);
                 }
                 else
                 {
                     goalie_pos =
-                            field.friendlyGoalpostNeg() + Vector(ROBOT_MAX_RADIUS_METERS, 0);
+                            field.friendlyGoalpostNeg() + Vector(0, ROBOT_MAX_RADIUS_METERS);
                 }
             }
             else

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -248,15 +248,16 @@ void GoalieTactic::calculateNextAction(ActionCoroutine::push_type &yield)
             // compute angle between two vectors, negative goal post to ball and positive
             // goal post to ball
             Angle block_cone_angle =
-                    (ball.position() - field.friendlyGoalpostNeg())
-                            .orientation()
-                            .minDiff((ball.position() - field.friendlyGoalpostPos()).orientation());
+                (ball.position() - field.friendlyGoalpostNeg())
+                    .orientation()
+                    .minDiff(
+                        (ball.position() - field.friendlyGoalpostPos()).orientation());
 
             // compute block cone position, allowing 1 ROBOT_MAX_RADIUS_METERS extra on
             // either side
             Point goalie_pos = calcBlockCone(
-                    field.friendlyGoalpostNeg(), field.friendlyGoalpostPos(), ball.position(),
-                    block_cone_radius * block_cone_angle.toRadians());
+                field.friendlyGoalpostNeg(), field.friendlyGoalpostPos(), ball.position(),
+                block_cone_radius * block_cone_angle.toRadians());
 
             // we want to restrict the block cone to the friendly crease, also potentially
             // scaled by a defense_area_deflation_parameter
@@ -267,7 +268,7 @@ void GoalieTactic::calculateNextAction(ActionCoroutine::push_type &yield)
             // restrained or if there is no proper intersection, then we safely default to
             // center of the goal
             auto clamped_goalie_pos =
-                    restrainGoalieInRectangle(goalie_pos, deflated_defense_area);
+                restrainGoalieInRectangle(goalie_pos, deflated_defense_area);
 
             // if the goalie could not be restrained in the deflated defense area,
             // then the ball must be either on a really sharp angle to the net where
@@ -278,12 +279,12 @@ void GoalieTactic::calculateNextAction(ActionCoroutine::push_type &yield)
                 if (ball.position().y() > 0)
                 {
                     goalie_pos =
-                            field.friendlyGoalpostPos() + Vector(0, -ROBOT_MAX_RADIUS_METERS);
+                        field.friendlyGoalpostPos() + Vector(0, -ROBOT_MAX_RADIUS_METERS);
                 }
                 else
                 {
                     goalie_pos =
-                            field.friendlyGoalpostNeg() + Vector(0, ROBOT_MAX_RADIUS_METERS);
+                        field.friendlyGoalpostNeg() + Vector(0, ROBOT_MAX_RADIUS_METERS);
                 }
             }
             else
@@ -292,9 +293,10 @@ void GoalieTactic::calculateNextAction(ActionCoroutine::push_type &yield)
             }
             Angle goalie_orientation = (ball.position() - goalie_pos).orientation();
 
-            move_action->updateControlParams(
-                    *robot, goalie_pos, goalie_orientation, goalie_final_speed,
-                    DribblerEnable::OFF, MoveType::NORMAL, AUTOCHIP, BallCollisionType::ALLOW);
+            move_action->updateControlParams(*robot, goalie_pos, goalie_orientation,
+                                             goalie_final_speed, DribblerEnable::OFF,
+                                             MoveType::NORMAL, AUTOCHIP,
+                                             BallCollisionType::ALLOW);
             next_action = move_action;
         }
 

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -152,14 +152,13 @@ void GoalieTactic::calculateNextAction(ActionCoroutine::push_type &yield)
         //
         std::shared_ptr<Action> next_action;
 
-        // Create a segment along the goal line, slightly shortened to account for the
-        // robot radius so as we move along the segment we don't try run into the goal
-        // posts. This will be used in case3 as a fallback when we don't have an
-        // intersection with the crease lines
-
         // compute intersection points from ball position and velocity
         Ray ball_ray = Ray(ball.position(), ball.velocity());
 
+        // Create a segment along the goal line, slightly shortened to account for the
+        // robot radius so as we move along the segment we don't try to run into the goal
+        // posts. This will be used in case 3 as a fallback when we don't have an
+        // intersection with the crease lines
         const Point neg_goal_line_inflated =
             field.friendlyGoalpostNeg() + Vector(0, -ROBOT_MAX_RADIUS_METERS);
         const Point pos_goal_line_inflated =
@@ -186,7 +185,7 @@ void GoalieTactic::calculateNextAction(ActionCoroutine::push_type &yield)
                                      ->getGoalieTacticConfig()
                                      ->BlockConeRadius()
                                      ->value();
-        // by how much should the defense are be decreased so the goalie stays close
+        // by how much should the defense area be decreased so the goalie stays close
         // towards the net
         auto defense_area_deflation = Util::DynamicParameters->getAIConfig()
                                           ->getGoalieTacticConfig()

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -68,9 +68,11 @@ std::optional<Point> GoalieTactic::restrainGoalieInRectangle(
     // Due to the nature of the line intersection, its important to make sure the
     // corners are included, if the goalies desired position intersects with width (see
     // above), use those positions
+    // The last comparison is for the edge case when the ball is behind the net
     else if (width_x_goal &&
              width_x_goal->y() <= goalie_restricted_area.posXPosYCorner().y() &&
-             width_x_goal->y() >= goalie_restricted_area.posXNegYCorner().y())
+             width_x_goal->y() >= goalie_restricted_area.posXNegYCorner().y() &&
+             field.friendlyGoal().x() <= goalie_desired_position.x())
     {
         return std::make_optional<Point>(*width_x_goal);
     }
@@ -243,82 +245,58 @@ void GoalieTactic::calculateNextAction(ActionCoroutine::push_type &yield)
         // position goalie in best position to block shot
         else
         {
-            // block the cone by default
-            float radius = Util::DynamicParameters->getAIConfig()
-                               ->getGoalieTacticConfig()
-                               ->BlockConeBuffer()
-                               ->value() +
-                           ROBOT_MAX_RADIUS_METERS;
+            // compute angle between two vectors, negative goal post to ball and positive
+            // goal post to ball
+            Angle block_cone_angle =
+                    (ball.position() - field.friendlyGoalpostNeg())
+                            .orientation()
+                            .minDiff((ball.position() - field.friendlyGoalpostPos()).orientation());
 
-            Point goalie_pos =
-                calcBlockCone(field.friendlyGoalpostNeg(), field.friendlyGoalpostPos(),
-                              ball.position(), radius);
+            // compute block cone position, allowing 1 ROBOT_MAX_RADIUS_METERS extra on
+            // either side
+            Point goalie_pos = calcBlockCone(
+                    field.friendlyGoalpostNeg(), field.friendlyGoalpostPos(), ball.position(),
+                    block_cone_radius * block_cone_angle.toRadians());
 
-            // restrict the goalie to a semicircle inscribed inside the defense area
-            Point goalie_restricted_pos =
-                field.friendlyGoal() - (field.friendlyDefenseArea().yLength() *
-                                        (field.friendlyGoal() - goalie_pos).normalize());
+            // we want to restrict the block cone to the friendly crease, also potentially
+            // scaled by a defense_area_deflation_parameter
+            Rectangle deflated_defense_area = field.friendlyDefenseArea();
+            deflated_defense_area.expand(-defense_area_deflation);
 
-            // restrict the point to be within the defense area
-            auto goalie_orientation = (ball.position() - goalie_pos).orientation();
-            move_action->updateControlParams(*robot, goalie_restricted_pos,
-                                             goalie_orientation, 0.0, DribblerEnable::OFF,
-                                             MoveType::NORMAL, AUTOCHIP,
-                                             BallCollisionType::ALLOW);
-            next_action = move_action;
-        }
+            // restrain the goalie in the deflated defense area, if the goalie cannot be
+            // restrained or if there is no proper intersection, then we safely default to
+            // center of the goal
+            auto clamped_goalie_pos =
+                    restrainGoalieInRectangle(goalie_pos, deflated_defense_area);
 
-        // compute angle between two vectors, negative goal post to ball and positive
-        // goal post to ball
-        Angle block_cone_angle =
-            (ball.position() - field.friendlyGoalpostNeg())
-                .orientation()
-                .minDiff((ball.position() - field.friendlyGoalpostPos()).orientation());
-
-        // compute block cone position, allowing 1 ROBOT_MAX_RADIUS_METERS extra on
-        // either side
-        Point goalie_pos = calcBlockCone(
-            field.friendlyGoalpostNeg(), field.friendlyGoalpostPos(), ball.position(),
-            block_cone_radius * block_cone_angle.toRadians());
-
-        // we want to restrict the block cone to the friendly crease, also potentially
-        // scaled by a defense_area_deflation_parameter
-        Rectangle deflated_defense_area = field.friendlyDefenseArea();
-        deflated_defense_area.expand(-defense_area_deflation);
-
-        // restrain the goalie in the deflated defense area, if the goalie cannot be
-        // restrained or if there is no proper intersection, then we safely default to
-        // center of the goal
-        auto clamped_goalie_pos =
-            restrainGoalieInRectangle(goalie_pos, deflated_defense_area);
-
-        // if the goalie could not be restrained in the deflated defense area,
-        // then the ball must be either on a really sharp angle to the net where
-        // its impossible to get a shot, or the ball is behind the net, in which
-        // case we snap to either post
-        if (!clamped_goalie_pos)
-        {
-            if (ball.position().y() > 0)
+            // if the goalie could not be restrained in the deflated defense area,
+            // then the ball must be either on a really sharp angle to the net where
+            // its impossible to get a shot, or the ball is behind the net, in which
+            // case we snap to either post
+            if (!clamped_goalie_pos)
             {
-                goalie_pos =
-                    field.friendlyGoalpostPos() + Vector(-ROBOT_MAX_RADIUS_METERS, 0);
+                if (ball.position().y() > 0)
+                {
+                    goalie_pos =
+                            field.friendlyGoalpostPos() + Vector(-ROBOT_MAX_RADIUS_METERS, 0);
+                }
+                else
+                {
+                    goalie_pos =
+                            field.friendlyGoalpostNeg() + Vector(ROBOT_MAX_RADIUS_METERS, 0);
+                }
             }
             else
             {
-                goalie_pos =
-                    field.friendlyGoalpostNeg() + Vector(ROBOT_MAX_RADIUS_METERS, 0);
+                goalie_pos = *clamped_goalie_pos;
             }
-        }
-        else
-        {
-            goalie_pos = *clamped_goalie_pos;
-        }
-        Angle goalie_orientation = (ball.position() - goalie_pos).orientation();
+            Angle goalie_orientation = (ball.position() - goalie_pos).orientation();
 
-        move_action->updateControlParams(
-            *robot, goalie_pos, goalie_orientation, goalie_final_speed,
-            DribblerEnable::OFF, MoveType::NORMAL, AUTOCHIP, BallCollisionType::ALLOW);
-        next_action = move_action;
+            move_action->updateControlParams(
+                    *robot, goalie_pos, goalie_orientation, goalie_final_speed,
+                    DribblerEnable::OFF, MoveType::NORMAL, AUTOCHIP, BallCollisionType::ALLOW);
+            next_action = move_action;
+        }
 
         yield(next_action);
     } while (!move_action->done());

--- a/src/software/ai/hl/stp/tactic/goalie_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic_test.cpp
@@ -5,10 +5,10 @@
 #include <utility>
 
 #include "shared/constants.h"
-#include "software/test_util/test_util.h"
+#include "software/ai/hl/stp/action/chip_action.h"
 #include "software/ai/hl/stp/action/move_action.h"
 #include "software/ai/hl/stp/action/stop_action.h"
-#include "software/ai/hl/stp/action/chip_action.h"
+#include "software/test_util/test_util.h"
 
 // The following tests will make sure the goalie stays in the requested
 // deflated defense area when best positioning to defend the ball.
@@ -81,102 +81,98 @@ INSTANTIATE_TEST_CASE_P(Positions, GoalieRestrainTest,
 
 class GoalieTacticTest : public testing::Test
 {
-    protected:
-        void expectMoveAction(Ball ball, const Point& destination)
-        {
-            World world = ::Test::TestUtil::createBlankTestingWorld();
-            world.mutableBall() = std::move(ball);
+   protected:
+    void expectMoveAction(Ball ball, const Point& destination)
+    {
+        World world         = ::Test::TestUtil::createBlankTestingWorld();
+        world.mutableBall() = std::move(ball);
 
-            Robot goalie = Robot(0, Point(-4.5, 0), Vector(0, 0),
-                                 Angle::zero(), AngularVelocity::zero(), Timestamp::fromSeconds(0));
-            world.mutableFriendlyTeam().updateRobots({goalie});
-            world.mutableFriendlyTeam().assignGoalie(0);
+        Robot goalie = Robot(0, Point(-4.5, 0), Vector(0, 0), Angle::zero(),
+                             AngularVelocity::zero(), Timestamp::fromSeconds(0));
+        world.mutableFriendlyTeam().updateRobots({goalie});
+        world.mutableFriendlyTeam().assignGoalie(0);
 
-            GoalieTactic tactic =
-                    GoalieTactic(world.ball(), world.field(), world.friendlyTeam(),
-                                 world.enemyTeam());
-            tactic.updateRobot(goalie);
-            auto action_ptr = tactic.getNextAction();
+        GoalieTactic tactic = GoalieTactic(world.ball(), world.field(),
+                                           world.friendlyTeam(), world.enemyTeam());
+        tactic.updateRobot(goalie);
+        auto action_ptr = tactic.getNextAction();
 
-            EXPECT_TRUE(action_ptr);
+        EXPECT_TRUE(action_ptr);
 
-            auto move_action = std::dynamic_pointer_cast<MoveAction>(action_ptr);
-            ASSERT_NE(move_action, nullptr);
-            EXPECT_TRUE(move_action->getDestination().isClose(destination, 0.03));
-            EXPECT_NEAR(move_action->getFinalSpeed(), 0, 0.001);
-        }
-        void expectStopAction(Ball ball) {
-            World world = ::Test::TestUtil::createBlankTestingWorld();
-            world.mutableBall() = std::move(ball);
+        auto move_action = std::dynamic_pointer_cast<MoveAction>(action_ptr);
+        ASSERT_NE(move_action, nullptr);
+        EXPECT_TRUE(move_action->getDestination().isClose(destination, 0.03));
+        EXPECT_NEAR(move_action->getFinalSpeed(), 0, 0.001);
+    }
+    void expectStopAction(Ball ball)
+    {
+        World world         = ::Test::TestUtil::createBlankTestingWorld();
+        world.mutableBall() = std::move(ball);
 
-            Robot goalie = Robot(0, Point(-4.5, 0), Vector(0, 0),
-                                 Angle::zero(), AngularVelocity::zero(), Timestamp::fromSeconds(0));
-            world.mutableFriendlyTeam().updateRobots({goalie});
-            world.mutableFriendlyTeam().assignGoalie(0);
+        Robot goalie = Robot(0, Point(-4.5, 0), Vector(0, 0), Angle::zero(),
+                             AngularVelocity::zero(), Timestamp::fromSeconds(0));
+        world.mutableFriendlyTeam().updateRobots({goalie});
+        world.mutableFriendlyTeam().assignGoalie(0);
 
-            GoalieTactic tactic =
-                    GoalieTactic(world.ball(), world.field(), world.friendlyTeam(),
-                                 world.enemyTeam());
-            tactic.updateRobot(goalie);
-            auto action_ptr = tactic.getNextAction();
+        GoalieTactic tactic = GoalieTactic(world.ball(), world.field(),
+                                           world.friendlyTeam(), world.enemyTeam());
+        tactic.updateRobot(goalie);
+        auto action_ptr = tactic.getNextAction();
 
-            EXPECT_TRUE(action_ptr);
+        EXPECT_TRUE(action_ptr);
 
-            auto stop_action = std::dynamic_pointer_cast<StopAction>(action_ptr);
-            ASSERT_NE(stop_action, nullptr);
-        }
-        void expectChipAction(Ball ball) {
-            World world = ::Test::TestUtil::createBlankTestingWorld();
-            world.mutableBall() = std::move(ball);
+        auto stop_action = std::dynamic_pointer_cast<StopAction>(action_ptr);
+        ASSERT_NE(stop_action, nullptr);
+    }
+    void expectChipAction(Ball ball)
+    {
+        World world         = ::Test::TestUtil::createBlankTestingWorld();
+        world.mutableBall() = std::move(ball);
 
-            Robot goalie = Robot(0, Point(-4.5, 0), Vector(0, 0),
-                                 Angle::zero(), AngularVelocity::zero(), Timestamp::fromSeconds(0));
-            world.mutableFriendlyTeam().updateRobots({goalie});
-            world.mutableFriendlyTeam().assignGoalie(0);
+        Robot goalie = Robot(0, Point(-4.5, 0), Vector(0, 0), Angle::zero(),
+                             AngularVelocity::zero(), Timestamp::fromSeconds(0));
+        world.mutableFriendlyTeam().updateRobots({goalie});
+        world.mutableFriendlyTeam().assignGoalie(0);
 
-            GoalieTactic tactic =
-                    GoalieTactic(world.ball(), world.field(), world.friendlyTeam(),
-                                 world.enemyTeam());
-            tactic.updateRobot(goalie);
-            auto action_ptr = tactic.getNextAction();
+        GoalieTactic tactic = GoalieTactic(world.ball(), world.field(),
+                                           world.friendlyTeam(), world.enemyTeam());
+        tactic.updateRobot(goalie);
+        auto action_ptr = tactic.getNextAction();
 
-            EXPECT_TRUE(action_ptr);
+        EXPECT_TRUE(action_ptr);
 
-            auto chip_action = std::dynamic_pointer_cast<ChipAction>(action_ptr);
-            ASSERT_NE(chip_action, nullptr);
-            EXPECT_TRUE(chip_action->getChipOrigin().isClose(world.ball().position(), 0.001));
-            EXPECT_EQ(chip_action->getChipDirection(),(world.ball().position() - world.field().friendlyGoal()).orientation());
-            EXPECT_NEAR(chip_action->getChipDistanceMeters(), 2, 0.001);
-        }
-
+        auto chip_action = std::dynamic_pointer_cast<ChipAction>(action_ptr);
+        ASSERT_NE(chip_action, nullptr);
+        EXPECT_TRUE(chip_action->getChipOrigin().isClose(world.ball().position(), 0.001));
+        EXPECT_EQ(chip_action->getChipDirection(),
+                  (world.ball().position() - world.field().friendlyGoal()).orientation());
+        EXPECT_NEAR(chip_action->getChipDistanceMeters(), 2, 0.001);
+    }
 };
 
 TEST_F(GoalieTacticTest, ball_very_fast_in_straight_line)
 {
-    Ball ball = Ball(Point(0,0), Vector(-4,0),
-                     Timestamp::fromSeconds(0));
-    expectMoveAction(ball, Point(-4.5,0));
+    Ball ball = Ball(Point(0, 0), Vector(-4, 0), Timestamp::fromSeconds(0));
+    expectMoveAction(ball, Point(-4.5, 0));
 }
 
 TEST_F(GoalieTacticTest, ball_very_fast_in_diagonal_line)
 {
-    Ball ball = Ball(Point(0,0), Vector(-4.5,0.25),
-                               Timestamp::fromSeconds(0));
+    Ball ball = Ball(Point(0, 0), Vector(-4.5, 0.25), Timestamp::fromSeconds(0));
     expectMoveAction(ball, Point(-4.5, 0.25));
 }
 
 TEST_F(GoalieTacticTest, ball_very_fast_miss)
 {
-    Ball ball = Ball(Point(0,0), Vector(-4.5,1),
-                     Timestamp::fromSeconds(0));
-    //Goalie is expected to default to centre of goal
+    Ball ball = Ball(Point(0, 0), Vector(-4.5, 1), Timestamp::fromSeconds(0));
+    // Goalie is expected to default to centre of goal
     expectMoveAction(ball, Point(-3.7, 0));
 }
 
 TEST_F(GoalieTacticTest, ball_slow_inside_dont_chip_rectangle)
 {
-    Ball ball = Ball(Point(-4.5 + ROBOT_MAX_RADIUS_METERS,0), Vector(-0.1,0.1),
-                               Timestamp::fromSeconds(0));
+    Ball ball = Ball(Point(-4.5 + ROBOT_MAX_RADIUS_METERS, 0), Vector(-0.1, 0.1),
+                     Timestamp::fromSeconds(0));
     expectStopAction(ball);
 }
 
@@ -187,16 +183,16 @@ TEST_F(GoalieTacticTest, ball_slow_outside_dont_chip_rectangle)
     expectChipAction(ball);
 }
 
-TEST_F(GoalieTacticTest, ball_behind_net_and_moving_toward_net) //snap to closer goal post
+TEST_F(GoalieTacticTest,
+       ball_behind_net_and_moving_toward_net)  // snap to closer goal post
 {
-    Ball ball = Ball(Point(-5.8,0.3), Vector(0.5, 0.5),
-            Timestamp::fromSeconds(0));
+    Ball ball = Ball(Point(-5.8, 0.3), Vector(0.5, 0.5), Timestamp::fromSeconds(0));
     expectMoveAction(ball, Point(-4.5, 0.5 - ROBOT_MAX_RADIUS_METERS));
 }
 
-TEST_F(GoalieTacticTest, ball_angle_very_sharp_and_low_velocity) // snap to closer goal post
+TEST_F(GoalieTacticTest,
+       ball_angle_very_sharp_and_low_velocity)  // snap to closer goal post
 {
-    Ball ball = Ball(Point(-4.5, -3), Vector(0, 0.1),
-            Timestamp::fromSeconds(0));
+    Ball ball = Ball(Point(-4.5, -3), Vector(0, 0.1), Timestamp::fromSeconds(0));
     expectMoveAction(ball, Point(-4.5, -0.5 + ROBOT_MAX_RADIUS_METERS));
 }

--- a/src/software/ai/hl/stp/tactic/goalie_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic_test.cpp
@@ -3,6 +3,9 @@
 #include <gtest/gtest.h>
 
 #include "software/test_util/test_util.h"
+#include "software/ai/hl/stp/action/move_action.h"
+#include "software/ai/hl/stp/action/stop_action.h"
+#include "software/ai/hl/stp/action/chip_action.h"
 
 // The following tests will make sure the goalie stays in the requested
 // deflated defense area when best positioning to defend the ball.
@@ -71,3 +74,155 @@ TEST_P(GoalieRestrainTest, goalie_position_safe)
 INSTANTIATE_TEST_CASE_P(Positions, GoalieRestrainTest,
                         ::testing::Values(Point(0, 0), Point(1, 2), Point(0, 2),
                                           Point(1, 1), Point(0.5, 1), Point(1, 0.5)));
+
+//coords friendly side is -x
+//+y is up, -y is down
+//fast is > 0.2
+// deflation of goal is 0.2
+// move equality is destination, orientation, dribbler_enable, ball_collsiion, autochick, movetype, final speed
+TEST(GoalieTacticTest, ball_very_fast_in_straight_line)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    world.mutableBall() = Ball(Point(-4,0), Vector(-0.01,1),
+            Timestamp::fromSeconds(0));
+
+    Robot goalie = Robot(0, Point(-4, -1), Vector(0, 0),
+            Angle::zero(), AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().assignGoalie(0);
+
+    GoalieTactic tactic =
+            GoalieTactic(world.ball(), world.field(), world.friendlyTeam(),
+                         world.enemyTeam());
+    tactic.updateRobot(goalie);
+    auto action_ptr = tactic.getNextAction();
+
+    EXPECT_TRUE(action_ptr);
+
+    auto move_action = std::dynamic_pointer_cast<MoveAction>(action_ptr);
+    ASSERT_NE(move_action, nullptr);
+    std::cout << move_action->getDestination() << std::endl;
+    EXPECT_TRUE(move_action->getDestination().isClose(Point(-4, 0), 0.05));
+}
+
+TEST(GoalieTacticTest, ball_very_fast_in_diagonal_line)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    ::Test::TestUtil::setBallPosition(world, Point(0,0), Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setBallVelocity(world, Vector(4, -0.5), Timestamp::fromSeconds(0));
+    ::Test::TestUtil::setEnemyRobotPositions(world, {Point(0.09, 0)}, Timestamp::fromSeconds(0));
+
+    Robot goalie = Robot(0, Point(-4, -0.5), Vector(0, 0), Angle::zero(),
+                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().updateRobots({goalie});
+    world.mutableFriendlyTeam().assignGoalie(0);
+
+    GoalieTactic tactic =
+            GoalieTactic(world.ball(), world.field(), world.friendlyTeam(),
+                         world.enemyTeam());
+    auto action_ptr = tactic.getNextAction();
+
+    EXPECT_TRUE(action_ptr);
+
+    auto move_action = std::dynamic_pointer_cast<MoveAction>(action_ptr);
+    ASSERT_NE(move_action, nullptr);
+    EXPECT_TRUE(move_action->getDestination().isClose(Point(-4,0.5), 0.05));
+}
+
+TEST(GoalieTacticTest, ball_slow_inside_restrained_area)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    world.mutableBall() = Ball(Point(-4,0), Vector(-0.01,1), Timestamp::fromSeconds(0));
+
+    Robot goalie = Robot(0, Point(-4, -1), Vector(0, 0), Angle::zero(),
+                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().assignGoalie(0);
+
+    GoalieTactic tactic =
+            GoalieTactic(world.ball(), world.field(), world.friendlyTeam(),
+                         world.enemyTeam());
+    tactic.updateRobot(goalie);
+    auto action_ptr = tactic.getNextAction();
+
+    EXPECT_TRUE(action_ptr);
+
+    auto stop_action = std::dynamic_pointer_cast<ChipAction>(action_ptr);
+    ASSERT_NE(stop_action, nullptr);
+}
+
+TEST(GoalieTacticTest, ball_slow_outside_restrained_area)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    world.mutableBall() = Ball(Point(-3.5,0.5), Vector(-0.01,-0.5), Timestamp::fromSeconds(0));
+
+    Robot goalie = Robot(0, Point(-4, -1), Vector(0, 0), Angle::zero(),
+                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().assignGoalie(0);
+
+    GoalieTactic tactic =
+            GoalieTactic(world.ball(), world.field(), world.friendlyTeam(),
+                         world.enemyTeam());
+    tactic.updateRobot(goalie);
+    auto action_ptr = tactic.getNextAction();
+
+    EXPECT_TRUE(action_ptr);
+
+    auto chip_action = std::dynamic_pointer_cast<ChipAction>(action_ptr);
+    ASSERT_NE(chip_action, nullptr);
+    // check chip equality
+}
+
+TEST(GoalieTacticTest, ball_miss)
+{
+    //expect move_action to close point
+
+    // cases:
+    // restrict to semicircle inside defense area
+    // restrict to inside defense area
+    // normal
+}
+
+TEST(GoalieTacticTest, ball_behind_net) //snap to closer goal post
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    world.mutableBall() = Ball(Point(-4.8,0.3), Vector(0.5, 0.5), Timestamp::fromSeconds(0));
+
+    Robot goalie = Robot(0, Point(-4, -1), Vector(0, 0), Angle::zero(),
+                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().assignGoalie(0);
+
+    GoalieTactic tactic =
+            GoalieTactic(world.ball(), world.field(), world.friendlyTeam(),
+                         world.enemyTeam());
+    tactic.updateRobot(goalie);
+    auto action_ptr = tactic.getNextAction();
+
+    EXPECT_TRUE(action_ptr);
+
+    auto move_action = std::dynamic_pointer_cast<MoveAction>(action_ptr);
+    ASSERT_NE(move_action, nullptr);
+    std::cout << move_action->getDestination() << std::endl;
+    EXPECT_TRUE(move_action->getDestination().isClose(Point(-4.5, 0.5), 0.01));
+}
+
+TEST(GoalieTacticTest, ball_angle_very_sharp) // snap to closer goal post
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+    world.mutableBall() = Ball(Point(-4.5, -2), Vector(0, 2), Timestamp::fromSeconds(0));
+
+    Robot goalie = Robot(0, Point(-4.5, 0), Vector(0, 0), Angle::zero(),
+                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().assignGoalie(0);
+
+    GoalieTactic tactic =
+            GoalieTactic(world.ball(), world.field(), world.friendlyTeam(),
+                         world.enemyTeam());
+    tactic.updateRobot(goalie);
+    auto action_ptr = tactic.getNextAction();
+
+    EXPECT_TRUE(action_ptr);
+
+    auto move_action = std::dynamic_pointer_cast<MoveAction>(action_ptr);
+    ASSERT_NE(move_action, nullptr);
+    std::cout << move_action->getDestination() << std::endl;
+    EXPECT_TRUE(move_action->getDestination().isClose(Point(-4.5, -0.5), 0.01));
+}

--- a/src/software/ai/hl/stp/tactic/goalie_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic_test.cpp
@@ -79,11 +79,11 @@ INSTANTIATE_TEST_CASE_P(Positions, GoalieRestrainTest,
 //+y is up, -y is down
 //fast is > 0.2
 // deflation of goal is 0.2
-// move equality is destination, orientation, dribbler_enable, ball_collsiion, autochick, movetype, final speed
+// move equality is destination, orientation, dribbler_enable, ball_collsion, autochip, movetype, final speed
 TEST(GoalieTacticTest, ball_very_fast_in_straight_line)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
-    world.mutableBall() = Ball(Point(-4,0), Vector(-0.01,1),
+    world.mutableBall() = Ball(Point(4,0), Vector(-4,0),
             Timestamp::fromSeconds(0));
 
     Robot goalie = Robot(0, Point(-4, -1), Vector(0, 0),
@@ -101,7 +101,7 @@ TEST(GoalieTacticTest, ball_very_fast_in_straight_line)
     auto move_action = std::dynamic_pointer_cast<MoveAction>(action_ptr);
     ASSERT_NE(move_action, nullptr);
     std::cout << move_action->getDestination() << std::endl;
-    EXPECT_TRUE(move_action->getDestination().isClose(Point(-4, 0), 0.05));
+    EXPECT_TRUE(move_action->getDestination().isClose(Point(0, 0), 0.05));
 }
 
 TEST(GoalieTacticTest, ball_very_fast_in_diagonal_line)
@@ -152,7 +152,7 @@ TEST(GoalieTacticTest, ball_slow_inside_restrained_area)
 TEST(GoalieTacticTest, ball_slow_outside_restrained_area)
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
-    world.mutableBall() = Ball(Point(-3.5,0.5), Vector(-0.01,-0.5), Timestamp::fromSeconds(0));
+    world.mutableBall() = Ball(Point(-3.5, 0.5), Vector(-0.01, -0.5), Timestamp::fromSeconds(0));
 
     Robot goalie = Robot(0, Point(-4, -1), Vector(0, 0), Angle::zero(),
                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
@@ -167,7 +167,7 @@ TEST(GoalieTacticTest, ball_slow_outside_restrained_area)
     EXPECT_TRUE(action_ptr);
 
     auto chip_action = std::dynamic_pointer_cast<ChipAction>(action_ptr);
-    ASSERT_NE(chip_action, nullptr);
+    //ASSERT_NE(chip_action, nullptr);
     // check chip equality
 }
 
@@ -184,7 +184,7 @@ TEST(GoalieTacticTest, ball_miss)
 TEST(GoalieTacticTest, ball_behind_net) //snap to closer goal post
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
-    world.mutableBall() = Ball(Point(-4.8,0.3), Vector(0.5, 0.5), Timestamp::fromSeconds(0));
+    world.mutableBall() = Ball(Point(-5.8,0.3), Vector(0.5, 0.5), Timestamp::fromSeconds(0));
 
     Robot goalie = Robot(0, Point(-4, -1), Vector(0, 0), Angle::zero(),
                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
@@ -200,14 +200,13 @@ TEST(GoalieTacticTest, ball_behind_net) //snap to closer goal post
 
     auto move_action = std::dynamic_pointer_cast<MoveAction>(action_ptr);
     ASSERT_NE(move_action, nullptr);
-    std::cout << move_action->getDestination() << std::endl;
-    EXPECT_TRUE(move_action->getDestination().isClose(Point(-4.5, 0.5), 0.01));
+    EXPECT_TRUE(move_action->getDestination().isClose(Point(-4.59, 0.5), 0.01));
 }
 
-TEST(GoalieTacticTest, ball_angle_very_sharp) // snap to closer goal post
+TEST(GoalieTacticTest, ball_angle_very_sharp_and_below_panic) // snap to closer goal post
 {
     World world = ::Test::TestUtil::createBlankTestingWorld();
-    world.mutableBall() = Ball(Point(-4.5, -2), Vector(0, 2), Timestamp::fromSeconds(0));
+    world.mutableBall() = Ball(Point(-4.5, -3), Vector(0, 0.1), Timestamp::fromSeconds(0));
 
     Robot goalie = Robot(0, Point(-4.5, 0), Vector(0, 0), Angle::zero(),
                          AngularVelocity::zero(), Timestamp::fromSeconds(0));
@@ -223,6 +222,5 @@ TEST(GoalieTacticTest, ball_angle_very_sharp) // snap to closer goal post
 
     auto move_action = std::dynamic_pointer_cast<MoveAction>(action_ptr);
     ASSERT_NE(move_action, nullptr);
-    std::cout << move_action->getDestination() << std::endl;
-    EXPECT_TRUE(move_action->getDestination().isClose(Point(-4.5, -0.5), 0.01));
+    EXPECT_TRUE(move_action->getDestination().isClose(Point(-4.59, -0.5), 0.01));
 }

--- a/src/software/ai/hl/stp/tactic/goalie_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic_test.cpp
@@ -8,8 +8,8 @@
 #include "software/ai/hl/stp/action/chip_action.h"
 #include "software/ai/hl/stp/action/move_action.h"
 #include "software/ai/hl/stp/action/stop_action.h"
-#include "software/test_util/test_util.h"
 #include "software/geom/util.h"
+#include "software/test_util/test_util.h"
 
 // The following tests will make sure the goalie stays in the requested
 // deflated defense area when best positioning to defend the ball.
@@ -186,42 +186,39 @@ TEST_F(GoalieTacticTest, ball_slow_outside_dont_chip_rectangle)
     expectChipAction(ball);
 }
 
-TEST_F(GoalieTacticTest,
-       ball_behind_net_and_moving_toward_net)
+TEST_F(GoalieTacticTest, ball_behind_net_and_moving_toward_net)
 {
     Ball ball = Ball(Point(-5.8, 0.3), Vector(0.5, 0.5), Timestamp::fromSeconds(0));
     // snap to closer goal post
     expectMoveAction(ball, Point(-4.5, 0.5 - ROBOT_MAX_RADIUS_METERS));
 }
 
-TEST_F(GoalieTacticTest,
-       ball_angle_very_sharp_and_low_velocity)
+TEST_F(GoalieTacticTest, ball_angle_very_sharp_and_low_velocity)
 {
     Ball ball = Ball(Point(-4.5, -3), Vector(0, 0.1), Timestamp::fromSeconds(0));
     // snap to closer goal post
     expectMoveAction(ball, Point(-4.5, -0.5 + ROBOT_MAX_RADIUS_METERS));
 }
 
-TEST_F(GoalieTacticTest,
-        ball_far_away_and_zero_velocity)
+TEST_F(GoalieTacticTest, ball_far_away_and_zero_velocity)
 {
-    Ball ball = Ball(Point(4.5, 1), Vector(0,0), Timestamp::fromSeconds(0));
+    Ball ball = Ball(Point(4.5, 1), Vector(0, 0), Timestamp::fromSeconds(0));
     // (-4.5, 0) is friendly goal (-3.7, 0.8), (-3.7, -0.8) is defense area
-    std::optional<Point> intersection = lineIntersection(Point(4.5, 1), Point(-4.5, 0), Point(-3.7, 0.8), Point(-3.7, -0.8));
+    std::optional<Point> intersection = lineIntersection(
+        Point(4.5, 1), Point(-4.5, 0), Point(-3.7, 0.8), Point(-3.7, -0.8));
     expectMoveAction(ball, *intersection);
 }
 
-TEST_F(GoalieTacticTest,
-        ball_outside_defense_area_and_zero_velocity)
+TEST_F(GoalieTacticTest, ball_outside_defense_area_and_zero_velocity)
 {
     Ball ball = Ball(Point(-3, -0.5), Vector(0, 0), Timestamp::fromSeconds(0));
     // (-4.5, 0) is friendly goal (-3.7, 0.8), (-3.7, -0.8) is defense area
-    std::optional<Point> intersection = lineIntersection(Point(-3, -0.5), Point(-4.5, 0), Point(-3.7, 0.8), Point(-3.7, -0.8));
+    std::optional<Point> intersection = lineIntersection(
+        Point(-3, -0.5), Point(-4.5, 0), Point(-3.7, 0.8), Point(-3.7, -0.8));
     expectMoveAction(ball, *intersection);
 }
 
-TEST_F(GoalieTacticTest,
-       ball_in_defense_area_and_zero_velocity)
+TEST_F(GoalieTacticTest, ball_in_defense_area_and_zero_velocity)
 {
     Ball ball = Ball(Point(-4, -0.5), Vector(0, 0), Timestamp::fromSeconds(0));
     expectChipAction(ball);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Wrote Unit Tests for Goalie Tactic
Modified some of the logic 
- Moved the restraining to rectangle code to case 3 as it was overwriting next_action
- Deleted what was in case 3 before because it gave similar values to the cone blocking logic in the restraining code

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Ran all tests
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #817 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
