### PR TITLE
Move Action looping logic to superclass

### DIFF
--- a/src/software/ai/hl/stp/action/action.cpp
+++ b/src/software/ai/hl/stp/action/action.cpp
@@ -44,8 +44,9 @@ std::unique_ptr<Intent> Action::getNextIntent()
             // Extract the result from the coroutine. This will be whatever value was
             // yielded by the calculateNextIntent function
             next_intent = intent_sequence.get();
-        } else if (loop_forever) {
-
+        }
+        else if (loop_forever)
+        {
             restart();
             intent_sequence();
             next_intent = intent_sequence.get();

--- a/src/software/ai/hl/stp/action/action.cpp
+++ b/src/software/ai/hl/stp/action/action.cpp
@@ -2,8 +2,9 @@
 
 #include <g3log/g3log.hpp>
 
-Action::Action()
-    : intent_sequence(boost::bind(&Action::calculateNextIntentWrapper, this, _1))
+Action::Action(bool loop_forever)
+    : intent_sequence(boost::bind(&Action::calculateNextIntentWrapper, this, _1)),
+      loop_forever(loop_forever)
 {
 }
 
@@ -42,6 +43,11 @@ std::unique_ptr<Intent> Action::getNextIntent()
         {
             // Extract the result from the coroutine. This will be whatever value was
             // yielded by the calculateNextIntent function
+            next_intent = intent_sequence.get();
+        } else if (loop_forever) {
+
+            restart();
+            intent_sequence();
             next_intent = intent_sequence.get();
         }
     }

--- a/src/software/ai/hl/stp/action/action.h
+++ b/src/software/ai/hl/stp/action/action.h
@@ -27,8 +27,9 @@ class Action
    public:
     /**
      * Creates a new Action for the given robot.
+     * @param loop_forever: whether action should continuously restart once its done
      */
-    explicit Action();
+    explicit Action(bool loop_forever);
 
     /**
      * Returns true if the Action is done and false otherwise. The Action is considered
@@ -116,4 +117,7 @@ class Action
      * @param yield The coroutine push_type for the Action
      */
     virtual void calculateNextIntent(IntentCoroutine::push_type &yield) = 0;
+
+    // Whether or not this action should loop forever by restarting each time it is done
+    bool loop_forever;
 };

--- a/src/software/ai/hl/stp/action/action_test.cpp
+++ b/src/software/ai/hl/stp/action/action_test.cpp
@@ -77,16 +77,18 @@ TEST(ActionTest, action_with_loop_forever_does_not_return_nullptr)
     MoveTestAction action = MoveTestAction(0.05, true);
     action.updateControlParams(robot, Point());
 
