### PR TITLE
Added Convention For Labelling Params As [in] and [out] In C Javadocs

### DIFF
--- a/docs/code-style-guide.md
+++ b/docs/code-style-guide.md
@@ -62,6 +62,32 @@ The vast majority of the things noted in this document will apply to `C` code as
 
 * Functions that take no arguments must be declared as `foo(void)` **not** `foo()`, as the second option allows `foo` to take anything as it's arguments ([reference](https://softwareengineering.stackexchange.com/questions/286490/what-is-the-difference-between-function-and-functionvoid/286494))
 
+* Functions that return values via argument must have all parameters labelled as `[in]` or `[out]` in the javadoc, with all `[out]` coming after `[in]` if possible
+
+  ``` C
+  // Incorrect
+  /**
+   * Create a trajectory with given max speed
+   * 
+   * @param created_trajectory A pointer that will be set to the created
+   *                           created trajectory.
+   * @param max_speed The maximum speed on the trajectory
+   * @return True if the trajectory was generated succesfully, false otherwise
+   */
+  bool generateTrajectory(Trajectory* created_trajectory, float max_speed)
+
+  // Correct
+  /**
+   * Create a trajectory with given max speed
+   * 
+   * @param max_speed [in] The maximum speed on the trajectory
+   * @param created_trajectory [out] A pointer that will be set to the created
+   *                                 created trajectory.
+   * @return True if the trajectory was generated succesfully, false otherwise
+   */
+  bool generateTrajectory(float max_speed, Trajectory* created_trajectory)
+  ```
+
 ### Names and Variables
 
 * Classes, structures, namespaces, unions, enumerates, "typename"-type template parameters, and typedefs names uses `CamelCase` with a capital letter.

--- a/docs/code-style-guide.md
+++ b/docs/code-style-guide.md
@@ -62,7 +62,7 @@ The vast majority of the things noted in this document will apply to `C` code as
 
 * Functions that take no arguments must be declared as `foo(void)` **not** `foo()`, as the second option allows `foo` to take anything as it's arguments ([reference](https://softwareengineering.stackexchange.com/questions/286490/what-is-the-difference-between-function-and-functionvoid/286494))
 
-* Functions that return values via argument must have all parameters labelled as `[in]`, `[in/out]`, or `[out]` in the javadoc, **in that order**.
+* Functions that return values via argument(s) must have all parameters labelled as `[in]`, `[in/out]`, or `[out]` in the javadoc, **in that order**.
 
   ``` C
   // Incorrect

--- a/docs/code-style-guide.md
+++ b/docs/code-style-guide.md
@@ -78,7 +78,9 @@ The vast majority of the things noted in this document will apply to `C` code as
    *                  trajectory.
    * @return true if the trajectory was generated successfully, false otherwise
    */
-  bool generateTrajectory(Trajectory* created_trajectory, float max_speed)
+  bool generateTrajectory(float* max_acceleration, 
+                          Trajectory* created_trajectory, 
+                          float max_speed);
 
   // Correct
   /**
@@ -93,7 +95,9 @@ The vast majority of the things noted in this document will apply to `C` code as
    *                           created trajectory.
    * @return true if the trajectory was generated successfully, false otherwise
    */
-  bool generateTrajectory(float max_speed, Trajectory* created_trajectory)
+  bool generateTrajectory(float max_speed, 
+                          float* max_acceleration, 
+                          Trajectory* created_trajectory);
   ```
 
 ### Names and Variables

--- a/docs/code-style-guide.md
+++ b/docs/code-style-guide.md
@@ -62,17 +62,21 @@ The vast majority of the things noted in this document will apply to `C` code as
 
 * Functions that take no arguments must be declared as `foo(void)` **not** `foo()`, as the second option allows `foo` to take anything as it's arguments ([reference](https://softwareengineering.stackexchange.com/questions/286490/what-is-the-difference-between-function-and-functionvoid/286494))
 
-* Functions that return values via argument must have all parameters labelled as `[in]` or `[out]` in the javadoc, with all `[out]` coming after `[in]` if possible
+* Functions that return values via argument must have all parameters labelled as `[in]`, `[in/out]`, or `[out]` in the javadoc, **in that order**.
 
   ``` C
   // Incorrect
   /**
    * Create a trajectory with given max speed
    * 
-   * @param created_trajectory A pointer that will be set to the created
+   * @param max_acceleration The maximum acceleration permitted. This will be
+   *                         updated to the maximum acceleration actually seen
+   *                         on the generated trajectory.
+   * @param created_trajectory A pointer that will be set to the created 
    *                           created trajectory.
-   * @param max_speed The maximum speed on the trajectory
-   * @return True if the trajectory was generated succesfully, false otherwise
+   * @param max_speed The maximum speed on the trajectory permitted on the 
+   *                  trajectory.
+   * @return true if the trajectory was generated successfully, false otherwise
    */
   bool generateTrajectory(Trajectory* created_trajectory, float max_speed)
 
@@ -80,10 +84,14 @@ The vast majority of the things noted in this document will apply to `C` code as
   /**
    * Create a trajectory with given max speed
    * 
-   * @param max_speed [in] The maximum speed on the trajectory
-   * @param created_trajectory [out] A pointer that will be set to the created
-   *                                 created trajectory.
-   * @return True if the trajectory was generated succesfully, false otherwise
+   * @param max_speed [in] The maximum speed on the trajectory permitted on the 
+   *                       trajectory.
+   * @param max_acceleration [in/out] The maximum acceleration permitted. This 
+   *                                  will be updated to the maximum acceleration 
+   *                                  actually seen on the generated trajectory.
+   * @param created_trajectory A pointer that will be set to the created 
+   *                           created trajectory.
+   * @return true if the trajectory was generated successfully, false otherwise
    */
   bool generateTrajectory(float max_speed, Trajectory* created_trajectory)
   ```

--- a/docs/code-style-guide.md
+++ b/docs/code-style-guide.md
@@ -91,8 +91,8 @@ The vast majority of the things noted in this document will apply to `C` code as
    * @param max_acceleration [in/out] The maximum acceleration permitted. This 
    *                                  will be updated to the maximum acceleration 
    *                                  actually seen on the generated trajectory.
-   * @param created_trajectory A pointer that will be set to the created 
-   *                           created trajectory.
+   * @param created_trajectory [out] A pointer that will be set to the created 
+   *                                 created trajectory.
    * @return true if the trajectory was generated successfully, false otherwise
    */
   bool generateTrajectory(float max_speed, 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Realized while reviewing https://github.com/UBC-Thunderbots/Software/pull/1412 that we didn't have this documented. We could enforce this on _all_ javadocs, but that seems like overkill, and we would have a lot of work updating them all / enforcing that.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
