### PR TITLE
Update simulator interface to expose blue and yellow teams

### DIFF
--- a/src/software/backend/simulator_backend.cpp
+++ b/src/software/backend/simulator_backend.cpp
@@ -82,7 +82,8 @@ void SimulatorBackend::runSimulationLoop(World world)
     simulator.setBallState(world.ball().currentState().ballState());
     // Note: The SimulatorBackend currently maintains the invariant that the
     // friendly team is the yellow team
-    // TODO: when will this be fixed?
+    // This should be resolved along with
+    // https://github.com/UBC-Thunderbots/Software/issues/1439
     for (const auto& robot : world.friendlyTeam().getAllRobots())
     {
         RobotStateWithId state = {.id          = robot.id(),

--- a/src/software/backend/simulator_backend.cpp
+++ b/src/software/backend/simulator_backend.cpp
@@ -11,7 +11,7 @@
 const std::string SimulatorBackend::name = "simulator";
 
 SimulatorBackend::SimulatorBackend(
-    const Duration &physics_time_step, const Duration &world_time_increment,
+    const Duration& physics_time_step, const Duration& world_time_increment,
     SimulatorBackend::SimulationSpeed simulation_speed_mode)
     : simulation_thread_started(false),
       in_destructor(false),
@@ -83,12 +83,16 @@ void SimulatorBackend::runSimulationLoop(World world)
     // Note: The SimulatorBackend currently maintains the invariant that the
     // friendly team is the yellow team
     // TODO: when will this be fixed?
-    for(const auto& robot : world.friendlyTeam().getAllRobots()) {
-        RobotStateWithId state = {.id = robot.id(), .robot_state = robot.currentState().robotState()};
+    for (const auto& robot : world.friendlyTeam().getAllRobots())
+    {
+        RobotStateWithId state = {.id          = robot.id(),
+                                  .robot_state = robot.currentState().robotState()};
         simulator.addYellowRobots({state});
     }
-    for(const auto& robot : world.enemyTeam().getAllRobots()) {
-        RobotStateWithId state = {.id = robot.id(), .robot_state = robot.currentState().robotState()};
+    for (const auto& robot : world.enemyTeam().getAllRobots())
+    {
+        RobotStateWithId state = {.id          = robot.id(),
+                                  .robot_state = robot.currentState().robotState()};
         simulator.addBlueRobots({state});
     }
 

--- a/src/software/simulated_tests/example_play_test.cpp
+++ b/src/software/simulated_tests/example_play_test.cpp
@@ -15,6 +15,7 @@ class ExamplePlayTest : public SimulatedTest
 
 TEST_F(ExamplePlayTest, test_example_play)
 {
+    enableVisualizer();
     World world = ::Test::TestUtil::createBlankTestingWorld();
     world       = ::Test::TestUtil::setFriendlyRobotPositions(
         world,

--- a/src/software/simulated_tests/example_play_test.cpp
+++ b/src/software/simulated_tests/example_play_test.cpp
@@ -15,7 +15,6 @@ class ExamplePlayTest : public SimulatedTest
 
 TEST_F(ExamplePlayTest, test_example_play)
 {
-    enableVisualizer();
     World world = ::Test::TestUtil::createBlankTestingWorld();
     world       = ::Test::TestUtil::setFriendlyRobotPositions(
         world,

--- a/src/software/simulation/physics/physics_world.cpp
+++ b/src/software/simulation/physics/physics_world.cpp
@@ -189,18 +189,34 @@ void PhysicsWorld::stepSimulation(const Duration& time_step)
     current_timestamp = current_timestamp + time_step;
 }
 
-std::vector<std::weak_ptr<PhysicsRobot>> PhysicsWorld::getFriendlyPhysicsRobots() const
+std::vector<std::weak_ptr<PhysicsRobot>> PhysicsWorld::getYellowPhysicsRobots() const
 {
     std::vector<std::weak_ptr<PhysicsRobot>> robots;
-    for (const auto& friendly_physics_robot : yellow_physics_robots)
+    for (const auto& yellow_physics_robot : yellow_physics_robots)
     {
-        if (!friendly_physics_robot)
+        if (!yellow_physics_robot)
         {
             LOG(FATAL)
                 << "Encountered a nullptr to a yellow physics robot in the physics world";
         }
 
-        robots.emplace_back(friendly_physics_robot);
+        robots.emplace_back(yellow_physics_robot);
+    }
+    return robots;
+}
+
+std::vector<std::weak_ptr<PhysicsRobot>> PhysicsWorld::getBluePhysicsRobots() const
+{
+    std::vector<std::weak_ptr<PhysicsRobot>> robots;
+    for (const auto& blue_physics_robot : blue_physics_robots)
+    {
+        if (!blue_physics_robot)
+        {
+            LOG(FATAL)
+                << "Encountered a nullptr to a blue physics robot in the physics world";
+        }
+
+        robots.emplace_back(blue_physics_robot);
     }
     return robots;
 }

--- a/src/software/simulation/physics/physics_world.h
+++ b/src/software/simulation/physics/physics_world.h
@@ -136,11 +136,18 @@ class PhysicsWorld
     void stepSimulation(const Duration& time_step);
 
     /**
-     * Returns the friendly PhysicsRobots currently in the world
+     * Returns the yellow PhysicsRobots currently in the world
      *
-     * @return the friendly PhysicsRobots in the world
+     * @return the yellow PhysicsRobots in the world
      */
-    std::vector<std::weak_ptr<PhysicsRobot>> getFriendlyPhysicsRobots() const;
+    std::vector<std::weak_ptr<PhysicsRobot>> getYellowPhysicsRobots() const;
+
+    /**
+     * Returns the blue PhysicsRobots currently in the world
+     *
+     * @return the blue PhysicsRobots in the world
+     */
+    std::vector<std::weak_ptr<PhysicsRobot>> getBluePhysicsRobots() const;
 
     /**
      * Returns the PhysicsBall currently in the world

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -33,7 +33,6 @@ void Simulator::addYellowRobots(const std::vector<RobotStateWithId>& robots)
         auto simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
         auto firmware_robot  = SimulatorRobotSingleton::createFirmwareRobot();
         auto firmware_ball   = SimulatorBallSingleton::createFirmwareBall();
-        // Release ownership of the pointers so the firmware_world can take ownership
         FirmwareWorld_t* firmware_world_raw =
             app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
         auto firmware_world =
@@ -51,7 +50,6 @@ void Simulator::addBlueRobots(const std::vector<RobotStateWithId>& robots)
         auto simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
         auto firmware_robot  = SimulatorRobotSingleton::createFirmwareRobot();
         auto firmware_ball   = SimulatorBallSingleton::createFirmwareBall();
-        // Release ownership of the pointers so the firmware_world can take ownership
         FirmwareWorld_t* firmware_world_raw =
             app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
         auto firmware_world =
@@ -68,6 +66,9 @@ void Simulator::setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives)
         return;
     }
 
+    // Set the ball being referenced in each firmware_world.
+    // We only need to do this a single time since all robots
+    // can see and interact with the same ball
     SimulatorBallSingleton::setSimulatorBall(simulator_ball);
     for (const auto& primitive_ptr : *primitives)
     {
@@ -125,6 +126,9 @@ void Simulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives)
 
 void Simulator::stepSimulation(const Duration& time_step)
 {
+    // Set the ball being referenced in each firmware_world.
+    // We only need to do this a single time since all robots
+    // can see and interact with the same ball
     SimulatorBallSingleton::setSimulatorBall(simulator_ball);
 
     for (auto& iter : yellow_simulator_robots)

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -28,7 +28,8 @@ void Simulator::removeBall()
 void Simulator::addYellowRobots(const std::vector<RobotStateWithId>& robots)
 {
     physics_world.addYellowRobots(robots);
-    updateSimulatorRobots(physics_world.getYellowPhysicsRobots(), yellow_simulator_robots);
+    updateSimulatorRobots(physics_world.getYellowPhysicsRobots(),
+                          yellow_simulator_robots);
 }
 
 void Simulator::addBlueRobots(const std::vector<RobotStateWithId>& robots)
@@ -37,17 +38,20 @@ void Simulator::addBlueRobots(const std::vector<RobotStateWithId>& robots)
     updateSimulatorRobots(physics_world.getBluePhysicsRobots(), blue_simulator_robots);
 }
 
-void Simulator::updateSimulatorRobots(const std::vector<std::weak_ptr<PhysicsRobot>>& physics_robots,
-                                      std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>> &simulator_robots) {
+void Simulator::updateSimulatorRobots(
+    const std::vector<std::weak_ptr<PhysicsRobot>>& physics_robots,
+    std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
+        simulator_robots)
+{
     for (const auto& physics_robot : physics_robots)
     {
         auto simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
         auto firmware_robot  = SimulatorRobotSingleton::createFirmwareRobot();
         auto firmware_ball   = SimulatorBallSingleton::createFirmwareBall();
         FirmwareWorld_t* firmware_world_raw =
-                app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
+            app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
         auto firmware_world =
-                std::shared_ptr<FirmwareWorld_t>(firmware_world_raw, FirmwareWorldDeleter());
+            std::shared_ptr<FirmwareWorld_t>(firmware_world_raw, FirmwareWorldDeleter());
 
         simulator_robots.insert(std::make_pair(simulator_robot, firmware_world));
     }
@@ -63,8 +67,12 @@ void Simulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives)
     setRobotPrimitives(primitives, blue_simulator_robots, simulator_ball);
 }
 
-void Simulator::setRobotPrimitives(ConstPrimitiveVectorPtr primitives,
-                                   std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>> &simulator_robots, const std::shared_ptr<SimulatorBall>& simulator_ball) {
+void Simulator::setRobotPrimitives(
+    ConstPrimitiveVectorPtr primitives,
+    std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
+        simulator_robots,
+    const std::shared_ptr<SimulatorBall>& simulator_ball)
+{
     if (!primitives)
     {
         return;
@@ -77,11 +85,11 @@ void Simulator::setRobotPrimitives(ConstPrimitiveVectorPtr primitives,
         unsigned int primitive_index        = getPrimitiveIndex(primitive_ptr);
 
         auto simulator_robots_iter =
-                std::find_if(simulator_robots.begin(), simulator_robots.end(),
-                             [&primitive_ptr](const auto& robot_world_pair) {
-                                 return robot_world_pair.first->getRobotId() ==
-                                        primitive_ptr->getRobotId();
-                             });
+            std::find_if(simulator_robots.begin(), simulator_robots.end(),
+                         [&primitive_ptr](const auto& robot_world_pair) {
+                             return robot_world_pair.first->getRobotId() ==
+                                    primitive_ptr->getRobotId();
+                         });
 
         if (simulator_robots_iter != simulator_robots.end())
         {
@@ -89,7 +97,7 @@ void Simulator::setRobotPrimitives(ConstPrimitiveVectorPtr primitives,
             auto firmware_world  = (*simulator_robots_iter).second;
             SimulatorRobotSingleton::setSimulatorRobot(simulator_robot);
             SimulatorRobotSingleton::startNewPrimitiveOnCurrentSimulatorRobot(
-                    firmware_world, primitive_index, primitive_params);
+                firmware_world, primitive_index, primitive_params);
         }
     }
 }

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -11,34 +11,23 @@ extern "C"
 #include "firmware/app/world/firmware_world.h"
 }
 
-Simulator::Simulator(const World& world)
-    : physics_world(world.field()), friendly_goalie_id(world.friendlyTeam().getGoalieID())
-{
-    physics_world.setBallState(world.ball().currentState().ballState());
-    // Note: The simulator currently makes the invariant that friendly robots
-    // are yellow robots, and enemies are blue. This will be fixed in
-    // https://github.com/UBC-Thunderbots/Software/issues/1325
-    std::vector<RobotStateWithId> yellow_robots;
-    for (const auto& robot : world.friendlyTeam().getAllRobots())
-    {
-        RobotStateWithId state{.id          = robot.id(),
-                               .robot_state = robot.currentState().robotState()};
-        yellow_robots.emplace_back(state);
-    }
-    physics_world.addYellowRobots(yellow_robots);
-    std::vector<RobotStateWithId> blue_robots;
-    for (const auto& robot : world.enemyTeam().getAllRobots())
-    {
-        RobotStateWithId state{.id          = robot.id(),
-                               .robot_state = robot.currentState().robotState()};
-        blue_robots.emplace_back(state);
-    }
-    physics_world.addBlueRobots(blue_robots);
+Simulator::Simulator(const Field& field) : physics_world(field) {}
 
-    for (auto physics_robot : physics_world.getFriendlyPhysicsRobots())
+void Simulator::setBallState(const BallState &ball_state) {
+    physics_world.setBallState(ball_state);
+    simulator_ball = std::make_shared<SimulatorBall>(physics_world.getPhysicsBall());
+}
+
+void Simulator::removeBall() {
+    simulator_ball.reset();
+    physics_world.removeBall();
+}
+
+void Simulator::addYellowRobots(const std::vector<RobotStateWithId> &robots) {
+    physics_world.addYellowRobots(robots);
+    for (auto physics_robot : physics_world.getYellowPhysicsRobots())
     {
         auto simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
-
         auto firmware_robot = SimulatorRobotSingleton::createFirmwareRobot();
         auto firmware_ball  = SimulatorBallSingleton::createFirmwareBall();
         // Release ownership of the pointers so the firmware_world can take ownership
@@ -47,27 +36,28 @@ Simulator::Simulator(const World& world)
         auto firmware_world =
             std::shared_ptr<FirmwareWorld_t>(firmware_world_raw, FirmwareWorldDeleter());
 
-        simulator_robots.insert(std::make_pair(simulator_robot, firmware_world));
+        yellow_simulator_robots.insert(std::make_pair(simulator_robot, firmware_world));
     }
-
-    simulator_ball = std::make_shared<SimulatorBall>(physics_world.getPhysicsBall());
 }
 
-void Simulator::stepSimulation(const Duration& time_step)
-{
-    SimulatorBallSingleton::setSimulatorBall(simulator_ball);
-    for (auto& iter : simulator_robots)
+void Simulator::addBlueRobots(const std::vector<RobotStateWithId> &robots) {
+    physics_world.addBlueRobots(robots);
+    for (auto physics_robot : physics_world.getBluePhysicsRobots())
     {
-        auto simulator_robot = iter.first;
-        auto firmware_world  = iter.second;
-        SimulatorRobotSingleton::setSimulatorRobot(simulator_robot);
-        SimulatorRobotSingleton::runPrimitiveOnCurrentSimulatorRobot(firmware_world);
-    }
+        auto simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
+        auto firmware_robot = SimulatorRobotSingleton::createFirmwareRobot();
+        auto firmware_ball  = SimulatorBallSingleton::createFirmwareBall();
+        // Release ownership of the pointers so the firmware_world can take ownership
+        FirmwareWorld_t* firmware_world_raw =
+                app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
+        auto firmware_world =
+                std::shared_ptr<FirmwareWorld_t>(firmware_world_raw, FirmwareWorldDeleter());
 
-    physics_world.stepSimulation(time_step);
+        blue_simulator_robots.insert(std::make_pair(simulator_robot, firmware_world));
+    }
 }
 
-void Simulator::setPrimitives(ConstPrimitiveVectorPtr primitives)
+void Simulator::setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives)
 {
     if (!primitives)
     {
@@ -81,13 +71,13 @@ void Simulator::setPrimitives(ConstPrimitiveVectorPtr primitives)
         unsigned int primitive_index        = getPrimitiveIndex(primitive_ptr);
 
         auto simulator_robots_iter =
-            std::find_if(simulator_robots.begin(), simulator_robots.end(),
+            std::find_if(yellow_simulator_robots.begin(), yellow_simulator_robots.end(),
                          [&primitive_ptr](const auto& robot_world_pair) {
                              return robot_world_pair.first->getRobotId() ==
                                     primitive_ptr->getRobotId();
                          });
 
-        if (simulator_robots_iter != simulator_robots.end())
+        if (simulator_robots_iter != yellow_simulator_robots.end())
         {
             auto simulator_robot = (*simulator_robots_iter).first;
             auto firmware_world  = (*simulator_robots_iter).second;
@@ -98,7 +88,61 @@ void Simulator::setPrimitives(ConstPrimitiveVectorPtr primitives)
     }
 }
 
-World Simulator::getWorld()
+void Simulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives)
+{
+    if (!primitives)
+    {
+        return;
+    }
+
+    SimulatorBallSingleton::setSimulatorBall(simulator_ball);
+    for (const auto& primitive_ptr : *primitives)
+    {
+        primitive_params_t primitive_params = getPrimitiveParams(primitive_ptr);
+        unsigned int primitive_index        = getPrimitiveIndex(primitive_ptr);
+
+        auto simulator_robots_iter =
+                std::find_if(blue_simulator_robots.begin(), blue_simulator_robots.end(),
+                             [&primitive_ptr](const auto& robot_world_pair) {
+                                 return robot_world_pair.first->getRobotId() ==
+                                        primitive_ptr->getRobotId();
+                             });
+
+        if (simulator_robots_iter != blue_simulator_robots.end())
+        {
+            auto simulator_robot = (*simulator_robots_iter).first;
+            auto firmware_world  = (*simulator_robots_iter).second;
+            SimulatorRobotSingleton::setSimulatorRobot(simulator_robot);
+            SimulatorRobotSingleton::startNewPrimitiveOnCurrentSimulatorRobot(
+                    firmware_world, primitive_index, primitive_params);
+        }
+    }
+}
+
+void Simulator::stepSimulation(const Duration& time_step)
+{
+    SimulatorBallSingleton::setSimulatorBall(simulator_ball);
+
+    for (auto& iter : yellow_simulator_robots)
+    {
+        auto simulator_robot = iter.first;
+        auto firmware_world  = iter.second;
+        SimulatorRobotSingleton::setSimulatorRobot(simulator_robot);
+        SimulatorRobotSingleton::runPrimitiveOnCurrentSimulatorRobot(firmware_world);
+    }
+
+    for (auto& iter : blue_simulator_robots)
+    {
+        auto simulator_robot = iter.first;
+        auto firmware_world  = iter.second;
+        SimulatorRobotSingleton::setSimulatorRobot(simulator_robot);
+        SimulatorRobotSingleton::runPrimitiveOnCurrentSimulatorRobot(firmware_world);
+    }
+
+    physics_world.stepSimulation(time_step);
+}
+
+World Simulator::getWorld() const
 {
     Timestamp timestamp = physics_world.getTimestamp();
     // The world currently must contain a ball. The ability to represent no ball
@@ -136,11 +180,11 @@ World Simulator::getWorld()
     // TODO: This is a hack to persist goalie ID from the initial test setup
     // It will be removed as part of
     // https://github.com/UBC-Thunderbots/Software/issues/1325
-    auto id = friendly_goalie_id;
-    if (id)
-    {
-        world.mutableFriendlyTeam().assignGoalie(*id);
-    }
+//    auto id = friendly_goalie_id;
+//    if (id)
+//    {
+//        world.mutableFriendlyTeam().assignGoalie(*id);
+//    }
     return world;
 }
 

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -28,73 +28,43 @@ void Simulator::removeBall()
 void Simulator::addYellowRobots(const std::vector<RobotStateWithId>& robots)
 {
     physics_world.addYellowRobots(robots);
-    for (auto physics_robot : physics_world.getYellowPhysicsRobots())
-    {
-        auto simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
-        auto firmware_robot  = SimulatorRobotSingleton::createFirmwareRobot();
-        auto firmware_ball   = SimulatorBallSingleton::createFirmwareBall();
-        FirmwareWorld_t* firmware_world_raw =
-            app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
-        auto firmware_world =
-            std::shared_ptr<FirmwareWorld_t>(firmware_world_raw, FirmwareWorldDeleter());
-
-        yellow_simulator_robots.insert(std::make_pair(simulator_robot, firmware_world));
-    }
+    updateSimulatorRobots(physics_world.getYellowPhysicsRobots(), yellow_simulator_robots);
 }
 
 void Simulator::addBlueRobots(const std::vector<RobotStateWithId>& robots)
 {
     physics_world.addBlueRobots(robots);
-    for (auto physics_robot : physics_world.getBluePhysicsRobots())
+    updateSimulatorRobots(physics_world.getBluePhysicsRobots(), blue_simulator_robots);
+}
+
+void Simulator::updateSimulatorRobots(const std::vector<std::weak_ptr<PhysicsRobot>>& physics_robots,
+                                      std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>> &simulator_robots) {
+    for (const auto& physics_robot : physics_robots)
     {
         auto simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
         auto firmware_robot  = SimulatorRobotSingleton::createFirmwareRobot();
         auto firmware_ball   = SimulatorBallSingleton::createFirmwareBall();
         FirmwareWorld_t* firmware_world_raw =
-            app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
+                app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
         auto firmware_world =
-            std::shared_ptr<FirmwareWorld_t>(firmware_world_raw, FirmwareWorldDeleter());
+                std::shared_ptr<FirmwareWorld_t>(firmware_world_raw, FirmwareWorldDeleter());
 
-        blue_simulator_robots.insert(std::make_pair(simulator_robot, firmware_world));
+        simulator_robots.insert(std::make_pair(simulator_robot, firmware_world));
     }
 }
 
 void Simulator::setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives)
 {
-    if (!primitives)
-    {
-        return;
-    }
-
-    // Set the ball being referenced in each firmware_world.
-    // We only need to do this a single time since all robots
-    // can see and interact with the same ball
-    SimulatorBallSingleton::setSimulatorBall(simulator_ball);
-    for (const auto& primitive_ptr : *primitives)
-    {
-        primitive_params_t primitive_params = getPrimitiveParams(primitive_ptr);
-        unsigned int primitive_index        = getPrimitiveIndex(primitive_ptr);
-
-        auto simulator_robots_iter =
-            std::find_if(yellow_simulator_robots.begin(), yellow_simulator_robots.end(),
-                         [&primitive_ptr](const auto& robot_world_pair) {
-                             return robot_world_pair.first->getRobotId() ==
-                                    primitive_ptr->getRobotId();
-                         });
-
-        if (simulator_robots_iter != yellow_simulator_robots.end())
-        {
-            auto simulator_robot = (*simulator_robots_iter).first;
-            auto firmware_world  = (*simulator_robots_iter).second;
-            SimulatorRobotSingleton::setSimulatorRobot(simulator_robot);
-            SimulatorRobotSingleton::startNewPrimitiveOnCurrentSimulatorRobot(
-                firmware_world, primitive_index, primitive_params);
-        }
-    }
+    setRobotPrimitives(primitives, yellow_simulator_robots, simulator_ball);
 }
 
 void Simulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives)
 {
+    setRobotPrimitives(primitives, blue_simulator_robots, simulator_ball);
+}
+
+void Simulator::setRobotPrimitives(ConstPrimitiveVectorPtr primitives,
+                                   std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>> &simulator_robots, const std::shared_ptr<SimulatorBall>& simulator_ball) {
     if (!primitives)
     {
         return;
@@ -107,19 +77,19 @@ void Simulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives)
         unsigned int primitive_index        = getPrimitiveIndex(primitive_ptr);
 
         auto simulator_robots_iter =
-            std::find_if(blue_simulator_robots.begin(), blue_simulator_robots.end(),
-                         [&primitive_ptr](const auto& robot_world_pair) {
-                             return robot_world_pair.first->getRobotId() ==
-                                    primitive_ptr->getRobotId();
-                         });
+                std::find_if(simulator_robots.begin(), simulator_robots.end(),
+                             [&primitive_ptr](const auto& robot_world_pair) {
+                                 return robot_world_pair.first->getRobotId() ==
+                                        primitive_ptr->getRobotId();
+                             });
 
-        if (simulator_robots_iter != blue_simulator_robots.end())
+        if (simulator_robots_iter != simulator_robots.end())
         {
             auto simulator_robot = (*simulator_robots_iter).first;
             auto firmware_world  = (*simulator_robots_iter).second;
             SimulatorRobotSingleton::setSimulatorRobot(simulator_robot);
             SimulatorRobotSingleton::startNewPrimitiveOnCurrentSimulatorRobot(
-                firmware_world, primitive_index, primitive_params);
+                    firmware_world, primitive_index, primitive_params);
         }
     }
 }

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -180,15 +180,6 @@ World Simulator::getWorld() const
     Team enemy_team(enemy_team_robots, Duration::fromSeconds(0.5));
 
     World world(physics_world.getField(), ball, friendly_team, enemy_team);
-
-    // TODO: This is a hack to persist goalie ID from the initial test setup
-    // It will be removed as part of
-    // https://github.com/UBC-Thunderbots/Software/issues/1325
-    //    auto id = friendly_goalie_id;
-    //    if (id)
-    //    {
-    //        world.mutableFriendlyTeam().assignGoalie(*id);
-    //    }
     return world;
 }
 

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -13,23 +13,26 @@ extern "C"
 
 Simulator::Simulator(const Field& field) : physics_world(field) {}
 
-void Simulator::setBallState(const BallState &ball_state) {
+void Simulator::setBallState(const BallState& ball_state)
+{
     physics_world.setBallState(ball_state);
     simulator_ball = std::make_shared<SimulatorBall>(physics_world.getPhysicsBall());
 }
 
-void Simulator::removeBall() {
+void Simulator::removeBall()
+{
     simulator_ball.reset();
     physics_world.removeBall();
 }
 
-void Simulator::addYellowRobots(const std::vector<RobotStateWithId> &robots) {
+void Simulator::addYellowRobots(const std::vector<RobotStateWithId>& robots)
+{
     physics_world.addYellowRobots(robots);
     for (auto physics_robot : physics_world.getYellowPhysicsRobots())
     {
         auto simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
-        auto firmware_robot = SimulatorRobotSingleton::createFirmwareRobot();
-        auto firmware_ball  = SimulatorBallSingleton::createFirmwareBall();
+        auto firmware_robot  = SimulatorRobotSingleton::createFirmwareRobot();
+        auto firmware_ball   = SimulatorBallSingleton::createFirmwareBall();
         // Release ownership of the pointers so the firmware_world can take ownership
         FirmwareWorld_t* firmware_world_raw =
             app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
@@ -40,18 +43,19 @@ void Simulator::addYellowRobots(const std::vector<RobotStateWithId> &robots) {
     }
 }
 
-void Simulator::addBlueRobots(const std::vector<RobotStateWithId> &robots) {
+void Simulator::addBlueRobots(const std::vector<RobotStateWithId>& robots)
+{
     physics_world.addBlueRobots(robots);
     for (auto physics_robot : physics_world.getBluePhysicsRobots())
     {
         auto simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
-        auto firmware_robot = SimulatorRobotSingleton::createFirmwareRobot();
-        auto firmware_ball  = SimulatorBallSingleton::createFirmwareBall();
+        auto firmware_robot  = SimulatorRobotSingleton::createFirmwareRobot();
+        auto firmware_ball   = SimulatorBallSingleton::createFirmwareBall();
         // Release ownership of the pointers so the firmware_world can take ownership
         FirmwareWorld_t* firmware_world_raw =
-                app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
+            app_firmware_world_create(firmware_robot.release(), firmware_ball.release());
         auto firmware_world =
-                std::shared_ptr<FirmwareWorld_t>(firmware_world_raw, FirmwareWorldDeleter());
+            std::shared_ptr<FirmwareWorld_t>(firmware_world_raw, FirmwareWorldDeleter());
 
         blue_simulator_robots.insert(std::make_pair(simulator_robot, firmware_world));
     }
@@ -102,11 +106,11 @@ void Simulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives)
         unsigned int primitive_index        = getPrimitiveIndex(primitive_ptr);
 
         auto simulator_robots_iter =
-                std::find_if(blue_simulator_robots.begin(), blue_simulator_robots.end(),
-                             [&primitive_ptr](const auto& robot_world_pair) {
-                                 return robot_world_pair.first->getRobotId() ==
-                                        primitive_ptr->getRobotId();
-                             });
+            std::find_if(blue_simulator_robots.begin(), blue_simulator_robots.end(),
+                         [&primitive_ptr](const auto& robot_world_pair) {
+                             return robot_world_pair.first->getRobotId() ==
+                                    primitive_ptr->getRobotId();
+                         });
 
         if (simulator_robots_iter != blue_simulator_robots.end())
         {
@@ -114,7 +118,7 @@ void Simulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives)
             auto firmware_world  = (*simulator_robots_iter).second;
             SimulatorRobotSingleton::setSimulatorRobot(simulator_robot);
             SimulatorRobotSingleton::startNewPrimitiveOnCurrentSimulatorRobot(
-                    firmware_world, primitive_index, primitive_params);
+                firmware_world, primitive_index, primitive_params);
         }
     }
 }
@@ -180,11 +184,11 @@ World Simulator::getWorld() const
     // TODO: This is a hack to persist goalie ID from the initial test setup
     // It will be removed as part of
     // https://github.com/UBC-Thunderbots/Software/issues/1325
-//    auto id = friendly_goalie_id;
-//    if (id)
-//    {
-//        world.mutableFriendlyTeam().assignGoalie(*id);
-//    }
+    //    auto id = friendly_goalie_id;
+    //    if (id)
+    //    {
+    //        world.mutableFriendlyTeam().assignGoalie(*id);
+    //    }
     return world;
 }
 

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -128,7 +128,10 @@ class Simulator
      * @param physics_robots The physics robots to add to the simulator robots
      * @param simulator_robots The simulator robots to add the physics robots to
      */
-    static void updateSimulatorRobots(const std::vector<std::weak_ptr<PhysicsRobot>>& physics_robots, std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>& simulator_robots);
+    static void updateSimulatorRobots(
+        const std::vector<std::weak_ptr<PhysicsRobot>>& physics_robots,
+        std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
+            simulator_robots);
 
     /**
      * Sets the given primitives on the given simulator robots
@@ -137,7 +140,11 @@ class Simulator
      * @param simulator_robots The robots to set the primitives on
      * @param simulator_ball The simulator ball to use in the primitives
      */
-    static void setRobotPrimitives(ConstPrimitiveVectorPtr primitives, std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>& simulator_robots, const std::shared_ptr<SimulatorBall>& simulator_ball);
+    static void setRobotPrimitives(
+        ConstPrimitiveVectorPtr primitives,
+        std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
+            simulator_robots,
+        const std::shared_ptr<SimulatorBall>& simulator_ball);
 
     /**
      * Returns the encoded primitive parameters for the given Primitive
@@ -146,7 +153,8 @@ class Simulator
      *
      * @return The encoded primitive parameters for the given Primitive
      */
-    static primitive_params_t getPrimitiveParams(const std::unique_ptr<Primitive>& primitive);
+    static primitive_params_t getPrimitiveParams(
+        const std::unique_ptr<Primitive>& primitive);
 
     /**
      * Returns the primitive index for the given Primitive

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "software/primitive/primitive.h"
+#include "software/proto/messages_robocup_ssl_wrapper.pb.h"
 #include "software/simulation/physics/physics_world.h"
 #include "software/simulation/simulator_ball.h"
 #include "software/simulation/simulator_robot.h"
 #include "software/world/world.h"
-#include "software/proto/messages_robocup_ssl_wrapper.pb.h"
 
 /**
  * Because the FirmwareWorld_t struct is defined in the .c file (rather than the .h file),
@@ -152,11 +152,11 @@ class Simulator
      */
     unsigned int getPrimitiveIndex(const std::unique_ptr<Primitive>& primitive);
 
-//    std::optional<unsigned int> friendly_goalie_id;
+    //    std::optional<unsigned int> friendly_goalie_id;
     PhysicsWorld physics_world;
     std::shared_ptr<SimulatorBall> simulator_ball;
     std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>
         yellow_simulator_robots;
     std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>
-            blue_simulator_robots;
+        blue_simulator_robots;
 };

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -5,6 +5,7 @@
 #include "software/simulation/simulator_ball.h"
 #include "software/simulation/simulator_robot.h"
 #include "software/world/world.h"
+#include "software/proto/messages_robocup_ssl_wrapper.pb.h"
 
 /**
  * Because the FirmwareWorld_t struct is defined in the .c file (rather than the .h file),
@@ -64,8 +65,58 @@ class Simulator
      *
      * @param world The world to initialize the simulation with
      */
-    explicit Simulator(const World& world);
+    explicit Simulator(const Field& field);
     Simulator() = delete;
+
+    /**
+     * Sets the state of the ball in the simulation. No more than 1 ball may exist
+     * in the simulation at a time. If a ball does not already exist, a ball
+     * is added with the given state. If a ball already exists, it's state is set to the
+     * given state.
+     *
+     * @param ball_state The new ball state
+     */
+    void setBallState(const BallState& ball_state);
+
+    /**
+     * Removes the ball from the physics world
+     */
+    void removeBall();
+
+    /**
+     * Adds robots to the yellow team with the given initial states.
+     *
+     * @pre The robot IDs must not be duplicated and must not match the ID
+     * of any robot already on the yellow team.
+     *
+     * @throws runtime_error if any of the given robot ids are duplicated, or a
+     * yellow robot already exists with the ID
+     *
+     * @param robots the robots to add
+     */
+    void addYellowRobots(const std::vector<RobotStateWithId>& robots);
+
+    /**
+     * Adds robots to the yellow team with the given initial states.
+     *
+     * @pre The robot IDs must not be duplicated and must not match the ID
+     * of any robot already on the blue team.
+     *
+     * @throws runtime_error if any of the given robot ids are duplicated, or a
+     * yellow robot already exists with the ID
+     *
+     * @param robots the robots to add
+     */
+    void addBlueRobots(const std::vector<RobotStateWithId>& robots);
+
+    /**
+     * Sets the primitives being simulated by the robots in simulation
+     *
+     * @param primitives The primitives to simulate
+     */
+    void setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives);
+
+    void setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives);
 
     /**
      * Advances the simulation by the given time step. This will simulate
@@ -76,18 +127,11 @@ class Simulator
     void stepSimulation(const Duration& time_step);
 
     /**
-     * Sets the primitives being simulated by the robots in simulation
-     *
-     * @param primitives The primitives to simulate
-     */
-    void setPrimitives(ConstPrimitiveVectorPtr primitives);
-
-    /**
      * Returns the current state of the world in the simulation
      *
      * @return the current state of the world in the simulation
      */
-    World getWorld();
+    World getWorld() const;
 
    private:
     /**
@@ -108,9 +152,11 @@ class Simulator
      */
     unsigned int getPrimitiveIndex(const std::unique_ptr<Primitive>& primitive);
 
-    std::optional<unsigned int> friendly_goalie_id;
+//    std::optional<unsigned int> friendly_goalie_id;
     PhysicsWorld physics_world;
     std::shared_ptr<SimulatorBall> simulator_ball;
     std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>
-        simulator_robots;
+        yellow_simulator_robots;
+    std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>
+            blue_simulator_robots;
 };

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -60,10 +60,10 @@ class Simulator
 {
    public:
     /**
-     * Creates a new Simulator with the given world. The starting state of the simulation
-     * will match the state of the given world
+     * Creates a new Simulator. The starting state of the simulation
+     * will have the given field, with no robots or ball.
      *
-     * @param world The world to initialize the simulation with
+     * @param field The field to initialize the simulation with
      */
     explicit Simulator(const Field& field);
     Simulator() = delete;
@@ -79,34 +79,23 @@ class Simulator
     void setBallState(const BallState& ball_state);
 
     /**
-     * Removes the ball from the physics world
+     * Removes the ball from the physics world. If a ball does not already exist,
+     * this has no effect.
      */
     void removeBall();
 
     /**
-     * Adds robots to the yellow team with the given initial states.
+     * Adds robots to the specified team with the given initial states.
      *
      * @pre The robot IDs must not be duplicated and must not match the ID
-     * of any robot already on the yellow team.
+     * of any robot already on the specified team.
      *
      * @throws runtime_error if any of the given robot ids are duplicated, or a
-     * yellow robot already exists with the ID
+     * robot already exists on the specified team with one of the new IDs
      *
      * @param robots the robots to add
      */
     void addYellowRobots(const std::vector<RobotStateWithId>& robots);
-
-    /**
-     * Adds robots to the yellow team with the given initial states.
-     *
-     * @pre The robot IDs must not be duplicated and must not match the ID
-     * of any robot already on the blue team.
-     *
-     * @throws runtime_error if any of the given robot ids are duplicated, or a
-     * yellow robot already exists with the ID
-     *
-     * @param robots the robots to add
-     */
     void addBlueRobots(const std::vector<RobotStateWithId>& robots);
 
     /**
@@ -115,7 +104,6 @@ class Simulator
      * @param primitives The primitives to simulate
      */
     void setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives);
-
     void setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives);
 
     /**

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -152,7 +152,6 @@ class Simulator
      */
     unsigned int getPrimitiveIndex(const std::unique_ptr<Primitive>& primitive);
 
-    //    std::optional<unsigned int> friendly_goalie_id;
     PhysicsWorld physics_world;
     std::shared_ptr<SimulatorBall> simulator_ball;
     std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -123,13 +123,30 @@ class Simulator
 
    private:
     /**
+     * Updates the given simulator_robots to contain and control the given physics_robots
+     *
+     * @param physics_robots The physics robots to add to the simulator robots
+     * @param simulator_robots The simulator robots to add the physics robots to
+     */
+    static void updateSimulatorRobots(const std::vector<std::weak_ptr<PhysicsRobot>>& physics_robots, std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>& simulator_robots);
+
+    /**
+     * Sets the given primitives on the given simulator robots
+     *
+     * @param primitives The primitives to set
+     * @param simulator_robots The robots to set the primitives on
+     * @param simulator_ball The simulator ball to use in the primitives
+     */
+    static void setRobotPrimitives(ConstPrimitiveVectorPtr primitives, std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>& simulator_robots, const std::shared_ptr<SimulatorBall>& simulator_ball);
+
+    /**
      * Returns the encoded primitive parameters for the given Primitive
      *
      * @param primitive The Primitive to get the parameters for
      *
      * @return The encoded primitive parameters for the given Primitive
      */
-    primitive_params_t getPrimitiveParams(const std::unique_ptr<Primitive>& primitive);
+    static primitive_params_t getPrimitiveParams(const std::unique_ptr<Primitive>& primitive);
 
     /**
      * Returns the primitive index for the given Primitive
@@ -138,7 +155,7 @@ class Simulator
      *
      * @return The index for the given Primitive
      */
-    unsigned int getPrimitiveIndex(const std::unique_ptr<Primitive>& primitive);
+    static unsigned int getPrimitiveIndex(const std::unique_ptr<Primitive>& primitive);
 
     PhysicsWorld physics_world;
     std::shared_ptr<SimulatorBall> simulator_ball;

--- a/src/software/simulation/simulator_robot_singleton_test.cpp
+++ b/src/software/simulation/simulator_robot_singleton_test.cpp
@@ -44,7 +44,7 @@ class SimulatorRobotSingletonTest : public testing::Test
         }
 
         std::shared_ptr<SimulatorRobot> simulator_robot;
-        auto physics_robot = physics_world->getFriendlyPhysicsRobots().at(0);
+        auto physics_robot = physics_world->getYellowPhysicsRobots().at(0);
         if (physics_robot.lock())
         {
             simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
@@ -1050,7 +1050,7 @@ TEST_F(SimulatorRobotSingletonTest, test_change_simulator_robot)
                                       Angle::fromRadians(0.3), AngularVelocity::half())}};
     physics_world->addYellowRobots(robot_states);
 