-    //run action multiple times, should return an intent every time
-    for(int i = 0; i < 5; i++) {
+    // run action multiple times, should return an intent every time
+    for (int i = 0; i < 5; i++)
+    {
         auto intent_ptr = action.getNextIntent();
         EXPECT_TRUE(intent_ptr);
         EXPECT_FALSE(action.done());
     }
 
-    //change point destination and expect intent to be returned every time
-    action.updateControlParams(robot, Point(1,1));
-    for(int i = 0; i < 5; i++) {
+    // change point destination and expect intent to be returned every time
+    action.updateControlParams(robot, Point(1, 1));
+    for (int i = 0; i < 5; i++)
+    {
         auto intent_ptr = action.getNextIntent();
         EXPECT_TRUE(intent_ptr);
         EXPECT_FALSE(action.done());

--- a/src/software/ai/hl/stp/action/action_test.cpp
+++ b/src/software/ai/hl/stp/action/action_test.cpp
@@ -11,7 +11,7 @@
 
 TEST(ActionTest, test_action_reports_done_at_same_time_nullptr_returned)
 {
-    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+    Robot robot = Robot(0, Point(0,0), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
     MoveTestAction action = MoveTestAction(0.05, false);
 
@@ -46,13 +46,13 @@ TEST(ActionTest, getRobot)
 
 TEST(ActionTest, restart_after_done_makes_done_false)
 {
-    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+    Robot robot = Robot(0, Point(0,0), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
     MoveTestAction action = MoveTestAction(0.05, false);
 
     // The first time the Action runs it will always return an Intent to make sure we
     // are doing the correct thing
-    action.updateControlParams(robot, Point());
+    action.updateControlParams(robot, Point(0,0));
     auto intent_ptr = action.getNextIntent();
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
@@ -72,10 +72,10 @@ TEST(ActionTest, restart_after_done_makes_done_false)
 
 TEST(ActionTest, action_with_loop_forever_does_not_return_nullptr)
 {
-    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+    Robot robot = Robot(0, Point(0,0), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
     MoveTestAction action = MoveTestAction(0.05, true);
-    action.updateControlParams(robot, Point());
+    action.updateControlParams(robot, Point(0,0));
 
     // run action multiple times, should return an intent every time
     for (int i = 0; i < 5; i++)

--- a/src/software/ai/hl/stp/action/action_test.cpp
+++ b/src/software/ai/hl/stp/action/action_test.cpp
@@ -11,7 +11,7 @@
 
 TEST(ActionTest, test_action_reports_done_at_same_time_nullptr_returned)
 {
-    Robot robot = Robot(0, Point(0,0), Vector(), Angle::zero(), AngularVelocity::zero(),
+    Robot robot = Robot(0, Point(0, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
     MoveTestAction action = MoveTestAction(0.05, false);
 
@@ -46,13 +46,13 @@ TEST(ActionTest, getRobot)
 
 TEST(ActionTest, restart_after_done_makes_done_false)
 {
-    Robot robot = Robot(0, Point(0,0), Vector(), Angle::zero(), AngularVelocity::zero(),
+    Robot robot = Robot(0, Point(0, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
     MoveTestAction action = MoveTestAction(0.05, false);
 
     // The first time the Action runs it will always return an Intent to make sure we
     // are doing the correct thing
-    action.updateControlParams(robot, Point(0,0));
+    action.updateControlParams(robot, Point(0, 0));
     auto intent_ptr = action.getNextIntent();
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
@@ -72,10 +72,10 @@ TEST(ActionTest, restart_after_done_makes_done_false)
 
 TEST(ActionTest, action_with_loop_forever_does_not_return_nullptr)
 {
-    Robot robot = Robot(0, Point(0,0), Vector(), Angle::zero(), AngularVelocity::zero(),
+    Robot robot = Robot(0, Point(0, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
     MoveTestAction action = MoveTestAction(0.05, true);
-    action.updateControlParams(robot, Point(0,0));
+    action.updateControlParams(robot, Point(0, 0));
 
     // run action multiple times, should return an intent every time
     for (int i = 0; i < 5; i++)

--- a/src/software/ai/hl/stp/action/action_test.cpp
+++ b/src/software/ai/hl/stp/action/action_test.cpp
@@ -13,7 +13,7 @@ TEST(ActionTest, test_action_reports_done_at_same_time_nullptr_returned)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveTestAction action = MoveTestAction(0.05);
+    MoveTestAction action = MoveTestAction(0.05, false);
 
     // The first time the Action runs it will always return an Intent to make sure we
     // are doing the correct thing
@@ -36,7 +36,7 @@ TEST(ActionTest, getRobot)
 {
     Robot robot           = Robot(13, Point(1, 2), Vector(3, 4), Angle::fromDegrees(5),
                         AngularVelocity::fromDegrees(6), Timestamp::fromSeconds(7));
-    MoveTestAction action = MoveTestAction(0.05);
+    MoveTestAction action = MoveTestAction(0.05, false);
     action.updateControlParams(robot, Point());
 
     std::optional<Robot> robot_opt = action.getRobot();
@@ -48,7 +48,7 @@ TEST(ActionTest, restart_after_done_makes_done_false)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveTestAction action = MoveTestAction(0.05);
+    MoveTestAction action = MoveTestAction(0.05, false);
 
     // The first time the Action runs it will always return an Intent to make sure we
     // are doing the correct thing
@@ -68,4 +68,27 @@ TEST(ActionTest, restart_after_done_makes_done_false)
     intent_ptr = action.getNextIntent();
     EXPECT_TRUE(intent_ptr);
     EXPECT_FALSE(action.done());
+}
+
+TEST(ActionTest, action_with_loop_forever_does_not_return_nullptr)
+{
+    Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        Timestamp::fromSeconds(0));
+    MoveTestAction action = MoveTestAction(0.05, true);
+    action.updateControlParams(robot, Point());
+
+    //run action multiple times, should return an intent every time
+    for(int i = 0; i < 5; i++) {
+        auto intent_ptr = action.getNextIntent();
+        EXPECT_TRUE(intent_ptr);
+        EXPECT_FALSE(action.done());
+    }
+
+    //change point destination and expect intent to be returned every time
+    action.updateControlParams(robot, Point(1,1));
+    for(int i = 0; i < 5; i++) {
+        auto intent_ptr = action.getNextIntent();
+        EXPECT_TRUE(intent_ptr);
+        EXPECT_FALSE(action.done());
+    }
 }

--- a/src/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/software/ai/hl/stp/action/chip_action.cpp
@@ -6,7 +6,9 @@
 #include "software/geom/util.h"
 #include "software/new_geom/polygon.h"
 
-ChipAction::ChipAction() : Action(true), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0)) {}
+ChipAction::ChipAction() : Action(true), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0))
+{
+}
 
 void ChipAction::updateWorldParams(const Ball& ball)
 {
@@ -85,8 +87,7 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     //                     direction of chip
 
     // A vector in the direction opposite the chip (behind the ball)
-    Vector behind_ball =
-        Vector::createFromAngle(this->chip_direction + Angle::half());
+    Vector behind_ball = Vector::createFromAngle(this->chip_direction + Angle::half());
 
 
     // The points below make up the triangle that defines the region we treat as
@@ -114,10 +115,9 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     // If we're not in position to chip, move into position
     if (!robot_behind_ball)
     {
-        yield(std::make_unique<MoveIntent>(
-            robot->id(), point_behind_ball, chip_direction, 0.0, 0,
-            DribblerEnable::OFF, MoveType::NORMAL, AutokickType::NONE,
-            BallCollisionType::ALLOW));
+        yield(std::make_unique<MoveIntent>(robot->id(), point_behind_ball, chip_direction,
+                                           0.0, 0, DribblerEnable::OFF, MoveType::NORMAL,
+                                           AutokickType::NONE, BallCollisionType::ALLOW));
     }
     else
     {

--- a/src/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/software/ai/hl/stp/action/chip_action.cpp
@@ -6,7 +6,7 @@
 #include "software/geom/util.h"
 #include "software/new_geom/polygon.h"
 
-ChipAction::ChipAction() : Action(), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0)) {}
+ChipAction::ChipAction() : Action(true), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0)) {}
 
 void ChipAction::updateWorldParams(const Ball& ball)
 {
@@ -84,47 +84,44 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     //                             V
     //                     direction of chip
 
-    do
+    // A vector in the direction opposite the chip (behind the ball)
+    Vector behind_ball =
+        Vector::createFromAngle(this->chip_direction + Angle::half());
+
+
+    // The points below make up the triangle that defines the region we treat as
+    // "behind the ball". They correspond to the vertices labeled 'A', 'B', and 'C'
+    // in the ASCII diagram
+
+    // We make the region close enough to the ball so that the robot will still be
+    // inside it when taking the chip.
+    Point behind_ball_vertex_A = chip_origin;
+    Point behind_ball_vertex_B =
+        behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) +
+        behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
+    Point behind_ball_vertex_C =
+        behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) -
+        behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
+
+    Triangle behind_ball_region =
+        Triangle(behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C);
+
+    bool robot_behind_ball = behind_ball_region.contains(robot->position());
+    // The point in the middle of the region behind the ball
+    Point point_behind_ball =
+        chip_origin + behind_ball.normalize(size_of_region_behind_ball * 3 / 4);
+
+    // If we're not in position to chip, move into position
+    if (!robot_behind_ball)
     {
-        // A vector in the direction opposite the chip (behind the ball)
-        Vector behind_ball =
-            Vector::createFromAngle(this->chip_direction + Angle::half());
-
-
-        // The points below make up the triangle that defines the region we treat as
-        // "behind the ball". They correspond to the vertices labeled 'A', 'B', and 'C'
-        // in the ASCII diagram
-
-        // We make the region close enough to the ball so that the robot will still be
-        // inside it when taking the chip.
-        Point behind_ball_vertex_A = chip_origin;
-        Point behind_ball_vertex_B =
-            behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) +
-            behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
-        Point behind_ball_vertex_C =
-            behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) -
-            behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
-
-        Triangle behind_ball_region =
-            Triangle(behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C);
-
-        bool robot_behind_ball = behind_ball_region.contains(robot->position());
-        // The point in the middle of the region behind the ball
-        Point point_behind_ball =
-            chip_origin + behind_ball.normalize(size_of_region_behind_ball * 3 / 4);
-
-        // If we're not in position to chip, move into position
-        if (!robot_behind_ball)
-        {
-            yield(std::make_unique<MoveIntent>(
-                robot->id(), point_behind_ball, chip_direction, 0.0, 0,
-                DribblerEnable::OFF, MoveType::NORMAL, AutokickType::NONE,
-                BallCollisionType::ALLOW));
-        }
-        else
-        {
-            yield(std::make_unique<ChipIntent>(robot->id(), chip_origin, chip_direction,
-                                               chip_distance_meters, 0));
-        }
-    } while (true);
+        yield(std::make_unique<MoveIntent>(
+            robot->id(), point_behind_ball, chip_direction, 0.0, 0,
+            DribblerEnable::OFF, MoveType::NORMAL, AutokickType::NONE,
+            BallCollisionType::ALLOW));
+    }
+    else
+    {
+        yield(std::make_unique<ChipIntent>(robot->id(), chip_origin, chip_direction,
+                                           chip_distance_meters, 0));
+    }
 }

--- a/src/software/ai/hl/stp/action/dribble_action.cpp
+++ b/src/software/ai/hl/stp/action/dribble_action.cpp
@@ -3,7 +3,7 @@
 #include "software/ai/intent/dribble_intent.h"
 
 DribbleAction::DribbleAction(double close_to_dest_threshold)
-    : Action(), close_to_dest_threshold(close_to_dest_threshold)
+    : Action(false), close_to_dest_threshold(close_to_dest_threshold)
 {
 }
 

--- a/src/software/ai/hl/stp/action/intercept_ball_action.cpp
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.cpp
@@ -14,7 +14,7 @@
 
 InterceptBallAction::InterceptBallAction(const Field& field, const Ball& ball,
                                          bool loop_forever)
-    : Action(), field(field), ball(ball), loop_forever(loop_forever)
+    : Action(loop_forever), field(field), ball(ball)
 {
 }
 
@@ -121,7 +121,7 @@ void InterceptBallAction::calculateNextIntent(IntentCoroutine::push_type& yield)
                 DribblerEnable::ON, MoveType::NORMAL, AutokickType::NONE,
                 BallCollisionType::ALLOW));
         }
-    } while (!Evaluation::robotHasPossession(ball, *robot) || loop_forever);
+    } while (!Evaluation::robotHasPossession(ball, *robot));
 }
 
 void InterceptBallAction::moveToInterceptPosition(IntentCoroutine::push_type& yield,

--- a/src/software/ai/hl/stp/action/intercept_ball_action.h
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.h
@@ -69,5 +69,4 @@ class InterceptBallAction : public Action
     // Action parameters
     Field field;
     Ball ball;
-    bool loop_forever;
 };

--- a/src/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/software/ai/hl/stp/action/kick_action.cpp
@@ -7,7 +7,9 @@
 #include "software/new_geom/polygon.h"
 #include "software/world/ball.h"
 
-KickAction::KickAction() : Action(true), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0)) {}
+KickAction::KickAction() : Action(true), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0))
+{
+}
 
 void KickAction::updateWorldParams(const Ball &ball)
 {
@@ -83,8 +85,7 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
     //                     direction of kick
 
     // A vector in the direction opposite the kick (behind the ball)
-    Vector behind_ball =
-        Vector::createFromAngle(this->kick_direction + Angle::half());
+    Vector behind_ball = Vector::createFromAngle(this->kick_direction + Angle::half());
 
 
     // The points below make up the triangle that defines the region we treat as
@@ -112,10 +113,9 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
     // If we're not in position to kick, move into position
     if (!robot_behind_ball)
     {
-        yield(std::make_unique<MoveIntent>(
-            robot->id(), point_behind_ball, kick_direction, 0.0, 0,
-            DribblerEnable::OFF, MoveType::NORMAL, AutokickType::NONE,
-            BallCollisionType::ALLOW));
+        yield(std::make_unique<MoveIntent>(robot->id(), point_behind_ball, kick_direction,
+                                           0.0, 0, DribblerEnable::OFF, MoveType::NORMAL,
+                                           AutokickType::NONE, BallCollisionType::ALLOW));
     }
     else
     {

--- a/src/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/software/ai/hl/stp/action/kick_action.cpp
@@ -7,7 +7,7 @@
 #include "software/new_geom/polygon.h"
 #include "software/world/ball.h"
 
-KickAction::KickAction() : Action(), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0)) {}
+KickAction::KickAction() : Action(true), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0)) {}
 
 void KickAction::updateWorldParams(const Ball &ball)
 {
@@ -82,47 +82,44 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
     //                             V
     //                     direction of kick
 
-    do
+    // A vector in the direction opposite the kick (behind the ball)
+    Vector behind_ball =
+        Vector::createFromAngle(this->kick_direction + Angle::half());
+
+
+    // The points below make up the triangle that defines the region we treat as
+    // "behind the ball". They correspond to the vertices labeled 'A', 'B', and 'C'
+    // in the ASCII diagram
+
+    // We make the region close enough to the ball so that the robot will still be
+    // inside it when taking the kick.
+    Point behind_ball_vertex_A = kick_origin;
+    Point behind_ball_vertex_B =
+        behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) +
+        behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
+    Point behind_ball_vertex_C =
+        behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) -
+        (behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2));
+
+    Polygon behind_ball_region =
+        Polygon({behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C});
+
+    bool robot_behind_ball = behind_ball_region.contains(robot->position());
+    // The point in the middle of the region behind the ball
+    Point point_behind_ball =
+        kick_origin + behind_ball.normalize(size_of_region_behind_ball * 3 / 4);
+
+    // If we're not in position to kick, move into position
+    if (!robot_behind_ball)
     {
-        // A vector in the direction opposite the kick (behind the ball)
-        Vector behind_ball =
-            Vector::createFromAngle(this->kick_direction + Angle::half());
-
-
-        // The points below make up the triangle that defines the region we treat as
-        // "behind the ball". They correspond to the vertices labeled 'A', 'B', and 'C'
-        // in the ASCII diagram
-
-        // We make the region close enough to the ball so that the robot will still be
-        // inside it when taking the kick.
-        Point behind_ball_vertex_A = kick_origin;
-        Point behind_ball_vertex_B =
-            behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) +
-            behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
-        Point behind_ball_vertex_C =
-            behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) -
-            (behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2));
-
-        Polygon behind_ball_region =
-            Polygon({behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C});
-
-        bool robot_behind_ball = behind_ball_region.contains(robot->position());
-        // The point in the middle of the region behind the ball
-        Point point_behind_ball =
-            kick_origin + behind_ball.normalize(size_of_region_behind_ball * 3 / 4);
-
-        // If we're not in position to kick, move into position
-        if (!robot_behind_ball)
-        {
-            yield(std::make_unique<MoveIntent>(
-                robot->id(), point_behind_ball, kick_direction, 0.0, 0,
-                DribblerEnable::OFF, MoveType::NORMAL, AutokickType::NONE,
-                BallCollisionType::ALLOW));
-        }
-        else
-        {
-            yield(std::make_unique<KickIntent>(robot->id(), kick_origin, kick_direction,
-                                               kick_speed_meters_per_second, 0));
-        }
-    } while (true);
+        yield(std::make_unique<MoveIntent>(
+            robot->id(), point_behind_ball, kick_direction, 0.0, 0,
+            DribblerEnable::OFF, MoveType::NORMAL, AutokickType::NONE,
+            BallCollisionType::ALLOW));
+    }
+    else
+    {
+        yield(std::make_unique<KickIntent>(robot->id(), kick_origin, kick_direction,
+                                           kick_speed_meters_per_second, 0));
+    }
 }

