### PR TITLE
Refine usage of loop_forever in Actions

### DIFF
--- a/src/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/software/ai/hl/stp/action/chip_action.cpp
@@ -58,7 +58,6 @@ void ChipAction::accept(MutableActionVisitor& visitor)
 
 void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
-
     // How large the triangle is that defines the region where the robot is
     // behind the ball and ready to chip.
     // We want to keep the region small enough that we won't use the ChipIntent from too
@@ -70,7 +69,6 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 
     do
     {
-
         // ASCII art showing the region behind the ball
         // Diagram not to scale
         //
@@ -92,7 +90,8 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 
         // A vector in the direction opposite the chip (behind the ball)
 
-        Vector behind_ball = Vector::createFromAngle(this->chip_direction + Angle::half());
+        Vector behind_ball =
+            Vector::createFromAngle(this->chip_direction + Angle::half());
 
 
         // The points below make up the triangle that defines the region we treat as
@@ -103,26 +102,27 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         // inside it when taking the chip.
         Point behind_ball_vertex_A = chip_origin;
         Point behind_ball_vertex_B =
-                behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) +
-                behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
+            behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) +
+            behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
         Point behind_ball_vertex_C =
-                behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) -
-                behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
+            behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) -
+            behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
 
         Triangle behind_ball_region =
-                Triangle(behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C);
+            Triangle(behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C);
 
         bool robot_behind_ball = behind_ball_region.contains(robot->position());
         // The point in the middle of the region behind the ball
         Point point_behind_ball =
-                chip_origin + behind_ball.normalize(size_of_region_behind_ball * 3 / 4);
+            chip_origin + behind_ball.normalize(size_of_region_behind_ball * 3 / 4);
 
         // If we're not in position to chip, move into position
         if (!robot_behind_ball)
         {
-            yield(std::make_unique<MoveIntent>(robot->id(), point_behind_ball, chip_direction,
-                                               0.0, 0, DribblerEnable::OFF, MoveType::NORMAL,
-                                               AutokickType::NONE, BallCollisionType::ALLOW));
+            yield(std::make_unique<MoveIntent>(
+                robot->id(), point_behind_ball, chip_direction, 0.0, 0,
+                DribblerEnable::OFF, MoveType::NORMAL, AutokickType::NONE,
+                BallCollisionType::ALLOW));
         }
         else
         {
@@ -132,5 +132,4 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         }
 
     } while (true);
-
 }

--- a/src/software/ai/hl/stp/action/intercept_ball_action.cpp
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.cpp
@@ -12,9 +12,8 @@
 #include "software/new_geom/util/distance.h"
 #include "software/new_geom/util/intersection.h"
 
-InterceptBallAction::InterceptBallAction(const Field& field, const Ball& ball,
-                                         bool loop_forever)
-    : Action(loop_forever), field(field), ball(ball)
+InterceptBallAction::InterceptBallAction(const Field& field, const Ball& ball)
+    : Action(false), field(field), ball(ball)
 {
 }
 

--- a/src/software/ai/hl/stp/action/intercept_ball_action.h
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.h
@@ -17,7 +17,7 @@ class InterceptBallAction : public Action
      * @param loop_forever Continue yielding new Move Intents, even after we have reached
      *                     our goal
      */