-    auto friendly_physics_robots = physics_world->getFriendlyPhysicsRobots();
+    auto friendly_physics_robots = physics_world->getYellowPhysicsRobots();
     ASSERT_EQ(2, friendly_physics_robots.size());
     auto simulator_robot_7 =
         std::make_shared<SimulatorRobot>(friendly_physics_robots.at(0));

--- a/src/software/simulation/simulator_robot_test.cpp
+++ b/src/software/simulation/simulator_robot_test.cpp
@@ -24,7 +24,7 @@ class SimulatorRobotTest : public testing::Test
             .id = robot.id(), .robot_state = robot.currentState().robotState()}});
 
         std::shared_ptr<SimulatorRobot> simulator_robot;
-        auto physics_robot = physics_world->getFriendlyPhysicsRobots().at(0);
+        auto physics_robot = physics_world->getYellowPhysicsRobots().at(0);
         if (physics_robot.lock())
         {
             simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);

--- a/src/software/simulation/simulator_test.cpp
+++ b/src/software/simulation/simulator_test.cpp
@@ -7,132 +7,389 @@
 #include "software/test_util/test_util.h"
 #include "software/world/world.h"
 
-TEST(SimulatorTest, test_simulation_step_updates_the_ball)
-{
-    // A sanity test to make sure stepping the simulation actually updates\
-    // the state of the world
+// TODO: Add more specific tests for adding a ball when there is / isn't
+// already a ball. Need to wait until the world output is replaced with
+// proto in https://github.com/UBC-Thunderbots/Software/issues/1244
 
-    World world = ::Test::TestUtil::createBlankTestingWorld();
-    world.mutableBall() =
-        Ball(Point(0.4, 0), Vector(-1.3, 2.01), Timestamp::fromSeconds(0));
+TEST(SimulatorTest, test_set_ball_state) {
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
-    Simulator simulator(world);
-    simulator.stepSimulation(Duration::fromSeconds(0.1));
-    std::optional<World> new_world = simulator.getWorld();
-    EXPECT_TRUE(new_world);
-    Point p = new_world->ball().position();
-    EXPECT_NE(Point(0.4, 0), p);
+    BallState ball_state(Point(1, 2), Vector(0, -3));
+    simulator.setBallState(ball_state);
+
+    World world = simulator.getWorld();
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(ball_state, world.ball().currentState().ballState(), 1e-6));
 }
 