--- a/src/software/ai/hl/stp/action/move_action.cpp
+++ b/src/software/ai/hl/stp/action/move_action.cpp
@@ -73,8 +73,7 @@ void MoveAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         yield(std::make_unique<MoveIntent>(robot->id(), destination, final_orientation,
                                            final_speed, 0, enable_dribbler, move_type,
                                            autokick_type, ball_collision_type));
-    } while (
-             (robot->position() - destination).length() > close_to_dest_threshold ||
+    } while ((robot->position() - destination).length() > close_to_dest_threshold ||
              (robot->orientation().minDiff(final_orientation) >
               close_to_orientation_threshold));
 }

--- a/src/software/ai/hl/stp/action/move_action.cpp
+++ b/src/software/ai/hl/stp/action/move_action.cpp
@@ -2,7 +2,7 @@
 
 MoveAction::MoveAction(bool loop_forever, double close_to_dest_threshold,
                        Angle close_to_orientation_threshold)
-    : Action(),
+    : Action(loop_forever),
       destination(0, 0),
       final_orientation(Angle::zero()),
       final_speed(0.0),
@@ -11,8 +11,7 @@ MoveAction::MoveAction(bool loop_forever, double close_to_dest_threshold,
       autokick_type(AutokickType::NONE),
       ball_collision_type(BallCollisionType::AVOID),
       close_to_dest_threshold(close_to_dest_threshold),
-      close_to_orientation_threshold(close_to_orientation_threshold),
-      loop_forever(loop_forever)
+      close_to_orientation_threshold(close_to_orientation_threshold)
 {
 }
 
@@ -74,7 +73,7 @@ void MoveAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         yield(std::make_unique<MoveIntent>(robot->id(), destination, final_orientation,
                                            final_speed, 0, enable_dribbler, move_type,
                                            autokick_type, ball_collision_type));
-    } while (loop_forever ||
+    } while (
              (robot->position() - destination).length() > close_to_dest_threshold ||
              (robot->orientation().minDiff(final_orientation) >
               close_to_orientation_threshold));

