### PR TITLE
Cleanup visitor headers

### DIFF
--- a/src/software/ai/hl/stp/tactic/tactic_world_params_update_visitor.cpp
+++ b/src/software/ai/hl/stp/tactic/tactic_world_params_update_visitor.cpp
@@ -1,8 +1,5 @@
 #include "software/ai/hl/stp/tactic/tactic_world_params_update_visitor.h"
 
-// We disable clang-format here because it makes these lists borderline unreadable,
-// and certainly way more difficult to edit
-// clang-format off
 TacticWorldParamsUpdateVisitor::TacticWorldParamsUpdateVisitor(const World &world)
 {
     this->world = world;
@@ -75,4 +72,3 @@ void TacticWorldParamsUpdateVisitor::visit(DefenseShadowEnemyTactic &tactic)
 void TacticWorldParamsUpdateVisitor::visit(MoveTestTactic &tactic) {}
 void TacticWorldParamsUpdateVisitor::visit(StopTestTactic &tactic) {}
 void TacticWorldParamsUpdateVisitor::visit(GoalieTestTactic &tactic) {}
-// clang-format on

--- a/src/software/ai/intent/intent_visitor.h
+++ b/src/software/ai/intent/intent_visitor.h
@@ -28,72 +28,18 @@ class IntentVisitor
     virtual ~IntentVisitor() = default;
 
     /**
-     * Visits a CatchIntent to perform an operation.
+     * Visits an Intent to perform an operation.
      *
-     * @param catch_intent The CatchIntent to visit
+     * @param The Intent to visit
      */
     virtual void visit(const CatchIntent &catch_intent) = 0;
-
-    /**
-     * Visits a ChipIntent to perform an operation.
-     *
-     * @param chip_intent The ChipIntent to visit
-     */
     virtual void visit(const ChipIntent &chip_intent) = 0;
-
-    /**
-     * Visits a DirectVelocityIntent to perform an operation.
-     *
-     * @param direct_velocity_intent The DirectVelocityIntent to visit
-     */
     virtual void visit(const DirectVelocityIntent &direct_velocity_intent) = 0;
-
-    /**
-     * Visits a DirectWheelsIntent to perform an operation.
-     *
-     * @param direct_wheels_intent The DirectWheelsIntent to visit
-     */
     virtual void visit(const DirectWheelsIntent &direct_wheels_intent) = 0;
-
-    /**
-     * Visits a DribbleIntent to perform an operation.
-     *
-     * @param direct_wheels_intent The DribbleIntent to visit
-     */
     virtual void visit(const DribbleIntent &direct_wheels_intent) = 0;
-
-    /**
-     * Visits a KickIntent to perform an operation.
-     *
-     * @param kick_intent The KickIntent to visit
-     */
     virtual void visit(const KickIntent &kick_intent) = 0;
-
-    /**
-     * Visits a MoveIntent to perform an operation.
-     *
-     * @param move_intent The MoveIntent to visit
-     */
     virtual void visit(const MoveIntent &move_intent) = 0;
-
-    /**
-     * Visits a MoveSpinIntent to perform an operation.
-     *
-     * @param move_spin_intent The MoveSpinIntent to visit
-     */
     virtual void visit(const MoveSpinIntent &move_spin_intent) = 0;
-
-    /**
-     * Visits a PivotIntent to perform an operation.
-     *
-     * @param pivot_intent The PivotIntent to visit
-     */
     virtual void visit(const PivotIntent &pivot_intent) = 0;
-
-    /**
-     * Visits a StopIntent to perform an operation.
-     *
-     * @param stop_intent The StopIntent to visit
-     */
     virtual void visit(const StopIntent &stop_intent) = 0;
 };

--- a/src/software/ai/intent/intent_visitor.h
+++ b/src/software/ai/intent/intent_visitor.h
@@ -32,14 +32,14 @@ class IntentVisitor
      *
      * @param The Intent to visit
      */
-    virtual void visit(const CatchIntent &catch_intent) = 0;
-    virtual void visit(const ChipIntent &chip_intent) = 0;
+    virtual void visit(const CatchIntent &catch_intent)                    = 0;
+    virtual void visit(const ChipIntent &chip_intent)                      = 0;
     virtual void visit(const DirectVelocityIntent &direct_velocity_intent) = 0;