-TEST(SimulatorTest, test_simulate_robots_with_no_primitives)
-{
-    World world = ::Test::TestUtil::createBlankTestingWorld();
-    Robot robot(0, Point(0, 0), Vector(0, 0), Angle::zero(), AngularVelocity::zero(),
-                Timestamp::fromSeconds(0));
-    world.mutableFriendlyTeam().updateRobots({robot});
+TEST(SimulatorTest, test_remove_ball) {
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
-    Simulator simulator(world);
+    BallState ball_state(Point(1, 2), Vector(0, -3));
+    simulator.setBallState(ball_state);
+
+    World world = simulator.getWorld();
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(ball_state, world.ball().currentState().ballState(), 1e-6));
+
+    simulator.removeBall();
+    world = simulator.getWorld();
+
+    // TODO: Check the ball is actually removed once we have proto output
+    // https://github.com/UBC-Thunderbots/Software/issues/1244
+    // The World can't represent "no ball"
+    BallState expected_ball_state(Point(0, 0), Vector(0, 0));
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(expected_ball_state, world.ball().currentState().ballState(), 1e-6));
+}
+
+TEST(SimualtorTest, add_zero_yellow_robots) {
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    simulator.addYellowRobots({});
+
+    World world = simulator.getWorld();
+    EXPECT_EQ(0, world.friendlyTeam().numRobots());
+}
+
+TEST(SimulatorTest, add_multiple_yellow_robots_with_valid_ids) {
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
+                            AngularVelocity::half());
+    RobotState robot_state2(Point(0, 0), Vector(3, 0), Angle::half(),
+                            AngularVelocity::quarter());
+    RobotState robot_state3(Point(-2, -2), Vector(0, 4), Angle::zero(),
+                            AngularVelocity::zero());
+    std::vector<RobotStateWithId> states = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+            RobotStateWithId{.id = 2, .robot_state = robot_state2},
+            RobotStateWithId{.id = 3, .robot_state = robot_state3},
+    };
+    simulator.addYellowRobots(states);
+
+    World world = simulator.getWorld();
+    EXPECT_EQ(3, world.friendlyTeam().numRobots());
+}
+
+TEST(SimulatorTest, add_yellow_robots_with_duplicate_ids) {
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
+                            AngularVelocity::half());
+    RobotState robot_state2(Point(0, 0), Vector(3, 0), Angle::half(),
+                            AngularVelocity::quarter());
+    std::vector<RobotStateWithId> states = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+            RobotStateWithId{.id = 1, .robot_state = robot_state2},
+    };
+
+    EXPECT_THROW(simulator.addYellowRobots(states), std::runtime_error);
+}
+
+TEST(SimulatorTest, add_yellow_robots_with_ids_that_already_exist_in_the_simulation) {
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
+                            AngularVelocity::half());
+    std::vector<RobotStateWithId> states1 = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+
+    EXPECT_NO_THROW(simulator.addYellowRobots(states1));
+
+    RobotState robot_state2(Point(0, 0), Vector(3, 0), Angle::half(),
+                            AngularVelocity::quarter());
+    std::vector<RobotStateWithId> states2 = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+
+    EXPECT_THROW(simulator.addYellowRobots(states2), std::runtime_error);
+}
+
+TEST(SimualtorTest, add_zero_blue_robots) {
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    simulator.addBlueRobots({});
+
+    World world = simulator.getWorld();
+    EXPECT_EQ(0, world.enemyTeam().numRobots());
+}
+
+TEST(SimulatorTest, add_multiple_blue_robots_with_valid_ids) {
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
+                            AngularVelocity::half());
+    RobotState robot_state2(Point(0, 0), Vector(3, 0), Angle::half(),
+                            AngularVelocity::quarter());
+    RobotState robot_state3(Point(-2, -2), Vector(0, 4), Angle::zero(),
+                            AngularVelocity::zero());
+    std::vector<RobotStateWithId> states = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+            RobotStateWithId{.id = 2, .robot_state = robot_state2},
+            RobotStateWithId{.id = 3, .robot_state = robot_state3},
+    };
+    simulator.addBlueRobots(states);
+
+    World world = simulator.getWorld();
+    EXPECT_EQ(3, world.enemyTeam().numRobots());
+}
+
+TEST(SimulatorTest, add_blue_robots_with_duplicate_ids) {
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
+                            AngularVelocity::half());
+    RobotState robot_state2(Point(0, 0), Vector(3, 0), Angle::half(),
+                            AngularVelocity::quarter());
+    std::vector<RobotStateWithId> states = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+            RobotStateWithId{.id = 1, .robot_state = robot_state2},
+    };
+
+    EXPECT_THROW(simulator.addBlueRobots(states), std::runtime_error);
+}
+
+TEST(SimulatorTest, add_blue_robots_with_ids_that_already_exist_in_the_simulation) {
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
+                            AngularVelocity::half());
+    std::vector<RobotStateWithId> states1 = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+
+    EXPECT_NO_THROW(simulator.addBlueRobots(states1));
+
+    RobotState robot_state2(Point(0, 0), Vector(3, 0), Angle::half(),
+                            AngularVelocity::quarter());
+    std::vector<RobotStateWithId> states2 = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+
+    EXPECT_THROW(simulator.addBlueRobots(states2), std::runtime_error);
+}
+
+TEST(SimulatorTest, test_simulation_step_updates_the_ball)
+{
+    // A sanity test to make sure stepping the simulation actually updates
+    // the state of the world
+
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+    simulator.setBallState(BallState(Point(0.4, 0), Vector(-1.3, 2.01)));
+
+    simulator.stepSimulation(Duration::fromSeconds(0.1));
+    World world = simulator.getWorld();
+
+    Point ball_position = world.ball().position();
+    EXPECT_NE(Point(0.4, 0), ball_position);
+    Vector ball_velocity = world.ball().velocity();
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(Vector(-1.3, 2.01), ball_velocity, 1e-4));
+}
+
+TEST(SimulatorTest, test_simulate_yellow_robots_with_no_primitives)
+{
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    RobotState robot_state1(Point(0, 0), Vector(0, 0), Angle::zero(),
+                            AngularVelocity::zero());
+    std::vector<RobotStateWithId> states = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+    simulator.addYellowRobots(states);
+
     for (unsigned int i = 0; i < 60; i++)
     {
         simulator.stepSimulation(Duration::fromSeconds(1.0 / 60.0));
     }
 
     // Robots have not been assigned primitives and so should not move
-    std::optional<World> new_world = simulator.getWorld();
-    EXPECT_TRUE(new_world);
-    std::optional<Robot> new_robot = new_world->friendlyTeam().getRobotById(0);
-    ASSERT_TRUE(new_robot);
-    EXPECT_LT((new_robot->position() - Point(0, 0)).length(), 0.01);
+    World world = simulator.getWorld();
+    std::optional<Robot> robot = world.friendlyTeam().getRobotById(1);
+    ASSERT_TRUE(robot);
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(robot->position(), Point(0, 0), 0.01));
 }
 