--- a/src/software/ai/hl/stp/action/move_action.h
+++ b/src/software/ai/hl/stp/action/move_action.h
@@ -100,5 +100,4 @@ class MoveAction : public Action
 
     double close_to_dest_threshold;
     Angle close_to_orientation_threshold;
-    bool loop_forever;
 };

--- a/src/software/ai/hl/stp/action/movespin_action.cpp
+++ b/src/software/ai/hl/stp/action/movespin_action.cpp
@@ -3,7 +3,7 @@
 #include "software/ai/intent/movespin_intent.h"
 
 MoveSpinAction::MoveSpinAction(double close_to_dest_threshold)
-    : Action(), close_to_dest_threshold(close_to_dest_threshold)
+    : Action(false), close_to_dest_threshold(close_to_dest_threshold)
 {
 }
 

--- a/src/software/ai/hl/stp/action/pivot_action.cpp
+++ b/src/software/ai/hl/stp/action/pivot_action.cpp
@@ -9,7 +9,7 @@
 #include "software/new_geom/angle.h"
 #include "software/parameter/dynamic_parameters.h"
 
-PivotAction::PivotAction() : Action() {}
+PivotAction::PivotAction() : Action(true) {}
 
 void PivotAction::updateControlParams(const Robot& robot, Point pivot_point,
                                       Angle final_angle, Angle pivot_speed,
@@ -29,36 +29,33 @@ void PivotAction::accept(MutableActionVisitor& visitor)
 
 void PivotAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
-    do
+    // If we're not in position to pivot, move to grab the ball
+    if (!(robot->position()).isClose(pivot_point, 1.15))
     {
-        // If we're not in position to pivot, move to grab the ball
-        if (!(robot->position()).isClose(pivot_point, 1.15))
-        {
-            yield(std::make_unique<MoveIntent>(
-                robot->id(), pivot_point, (pivot_point - robot->position()).orientation(),
-                0.0, 0, enable_dribbler ? DribblerEnable::ON : DribblerEnable::OFF,
-                MoveType::NORMAL, AutokickType::NONE, BallCollisionType::AVOID));
-            LOG(DEBUG) << "obtaining ball, moving!";
-        }
-        else
-        {
-            // if the robot is close enough to the final position, call it a day
-            Angle threshold_angle =
-                Angle::fromDegrees(Util::DynamicParameters->getAIConfig()
-                                       ->getPivotActionConfig()
-                                       ->FinishAngleThreshold()
-                                       ->value() /
-                                   2);
+        yield(std::make_unique<MoveIntent>(
+            robot->id(), pivot_point, (pivot_point - robot->position()).orientation(),
+            0.0, 0, enable_dribbler ? DribblerEnable::ON : DribblerEnable::OFF,
+            MoveType::NORMAL, AutokickType::NONE, BallCollisionType::AVOID));
+        LOG(DEBUG) << "obtaining ball, moving!";
+    }
+    else
+    {
+        // if the robot is close enough to the final position, call it a day
+        Angle threshold_angle =
+            Angle::fromDegrees(Util::DynamicParameters->getAIConfig()
+                                   ->getPivotActionConfig()
+                                   ->FinishAngleThreshold()
+                                   ->value() /
+                               2);
 
-            if (robot->orientation() >= (final_angle - threshold_angle) &&
-                robot->orientation() < (final_angle + threshold_angle))
-            {
-                LOG(DEBUG) << "Pivot angle reached threshold";
-                break;
-            }
-
-            yield(std::make_unique<PivotIntent>(robot->id(), pivot_point, final_angle,
-                                                pivot_speed, enable_dribbler, 0));
+        if (robot->orientation() >= (final_angle - threshold_angle) &&
+            robot->orientation() < (final_angle + threshold_angle))
+        {
+            LOG(DEBUG) << "Pivot angle reached threshold";
+            return;
         }
-    } while (true);
+
+        yield(std::make_unique<PivotIntent>(robot->id(), pivot_point, final_angle,
+                                            pivot_speed, enable_dribbler, 0));
+    }
 }

