### PR TITLE
Added colour flag to warnings group in toolchain

### DIFF
--- a/src/cc_toolchain/cc_toolchain_config.bzl
+++ b/src/cc_toolchain/cc_toolchain_config.bzl
@@ -202,6 +202,7 @@ def _make_common_features(ctx):
 
     result["colour_feature"] = feature(
         name = "colour",
+        # the compiler will highlight warnings and errors with colour
         flag_sets = [
             flag_set(
                 actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],

--- a/src/cc_toolchain/cc_toolchain_config.bzl
+++ b/src/cc_toolchain/cc_toolchain_config.bzl
@@ -200,6 +200,20 @@ def _make_common_features(ctx):
         ],
     )
 
+    result["colour_feature"] = feature(
+        name = "colour",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-fdiagnostics-color=always"],
+                    ),
+                ],
+            ),
+        ],
+    )
+
     result["dbg_feature"] = feature(
         name = "dbg",
         flag_sets = [
@@ -539,6 +553,7 @@ def _linux_gcc_impl(ctx):
         implies = [
             "builtin_include_directories",
             "c++17",
+            "colour",
             "determinism",
             "warnings",
             "hardening",
@@ -715,6 +730,7 @@ def _stm32_impl(ctx):
         implies = [
             "stdlib",
             "c++17",
+            "colour",
             "determinism",
             "warnings",
             "no-canonical-prefixes",

--- a/src/cc_toolchain/cc_toolchain_config.bzl
+++ b/src/cc_toolchain/cc_toolchain_config.bzl
@@ -192,7 +192,7 @@ def _make_common_features(ctx):
                 actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
                 flag_groups = [
                     flag_group(
-                        flags = ["-fdiagnostics-color=always", "-Wall", "-Wextra", "-Wvla", "-Wconversion"] +
+                        flags = ["-Wall", "-Wextra", "-Wvla", "-Wconversion"] +
                                 ctx.attr.host_compiler_warnings,
                     ),
                 ],

--- a/src/cc_toolchain/cc_toolchain_config.bzl
+++ b/src/cc_toolchain/cc_toolchain_config.bzl
@@ -192,7 +192,7 @@ def _make_common_features(ctx):
                 actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
                 flag_groups = [
                     flag_group(
-                        flags = ["-Wall", "-Wextra", "-Wvla", "-Wconversion"] +
+                        flags = ["-fdiagnostics-color=always", "-Wall", "-Wextra", "-Wvla", "-Wconversion"] +
                                 ctx.attr.host_compiler_warnings,
                     ),
                 ],


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Added -fdiagnostics-color=always flag to warnings group in toolchain so that builds will highlight warnings and errors with colour
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Visual inspection
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Resolves #1311 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