-TEST(SimulatorTest, test_simulate_single_robot_with_primitive)
+TEST(SimulatorTest, test_simulate_single_yellow_robot_with_primitive)
 {
     // Simulate a robot with a primitive to sanity check that everything is connected
     // properly and we can properly simulate robot firmware. We use the MovePrimitve
     // because it is very commonly used and so unlikely to be significantly changed
     // or removed, and its behaviour is easy to validate
 
-    World world = ::Test::TestUtil::createBlankTestingWorld();
-    // Move the ball away from (0, 0) so it doesn't interfere with the robot
-    world.mutableBall() = Ball(Point(6, 0), Vector(0, 0), Timestamp::fromSeconds(0));
-    Robot robot(0, Point(0, 0), Vector(0, 0), Angle::zero(), AngularVelocity::zero(),
-                Timestamp::fromSeconds(0));
-    world.mutableFriendlyTeam().updateRobots({robot});
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    RobotState robot_state1(Point(0, 0), Vector(0, 0), Angle::zero(),
+                            AngularVelocity::zero());
+    std::vector<RobotStateWithId> states = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+    simulator.addYellowRobots(states);
 
     std::unique_ptr<Primitive> move_primitive = std::make_unique<MovePrimitive>(
-        0, Point(1, 0), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+        1, Point(1, 0), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
         AutokickType::NONE);
     std::vector<std::unique_ptr<Primitive>> primitives;
     primitives.emplace_back(std::move(move_primitive));
     auto primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
         std::move(primitives));