-    explicit InterceptBallAction(const Field& field, const Ball& ball, bool loop_forever);
+    explicit InterceptBallAction(const Field& field, const Ball& ball);
 
     /**
      * Updates this action with all the parameters it needs from the world

--- a/src/software/ai/hl/stp/action/intercept_ball_action_test.cpp
+++ b/src/software/ai/hl/stp/action/intercept_ball_action_test.cpp
@@ -14,7 +14,7 @@ TEST(InterceptBallActionTest, test_robot_ahead_of_ball_moves_in_front_of_ball)
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
 
-    InterceptBallAction action = InterceptBallAction(field, ball, true);
+    InterceptBallAction action = InterceptBallAction(field, ball);
 
     action.updateWorldParams(field, ball);
     action.updateControlParams(robot);
@@ -46,7 +46,7 @@ TEST(InterceptBallActionTest, test_robot_moves_to_edge_of_field_if_ball_moving_t
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
 
-    InterceptBallAction action = InterceptBallAction(field, ball, true);
+    InterceptBallAction action = InterceptBallAction(field, ball);
 
     action.updateWorldParams(field, ball);
     action.updateControlParams(robot);
@@ -78,7 +78,7 @@ TEST(InterceptBallActionTest, test_robot_moves_to_the_ball_if_the_ball_is_moving
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
 
-    InterceptBallAction action = InterceptBallAction(field, ball, true);
+    InterceptBallAction action = InterceptBallAction(field, ball);
 
     action.updateWorldParams(field, ball);
     action.updateControlParams(robot);

--- a/src/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/software/ai/hl/stp/action/kick_action.cpp
@@ -7,7 +7,7 @@
 #include "software/new_geom/polygon.h"
 #include "software/world/ball.h"
 
-KickAction::KickAction() : Action(true), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0))
+KickAction::KickAction() : Action(false), ball({0, 0}, {0, 0}, Timestamp::fromSeconds(0))
 {
 }
 
@@ -84,42 +84,47 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
     //                             V
     //                     direction of kick
 
-    // A vector in the direction opposite the kick (behind the ball)
-    Vector behind_ball = Vector::createFromAngle(this->kick_direction + Angle::half());
-
-
-    // The points below make up the triangle that defines the region we treat as
-    // "behind the ball". They correspond to the vertices labeled 'A', 'B', and 'C'
-    // in the ASCII diagram
-
-    // We make the region close enough to the ball so that the robot will still be
-    // inside it when taking the kick.
-    Point behind_ball_vertex_A = kick_origin;
-    Point behind_ball_vertex_B =
-        behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) +
-        behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
-    Point behind_ball_vertex_C =
-        behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) -
-        (behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2));
-
-    Polygon behind_ball_region =
-        Polygon({behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C});
-
-    bool robot_behind_ball = behind_ball_region.contains(robot->position());
-    // The point in the middle of the region behind the ball
-    Point point_behind_ball =
-        kick_origin + behind_ball.normalize(size_of_region_behind_ball * 3 / 4);
-
-    // If we're not in position to kick, move into position
-    if (!robot_behind_ball)
+    do
     {
-        yield(std::make_unique<MoveIntent>(robot->id(), point_behind_ball, kick_direction,
-                                           0.0, 0, DribblerEnable::OFF, MoveType::NORMAL,
-                                           AutokickType::NONE, BallCollisionType::ALLOW));
-    }
-    else
-    {
-        yield(std::make_unique<KickIntent>(robot->id(), kick_origin, kick_direction,
-                                           kick_speed_meters_per_second, 0));
-    }
+        // A vector in the direction opposite the kick (behind the ball)
+        Vector behind_ball = Vector::createFromAngle(this->kick_direction + Angle::half());
+
+
+        // The points below make up the triangle that defines the region we treat as
+        // "behind the ball". They correspond to the vertices labeled 'A', 'B', and 'C'
+        // in the ASCII diagram
+
+        // We make the region close enough to the ball so that the robot will still be
+        // inside it when taking the kick.
+        Point behind_ball_vertex_A = kick_origin;
+        Point behind_ball_vertex_B =
+                behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) +
+                behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
+        Point behind_ball_vertex_C =
+                behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) -
+                (behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2));
+
+        Polygon behind_ball_region =
+                Polygon({behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C});
+
+        bool robot_behind_ball = behind_ball_region.contains(robot->position());
+        // The point in the middle of the region behind the ball
+        Point point_behind_ball =
+                kick_origin + behind_ball.normalize(size_of_region_behind_ball * 3 / 4);
+
+        // If we're not in position to kick, move into position
+        if (!robot_behind_ball)
+        {
+            yield(std::make_unique<MoveIntent>(robot->id(), point_behind_ball, kick_direction,
+                                               0.0, 0, DribblerEnable::OFF, MoveType::NORMAL,
+                                               AutokickType::NONE, BallCollisionType::ALLOW));
+        }
+        else
+        {
+            yield(std::make_unique<KickIntent>(robot->id(), kick_origin, kick_direction,
+                                               kick_speed_meters_per_second, 0));
+            break;
+        }
+    } while(true);
+
 }

--- a/src/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/software/ai/hl/stp/action/kick_action.cpp
@@ -87,7 +87,8 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
     do
     {
         // A vector in the direction opposite the kick (behind the ball)
-        Vector behind_ball = Vector::createFromAngle(this->kick_direction + Angle::half());
+        Vector behind_ball =
+            Vector::createFromAngle(this->kick_direction + Angle::half());
 
 
         // The points below make up the triangle that defines the region we treat as
@@ -98,26 +99,27 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
         // inside it when taking the kick.
         Point behind_ball_vertex_A = kick_origin;
         Point behind_ball_vertex_B =
-                behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) +
-                behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
+            behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) +
+            behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2);
         Point behind_ball_vertex_C =
-                behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) -
-                (behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2));
+            behind_ball_vertex_A + behind_ball.normalize(size_of_region_behind_ball) -
+            (behind_ball.perpendicular().normalize(size_of_region_behind_ball / 2));
 
         Polygon behind_ball_region =
-                Polygon({behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C});
+            Polygon({behind_ball_vertex_A, behind_ball_vertex_B, behind_ball_vertex_C});
 
         bool robot_behind_ball = behind_ball_region.contains(robot->position());
         // The point in the middle of the region behind the ball
         Point point_behind_ball =
-                kick_origin + behind_ball.normalize(size_of_region_behind_ball * 3 / 4);
+            kick_origin + behind_ball.normalize(size_of_region_behind_ball * 3 / 4);
 
         // If we're not in position to kick, move into position
         if (!robot_behind_ball)
         {
-            yield(std::make_unique<MoveIntent>(robot->id(), point_behind_ball, kick_direction,
-                                               0.0, 0, DribblerEnable::OFF, MoveType::NORMAL,
-                                               AutokickType::NONE, BallCollisionType::ALLOW));
+            yield(std::make_unique<MoveIntent>(
+                robot->id(), point_behind_ball, kick_direction, 0.0, 0,
+                DribblerEnable::OFF, MoveType::NORMAL, AutokickType::NONE,
+                BallCollisionType::ALLOW));
         }
         else
         {
@@ -125,6 +127,5 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
                                                kick_speed_meters_per_second, 0));
             break;
         }
-    } while(true);
-
+    } while (true);
 }

--- a/src/software/ai/hl/stp/action/movespin_action.cpp
+++ b/src/software/ai/hl/stp/action/movespin_action.cpp
@@ -2,8 +2,8 @@
 
 #include "software/ai/intent/movespin_intent.h"
 
-MoveSpinAction::MoveSpinAction(double close_to_dest_threshold)
-    : Action(false), close_to_dest_threshold(close_to_dest_threshold)
+MoveSpinAction::MoveSpinAction(double close_to_dest_threshold, bool loop_forever)
+    : Action(loop_forever), close_to_dest_threshold(close_to_dest_threshold)
 {
 }
 

--- a/src/software/ai/hl/stp/action/movespin_action.cpp
+++ b/src/software/ai/hl/stp/action/movespin_action.cpp
@@ -2,7 +2,7 @@
 
 #include "software/ai/intent/movespin_intent.h"
 
-MoveSpinAction::MoveSpinAction(double close_to_dest_threshold, bool loop_forever)
+MoveSpinAction::MoveSpinAction(bool loop_forever, double close_to_dest_threshold)
     : Action(loop_forever), close_to_dest_threshold(close_to_dest_threshold)
 {
 }

--- a/src/software/ai/hl/stp/action/movespin_action.h
+++ b/src/software/ai/hl/stp/action/movespin_action.h
@@ -23,7 +23,7 @@ class MoveSpinAction : public Action
      * @param close_to_dest_threshold How far from the destination the robot must be
      * before the action is considered done
      */
