### PR TITLE
Geom: Integrate `contains(Point)` methods

### DIFF
--- a/src/software/ai/hl/stp/play/test_plays/halt_test_play.cpp
+++ b/src/software/ai/hl/stp/play/test_plays/halt_test_play.cpp
@@ -18,9 +18,7 @@ bool HaltTestPlay::isApplicable(const World &world) const
 
 bool HaltTestPlay::invariantHolds(const World &world) const
 {
-    return contains(
-        Rectangle(world.field().enemyCornerNeg(), world.field().friendlyCornerPos()),
-        world.ball().position());
+    return Rectangle(world.field().enemyCornerNeg(), world.field().friendlyCornerPos()).contains(world.ball().position());
 }
 
 void HaltTestPlay::getNextTactics(TacticCoroutine::push_type &yield)

--- a/src/software/ai/hl/stp/play/test_plays/halt_test_play.cpp
+++ b/src/software/ai/hl/stp/play/test_plays/halt_test_play.cpp
@@ -18,7 +18,8 @@ bool HaltTestPlay::isApplicable(const World &world) const
 
 bool HaltTestPlay::invariantHolds(const World &world) const
 {
-    return Rectangle(world.field().enemyCornerNeg(), world.field().friendlyCornerPos()).contains(world.ball().position());
+    return Rectangle(world.field().enemyCornerNeg(), world.field().friendlyCornerPos())
+        .contains(world.ball().position());
 }
 
 void HaltTestPlay::getNextTactics(TacticCoroutine::push_type &yield)

--- a/src/software/geom/util.h
+++ b/src/software/geom/util.h
@@ -22,17 +22,6 @@ constexpr int sign(double n)
     return n > EPS ? 1 : (n < -EPS ? -1 : 0);
 }
 
-/*
- * The family of `contains` functions determines whether
- * the second parameter is contained, even if partially,
- * inside the first parameter.
- */
-bool contains(const Triangle &out, const Point &in);
-bool contains(const Circle &out, const Point &in);
-bool contains(const Ray &out, const Point &in);
-bool contains(const Segment &out, const Point &in);
-bool contains(const Rectangle &out, const Point &in);
-
 double length(const Segment &segment);
 
 double lengthSquared(const Segment &segment);

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -14,24 +14,6 @@
 #include "software/test_util/test_util.h"
 #include "software/time/timestamp.h"
 
-TEST(GeomUtilTest, test_segment_contains_point_no_x_deviation)
-{
-    Segment segment = Segment(Point(0, 0), Point(0, 1));
-
-    Point point = Point(0, 0.5);
-
-    EXPECT_EQ(contains(segment, point), true);
-}
-
-TEST(GeomUtilTest, test_segment_contains_point_no_y_deviation)
-{
-    Segment segment = Segment(Point(0, 0), Point(1, 0));
-
-    Point point = Point(0.5, 0);
-
-    EXPECT_EQ(contains(segment, point), true);
-}
-
 TEST(GeomUtilTest, test_collinear)
 {
     for (unsigned int i = 0; i < 10; ++i)
@@ -44,40 +26,6 @@ TEST(GeomUtilTest, test_collinear)
         bool val     = collinear(pointA, pointB, pointC);
         EXPECT_TRUE(val);
     }
-}
-
-TEST(GeomUtilTest, test_point_in_rectangle)
-{
-    // Point in 1st quadrant, rectangle in the 3rd quadrant. Should fail!
-    EXPECT_TRUE(!contains(Rectangle(Point(0, 0), Point(-2, -2)), Point(1, 1)));
-
-    // Point in 3rd quadrant, rectangle in the 3rd quadrant. Pass!
-    EXPECT_TRUE(contains(Rectangle(Point(0, 0), Point(-2, -2)), Point(-1, -1)));
-
-    // Point is one of the corners of the rectangle. Pass
-    EXPECT_TRUE(contains(Rectangle(Point(0, 0), Point(2, 2)), Point(2, 2)));
-
-    // Point is on the edge of the rectangle. Pass
-    EXPECT_TRUE(contains(Rectangle(Point(0, 0), Point(3, 3)), Point(0, 1)));
-
-    // Point in the 1st quadrant, rectangle in the 1st quadrant. Pass
-    EXPECT_TRUE(contains(Rectangle(Point(0, 0), Point(3, 3)), Point(1, 2)));
-
-    // Point in the 2nd quadrant, rectangle in the 2nd quadrant. Point is off
-    // above, Fail.
-    EXPECT_TRUE(!contains(Rectangle(Point(0, 0), Point(-4, 4)), Point(-2, 5)));
-
-    // Point in the 2nd quadrant, rectangle in the 4th quadrant. Point is off to
-    // the left, Fail.
-    EXPECT_TRUE(!contains(Rectangle(Point(0, 0), Point(-4, 4)), Point(-7, 2)));
-
-    // Point in the 2nd quadrant, rectangle centered at origin. Point is off
-    // above, Fail.
-    EXPECT_TRUE(contains(Rectangle(Point(1, 1), Point(-1, -1)), Point(0.5, 0.5)));
-
-    // Point in the 2nd quadrant, rectangle centered at origin. Point is off to
-    // the left, Fail.
-    EXPECT_TRUE(!contains(Rectangle(Point(1, 1), Point(-1, -1)), Point(2, 2)));
 }
 
 TEST(GeomUtilTest, test_closest_lineseg_point)


### PR DESCRIPTION
### Description
Any `contains(Point)` methods and usages in old geom changed to their respective new geom methods.

### Testing Done
- Existing tests still pass

### Resolved Issues
resolves #1253 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