-
-    Simulator simulator(world);
-    simulator.setPrimitives(primitives_ptr);
+    simulator.setYellowRobotPrimitives(primitives_ptr);
 
     for (unsigned int i = 0; i < 120; i++)
     {
         simulator.stepSimulation(Duration::fromSeconds(1.0 / 60.0));
     }
 
-    std::optional<World> new_world = simulator.getWorld();
-    EXPECT_TRUE(new_world);
-    std::optional<Robot> new_robot = new_world->friendlyTeam().getRobotById(0);
-    ASSERT_TRUE(new_robot);
-    EXPECT_LT((new_robot->position() - Point(1, 0)).length(), 0.2);
+    World world = simulator.getWorld();
+    std::optional<Robot> robot = world.friendlyTeam().getRobotById(1);
+    ASSERT_TRUE(robot);
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(robot->position(), Point(1, 0), 0.2));
 }
 
-TEST(SimulatorTest, test_simulate_multiple_robots_with_primitives)
+TEST(SimulatorTest, test_simulate_blue_robots_with_no_primitives)
+{
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    RobotState robot_state1(Point(0, 0), Vector(0, 0), Angle::zero(),
+                            AngularVelocity::zero());
+    std::vector<RobotStateWithId> states = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+    simulator.addBlueRobots(states);
+
+    for (unsigned int i = 0; i < 60; i++)
+    {
+        simulator.stepSimulation(Duration::fromSeconds(1.0 / 60.0));
+    }
+
+    // Robots have not been assigned primitives and so should not move
+    World world = simulator.getWorld();
+    std::optional<Robot> robot = world.enemyTeam().getRobotById(1);
+    ASSERT_TRUE(robot);
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(robot->position(), Point(0, 0), 0.01));
+}
+
+TEST(SimulatorTest, test_simulate_single_blue_robot_with_primitive)
 {
     // Simulate a robot with a primitive to sanity check that everything is connected
     // properly and we can properly simulate robot firmware. We use the MovePrimitve
     // because it is very commonly used and so unlikely to be significantly changed
     // or removed, and its behaviour is easy to validate
 
-    World world = ::Test::TestUtil::createBlankTestingWorld();
-    // Move the ball away from (0, 0) so it doesn't interfere with the robots
-    world.mutableBall() = Ball(Point(6, 0), Vector(0, 0), Timestamp::fromSeconds(0));
-    Robot robot_0(0, Point(0, 0), Vector(0, 0), Angle::zero(), AngularVelocity::zero(),
-                  Timestamp::fromSeconds(0));
-    Robot robot_1(1, Point(-1, -1), Vector(0, 0), Angle::quarter(),
-                  AngularVelocity::zero(), Timestamp::fromSeconds(0));
-    world.mutableFriendlyTeam().updateRobots({robot_0, robot_1});
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
-    std::unique_ptr<Primitive> move_primitive_0 = std::make_unique<MovePrimitive>(
-        0, Point(1, 0), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
-        AutokickType::NONE);
-    std::unique_ptr<Primitive> move_primitive_1 = std::make_unique<MovePrimitive>(
-        1, Point(0, -2), Angle::half(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
-        AutokickType::NONE);
+    RobotState robot_state1(Point(0, 0), Vector(0, 0), Angle::zero(),
+                            AngularVelocity::zero());
+    std::vector<RobotStateWithId> states = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+    simulator.addBlueRobots(states);
+
+    std::unique_ptr<Primitive> move_primitive = std::make_unique<MovePrimitive>(
+            1, Point(1, 0), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+            AutokickType::NONE);
     std::vector<std::unique_ptr<Primitive>> primitives;
-    primitives.emplace_back(std::move(move_primitive_0));
-    primitives.emplace_back(std::move(move_primitive_1));
+    primitives.emplace_back(std::move(move_primitive));
     auto primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
-        std::move(primitives));
+            std::move(primitives));
+    simulator.setBlueRobotPrimitives(primitives_ptr);
 
