### PR TITLE
Barebones FriendlyKickoffPlay test

### DIFF
--- a/src/software/simulated_tests/BUILD
+++ b/src/software/simulated_tests/BUILD
@@ -56,3 +56,18 @@ cc_test(
         "@gtest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "kickoff_friendly_play_test",
+    srcs = ["kickoff_friendly_play_test.cpp"],
+    deps = [
+        ":simulated_test_fixture",
+        "//software/ai/hl/stp/play:kickoff_friendly_play",
+        "//software/simulated_tests/validation:validation_function",
+        "//software/test_util",
+        "//software/time:duration",
+        "//software/time:timestamp",
+        "//software/world",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/src/software/simulated_tests/kickoff_friendly_play_test.cpp
+++ b/src/software/simulated_tests/kickoff_friendly_play_test.cpp
@@ -1,0 +1,73 @@
+#include "software/ai/hl/stp/play/kickoff_friendly_play.h"
+
+#include <gtest/gtest.h>
+
+#include "software/simulated_tests/simulated_test_fixture.h"
+#include "software/simulated_tests/validation/validation_function.h"
+#include "software/test_util/test_util.h"
+#include "software/time/duration.h"
+#include "software/time/timestamp.h"
+#include "software/world/world.h"
+
+class KickoffFriendlyPlayTest : public SimulatedTest
+{
+};
+
+TEST_F(KickoffFriendlyPlayTest, test_kickoff_friendly_play)
+{
+    World world = ::Test::TestUtil::createBlankTestingWorld();
+
+    world = ::Test::TestUtil::setEnemyRobotPositions(
+        world,
+        {
+            Point(0.6, 0),
+            Point(0.2, 2.5),
+            Point(0.2, -2.5),
+            world.field().enemyGoalCenter(),
+            world.field().enemyDefenseArea().negXNegYCorner(),
+            world.field().enemyDefenseArea().negXPosYCorner(),
+        },
+        Timestamp::fromSeconds(0));
+
+    world = ::Test::TestUtil::setFriendlyRobotPositions(world,
+                                                        {
+                                                            Point(-3, 2.5),
+                                                            Point(-3, 1.5),
+                                                            Point(-3, 0.5),
+                                                            Point(-3, -0.5),
+                                                            Point(-3, -1.5),
+                                                            Point(-3, -2.5),
+                                                        },
+                                                        Timestamp::fromSeconds(0));
+    world.mutableFriendlyTeam().assignGoalie(0);
+
+    world.mutableBall() = Ball(Point(0, 0), Vector(0, 0), Timestamp::fromSeconds(0));
+
+    std::vector<ValidationFunction> validation_functions = {
+        // This will keep the test running for 9.5 seconds to give everything enough
+        // time to settle into position and be observed with the Visualizer
+        [](std::shared_ptr<World> world_ptr, ValidationCoroutine::push_type& yield) {
+            while (world_ptr->getMostRecentTimestamp() < Timestamp::fromSeconds(9.5))
+            {
+                yield();
+            }
+        }};
+
+    std::vector<ValidationFunction> continous_validation_functions = {};
+
+    Util::MutableDynamicParameters->getMutableAIControlConfig()
+        ->mutableOverrideAIPlay()
+        ->setValue(true);
+    Util::MutableDynamicParameters->getMutableAIControlConfig()
+        ->mutableCurrentAIPlay()
+        ->setValue(KickoffFriendlyPlay::name);
+    Util::MutableDynamicParameters->getMutableAIControlConfig()
+        ->getMutableRefboxConfig()
+        ->mutableFriendlyGoalieId()
+        ->setValue(0);
+
+    backend->startSimulation(world);
+    bool test_passed = world_state_validator->waitForValidationToPass(
+        validation_functions, continous_validation_functions, Duration::fromSeconds(10));
+    EXPECT_TRUE(test_passed);
+}

--- a/src/software/simulated_tests/kickoff_friendly_play_test.cpp
+++ b/src/software/simulated_tests/kickoff_friendly_play_test.cpp
@@ -46,6 +46,8 @@ TEST_F(KickoffFriendlyPlayTest, test_kickoff_friendly_play)
     std::vector<ValidationFunction> validation_functions = {
         // This will keep the test running for 9.5 seconds to give everything enough
         // time to settle into position and be observed with the Visualizer
+        // TODO: Implement proper validation
+        // https://github.com/UBC-Thunderbots/Software/issues/1396
         [](std::shared_ptr<World> world_ptr, ValidationCoroutine::push_type& yield) {
             while (world_ptr->getMostRecentTimestamp() < Timestamp::fromSeconds(9.5))
             {


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Had a short testing session where we experimented with a few simple plays. This PR adds the skeleton for testing the `KickoffFriendlyPlay`. It does not contain any validation functions.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
verified the test works by watching it, but this is not really code to be tested right now.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
