### PR TITLE
Added ThreadedSimulator

### DIFF
--- a/src/software/simulation/BUILD
+++ b/src/software/simulation/BUILD
@@ -144,3 +144,24 @@ cc_test(
         "@gtest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "threaded_simulator",
+    srcs = ["threaded_simulator.cpp"],
+    hdrs = ["threaded_simulator.h"],
+    deps = [
+        ":simulator",
+        "//software/proto:ssl_cc_proto",
+    ],
+)
+
+cc_test(
+    name = "threaded_simulator_test",
+    srcs = ["threaded_simulator_test.cpp"],
+    deps = [
+        ":threaded_simulator",
+        "//software/test_util",
+        "//software/world",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -1,26 +1,35 @@
 #include "software/simulation/threaded_simulator.h"
 
-ThreadedSimulator::ThreadedSimulator(const Field &field) : simulator(field), simulation_thread_started(false), stopping_simulation(false) {}
+ThreadedSimulator::ThreadedSimulator(const Field &field)
+    : simulator(field), simulation_thread_started(false), stopping_simulation(false)
+{
+}
 
-ThreadedSimulator::~ThreadedSimulator() {
+ThreadedSimulator::~ThreadedSimulator()
+{
     stopSimulation();
 }
 
-void ThreadedSimulator::registerOnSSLWrapperPacketReadyCallback(const std::function<void (SSL_WrapperPacket)>& callback) {
+void ThreadedSimulator::registerOnSSLWrapperPacketReadyCallback(
+    const std::function<void(SSL_WrapperPacket)> &callback)
+{
     std::scoped_lock lock(callback_mutex);
     ssl_wrapper_packet_callbacks.emplace_back(callback);
 }
 
-void ThreadedSimulator::startSimulation() {
+void ThreadedSimulator::startSimulation()
+{
     std::scoped_lock lock(simulation_thread_started_mutex);
     // Start the thread to do the simulation in the background
-    if(!simulation_thread_started) {
+    if (!simulation_thread_started)
+    {
         simulation_thread_started = true;
         simulation_thread = std::thread(&ThreadedSimulator::runSimulationLoop, this);
     }
 }
 
-void ThreadedSimulator::stopSimulation() {
+void ThreadedSimulator::stopSimulation()
+{
     std::scoped_lock lock(simulation_thread_started_mutex);
     if (simulation_thread_started)
     {
@@ -36,40 +45,48 @@ void ThreadedSimulator::stopSimulation() {
     }
 }
 
-void ThreadedSimulator::setBallState(const BallState &ball_state) {
+void ThreadedSimulator::setBallState(const BallState &ball_state)
+{
     std::scoped_lock lock(simulator_mutex);
     simulator.setBallState(ball_state);
 }
 
-void ThreadedSimulator::removeBall() {
+void ThreadedSimulator::removeBall()
+{
     std::scoped_lock lock(simulator_mutex);
     simulator.removeBall();
 }
 
-void ThreadedSimulator::addYellowRobots(const std::vector<RobotStateWithId> &robots) {
+void ThreadedSimulator::addYellowRobots(const std::vector<RobotStateWithId> &robots)
+{
     std::scoped_lock lock(simulator_mutex);
     simulator.addYellowRobots(robots);
 }
 
-void ThreadedSimulator::addBlueRobots(const std::vector<RobotStateWithId> &robots) {
+void ThreadedSimulator::addBlueRobots(const std::vector<RobotStateWithId> &robots)
+{
     std::scoped_lock lock(simulator_mutex);
     simulator.addBlueRobots(robots);
 }
 
-void ThreadedSimulator::setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives) {
+void ThreadedSimulator::setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives)
+{
     std::scoped_lock lock(simulator_mutex);
     simulator.setYellowRobotPrimitives(primitives);
 }
 
-void ThreadedSimulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives) {
+void ThreadedSimulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives)
+{
     std::scoped_lock lock(simulator_mutex);
     simulator.setBlueRobotPrimitives(primitives);
 }
 
-void ThreadedSimulator::runSimulationLoop() {
+void ThreadedSimulator::runSimulationLoop()
+{
     Duration time_step = Duration::fromSeconds(TIME_STEP_SECONDS);
 
-    while(!stopping_simulation.load()) {
+    while (!stopping_simulation.load())
+    {
         auto simulation_step_start_time = std::chrono::steady_clock::now();
 
         simulator_mutex.lock();
@@ -82,13 +99,17 @@ void ThreadedSimulator::runSimulationLoop() {
 
         {
             std::scoped_lock lock(callback_mutex);
-            for(const auto& callback : ssl_wrapper_packet_callbacks) {
+            for (const auto &callback : ssl_wrapper_packet_callbacks)
+            {
                 callback(ssl_wrapper_packet);
             }
         }
 
 
-        auto simulation_step_end_time = simulation_step_start_time + std::chrono::microseconds(static_cast<unsigned int>(TIME_STEP_SECONDS * MICROSECONDS_PER_SECOND));
+        auto simulation_step_end_time =
+            simulation_step_start_time +
+            std::chrono::microseconds(
+                static_cast<unsigned int>(TIME_STEP_SECONDS * MICROSECONDS_PER_SECOND));
         // TODO: Warn or indicate if we are running slower than real-time
         // https://github.com/UBC-Thunderbots/Software/issues/1491
         std::this_thread::sleep_until(simulation_step_end_time);

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -1,0 +1,87 @@
+#include "software/simulation/threaded_simulator.h"
+
+ThreadedSimulator::ThreadedSimulator(const Field &field) : simulator(field), simulation_thread_started(false), stopping_simulation(false) {}
+
+ThreadedSimulator::~ThreadedSimulator() {
+    stopSimulation();
+}
+
+void ThreadedSimulator::registerOnSSLWrapperPacketReadyCallback(const std::function<void (SSL_WrapperPacket)>& callback) {
+    ssl_wrapper_packet_callbacks.emplace_back(callback);
+}
+
+void ThreadedSimulator::startSimulation() {
+    // Start the thread to do the simulation in the background
+    if(!simulation_thread_started.load()) {
+        simulation_thread_started = true;
+        simulation_thread = std::thread(&ThreadedSimulator::runSimulationLoop, this);
+    }
+}
+
+void ThreadedSimulator::stopSimulation() {
+    if (simulation_thread_started.load())
+    {
+        simulation_thread_started = false;
+
+        // Set this flag so the simulation_thread knows to end
+        stopping_simulation = true;
+
+        simulation_thread.join();
+
+        // Reset the flag in case we want to re-start the simulation
+        stopping_simulation = false;
+    }
+}
+
+void ThreadedSimulator::setBallState(const BallState &ball_state) {
+    std::scoped_lock lock(simulator_mutex);
+    simulator.setBallState(ball_state);
+}
+
+void ThreadedSimulator::removeBall() {
+    std::scoped_lock lock(simulator_mutex);
+    simulator.removeBall();
+}
+
+void ThreadedSimulator::addYellowRobots(const std::vector<RobotStateWithId> &robots) {
+    std::scoped_lock lock(simulator_mutex);
+    simulator.addYellowRobots(robots);
+}
+
+void ThreadedSimulator::addBlueRobots(const std::vector<RobotStateWithId> &robots) {
+    std::scoped_lock lock(simulator_mutex);
+    simulator.addBlueRobots(robots);
+}
+
+void ThreadedSimulator::setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives) {
+    std::scoped_lock lock(simulator_mutex);
+    simulator.setYellowRobotPrimitives(primitives);
+}
+
+void ThreadedSimulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives) {
+    std::scoped_lock lock(simulator_mutex);
+    simulator.setBlueRobotPrimitives(primitives);
+}
+
+void ThreadedSimulator::runSimulationLoop() {
+    Duration time_step = Duration::fromSeconds(TIME_STEP_SECONDS);
+
+    while(!stopping_simulation.load()) {
+        auto simulation_step_start_time = std::chrono::steady_clock::now();
+
+        simulator_mutex.lock();
+        simulator.stepSimulation(time_step);
+        auto ssl_wrapper_packet_ptr = simulator.getSSLWrapperPacket();
+        simulator_mutex.unlock();
+
+        assert(ssl_wrapper_packet_ptr);
+        SSL_WrapperPacket ssl_wrapper_packet = *(ssl_wrapper_packet_ptr.release());
+
+        for(const auto& callback : ssl_wrapper_packet_callbacks) {
+            callback(ssl_wrapper_packet);
+        }
+
+        auto simulation_step_end_time = simulation_step_start_time + std::chrono::microseconds(static_cast<unsigned int>(TIME_STEP_SECONDS * MICROSECONDS_PER_SECOND));
+        std::this_thread::sleep_until(simulation_step_end_time);
+    }
+}

--- a/src/software/simulation/threaded_simulator.h
+++ b/src/software/simulation/threaded_simulator.h
@@ -1,16 +1,18 @@
 #pragma once
 
-#include "software/simulation/simulator.h"
-#include "software/proto/messages_robocup_ssl_wrapper.pb.h"
-#include <thread>
 #include <atomic>
+#include <thread>
+
+#include "software/proto/messages_robocup_ssl_wrapper.pb.h"
+#include "software/simulation/simulator.h"
 
 /**
  * A simulator that runs in a separate thread and publishes protobuf
  * data asynchronously.
  */
-class ThreadedSimulator {
-public:
+class ThreadedSimulator
+{
+   public:
     /**
      * Creates a new ThreadedSimulator. The starting state of the simulation
      * will have the given field, with no robots or ball.
@@ -29,7 +31,8 @@ public:
      *
      * @param callback The callback function to register
      */
-    void registerOnSSLWrapperPacketReadyCallback(const std::function<void(SSL_WrapperPacket)>& callback);
+    void registerOnSSLWrapperPacketReadyCallback(
+        const std::function<void(SSL_WrapperPacket)>& callback);
 
     /**
      * Starts running the simulator in a new thread. This is a non-blocking call.
@@ -93,7 +96,7 @@ public:
     void setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives);
     void setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives);
 
-private:
+   private:
     /**
      * The function that runs inside the simulation thread, handling
      * updating the simulation and calling the callback functions.

--- a/src/software/simulation/threaded_simulator.h
+++ b/src/software/simulation/threaded_simulator.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "software/simulation/simulator.h"
+#include "software/proto/messages_robocup_ssl_wrapper.pb.h"
+#include <thread>
+#include <atomic>
+
+/**
+ * A simulator that runs in a separate thread and publishes protobuf
+ * data asynchronously.
+ */
+class ThreadedSimulator {
+public:
+    /**
+     * Creates a new ThreadedSimulator. The starting state of the simulation
+     * will have the given field, with no robots or ball.
+     *
+     * @param field The field to initialize the simulation with
+     */
+    explicit ThreadedSimulator(const Field& field);
+    ~ThreadedSimulator();
+
+    /**
+     * Registers the given callback function. This callback function will be
+     * called each time the simulation updates and a new SSL_WrapperPacket
+     * is generated.
+     *
+     * @param callback The callback function to register
+     */
+    void registerOnSSLWrapperPacketReadyCallback(const std::function<void(SSL_WrapperPacket)>& callback);
+
+    /**
+     * Starts running the simulator in a new thread. This is a non-blocking call.
+     * If the simulator is already running, this function does nothing.
+     */
+    void startSimulation();
+
+    /**
+     * Stops the simulation if it is running. If the simulation is not already
+     * running, this function does nothing.
+     */
+    void stopSimulation();
+
+    /**
+     * Sets the state of the ball in the simulation. No more than 1 ball may exist
+     * in the simulation at a time. If a ball does not already exist, a ball
+     * is added with the given state. If a ball already exists, it's state is set to the
+     * given state.
+     *
+     * @param ball_state The new ball state
+     */
+    void setBallState(const BallState& ball_state);
+
+    /**
+     * Removes the ball from the physics world. If a ball does not already exist,
+     * this has no effect.
+     */
+    void removeBall();
+
+    /**
+     * Adds robots to the specified team with the given initial states.
+     *
+     * @pre The robot IDs must not be duplicated and must not match the ID
+     * of any robot already on the specified team.
+     *
+     * @throws runtime_error if any of the given robot ids are duplicated, or a
+     * robot already exists on the specified team with one of the new IDs
+     *
+     * @param robots the robots to add
+     */
+    void addYellowRobots(const std::vector<RobotStateWithId>& robots);
+    void addBlueRobots(const std::vector<RobotStateWithId>& robots);
+
+    /**
+     * Sets the primitives being simulated by the robots in simulation
+     *
+     * @param primitives The primitives to simulate
+     */
+    void setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives);
+    void setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives);
+
+private:
+    /**
+     * The function that runs inside the simulation thread, handling
+     * updating the simulation and calling the callback functions
+     */
+    void runSimulationLoop();
+
+    std::vector<std::function<void(SSL_WrapperPacket)>> ssl_wrapper_packet_callbacks;
+
+    Simulator simulator;
+    std::mutex simulator_mutex;
+    std::thread simulation_thread;
+    std::atomic_bool simulation_thread_started;
+    std::atomic_bool stopping_simulation;
+
+    // 60HZ is approximately the framerate of the real-life cameras
+    static constexpr double TIME_STEP_SECONDS = 1.0 / 60.0;
+};

--- a/src/software/simulation/threaded_simulator_test.cpp
+++ b/src/software/simulation/threaded_simulator_test.cpp
@@ -1,0 +1,246 @@
+#include "software/simulation/threaded_simulator.h"
+
+#include <gtest/gtest.h>
+
+#include "software/primitive/move_primitive.h"
+#include "software/primitive/primitive.h"
+#include "software/test_util/test_util.h"
+
+class ThreadedSimulatorTest : public ::testing::Test {
+protected:
+    ThreadedSimulatorTest() : threaded_simulator(::TestUtil::createSSLDivBField()) {}
+
+    void SetUp() override {
+        most_recent_wrapper_packet = std::nullopt;
+        callback_called = false;
+        auto callback = [&](SSL_WrapperPacket packet) {
+            callback_called = true;
+            most_recent_wrapper_packet = packet;
+        };
+
+        threaded_simulator.registerOnSSLWrapperPacketReadyCallback(callback);
+    }
+
+    void runSimulation(const Duration& duration) {
+        threaded_simulator.startSimulation();
+        // yield and sleep to give the simulation thread the best chance of running
+        std::this_thread::yield();
+        std::this_thread::sleep_for(std::chrono::milliseconds (static_cast<unsigned int>(duration.getMilliseconds())));
+        threaded_simulator.stopSimulation();
+    }
+
+    std::optional<Point> getBallPosition() {
+        if(!most_recent_wrapper_packet) {
+            return std::nullopt;
+        }
+
+        if(!most_recent_wrapper_packet->has_detection()) {
+            return std::nullopt;
+        }
+
+        auto detection = most_recent_wrapper_packet->detection();
+        if(detection.balls_size() < 1) {
+            return std::nullopt;
+        }
+
+        auto ball = detection.balls(0);
+        return Point(ball.x(), ball.y());
+    }
+
+    ThreadedSimulator threaded_simulator;
+    bool callback_called;
+    std::optional<SSL_WrapperPacket> most_recent_wrapper_packet;
+};
+
+TEST_F(ThreadedSimulatorTest, callbacks_triggered_during_simulation) {
+    runSimulation(Duration::fromSeconds(1));
+    EXPECT_TRUE(callback_called);
+}
+
+TEST_F(ThreadedSimulatorTest, stop_simulation_when_not_running) {
+    threaded_simulator.stopSimulation();
+    EXPECT_FALSE(callback_called);
+}
+
+TEST_F(ThreadedSimulatorTest, start_simulation_when_already_running) {
+    threaded_simulator.startSimulation();
+    runSimulation(Duration::fromSeconds(1));
+    EXPECT_TRUE(callback_called);
+}
+
+TEST_F(ThreadedSimulatorTest, start_and_stop_simulation_several_times) {
+    BallState ball_state(Point(0, 0), Vector(1, 0));
+    threaded_simulator.setBallState(ball_state);
+
+    runSimulation(Duration::fromSeconds(1.0));
+
+    auto ball_position = getBallPosition();
+    ASSERT_TRUE(ball_position);
+    auto ball_x_1 = ball_position->x();
+    EXPECT_GT(ball_x_1, 0);
+
+    runSimulation(Duration::fromSeconds(1.0));
+
+    ball_position = getBallPosition();
+    ASSERT_TRUE(ball_position);
+    auto ball_x_2 = ball_position->x();
+    EXPECT_GT(ball_x_2, ball_x_1);
+
+    runSimulation(Duration::fromSeconds(1.0));
+
+    ball_position = getBallPosition();
+    ASSERT_TRUE(ball_position);
+    auto ball_x_3 = ball_position->x();
+    EXPECT_GT(ball_x_3, ball_x_2);
+}
+
+TEST_F(ThreadedSimulatorTest, add_and_remove_ball_during_simulation) {
+    threaded_simulator.startSimulation();
+
+    BallState ball_state(Point(0, 0), Vector(1, 0));
+    threaded_simulator.setBallState(ball_state);
+
+    // yield and sleep to give the simulation thread the best chance of running
+    std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::seconds (1));
+
+    EXPECT_TRUE(callback_called);
+
+    auto ball_position = getBallPosition();
+    ASSERT_TRUE(ball_position);
+    // Do a very coarse check for the ball's x coordinate because
+    // we don't really know how much the simulation thread got to run.
+    // This just roughly checks that physics is being updated as expected.
+    EXPECT_NEAR(ball_position->x(), 1000, 800);
+    EXPECT_NEAR(ball_position->y(), 0, 100);
+
+    threaded_simulator.removeBall();
+
+    // yield and sleep to give the simulation thread the best chance of running
+    std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::seconds (1));
+
+    threaded_simulator.stopSimulation();
+    ASSERT_FALSE(getBallPosition());
+}
+
+TEST_F(ThreadedSimulatorTest, add_robots_and_primitives_while_simulation_running) {
+    threaded_simulator.startSimulation();
+    // yield and sleep to give the simulation thread the best chance of running
+    std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds (1000));
+
+    // Simulate multiple robots with primitives to sanity check that everything is
+    // connected properly and we can properly simulate multiple instances of the robot
+    // firmware at once. We use the MovePrimitve because it is very commonly used and so
+    // unlikely to be significantly changed or removed, and its behaviour is easy to
+    // validate
+    RobotState blue_robot_state1(Point(-1, 0), Vector(0, 0), Angle::zero(),
+                                 AngularVelocity::zero());
+    RobotState blue_robot_state2(Point(-2, 1), Vector(0, 0), Angle::quarter(),
+                                 AngularVelocity::zero());
+    std::vector<RobotStateWithId> blue_robot_states = {
+        RobotStateWithId{.id = 1, .robot_state = blue_robot_state1},
+        RobotStateWithId{.id = 2, .robot_state = blue_robot_state2},
+    };
+    threaded_simulator.addBlueRobots(blue_robot_states);
+
+    RobotState yellow_robot_state1(Point(1, 1.5), Vector(0, 0), Angle::half(),
+                                   AngularVelocity::zero());
+    RobotState yellow_robot_state2(Point(2.5, -1), Vector(0, 0), Angle::threeQuarter(),
+                                   AngularVelocity::zero());
+    std::vector<RobotStateWithId> yellow_robot_states = {
+        RobotStateWithId{.id = 1, .robot_state = yellow_robot_state1},
+        RobotStateWithId{.id = 2, .robot_state = yellow_robot_state2},
+    };
+    threaded_simulator.addYellowRobots(yellow_robot_states);
+
+    std::unique_ptr<Primitive> blue_move_primitive1 = std::make_unique<MovePrimitive>(
+        1, Point(-1, -1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+        AutokickType::NONE);
+    std::unique_ptr<Primitive> blue_move_primitive2 = std::make_unique<MovePrimitive>(
+        2, Point(-3, 0), Angle::half(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+        AutokickType::NONE);
+    std::vector<std::unique_ptr<Primitive>> blue_robot_primitives;
+    blue_robot_primitives.emplace_back(std::move(blue_move_primitive1));
+    blue_robot_primitives.emplace_back(std::move(blue_move_primitive2));
+    auto blue_primitives_ptr =
+        std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
+            std::move(blue_robot_primitives));
+    threaded_simulator.setBlueRobotPrimitives(blue_primitives_ptr);
+
+    std::unique_ptr<Primitive> yellow_move_primitive1 = std::make_unique<MovePrimitive>(
+        1, Point(1, 1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+        AutokickType::NONE);
+    std::unique_ptr<Primitive> yellow_move_primitive2 = std::make_unique<MovePrimitive>(
+        2, Point(3, -2), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+        AutokickType::NONE);
+    std::vector<std::unique_ptr<Primitive>> yellow_robot_primitives;
+    yellow_robot_primitives.emplace_back(std::move(yellow_move_primitive1));
+    yellow_robot_primitives.emplace_back(std::move(yellow_move_primitive2));
+    auto yellow_primitives_ptr =
+        std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
+            std::move(yellow_robot_primitives));
+    threaded_simulator.setYellowRobotPrimitives(yellow_primitives_ptr);
+
+    std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds (2000));
+    threaded_simulator.stopSimulation();
+
+    // TODO: These tests are currently very lenient, and don't test final velocities.
+    //  This is because they currently rely on controller dynamics, and the existing
+    //  bang-bang controller tends to overshoot with the current physics damping
+    //  constants. In order to help decouple these tests from the controller / damping,
+    //  the test tolerances are larger for now. They should be tightened again when the
+    //  new controller is implemented.
+    //  https://github.com/UBC-Thunderbots/Software/issues/1187
+
+    auto ssl_wrapper_packet = most_recent_wrapper_packet;
+    ASSERT_TRUE(ssl_wrapper_packet);
+    ASSERT_TRUE(ssl_wrapper_packet->has_detection());
+    auto detection_frame = ssl_wrapper_packet->detection();
+    ASSERT_EQ(2, detection_frame.robots_yellow_size());
+    ASSERT_EQ(2, detection_frame.robots_blue_size());
+
+    auto yellow_robots = detection_frame.robots_yellow();
+    auto yellow_robot_1 =
+        std::find_if(yellow_robots.begin(), yellow_robots.end(),
+                     [](SSL_DetectionRobot robot) { return robot.robot_id() == 1; });
+    ASSERT_NE(yellow_robot_1, yellow_robots.end());
+    EXPECT_NEAR(1000.0f, yellow_robot_1->x(), 200);
+    EXPECT_NEAR(1000.0f, yellow_robot_1->y(), 200);
+    EXPECT_TRUE(::TestUtil::equalWithinTolerance(
+        Angle::zero(), Angle::fromRadians(yellow_robot_1->orientation()),
+        Angle::fromDegrees(10)));
+
+    auto yellow_robot_2 =
+        std::find_if(yellow_robots.begin(), yellow_robots.end(),
+                     [](SSL_DetectionRobot robot) { return robot.robot_id() == 2; });
+    ASSERT_NE(yellow_robot_2, yellow_robots.end());
+    EXPECT_NEAR(3000.0f, yellow_robot_2->x(), 200);
+    EXPECT_NEAR(-2000.0f, yellow_robot_2->y(), 200);
+    EXPECT_TRUE(::TestUtil::equalWithinTolerance(
+        Angle::zero(), Angle::fromRadians(yellow_robot_2->orientation()),
+        Angle::fromDegrees(10)));
+
+    auto blue_robots = detection_frame.robots_blue();
+    auto blue_robot_1 =
+        std::find_if(blue_robots.begin(), blue_robots.end(),
+                     [](SSL_DetectionRobot robot) { return robot.robot_id() == 1; });
+    ASSERT_NE(blue_robot_1, blue_robots.end());
+    EXPECT_NEAR(-1000.0f, blue_robot_1->x(), 300);
+    EXPECT_NEAR(-1000.0f, blue_robot_1->y(), 300);
+    EXPECT_TRUE(::TestUtil::equalWithinTolerance(
+        Angle::zero(), Angle::fromRadians(blue_robot_1->orientation()),
+        Angle::fromDegrees(10)));
+
+    auto blue_robot_2 =
+        std::find_if(blue_robots.begin(), blue_robots.end(),
+                     [](SSL_DetectionRobot robot) { return robot.robot_id() == 2; });
+    ASSERT_NE(blue_robot_2, blue_robots.end());
+    EXPECT_NEAR(-3000.0f, blue_robot_2->x(), 300);
+    EXPECT_NEAR(0.0f, blue_robot_2->y(), 300);
+    EXPECT_TRUE(::TestUtil::equalWithinTolerance(
+        Angle::half(), Angle::fromRadians(blue_robot_2->orientation()),
+        Angle::fromDegrees(10)));
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Added a new `ThreadedSimulator` that can run simulation at a fixed rate in a new thread, and publish data asynchronously. This will be used for the standalone simulator coming soon :tm: 

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
added unit tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #1328 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