-    Simulator simulator(world);
-    simulator.setPrimitives(primitives_ptr);
-
-    // Because simulation is very fast, and we don't want these tests to be fragile and
-    // break due to subtle issues with control or firmware, we let this simulation run for
-    // a long time to robots should settle at their final destinations before we perform
-    // our assertions. All we care about is that everything worked together to ultimately
-    // get them to their desired final states
-    for (unsigned int i = 0; i < 600; i++)
+    for (unsigned int i = 0; i < 120; i++)
     {
         simulator.stepSimulation(Duration::fromSeconds(1.0 / 60.0));
     }
 
-    std::optional<World> new_world = simulator.getWorld();
-    EXPECT_TRUE(new_world);
+    World world = simulator.getWorld();
+    std::optional<Robot> robot = world.enemyTeam().getRobotById(1);
+    ASSERT_TRUE(robot);
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(robot->position(), Point(1, 0), 0.2));
+}
 
-    std::optional<Robot> new_robot_0 = new_world->friendlyTeam().getRobotById(0);
-    ASSERT_TRUE(new_robot_0);
-    EXPECT_LT((new_robot_0->position() - Point(1, 0)).length(), 0.2);
-    EXPECT_LT((new_robot_0->orientation().minDiff(Angle::zero())), Angle::fromDegrees(2));
+TEST(SimulatorTest, test_simulate_multiple_blue_and_yellow_robots_with_primitives)
+{
+    // Simulate multiple robots with primitives to sanity check that everything is connected
+    // properly and we can properly simulate multiple instances of the robot firmware at once.
+    // We use the MovePrimitve because it is very commonly used and so unlikely to be
+    // significantly changed or removed, and its behaviour is easy to validate
 
-    std::optional<Robot> new_robot_1 = new_world->friendlyTeam().getRobotById(1);
-    ASSERT_TRUE(new_robot_1);
-    EXPECT_LT((new_robot_1->position() - Point(0, -2)).length(), 0.2);
-    EXPECT_LT((new_robot_1->orientation().minDiff(Angle::half())), Angle::fromDegrees(5));
+    Simulator simulator(::Test::TestUtil::createSSLDivBField());
+
+    RobotState blue_robot_state1(Point(-1, 0), Vector(0, 0), Angle::zero(),
+                            AngularVelocity::zero());
+    RobotState blue_robot_state2(Point(-2, 1), Vector(0, 0), Angle::quarter(),
+                                 AngularVelocity::zero());
+    std::vector<RobotStateWithId> blue_robot_states = {
+            RobotStateWithId{.id = 1, .robot_state = blue_robot_state1},
+            RobotStateWithId{.id = 2, .robot_state = blue_robot_state2},
+    };
+    simulator.addBlueRobots(blue_robot_states);
+
+    RobotState yellow_robot_state1(Point(1, 1.5), Vector(0, 0), Angle::half(),
+                                 AngularVelocity::zero());
+    RobotState yellow_robot_state2(Point(2.5, -1), Vector(0, 0), Angle::threeQuarter(),
+                                 AngularVelocity::zero());
+    std::vector<RobotStateWithId> yellow_robot_states = {
+            RobotStateWithId{.id = 1, .robot_state = yellow_robot_state1},
+            RobotStateWithId{.id = 2, .robot_state = yellow_robot_state2},
+    };
+    simulator.addYellowRobots(yellow_robot_states);
+
+    std::unique_ptr<Primitive> blue_move_primitive1 = std::make_unique<MovePrimitive>(
+            1, Point(-1, -1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+            AutokickType::NONE);
+    std::unique_ptr<Primitive> blue_move_primitive2 = std::make_unique<MovePrimitive>(
+            2, Point(-3, 0), Angle::half(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+            AutokickType::NONE);
+    std::vector<std::unique_ptr<Primitive>> blue_robot_primitives;
+    blue_robot_primitives.emplace_back(std::move(blue_move_primitive1));
+    blue_robot_primitives.emplace_back(std::move(blue_move_primitive2));
+    auto blue_primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
+            std::move(blue_robot_primitives));
+    simulator.setBlueRobotPrimitives(blue_primitives_ptr);
+
+    std::unique_ptr<Primitive> yellow_move_primitive1 = std::make_unique<MovePrimitive>(
+            1, Point(1, 1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+            AutokickType::NONE);
+    std::unique_ptr<Primitive> yellow_move_primitive2 = std::make_unique<MovePrimitive>(
+            2, Point(3, -2), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+            AutokickType::NONE);
+    std::vector<std::unique_ptr<Primitive>> yellow_robot_primitives;
+    yellow_robot_primitives.emplace_back(std::move(yellow_move_primitive1));
+    yellow_robot_primitives.emplace_back(std::move(yellow_move_primitive2));
+    auto yellow_primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
+            std::move(yellow_robot_primitives));
+    simulator.setYellowRobotPrimitives(yellow_primitives_ptr);
+
+    for (unsigned int i = 0; i < 120; i++)
+    {
+        simulator.stepSimulation(Duration::fromSeconds(1.0 / 60.0));
+    }
+
+    World world = simulator.getWorld();
+
+    // TODO: These tests are currently very lenient, and don't test final velocities.
+    //  This is because they currently rely on controller dynamics, and the existing
+    //  bang-bang controller tends to overshoot with the current physics damping constants.
+    //  In order to help decouple these tests from the controller / damping, the test
+    //  tolerances are larger for now. They should be tightened again when the new
+    //  controller is implemented.
+    //  https://github.com/UBC-Thunderbots/Software/issues/1187
+
+    std::optional<Robot> yellow_robot_1 = world.friendlyTeam().getRobotById(1);
+    ASSERT_TRUE(yellow_robot_1);
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Point(1, 1), yellow_robot_1->position(), 0.2)));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Angle::zero(), yellow_robot_1->orientation(), Angle::fromDegrees(10))));
+
+    std::optional<Robot> yellow_robot_2 = world.friendlyTeam().getRobotById(2);
+    ASSERT_TRUE(yellow_robot_2);
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Point(3, -2), yellow_robot_2->position(), 0.2)));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Angle::zero(), yellow_robot_2->orientation(), Angle::fromDegrees(10))));
+
+    std::optional<Robot> blue_robot_1 = world.enemyTeam().getRobotById(1);
+    ASSERT_TRUE(blue_robot_1);
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Point(-1, -1), blue_robot_1->position(), 0.3)));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Angle::zero(), blue_robot_1->orientation(), Angle::fromDegrees(10))));
+
+    std::optional<Robot> blue_robot_2 = world.enemyTeam().getRobotById(2);
+    ASSERT_TRUE(blue_robot_2);
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Point(-3, 0), blue_robot_2->position(), 0.3)));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Angle::half(), blue_robot_2->orientation(), Angle::fromDegrees(10))));
 }

