### PR TITLE
Removed -Wno-unused-command-line-argument From Toolchain Config

### DIFF
--- a/src/cc_toolchain/cc_toolchain_config.bzl
+++ b/src/cc_toolchain/cc_toolchain_config.bzl
@@ -109,7 +109,6 @@ def _make_common_features(ctx):
 
     result["static_link_cpp_runtimes"] = feature(
         name = "static_link_cpp_runtimes",
-        implies = ["no-unused-command-line-argument"],
     )
 
     result["unfiltered_compile_flags_feature"] = feature(
@@ -375,16 +374,6 @@ def _make_common_features(ctx):
             flag_set(
                 actions = ALL_CPP_ACTIONS,
                 flag_groups = [flag_group(flags = ["-fno-exceptions"])],
-            ),
-        ],
-    )
-
-    result["no-unused-command-line-argument"] = feature(
-        name = "no-unused-command-line-argument",
-        flag_sets = [
-            flag_set(
-                actions = ALL_COMPILE_ACTIONS + ALL_LINK_ACTIONS,
-                flag_groups = [flag_group(flags = ["-Wno-unused-command-line-argument"])],
             ),
         ],
     )

--- a/src/cc_toolchain/cc_toolchain_config.bzl
+++ b/src/cc_toolchain/cc_toolchain_config.bzl
@@ -107,10 +107,6 @@ ALL_CPP_ACTIONS = [
 def _make_common_features(ctx):
     result = {}
 
-    result["static_link_cpp_runtimes"] = feature(
-        name = "static_link_cpp_runtimes",
-    )
-
     result["unfiltered_compile_flags_feature"] = feature(
         name = "unfiltered_compile_flags",
         flag_sets = ([
@@ -552,7 +548,6 @@ def _linux_gcc_impl(ctx):
             "stdlib",
             "lld",
             "frame-pointer",
-            "static_link_cpp_runtimes",
         ],
     )
 

--- a/src/cc_toolchain/cc_toolchain_config.bzl
+++ b/src/cc_toolchain/cc_toolchain_config.bzl
@@ -107,6 +107,10 @@ ALL_CPP_ACTIONS = [
 def _make_common_features(ctx):
     result = {}
 
+    result["static_link_cpp_runtimes"] = feature(
+        name = "static_link_cpp_runtimes",
+    )
+
     result["unfiltered_compile_flags_feature"] = feature(
         name = "unfiltered_compile_flags",
         flag_sets = ([
@@ -548,6 +552,7 @@ def _linux_gcc_impl(ctx):
             "stdlib",
             "lld",
             "frame-pointer",
+            "static_link_cpp_runtimes",
         ],
     )
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
This is not a valid `gcc` flag and so was throwing a lot of warnings.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
If CI passes this should be good to go.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