-    virtual void visit(const DirectWheelsIntent &direct_wheels_intent) = 0;
-    virtual void visit(const DribbleIntent &direct_wheels_intent) = 0;
-    virtual void visit(const KickIntent &kick_intent) = 0;
-    virtual void visit(const MoveIntent &move_intent) = 0;
-    virtual void visit(const MoveSpinIntent &move_spin_intent) = 0;
-    virtual void visit(const PivotIntent &pivot_intent) = 0;
-    virtual void visit(const StopIntent &stop_intent) = 0;
+    virtual void visit(const DirectWheelsIntent &direct_wheels_intent)     = 0;
+    virtual void visit(const DribbleIntent &direct_wheels_intent)          = 0;
+    virtual void visit(const KickIntent &kick_intent)                      = 0;
+    virtual void visit(const MoveIntent &move_intent)                      = 0;
+    virtual void visit(const MoveSpinIntent &move_spin_intent)             = 0;
+    virtual void visit(const PivotIntent &pivot_intent)                    = 0;
+    virtual void visit(const StopIntent &stop_intent)                      = 0;
 };

--- a/src/software/backend/output/radio/mrf/mrf_primitive_visitor.h
+++ b/src/software/backend/output/radio/mrf/mrf_primitive_visitor.h
@@ -43,72 +43,19 @@ class MRFPrimitiveVisitor : public PrimitiveVisitor
     MRFPrimitiveVisitor() = default;
 
     /**
-     * Serializes the given CatchPrimitive into a radio packet
+     * Serializes the given Primitive into a radio packet
      *
-     * @param catch_primitive The CatchPrimitive to serialize
+     * @param The Primitive to serialize
      */
     void visit(const CatchPrimitive &catch_primitive) override;
-
-    /**
-     * Serializes the given ChipPrimitive into a radio packet
-     *
-     * @param chip_primitive The ChipPrimitive to simulate */
     void visit(const ChipPrimitive &chip_primitive) override;
-
-    /**
-     * Serializes the given DirectVelocityPrimitive into a radio packet
-     *
-     * @param direct_velocity_primitive The DirectVelocityPrimitive to simulate
-     */
     void visit(const DirectVelocityPrimitive &direct_velocity_primitive) override;
-
-    /**
-     * Visits a DirectWheelsPrimitive to perform an operation.
-     *
-     * @param direct_wheels_primitive The DirectWheelsPrimitive to visit
-     */
     void visit(const DirectWheelsPrimitive &direct_wheels_primitive) override;
-
-    /**
-     * Visits a DribblePrimitive to perform an operation.
-     *
-     * @param dribble_primitive The DribblePrimitive to visit
-     */
     void visit(const DribblePrimitive &dribble_primitive) override;
-
-    /**
-     * Serializes the given KickPrimitive into a radio packet
-     *
-     * @param kick_primitive The KickPrimitive to simulate
-     */
     void visit(const KickPrimitive &kick_primitive) override;
-
-    /**
-     * Serializes the given MovePrimitive into a radio packet
-     *
-     * @param move_primitive The MovePrimitive to simulate
-     */
     void visit(const MovePrimitive &move_primitive) override;
-
-    /**
-     * Serializes the given MoveSpinPrimitive into a radio packet
-     *
-     * @param movespin_primitive The MoveSpinPrimitive to simulate
-     */
     void visit(const MoveSpinPrimitive &movespin_primitive) override;
-
-    /**
-     * Serializes the given PivotPrimitive into a radio packet
-     *
-     * @param pivot_primitive The PivotPrimitive to simulate
-     */
     void visit(const PivotPrimitive &pivot_primitive) override;
-
-    /**
-     * Serializes the given StopPrimitive into a radio packet
-     *
-     * @param stop_primitive The StopPrimitive to simulate
-     */
     void visit(const StopPrimitive &stop_primitive) override;
 
     /**


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Just cleaned up some comments I noticed to shorten the visitor header files and make them consistent.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
N/A

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
N/A, just noticed this randomly

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