--- a/src/software/simulation/simulator_test.cpp
+++ b/src/software/simulation/simulator_test.cpp
@@ -11,24 +11,28 @@
 // already a ball. Need to wait until the world output is replaced with
 // proto in https://github.com/UBC-Thunderbots/Software/issues/1244
 
-TEST(SimulatorTest, test_set_ball_state) {
+TEST(SimulatorTest, test_set_ball_state)
+{
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     BallState ball_state(Point(1, 2), Vector(0, -3));
     simulator.setBallState(ball_state);
 
     World world = simulator.getWorld();
-    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(ball_state, world.ball().currentState().ballState(), 1e-6));
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(
+        ball_state, world.ball().currentState().ballState(), 1e-6));
 }
 
-TEST(SimulatorTest, test_remove_ball) {
+TEST(SimulatorTest, test_remove_ball)
+{
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     BallState ball_state(Point(1, 2), Vector(0, -3));
     simulator.setBallState(ball_state);
 
     World world = simulator.getWorld();
-    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(ball_state, world.ball().currentState().ballState(), 1e-6));
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(
+        ball_state, world.ball().currentState().ballState(), 1e-6));
 
     simulator.removeBall();
     world = simulator.getWorld();
@@ -37,10 +41,12 @@ TEST(SimulatorTest, test_remove_ball) {
     // https://github.com/UBC-Thunderbots/Software/issues/1244
     // The World can't represent "no ball"
     BallState expected_ball_state(Point(0, 0), Vector(0, 0));
-    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(expected_ball_state, world.ball().currentState().ballState(), 1e-6));
+    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(
+        expected_ball_state, world.ball().currentState().ballState(), 1e-6));
 }
 
-TEST(SimualtorTest, add_zero_yellow_robots) {
+TEST(SimualtorTest, add_zero_yellow_robots)
+{
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     simulator.addYellowRobots({});
@@ -49,7 +55,8 @@ TEST(SimualtorTest, add_zero_yellow_robots) {
     EXPECT_EQ(0, world.friendlyTeam().numRobots());
 }
 
-TEST(SimulatorTest, add_multiple_yellow_robots_with_valid_ids) {
+TEST(SimulatorTest, add_multiple_yellow_robots_with_valid_ids)
+{
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
@@ -59,9 +66,9 @@ TEST(SimulatorTest, add_multiple_yellow_robots_with_valid_ids) {
     RobotState robot_state3(Point(-2, -2), Vector(0, 4), Angle::zero(),
                             AngularVelocity::zero());
     std::vector<RobotStateWithId> states = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
-            RobotStateWithId{.id = 2, .robot_state = robot_state2},
-            RobotStateWithId{.id = 3, .robot_state = robot_state3},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 2, .robot_state = robot_state2},
+        RobotStateWithId{.id = 3, .robot_state = robot_state3},
     };
     simulator.addYellowRobots(states);
 
@@ -69,7 +76,8 @@ TEST(SimulatorTest, add_multiple_yellow_robots_with_valid_ids) {
     EXPECT_EQ(3, world.friendlyTeam().numRobots());
 }
 
-TEST(SimulatorTest, add_yellow_robots_with_duplicate_ids) {
+TEST(SimulatorTest, add_yellow_robots_with_duplicate_ids)
+{
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
@@ -77,20 +85,21 @@ TEST(SimulatorTest, add_yellow_robots_with_duplicate_ids) {
     RobotState robot_state2(Point(0, 0), Vector(3, 0), Angle::half(),
                             AngularVelocity::quarter());
     std::vector<RobotStateWithId> states = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
-            RobotStateWithId{.id = 1, .robot_state = robot_state2},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state2},
     };
 
     EXPECT_THROW(simulator.addYellowRobots(states), std::runtime_error);
 }
 
-TEST(SimulatorTest, add_yellow_robots_with_ids_that_already_exist_in_the_simulation) {
+TEST(SimulatorTest, add_yellow_robots_with_ids_that_already_exist_in_the_simulation)
+{
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
                             AngularVelocity::half());
     std::vector<RobotStateWithId> states1 = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
 
     EXPECT_NO_THROW(simulator.addYellowRobots(states1));
@@ -98,13 +107,14 @@ TEST(SimulatorTest, add_yellow_robots_with_ids_that_already_exist_in_the_simulat
     RobotState robot_state2(Point(0, 0), Vector(3, 0), Angle::half(),
                             AngularVelocity::quarter());
     std::vector<RobotStateWithId> states2 = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
 
     EXPECT_THROW(simulator.addYellowRobots(states2), std::runtime_error);
 }
 
-TEST(SimualtorTest, add_zero_blue_robots) {
+TEST(SimualtorTest, add_zero_blue_robots)
+{
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     simulator.addBlueRobots({});
@@ -113,7 +123,8 @@ TEST(SimualtorTest, add_zero_blue_robots) {
     EXPECT_EQ(0, world.enemyTeam().numRobots());
 }
 
-TEST(SimulatorTest, add_multiple_blue_robots_with_valid_ids) {
+TEST(SimulatorTest, add_multiple_blue_robots_with_valid_ids)
+{
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
@@ -123,9 +134,9 @@ TEST(SimulatorTest, add_multiple_blue_robots_with_valid_ids) {
     RobotState robot_state3(Point(-2, -2), Vector(0, 4), Angle::zero(),
                             AngularVelocity::zero());
     std::vector<RobotStateWithId> states = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
-            RobotStateWithId{.id = 2, .robot_state = robot_state2},
-            RobotStateWithId{.id = 3, .robot_state = robot_state3},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 2, .robot_state = robot_state2},
+        RobotStateWithId{.id = 3, .robot_state = robot_state3},
     };
     simulator.addBlueRobots(states);
 
@@ -133,7 +144,8 @@ TEST(SimulatorTest, add_multiple_blue_robots_with_valid_ids) {
     EXPECT_EQ(3, world.enemyTeam().numRobots());
 }
 
-TEST(SimulatorTest, add_blue_robots_with_duplicate_ids) {
+TEST(SimulatorTest, add_blue_robots_with_duplicate_ids)
+{
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
@@ -141,20 +153,21 @@ TEST(SimulatorTest, add_blue_robots_with_duplicate_ids) {
     RobotState robot_state2(Point(0, 0), Vector(3, 0), Angle::half(),
                             AngularVelocity::quarter());
     std::vector<RobotStateWithId> states = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
-            RobotStateWithId{.id = 1, .robot_state = robot_state2},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state2},
     };
 
     EXPECT_THROW(simulator.addBlueRobots(states), std::runtime_error);
 }
 
-TEST(SimulatorTest, add_blue_robots_with_ids_that_already_exist_in_the_simulation) {
+TEST(SimulatorTest, add_blue_robots_with_ids_that_already_exist_in_the_simulation)
+{
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
                             AngularVelocity::half());
     std::vector<RobotStateWithId> states1 = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
 
     EXPECT_NO_THROW(simulator.addBlueRobots(states1));
@@ -162,7 +175,7 @@ TEST(SimulatorTest, add_blue_robots_with_ids_that_already_exist_in_the_simulatio
     RobotState robot_state2(Point(0, 0), Vector(3, 0), Angle::half(),
                             AngularVelocity::quarter());
     std::vector<RobotStateWithId> states2 = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
 
     EXPECT_THROW(simulator.addBlueRobots(states2), std::runtime_error);
@@ -182,7 +195,8 @@ TEST(SimulatorTest, test_simulation_step_updates_the_ball)
     Point ball_position = world.ball().position();
     EXPECT_NE(Point(0.4, 0), ball_position);
     Vector ball_velocity = world.ball().velocity();
-    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(Vector(-1.3, 2.01), ball_velocity, 1e-4));
+    EXPECT_TRUE(
+        ::Test::TestUtil::equalWithinTolerance(Vector(-1.3, 2.01), ball_velocity, 1e-4));
 }
 
 TEST(SimulatorTest, test_simulate_yellow_robots_with_no_primitives)
@@ -192,7 +206,7 @@ TEST(SimulatorTest, test_simulate_yellow_robots_with_no_primitives)
     RobotState robot_state1(Point(0, 0), Vector(0, 0), Angle::zero(),
                             AngularVelocity::zero());
     std::vector<RobotStateWithId> states = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
     simulator.addYellowRobots(states);
 
@@ -202,10 +216,11 @@ TEST(SimulatorTest, test_simulate_yellow_robots_with_no_primitives)
     }
 
     // Robots have not been assigned primitives and so should not move
-    World world = simulator.getWorld();
+    World world                = simulator.getWorld();
     std::optional<Robot> robot = world.friendlyTeam().getRobotById(1);
     ASSERT_TRUE(robot);
-    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(robot->position(), Point(0, 0), 0.01));
+    EXPECT_TRUE(
+        ::Test::TestUtil::equalWithinTolerance(robot->position(), Point(0, 0), 0.01));
 }
 
 TEST(SimulatorTest, test_simulate_single_yellow_robot_with_primitive)
@@ -220,7 +235,7 @@ TEST(SimulatorTest, test_simulate_single_yellow_robot_with_primitive)
     RobotState robot_state1(Point(0, 0), Vector(0, 0), Angle::zero(),
                             AngularVelocity::zero());
     std::vector<RobotStateWithId> states = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
     simulator.addYellowRobots(states);
 
@@ -238,10 +253,11 @@ TEST(SimulatorTest, test_simulate_single_yellow_robot_with_primitive)
         simulator.stepSimulation(Duration::fromSeconds(1.0 / 60.0));
     }
 
-    World world = simulator.getWorld();
+    World world                = simulator.getWorld();
     std::optional<Robot> robot = world.friendlyTeam().getRobotById(1);
     ASSERT_TRUE(robot);
-    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(robot->position(), Point(1, 0), 0.2));
+    EXPECT_TRUE(
+        ::Test::TestUtil::equalWithinTolerance(robot->position(), Point(1, 0), 0.2));
 }
 
 TEST(SimulatorTest, test_simulate_blue_robots_with_no_primitives)
@@ -251,7 +267,7 @@ TEST(SimulatorTest, test_simulate_blue_robots_with_no_primitives)
     RobotState robot_state1(Point(0, 0), Vector(0, 0), Angle::zero(),
                             AngularVelocity::zero());
     std::vector<RobotStateWithId> states = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
     simulator.addBlueRobots(states);
 
@@ -261,10 +277,11 @@ TEST(SimulatorTest, test_simulate_blue_robots_with_no_primitives)
     }
 
     // Robots have not been assigned primitives and so should not move