--- a/src/software/ai/hl/stp/action/pivot_action.cpp
+++ b/src/software/ai/hl/stp/action/pivot_action.cpp
@@ -41,12 +41,11 @@ void PivotAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     else
     {
         // if the robot is close enough to the final position, call it a day
-        Angle threshold_angle =
-            Angle::fromDegrees(Util::DynamicParameters->getAIConfig()
-                                   ->getPivotActionConfig()
-                                   ->FinishAngleThreshold()
-                                   ->value() /
-                               2);
+        Angle threshold_angle = Angle::fromDegrees(Util::DynamicParameters->getAIConfig()
+                                                       ->getPivotActionConfig()
+                                                       ->FinishAngleThreshold()
+                                                       ->value() /
+                                                   2);
 
         if (robot->orientation() >= (final_angle - threshold_angle) &&
             robot->orientation() < (final_angle + threshold_angle))

--- a/src/software/ai/hl/stp/action/stop_action.cpp
+++ b/src/software/ai/hl/stp/action/stop_action.cpp
@@ -3,8 +3,7 @@
 #include "software/ai/intent/stop_intent.h"
 
 StopAction::StopAction(bool loop_forever, double stopped_speed_threshold)
-    : Action(loop_forever),
-      stopped_speed_threshold(stopped_speed_threshold)
+    : Action(loop_forever), stopped_speed_threshold(stopped_speed_threshold)
 
 {
 }

--- a/src/software/ai/hl/stp/action/stop_action.cpp
+++ b/src/software/ai/hl/stp/action/stop_action.cpp
@@ -3,9 +3,8 @@
 #include "software/ai/intent/stop_intent.h"
 
 StopAction::StopAction(bool loop_forever, double stopped_speed_threshold)
-    : Action(),
-      stopped_speed_threshold(stopped_speed_threshold),
-      loop_forever(loop_forever)
+    : Action(loop_forever),
+      stopped_speed_threshold(stopped_speed_threshold)
 
 {
 }
@@ -26,5 +25,5 @@ void StopAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<StopIntent>(robot->id(), coast, 0));
-    } while (loop_forever || robot->velocity().length() > stopped_speed_threshold);
+    } while (robot->velocity().length() > stopped_speed_threshold);
 }