-    explicit MoveSpinAction(
+    explicit MoveSpinAction( bool loop_forever,
         double close_to_dest_threshold = ROBOT_CLOSE_TO_DEST_THRESHOLD);
 
     /**

--- a/src/software/ai/hl/stp/action/movespin_action.h
+++ b/src/software/ai/hl/stp/action/movespin_action.h
@@ -23,8 +23,8 @@ class MoveSpinAction : public Action
      * @param close_to_dest_threshold How far from the destination the robot must be
      * before the action is considered done
      */
-    explicit MoveSpinAction( bool loop_forever,
-        double close_to_dest_threshold = ROBOT_CLOSE_TO_DEST_THRESHOLD);
+    explicit MoveSpinAction(bool loop_forever, double close_to_dest_threshold =
+                                                   ROBOT_CLOSE_TO_DEST_THRESHOLD);
 
     /**
      * Updates the params that cannot be derived from the world for this action

--- a/src/software/ai/hl/stp/action/movespin_action_test.cpp
+++ b/src/software/ai/hl/stp/action/movespin_action_test.cpp
@@ -8,7 +8,7 @@ TEST(MoveSpinActionTest, getDestination)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveSpinAction action = MoveSpinAction(0.05);
+    MoveSpinAction action = MoveSpinAction(0.05, false);
 
     action.updateControlParams(robot, Point(7, 13), AngularVelocity::quarter(), 1.0);
 
@@ -19,7 +19,7 @@ TEST(MoveSpinActionTest, robot_far_from_destination)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveSpinAction action = MoveSpinAction(0.05);
+    MoveSpinAction action = MoveSpinAction(0.05, false);
 
     action.updateControlParams(robot, Point(1, 0), AngularVelocity::quarter(), 1.0);
     auto intent_ptr = action.getNextIntent();
@@ -39,7 +39,7 @@ TEST(MoveSpinActionTest, robot_at_destination)
 {
     Robot robot = Robot(0, Point(), Vector(0, 0), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveSpinAction action = MoveSpinAction(0.02);
+    MoveSpinAction action = MoveSpinAction(0.02, false);
 
     // We call the action twice. The first time the Intent will always be returned to
     // ensure the Robot is doing the right thing. In all future calls, the action will be
@@ -55,7 +55,7 @@ TEST(MoveSpinActionTest, test_action_does_not_prematurely_report_done)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveSpinAction action = MoveSpinAction(0.05);
+    MoveSpinAction action = MoveSpinAction(0.05, false);
 
     // Run the Action several times
     for (int i = 0; i < 10; i++)

--- a/src/software/ai/hl/stp/action/movespin_action_test.cpp
+++ b/src/software/ai/hl/stp/action/movespin_action_test.cpp
@@ -19,7 +19,7 @@ TEST(MoveSpinActionTest, robot_far_from_destination)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveSpinAction action = MoveSpinAction(0.05, false);
+    MoveSpinAction action = MoveSpinAction(false, 0.05);
 
     action.updateControlParams(robot, Point(1, 0), AngularVelocity::quarter(), 1.0);
     auto intent_ptr = action.getNextIntent();
@@ -39,7 +39,7 @@ TEST(MoveSpinActionTest, robot_at_destination)
 {
     Robot robot = Robot(0, Point(), Vector(0, 0), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveSpinAction action = MoveSpinAction(0.02, false);
+    MoveSpinAction action = MoveSpinAction(false, 0.02);
 
     // We call the action twice. The first time the Intent will always be returned to
     // ensure the Robot is doing the right thing. In all future calls, the action will be
@@ -55,7 +55,7 @@ TEST(MoveSpinActionTest, test_action_does_not_prematurely_report_done)
 {
     Robot robot = Robot(0, Point(), Vector(), Angle::zero(), AngularVelocity::zero(),
                         Timestamp::fromSeconds(0));
-    MoveSpinAction action = MoveSpinAction(0.05, false);
+    MoveSpinAction action = MoveSpinAction(false, 0.05);
 
     // Run the Action several times
     for (int i = 0; i < 10; i++)

--- a/src/software/ai/hl/stp/action/pivot_action.cpp
+++ b/src/software/ai/hl/stp/action/pivot_action.cpp
@@ -8,7 +8,7 @@
 #include "software/new_geom/angle.h"
 #include "software/parameter/dynamic_parameters.h"
 
-PivotAction::PivotAction() : Action(true) {}
+PivotAction::PivotAction() : Action(false) {}
 
 void PivotAction::updateControlParams(const Robot& robot, Point pivot_point,
                                       Angle final_angle, Angle pivot_speed,

--- a/src/software/ai/hl/stp/action/stop_action.cpp
+++ b/src/software/ai/hl/stp/action/stop_action.cpp
@@ -2,8 +2,8 @@
 
 #include "software/ai/intent/stop_intent.h"
 
-StopAction::StopAction(bool loop_forever, double stopped_speed_threshold)
-    : Action(loop_forever), stopped_speed_threshold(stopped_speed_threshold)
+StopAction::StopAction(double stopped_speed_threshold)
+    : Action(false), stopped_speed_threshold(stopped_speed_threshold)
 
 {
 }

--- a/src/software/ai/hl/stp/action/stop_action.h
+++ b/src/software/ai/hl/stp/action/stop_action.h
@@ -22,7 +22,7 @@ class StopAction : public Action
      * @param stopped_speed_threshold How slow the robot must be moving before the action
      * is considered done
      */
-    explicit StopAction(bool loop_forever, double stopped_speed_threshold =
+    explicit StopAction(double stopped_speed_threshold =
                                                ROBOT_STOPPED_SPEED_THRESHOLD_DEFAULT);
 
     /**

--- a/src/software/ai/hl/stp/action/stop_action.h
+++ b/src/software/ai/hl/stp/action/stop_action.h
@@ -22,8 +22,8 @@ class StopAction : public Action
      * @param stopped_speed_threshold How slow the robot must be moving before the action
      * is considered done
      */
-    explicit StopAction(double stopped_speed_threshold =
-                                               ROBOT_STOPPED_SPEED_THRESHOLD_DEFAULT);
+    explicit StopAction(
+        double stopped_speed_threshold = ROBOT_STOPPED_SPEED_THRESHOLD_DEFAULT);
 
     /**
      * Updates the params that cannot be derived from the world for this action

--- a/src/software/ai/hl/stp/action/stop_action_test.cpp
+++ b/src/software/ai/hl/stp/action/stop_action_test.cpp
@@ -9,7 +9,7 @@ TEST(StopActionTest, robot_stopping_without_coasting_while_already_moving)
 {
     Robot robot       = Robot(0, Point(10, 10), Vector(1, 3), Angle::zero(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    StopAction action = StopAction(false, 0.05);
+    StopAction action = StopAction(0.05);
 
     action.updateControlParams(robot, false);
     auto intent_ptr = action.getNextIntent();
@@ -33,7 +33,7 @@ TEST(StopAction, robot_stopping_while_already_stopped)
 {
     Robot robot       = Robot(0, Point(10, 10), Vector(), Angle::zero(),
                         AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    StopAction action = StopAction(false, 0.05);
+    StopAction action = StopAction(0.05);
 
     // We call the action twice. The first time the Intent will always be returned to
     // ensure the Robot is doing the right thing. In all future calls, the action will be

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
@@ -180,7 +180,7 @@ std::optional<std::pair<Point, Angle>> CreaseDefenderTactic::calculateDesiredSta
 void CreaseDefenderTactic::calculateNextAction(ActionCoroutine::push_type &yield)
 {
     auto move_action = std::make_shared<MoveAction>(false, 0, Angle());
-    auto stop_action = std::make_shared<StopAction>(false);
+    auto stop_action = std::make_shared<StopAction>();
     do
     {
         std::optional<std::pair<Point, Angle>> desired_robot_state_opt =

--- a/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
@@ -71,6 +71,9 @@ void DefenseShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &y
             LOG(WARNING) << "Running DefenseShadowEnemyTactic without an enemy threat";
             stop_action->updateControlParams(*robot, false);
             yield(stop_action);
+            if(stop_action->done()) {
+                stop_action->restart();
+            }
         }
 
         Robot enemy_robot                   = enemy_threat->robot;

--- a/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
@@ -62,7 +62,7 @@ double DefenseShadowEnemyTactic::calculateRobotCost(const Robot &robot,
 void DefenseShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
 {
     auto move_action = std::make_shared<MoveAction>(false);
-    auto stop_action = std::make_shared<StopAction>(true);
+    auto stop_action = std::make_shared<StopAction>();
 
     do
     {

--- a/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
@@ -71,7 +71,8 @@ void DefenseShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &y
             LOG(WARNING) << "Running DefenseShadowEnemyTactic without an enemy threat";
             stop_action->updateControlParams(*robot, false);
             yield(stop_action);
-            if(stop_action->done()) {
+            if (stop_action->done())
+            {
                 stop_action->restart();
             }
         }

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -133,7 +133,7 @@ void GoalieTactic::calculateNextAction(ActionCoroutine::push_type &yield)
 {
     auto move_action = std::make_shared<MoveAction>(true);
     auto chip_action = std::make_shared<ChipAction>();
-    auto stop_action = std::make_shared<StopAction>(false);
+    auto stop_action = std::make_shared<StopAction>();
 
     do
     {

--- a/src/software/ai/hl/stp/tactic/patrol_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/patrol_tactic.cpp
@@ -56,7 +56,7 @@ void PatrolTactic::calculateNextAction(ActionCoroutine::push_type &yield)
 {
     if (patrol_points.empty())
     {
-        auto stop_action = std::make_shared<StopAction>(false);
+        auto stop_action = std::make_shared<StopAction>();
 
         do
         {

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -69,7 +69,8 @@ void ShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
         {
             stop_action->updateControlParams(*robot, false);
             yield(stop_action);
-            if(stop_action->done()) {
+            if (stop_action->done())
+            {
                 stop_action->restart();
             }
         }

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -61,7 +61,7 @@ double ShadowEnemyTactic::calculateRobotCost(const Robot &robot, const World &wo
 void ShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
 {
     auto move_action = std::make_shared<MoveAction>(false, 0, Angle());
-    auto stop_action = std::make_shared<StopAction>(true);
+    auto stop_action = std::make_shared<StopAction>();
 
     do
     {

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -69,6 +69,9 @@ void ShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
         {
             stop_action->updateControlParams(*robot, false);
             yield(stop_action);
+            if(stop_action->done()) {
+                stop_action->restart();
+            }
         }
 
         Robot enemy_robot = enemy_threat->robot;

--- a/src/software/ai/hl/stp/tactic/stop_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/stop_tactic.cpp
@@ -21,7 +21,7 @@ double StopTactic::calculateRobotCost(const Robot &robot, const World &world)
 
 void StopTactic::calculateNextAction(ActionCoroutine::push_type &yield)
 {
-    auto stop_action = std::make_shared<StopAction>(false);
+    auto stop_action = std::make_shared<StopAction>();
 
     do
     {


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
implemented proposed changes in the table in #1267 regarding which actions should have the option to "loop_forever" and which should be set to a default value. But essentially:

- Move, MoveSpin : optional loop_forever
- Chip, Kick, Intercept, Stop, Dribble, Pivot : loop_forever set to false

chip and kick actions become done after chipIntent / kickIntent is yielded. Briefly went through the tactics that use these actions to make sure no logic changes. The only thing I would note is that with our implementation of `ShootGoalTactic::shootUntilShotBlocked`, calling the shoot_goal_tactic after actually shooting can potentially yield null pointers. 

Also edited tactics that were assuming stop_action would loop forever. They now restart the stop_action once it completes. 

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
everything builds and existing tests pass

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #1267 
### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