-    World world = simulator.getWorld();
+    World world                = simulator.getWorld();
     std::optional<Robot> robot = world.enemyTeam().getRobotById(1);
     ASSERT_TRUE(robot);
-    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(robot->position(), Point(0, 0), 0.01));
+    EXPECT_TRUE(
+        ::Test::TestUtil::equalWithinTolerance(robot->position(), Point(0, 0), 0.01));
 }
 
 TEST(SimulatorTest, test_simulate_single_blue_robot_with_primitive)
@@ -279,17 +296,17 @@ TEST(SimulatorTest, test_simulate_single_blue_robot_with_primitive)
     RobotState robot_state1(Point(0, 0), Vector(0, 0), Angle::zero(),
                             AngularVelocity::zero());
     std::vector<RobotStateWithId> states = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
     simulator.addBlueRobots(states);
 
     std::unique_ptr<Primitive> move_primitive = std::make_unique<MovePrimitive>(
-            1, Point(1, 0), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
-            AutokickType::NONE);
+        1, Point(1, 0), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+        AutokickType::NONE);
     std::vector<std::unique_ptr<Primitive>> primitives;
     primitives.emplace_back(std::move(move_primitive));
     auto primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
-            std::move(primitives));
+        std::move(primitives));
     simulator.setBlueRobotPrimitives(primitives_ptr);
 
     for (unsigned int i = 0; i < 120; i++)
@@ -297,64 +314,68 @@ TEST(SimulatorTest, test_simulate_single_blue_robot_with_primitive)
         simulator.stepSimulation(Duration::fromSeconds(1.0 / 60.0));
     }
 
-    World world = simulator.getWorld();
+    World world                = simulator.getWorld();
     std::optional<Robot> robot = world.enemyTeam().getRobotById(1);
     ASSERT_TRUE(robot);
-    EXPECT_TRUE(::Test::TestUtil::equalWithinTolerance(robot->position(), Point(1, 0), 0.2));
+    EXPECT_TRUE(
+        ::Test::TestUtil::equalWithinTolerance(robot->position(), Point(1, 0), 0.2));
 }
 
 TEST(SimulatorTest, test_simulate_multiple_blue_and_yellow_robots_with_primitives)
 {
-    // Simulate multiple robots with primitives to sanity check that everything is connected
-    // properly and we can properly simulate multiple instances of the robot firmware at once.
-    // We use the MovePrimitve because it is very commonly used and so unlikely to be
-    // significantly changed or removed, and its behaviour is easy to validate
+    // Simulate multiple robots with primitives to sanity check that everything is
+    // connected properly and we can properly simulate multiple instances of the robot
+    // firmware at once. We use the MovePrimitve because it is very commonly used and so
+    // unlikely to be significantly changed or removed, and its behaviour is easy to
+    // validate
 
     Simulator simulator(::Test::TestUtil::createSSLDivBField());
 
     RobotState blue_robot_state1(Point(-1, 0), Vector(0, 0), Angle::zero(),
-                            AngularVelocity::zero());
+                                 AngularVelocity::zero());
     RobotState blue_robot_state2(Point(-2, 1), Vector(0, 0), Angle::quarter(),
                                  AngularVelocity::zero());
     std::vector<RobotStateWithId> blue_robot_states = {
-            RobotStateWithId{.id = 1, .robot_state = blue_robot_state1},
-            RobotStateWithId{.id = 2, .robot_state = blue_robot_state2},
+        RobotStateWithId{.id = 1, .robot_state = blue_robot_state1},
+        RobotStateWithId{.id = 2, .robot_state = blue_robot_state2},
     };
     simulator.addBlueRobots(blue_robot_states);
 
     RobotState yellow_robot_state1(Point(1, 1.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
+                                   AngularVelocity::zero());
     RobotState yellow_robot_state2(Point(2.5, -1), Vector(0, 0), Angle::threeQuarter(),
-                                 AngularVelocity::zero());
+                                   AngularVelocity::zero());
     std::vector<RobotStateWithId> yellow_robot_states = {
-            RobotStateWithId{.id = 1, .robot_state = yellow_robot_state1},
-            RobotStateWithId{.id = 2, .robot_state = yellow_robot_state2},
+        RobotStateWithId{.id = 1, .robot_state = yellow_robot_state1},
+        RobotStateWithId{.id = 2, .robot_state = yellow_robot_state2},
     };
     simulator.addYellowRobots(yellow_robot_states);
 
     std::unique_ptr<Primitive> blue_move_primitive1 = std::make_unique<MovePrimitive>(
-            1, Point(-1, -1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
-            AutokickType::NONE);
+        1, Point(-1, -1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+        AutokickType::NONE);
     std::unique_ptr<Primitive> blue_move_primitive2 = std::make_unique<MovePrimitive>(
-            2, Point(-3, 0), Angle::half(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
-            AutokickType::NONE);
+        2, Point(-3, 0), Angle::half(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+        AutokickType::NONE);
     std::vector<std::unique_ptr<Primitive>> blue_robot_primitives;
     blue_robot_primitives.emplace_back(std::move(blue_move_primitive1));
     blue_robot_primitives.emplace_back(std::move(blue_move_primitive2));
-    auto blue_primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
+    auto blue_primitives_ptr =
+        std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
             std::move(blue_robot_primitives));
     simulator.setBlueRobotPrimitives(blue_primitives_ptr);
 
     std::unique_ptr<Primitive> yellow_move_primitive1 = std::make_unique<MovePrimitive>(
-            1, Point(1, 1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
-            AutokickType::NONE);
+        1, Point(1, 1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+        AutokickType::NONE);
     std::unique_ptr<Primitive> yellow_move_primitive2 = std::make_unique<MovePrimitive>(
-            2, Point(3, -2), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
-            AutokickType::NONE);
+        2, Point(3, -2), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+        AutokickType::NONE);
     std::vector<std::unique_ptr<Primitive>> yellow_robot_primitives;
     yellow_robot_primitives.emplace_back(std::move(yellow_move_primitive1));
     yellow_robot_primitives.emplace_back(std::move(yellow_move_primitive2));
-    auto yellow_primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
+    auto yellow_primitives_ptr =
+        std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
             std::move(yellow_robot_primitives));
     simulator.setYellowRobotPrimitives(yellow_primitives_ptr);
 
@@ -367,29 +388,37 @@ TEST(SimulatorTest, test_simulate_multiple_blue_and_yellow_robots_with_primitive
 
     // TODO: These tests are currently very lenient, and don't test final velocities.
     //  This is because they currently rely on controller dynamics, and the existing
-    //  bang-bang controller tends to overshoot with the current physics damping constants.
-    //  In order to help decouple these tests from the controller / damping, the test
-    //  tolerances are larger for now. They should be tightened again when the new
-    //  controller is implemented.
+    //  bang-bang controller tends to overshoot with the current physics damping
+    //  constants. In order to help decouple these tests from the controller / damping,
+    //  the test tolerances are larger for now. They should be tightened again when the
+    //  new controller is implemented.
     //  https://github.com/UBC-Thunderbots/Software/issues/1187
 
     std::optional<Robot> yellow_robot_1 = world.friendlyTeam().getRobotById(1);
     ASSERT_TRUE(yellow_robot_1);
-    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Point(1, 1), yellow_robot_1->position(), 0.2)));
-    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Angle::zero(), yellow_robot_1->orientation(), Angle::fromDegrees(10))));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(
+        Point(1, 1), yellow_robot_1->position(), 0.2)));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(
+        Angle::zero(), yellow_robot_1->orientation(), Angle::fromDegrees(10))));
 
     std::optional<Robot> yellow_robot_2 = world.friendlyTeam().getRobotById(2);
     ASSERT_TRUE(yellow_robot_2);
-    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Point(3, -2), yellow_robot_2->position(), 0.2)));
-    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Angle::zero(), yellow_robot_2->orientation(), Angle::fromDegrees(10))));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(
+        Point(3, -2), yellow_robot_2->position(), 0.2)));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(
+        Angle::zero(), yellow_robot_2->orientation(), Angle::fromDegrees(10))));
 
     std::optional<Robot> blue_robot_1 = world.enemyTeam().getRobotById(1);
     ASSERT_TRUE(blue_robot_1);
-    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Point(-1, -1), blue_robot_1->position(), 0.3)));
-    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Angle::zero(), blue_robot_1->orientation(), Angle::fromDegrees(10))));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Point(-1, -1),
+                                                        blue_robot_1->position(), 0.3)));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(
+        Angle::zero(), blue_robot_1->orientation(), Angle::fromDegrees(10))));
 
     std::optional<Robot> blue_robot_2 = world.enemyTeam().getRobotById(2);
     ASSERT_TRUE(blue_robot_2);
-    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Point(-3, 0), blue_robot_2->position(), 0.3)));
-    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Angle::half(), blue_robot_2->orientation(), Angle::fromDegrees(10))));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(Point(-3, 0),
+                                                        blue_robot_2->position(), 0.3)));
+    EXPECT_TRUE((::Test::TestUtil::equalWithinTolerance(
+        Angle::half(), blue_robot_2->orientation(), Angle::fromDegrees(10))));
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
This PR updates the interface of the `Simulator` in a similar way to the `PhysicsWorld`. Now the minimum amount of state information is needed to set up the state of the simulation (rather than taking an entire `World` object), and the interface is now in terms of `yellow` and `blue` teams, rather than friendly and enemy.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Added unit tests for new functions, existing tests pass.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #1326 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
new tests are a fair amount of the diff, and old tests that got refactored are slightly longer due to how the simulator has to be set up.

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