--- a/src/software/ai/hl/stp/action/stop_action.h
+++ b/src/software/ai/hl/stp/action/stop_action.h
@@ -44,5 +44,4 @@ class StopAction : public Action
     bool coast;
     // The maximum speed the robot may be moving at to be considered stopped
     double stopped_speed_threshold;
-    bool loop_forever;
 };

--- a/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
+++ b/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
@@ -3,8 +3,8 @@
 #include "software/ai/hl/stp/action/mutable_action_visitor.h"
 #include "software/ai/intent/move_intent.h"
 
-MoveTestAction::MoveTestAction(double close_to_dest_threshold)
-    : Action(), close_to_dest_threshold(close_to_dest_threshold)
+MoveTestAction::MoveTestAction(double close_to_dest_threshold, bool loop_forever)
+    : Action(loop_forever), close_to_dest_threshold(close_to_dest_threshold)
 {
 }
 

--- a/src/software/ai/hl/stp/action/test_actions/move_test_action.h
+++ b/src/software/ai/hl/stp/action/test_actions/move_test_action.h
@@ -17,8 +17,9 @@ class MoveTestAction : public Action
      *
      * @param close_to_dest_threshold How far from the destination the robot must be
      * before the action is considered done
+     * @param loop_forever restarts the action one it completes
      */
-    explicit MoveTestAction(double close_to_dest_threshold);
+    explicit MoveTestAction(double close_to_dest_threshold, bool loop_forever);
 
     /**
      * Updates the params for this action that cannot be derived from the world


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
- moved loop_forever logic to action superclass
- this includes actions who are always implicitly looping (eg chip_action, kick_action, pivot_action)

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Passes existing tests. 
Also added loop_forever parameter to `move_test_action` and tested with it.  
### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #796 
### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
