### PR TITLE
Better ssl field line names

### DIFF
--- a/src/software/proto/message_translation/ssl_geometry.cpp
+++ b/src/software/proto/message_translation/ssl_geometry.cpp
@@ -2,6 +2,7 @@
 
 #include "shared/constants.h"
 #include "software/logger/logger.h"
+
 /**
  * These maps, along with the enums in the .h file, contain all the different
  * field lines and arcs that can be sent by SSL Vision.
@@ -19,24 +20,24 @@
  * - "Penalty" really refers to the defense area
  */
 static const std::map<SSLFieldLines, const std::string> ssl_field_line_names = {
-    {SSLFieldLines::TOP_TOUCH_LINE, "TopTouchLine"},
-    {SSLFieldLines::BOTTOM_TOUCH_LINE, "BottomTouchLine"},
-    {SSLFieldLines::LEFT_GOAL_LINE, "LeftGoalLine"},
-    {SSLFieldLines::RIGHT_GOAL_LINE, "RightGoalLine"},
+    {SSLFieldLines::POS_Y_FIELD_LINE, "TopTouchLine"},
+    {SSLFieldLines::NEG_Y_FIELD_LINE, "BottomTouchLine"},
+    {SSLFieldLines::NEG_X_FIELD_LINE, "LeftGoalLine"},
+    {SSLFieldLines::POS_X_FIELD_LINE, "RightGoalLine"},
     {SSLFieldLines::HALFWAY_LINE, "HalfwayLine"},
     {SSLFieldLines::CENTER_LINE, "CenterLine"},
-    {SSLFieldLines::LEFT_PENALTY_STRETCH, "LeftPenaltyStretch"},
-    {SSLFieldLines::RIGHT_PENALTY_STRETCH, "RightPenaltyStretch"},
-    {SSLFieldLines::RIGHT_GOAL_TOP_LINE, "RightGoalTopLine"},
-    {SSLFieldLines::RIGHT_GOAL_BOTTOM_LINE, "RightGoalBottomLine"},
-    {SSLFieldLines::RIGHT_GOAL_DEPTH_LINE, "RightGoalDepthLine"},
-    {SSLFieldLines::LEFT_GOAL_TOP_LINE, "LeftGoalTopLine"},
-    {SSLFieldLines::LEFT_GOAL_BOTTOM_LINE, "LeftGoalBottomLine"},
-    {SSLFieldLines::LEFT_GOAL_DEPTH_LINE, "LeftGoalDepthLine"},
-    {SSLFieldLines::LEFT_FIELD_LEFT_PENALTY_STRETCH, "LeftFieldLeftPenaltyStretch"},
-    {SSLFieldLines::LEFT_FIELD_RIGHT_PENALTY_STRETCH, "LeftFieldRightPenaltyStretch"},
-    {SSLFieldLines::RIGHT_FIELD_LEFT_PENALTY_STRETCH, "RightFieldLeftPenaltyStretch"},
-    {SSLFieldLines::RIGHT_FIELD_RIGHT_PENALTY_STRETCH, "RightFieldRightPenaltyStretch"},
+    {SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE, "LeftPenaltyStretch"},
+    {SSLFieldLines::POS_X_DEFENSE_AREA_FRONT_LINE, "RightPenaltyStretch"},
+    {SSLFieldLines::POS_Y_LINE_OF_POS_X_GOAL, "RightGoalTopLine"},
+    {SSLFieldLines::NEG_Y_LINE_OF_POS_X_GOAL, "RightGoalBottomLine"},
+    {SSLFieldLines::POS_X_GOAL_REAR_LINE, "RightGoalDepthLine"},
+    {SSLFieldLines::POS_Y_LINE_OF_NEG_X_GOAL, "LeftGoalTopLine"},
+    {SSLFieldLines::NEG_Y_LINE_OF_NEG_X_GOAL, "LeftGoalBottomLine"},
+    {SSLFieldLines::NEG_X_GOAL_REAR_LINE, "LeftGoalDepthLine"},
+    {SSLFieldLines::POS_Y_LINE_OF_NEG_X_DEFENSE_AREA, "LeftFieldLeftPenaltyStretch"},
+    {SSLFieldLines::NEG_Y_LINE_OF_NEG_X_DEFENSE_AREA, "LeftFieldRightPenaltyStretch"},
+    {SSLFieldLines::NEG_Y_LINE_OF_POS_X_DEFENSE_AREA, "RightFieldLeftPenaltyStretch"},
+    {SSLFieldLines::POS_Y_LINE_OF_POS_X_DEFENSE_AREA, "RightFieldRightPenaltyStretch"},
 };
 
 static const std::map<SSLCircularArcs, const std::string> ssl_circular_arc_names = {
@@ -165,7 +166,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment top_touch_line(field.fieldLines().negXPosYCorner(),
                            field.fieldLines().posXPosYCorner());
     *line =
-        *(createFieldLineSegment(top_touch_line, thickness, SSLFieldLines::TOP_TOUCH_LINE,
+        *(createFieldLineSegment(top_touch_line, thickness, SSLFieldLines::POS_Y_FIELD_LINE,
                                  SSL_FieldShapeType::TopTouchLine)
               .release());
 
@@ -173,7 +174,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment bottom_touch_line(field.fieldLines().negXNegYCorner(),
                               field.fieldLines().posXNegYCorner());
     *line = *(createFieldLineSegment(bottom_touch_line, thickness,
-                                     SSLFieldLines::BOTTOM_TOUCH_LINE,
+                                     SSLFieldLines::NEG_Y_FIELD_LINE,
                                      SSL_FieldShapeType::BottomTouchLine)
                   .release());
 
@@ -181,7 +182,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment left_goal_line(field.fieldLines().negXPosYCorner(),
                            field.fieldLines().negXNegYCorner());
     *line =
-        *(createFieldLineSegment(left_goal_line, thickness, SSLFieldLines::LEFT_GOAL_LINE,
+        *(createFieldLineSegment(left_goal_line, thickness, SSLFieldLines::NEG_X_FIELD_LINE,
                                  SSL_FieldShapeType::LeftGoalLine)
               .release());
 
@@ -189,7 +190,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment right_goal_line(field.fieldLines().posXPosYCorner(),
                             field.fieldLines().posXNegYCorner());
     *line = *(createFieldLineSegment(right_goal_line, thickness,
-                                     SSLFieldLines::RIGHT_GOAL_LINE,
+                                     SSLFieldLines::POS_X_FIELD_LINE,
                                      SSL_FieldShapeType::RightGoalLine)
                   .release());
 
@@ -209,7 +210,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment left_penalty_stretch = Segment(field.friendlyDefenseArea().posXNegYCorner(),
                                            field.friendlyDefenseArea().posXPosYCorner());
     *line = *(createFieldLineSegment(left_penalty_stretch, thickness,
-                                     SSLFieldLines::LEFT_PENALTY_STRETCH,
+                                     SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE,
                                      SSL_FieldShapeType::LeftPenaltyStretch)
                   .release());
 
@@ -217,7 +218,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment right_penalty_stretch = Segment(field.enemyDefenseArea().negXNegYCorner(),
                                             field.enemyDefenseArea().negXPosYCorner());
     *line = *(createFieldLineSegment(right_penalty_stretch, thickness,
-                                     SSLFieldLines::RIGHT_PENALTY_STRETCH,
+                                     SSLFieldLines::POS_X_DEFENSE_AREA_FRONT_LINE,
                                      SSL_FieldShapeType::RightPenaltyStretch)
                   .release());
 
@@ -225,7 +226,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment right_goal_top_line =
         Segment(field.enemyGoal().negXPosYCorner(), field.enemyGoal().posXPosYCorner());
     *line = *(createFieldLineSegment(right_goal_top_line, thickness,
-                                     SSLFieldLines::RIGHT_GOAL_TOP_LINE,
+                                     SSLFieldLines::POS_Y_LINE_OF_POS_X_GOAL,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
@@ -233,7 +234,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment right_goal_bottom_line =
         Segment(field.enemyGoal().negXNegYCorner(), field.enemyGoal().posXNegYCorner());
     *line = *(createFieldLineSegment(right_goal_bottom_line, thickness,
-                                     SSLFieldLines::RIGHT_GOAL_BOTTOM_LINE,
+                                     SSLFieldLines::NEG_Y_LINE_OF_POS_X_GOAL,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
@@ -241,7 +242,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment right_goal_depth_line =
         Segment(field.enemyGoal().posXPosYCorner(), field.enemyGoal().posXNegYCorner());
     *line = *(createFieldLineSegment(right_goal_depth_line, thickness,
-                                     SSLFieldLines::RIGHT_GOAL_DEPTH_LINE,
+                                     SSLFieldLines::POS_X_GOAL_REAR_LINE,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
@@ -249,7 +250,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment left_goal_top_line = Segment(field.friendlyGoal().negXPosYCorner(),
                                          field.friendlyGoal().posXPosYCorner());
     *line                      = *(createFieldLineSegment(left_goal_top_line, thickness,
-                                     SSLFieldLines::LEFT_GOAL_TOP_LINE,
+                                     SSLFieldLines::POS_Y_LINE_OF_NEG_X_GOAL,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
@@ -257,7 +258,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment left_goal_bottom_line = Segment(field.friendlyGoal().negXNegYCorner(),
                                             field.friendlyGoal().posXNegYCorner());
     *line = *(createFieldLineSegment(left_goal_bottom_line, thickness,
-                                     SSLFieldLines::LEFT_GOAL_BOTTOM_LINE,
+                                     SSLFieldLines::NEG_Y_LINE_OF_NEG_X_GOAL,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
@@ -265,7 +266,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     Segment left_goal_depth_line = Segment(field.friendlyGoal().negXPosYCorner(),
                                            field.friendlyGoal().negXNegYCorner());
     *line = *(createFieldLineSegment(left_goal_depth_line, thickness,
-                                     SSLFieldLines::LEFT_GOAL_DEPTH_LINE,
+                                     SSLFieldLines::NEG_X_GOAL_REAR_LINE,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
@@ -274,7 +275,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
         Segment(field.friendlyDefenseArea().negXPosYCorner(),
                 field.friendlyDefenseArea().posXPosYCorner());
     *line = *(createFieldLineSegment(left_field_left_penalty_stretch, thickness,
-                                     SSLFieldLines::LEFT_FIELD_LEFT_PENALTY_STRETCH,
+                                     SSLFieldLines::POS_Y_LINE_OF_NEG_X_DEFENSE_AREA,
                                      SSL_FieldShapeType::LeftFieldLeftPenaltyStretch)
                   .release());
 
@@ -283,7 +284,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
         Segment(field.friendlyDefenseArea().negXNegYCorner(),
                 field.friendlyDefenseArea().posXNegYCorner());
     *line = *(createFieldLineSegment(left_field_right_penalty_stretch, thickness,
-                                     SSLFieldLines::LEFT_FIELD_RIGHT_PENALTY_STRETCH,
+                                     SSLFieldLines::NEG_Y_LINE_OF_NEG_X_DEFENSE_AREA,
                                      SSL_FieldShapeType::LeftFieldRightPenaltyStretch)
                   .release());
 
@@ -292,7 +293,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
         Segment(field.enemyDefenseArea().negXNegYCorner(),
                 field.enemyDefenseArea().posXNegYCorner());
     *line = *(createFieldLineSegment(right_field_left_penalty_stretch, thickness,
-                                     SSLFieldLines::RIGHT_FIELD_LEFT_PENALTY_STRETCH,
+                                     SSLFieldLines::NEG_Y_LINE_OF_POS_X_DEFENSE_AREA,
                                      SSL_FieldShapeType::RightFieldLeftPenaltyStretch)
                   .release());
 
@@ -301,7 +302,7 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
         Segment(field.enemyDefenseArea().negXPosYCorner(),
                 field.enemyDefenseArea().posXPosYCorner());
     *line = *(createFieldLineSegment(right_field_right_penalty_stretch, thickness,
-                                     SSLFieldLines::RIGHT_FIELD_RIGHT_PENALTY_STRETCH,
+                                     SSLFieldLines::POS_Y_LINE_OF_POS_X_DEFENSE_AREA,
                                      SSL_FieldShapeType::RightFieldRightPenaltyStretch)
                   .release());
 
@@ -354,7 +355,7 @@ std::optional<Field> createField(const SSL_GeometryData& geometry_packet)
     double center_circle_radius = ssl_center_circle->radius() * METERS_PER_MILLIMETER;
 
     auto ssl_left_field_left_penalty_stretch = findLineSegment(
-        field_data.field_lines(), SSLFieldLines::LEFT_FIELD_LEFT_PENALTY_STRETCH);
+        field_data.field_lines(), SSLFieldLines::POS_Y_LINE_OF_NEG_X_DEFENSE_AREA);
     if (!ssl_left_field_left_penalty_stretch)
     {
         return std::nullopt;
@@ -369,7 +370,7 @@ std::optional<Field> createField(const SSL_GeometryData& geometry_packet)
         (defense_length_p2 - defense_length_p1).length() * METERS_PER_MILLIMETER;
 
     auto ssl_left_penalty_stretch =
-        findLineSegment(field_data.field_lines(), SSLFieldLines::LEFT_PENALTY_STRETCH);
+        findLineSegment(field_data.field_lines(), SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE);
     if (!ssl_left_penalty_stretch)
     {
         return std::nullopt;

--- a/src/software/proto/message_translation/ssl_geometry.cpp
+++ b/src/software/proto/message_translation/ssl_geometry.cpp
@@ -163,33 +163,33 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
         static_cast<int32_t>(field.defenseAreaYLength() * MILLIMETERS_PER_METER));
 
     auto line = geometry_field_size->add_field_lines();
-    Segment top_touch_line(field.fieldLines().negXPosYCorner(),
-                           field.fieldLines().posXPosYCorner());
+    Segment pos_y_field_line(field.fieldLines().negXPosYCorner(),
+                             field.fieldLines().posXPosYCorner());
     *line =
-        *(createFieldLineSegment(top_touch_line, thickness, SSLFieldLines::POS_Y_FIELD_LINE,
+        *(createFieldLineSegment(pos_y_field_line, thickness, SSLFieldLines::POS_Y_FIELD_LINE,
                                  SSL_FieldShapeType::TopTouchLine)
               .release());
 
     line = geometry_field_size->add_field_lines();
-    Segment bottom_touch_line(field.fieldLines().negXNegYCorner(),
-                              field.fieldLines().posXNegYCorner());
-    *line = *(createFieldLineSegment(bottom_touch_line, thickness,
+    Segment neg_y_field_line(field.fieldLines().negXNegYCorner(),
+                             field.fieldLines().posXNegYCorner());
+    *line = *(createFieldLineSegment(neg_y_field_line, thickness,
                                      SSLFieldLines::NEG_Y_FIELD_LINE,
                                      SSL_FieldShapeType::BottomTouchLine)
                   .release());
 
     line = geometry_field_size->add_field_lines();
-    Segment left_goal_line(field.fieldLines().negXPosYCorner(),
-                           field.fieldLines().negXNegYCorner());
+    Segment neg_x_field_line(field.fieldLines().negXPosYCorner(),
+                             field.fieldLines().negXNegYCorner());
     *line =
-        *(createFieldLineSegment(left_goal_line, thickness, SSLFieldLines::NEG_X_FIELD_LINE,
+        *(createFieldLineSegment(neg_x_field_line, thickness, SSLFieldLines::NEG_X_FIELD_LINE,
                                  SSL_FieldShapeType::LeftGoalLine)
               .release());
 
     line = geometry_field_size->add_field_lines();
-    Segment right_goal_line(field.fieldLines().posXPosYCorner(),
-                            field.fieldLines().posXNegYCorner());
-    *line = *(createFieldLineSegment(right_goal_line, thickness,
+    Segment pos_x_field_line(field.fieldLines().posXPosYCorner(),
+                             field.fieldLines().posXNegYCorner());
+    *line = *(createFieldLineSegment(pos_x_field_line, thickness,
                                      SSLFieldLines::POS_X_FIELD_LINE,
                                      SSL_FieldShapeType::RightGoalLine)
                   .release());
@@ -207,101 +207,101 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
                   .release());
 
     line                         = geometry_field_size->add_field_lines();
-    Segment left_penalty_stretch = Segment(field.friendlyDefenseArea().posXNegYCorner(),
-                                           field.friendlyDefenseArea().posXPosYCorner());
-    *line = *(createFieldLineSegment(left_penalty_stretch, thickness,
+    Segment neg_x_defense_area_front_line = Segment(field.friendlyDefenseArea().posXNegYCorner(),
+                                                    field.friendlyDefenseArea().posXPosYCorner());
+    *line = *(createFieldLineSegment(neg_x_defense_area_front_line, thickness,
                                      SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE,
                                      SSL_FieldShapeType::LeftPenaltyStretch)
                   .release());
 
     line                          = geometry_field_size->add_field_lines();
-    Segment right_penalty_stretch = Segment(field.enemyDefenseArea().negXNegYCorner(),
-                                            field.enemyDefenseArea().negXPosYCorner());
-    *line = *(createFieldLineSegment(right_penalty_stretch, thickness,
+    Segment pos_x_defense_area_front_line = Segment(field.enemyDefenseArea().negXNegYCorner(),
+                                                    field.enemyDefenseArea().negXPosYCorner());
+    *line = *(createFieldLineSegment(pos_x_defense_area_front_line, thickness,
                                      SSLFieldLines::POS_X_DEFENSE_AREA_FRONT_LINE,
                                      SSL_FieldShapeType::RightPenaltyStretch)
                   .release());
 
     line = geometry_field_size->add_field_lines();
-    Segment right_goal_top_line =
+    Segment pos_y_line_of_pos_x_goal =
         Segment(field.enemyGoal().negXPosYCorner(), field.enemyGoal().posXPosYCorner());
-    *line = *(createFieldLineSegment(right_goal_top_line, thickness,
+    *line = *(createFieldLineSegment(pos_y_line_of_pos_x_goal, thickness,
                                      SSLFieldLines::POS_Y_LINE_OF_POS_X_GOAL,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
     line = geometry_field_size->add_field_lines();
-    Segment right_goal_bottom_line =
+    Segment neg_y_line_of_pos_x_goal =
         Segment(field.enemyGoal().negXNegYCorner(), field.enemyGoal().posXNegYCorner());
-    *line = *(createFieldLineSegment(right_goal_bottom_line, thickness,
+    *line = *(createFieldLineSegment(neg_y_line_of_pos_x_goal, thickness,
                                      SSLFieldLines::NEG_Y_LINE_OF_POS_X_GOAL,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
     line = geometry_field_size->add_field_lines();
-    Segment right_goal_depth_line =
+    Segment pos_x_goal_rear_line =
         Segment(field.enemyGoal().posXPosYCorner(), field.enemyGoal().posXNegYCorner());
-    *line = *(createFieldLineSegment(right_goal_depth_line, thickness,
+    *line = *(createFieldLineSegment(pos_x_goal_rear_line, thickness,
                                      SSLFieldLines::POS_X_GOAL_REAR_LINE,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
     line                       = geometry_field_size->add_field_lines();
-    Segment left_goal_top_line = Segment(field.friendlyGoal().negXPosYCorner(),
-                                         field.friendlyGoal().posXPosYCorner());
-    *line                      = *(createFieldLineSegment(left_goal_top_line, thickness,
-                                     SSLFieldLines::POS_Y_LINE_OF_NEG_X_GOAL,
-                                     SSL_FieldShapeType::Undefined)
+    Segment pos_y_line_of_neg_x_goal = Segment(field.friendlyGoal().negXPosYCorner(),
+                                               field.friendlyGoal().posXPosYCorner());
+    *line                      = *(createFieldLineSegment(pos_y_line_of_neg_x_goal, thickness,
+                                                          SSLFieldLines::POS_Y_LINE_OF_NEG_X_GOAL,
+                                                          SSL_FieldShapeType::Undefined)
                   .release());
 
     line                          = geometry_field_size->add_field_lines();
-    Segment left_goal_bottom_line = Segment(field.friendlyGoal().negXNegYCorner(),
-                                            field.friendlyGoal().posXNegYCorner());
-    *line = *(createFieldLineSegment(left_goal_bottom_line, thickness,
+    Segment neg_y_line_of_neg_x_goal = Segment(field.friendlyGoal().negXNegYCorner(),
+                                               field.friendlyGoal().posXNegYCorner());
+    *line = *(createFieldLineSegment(neg_y_line_of_neg_x_goal, thickness,
                                      SSLFieldLines::NEG_Y_LINE_OF_NEG_X_GOAL,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
     line                         = geometry_field_size->add_field_lines();
-    Segment left_goal_depth_line = Segment(field.friendlyGoal().negXPosYCorner(),
+    Segment neg_x_goal_rear_line = Segment(field.friendlyGoal().negXPosYCorner(),
                                            field.friendlyGoal().negXNegYCorner());
-    *line = *(createFieldLineSegment(left_goal_depth_line, thickness,
+    *line = *(createFieldLineSegment(neg_x_goal_rear_line, thickness,
                                      SSLFieldLines::NEG_X_GOAL_REAR_LINE,
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
     line = geometry_field_size->add_field_lines();
-    Segment left_field_left_penalty_stretch =
+    Segment pos_y_line_of_neg_x_defense_area =
         Segment(field.friendlyDefenseArea().negXPosYCorner(),
                 field.friendlyDefenseArea().posXPosYCorner());
-    *line = *(createFieldLineSegment(left_field_left_penalty_stretch, thickness,
+    *line = *(createFieldLineSegment(pos_y_line_of_neg_x_defense_area, thickness,
                                      SSLFieldLines::POS_Y_LINE_OF_NEG_X_DEFENSE_AREA,
                                      SSL_FieldShapeType::LeftFieldLeftPenaltyStretch)
                   .release());
 
     line = geometry_field_size->add_field_lines();
-    Segment left_field_right_penalty_stretch =
+    Segment neg_y_line_of_neg_x_defense_area =
         Segment(field.friendlyDefenseArea().negXNegYCorner(),
                 field.friendlyDefenseArea().posXNegYCorner());
-    *line = *(createFieldLineSegment(left_field_right_penalty_stretch, thickness,
+    *line = *(createFieldLineSegment(neg_y_line_of_neg_x_defense_area, thickness,
                                      SSLFieldLines::NEG_Y_LINE_OF_NEG_X_DEFENSE_AREA,
                                      SSL_FieldShapeType::LeftFieldRightPenaltyStretch)
                   .release());
 
     line = geometry_field_size->add_field_lines();
-    Segment right_field_left_penalty_stretch =
+    Segment neg_y_line_of_pos_x_defense_area =
         Segment(field.enemyDefenseArea().negXNegYCorner(),
                 field.enemyDefenseArea().posXNegYCorner());
-    *line = *(createFieldLineSegment(right_field_left_penalty_stretch, thickness,
+    *line = *(createFieldLineSegment(neg_y_line_of_pos_x_defense_area, thickness,
                                      SSLFieldLines::NEG_Y_LINE_OF_POS_X_DEFENSE_AREA,
                                      SSL_FieldShapeType::RightFieldLeftPenaltyStretch)
                   .release());
 
     line = geometry_field_size->add_field_lines();
-    Segment right_field_right_penalty_stretch =
+    Segment pos_y_line_of_pos_x_defense_area =
         Segment(field.enemyDefenseArea().negXPosYCorner(),
                 field.enemyDefenseArea().posXPosYCorner());
-    *line = *(createFieldLineSegment(right_field_right_penalty_stretch, thickness,
+    *line = *(createFieldLineSegment(pos_y_line_of_pos_x_defense_area, thickness,
                                      SSLFieldLines::POS_Y_LINE_OF_POS_X_DEFENSE_AREA,
                                      SSL_FieldShapeType::RightFieldRightPenaltyStretch)
                   .release());
@@ -354,33 +354,33 @@ std::optional<Field> createField(const SSL_GeometryData& geometry_packet)
     double boundary_width       = field_data.boundary_width() * METERS_PER_MILLIMETER;
     double center_circle_radius = ssl_center_circle->radius() * METERS_PER_MILLIMETER;
 
-    auto ssl_left_field_left_penalty_stretch = findLineSegment(
+    auto pos_y_line_of_neg_x_defense_area = findLineSegment(
         field_data.field_lines(), SSLFieldLines::POS_Y_LINE_OF_NEG_X_DEFENSE_AREA);
-    if (!ssl_left_field_left_penalty_stretch)
+    if (!pos_y_line_of_neg_x_defense_area)
     {
         return std::nullopt;
     }
 
-    // We arbitraily use the left side here since the left and right sides are identical
-    Point defense_length_p1 = Point(ssl_left_field_left_penalty_stretch->p1().x(),
-                                    ssl_left_field_left_penalty_stretch->p1().y());
-    Point defense_length_p2 = Point(ssl_left_field_left_penalty_stretch->p2().x(),
-                                    ssl_left_field_left_penalty_stretch->p2().y());
+    // We arbitrarily use the left side here since the left and right sides are identical
+    Point defense_length_p1 = Point(pos_y_line_of_neg_x_defense_area->p1().x(),
+                                    pos_y_line_of_neg_x_defense_area->p1().y());
+    Point defense_length_p2 = Point(pos_y_line_of_neg_x_defense_area->p2().x(),
+                                    pos_y_line_of_neg_x_defense_area->p2().y());
     double defense_length =
         (defense_length_p2 - defense_length_p1).length() * METERS_PER_MILLIMETER;
 
-    auto ssl_left_penalty_stretch =
+    auto neg_x_defense_area_front_line =
         findLineSegment(field_data.field_lines(), SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE);
-    if (!ssl_left_penalty_stretch)
+    if (!neg_x_defense_area_front_line)
     {
         return std::nullopt;
     }
 
-    // We arbitraily use the left side here since the left and right sides are identical
+    // We arbitrarily use the left side here since the left and right sides are identical
     Point defense_width_p1 =
-        Point(ssl_left_penalty_stretch->p1().x(), ssl_left_penalty_stretch->p1().y());
+        Point(neg_x_defense_area_front_line->p1().x(), neg_x_defense_area_front_line->p1().y());
     Point defense_width_p2 =
-        Point(ssl_left_penalty_stretch->p2().x(), ssl_left_penalty_stretch->p2().y());
+        Point(neg_x_defense_area_front_line->p2().x(), neg_x_defense_area_front_line->p2().y());
     double defense_width =
         (defense_width_p1 - defense_width_p2).length() * METERS_PER_MILLIMETER;
 

--- a/src/software/proto/message_translation/ssl_geometry.cpp
+++ b/src/software/proto/message_translation/ssl_geometry.cpp
@@ -165,10 +165,10 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     auto line = geometry_field_size->add_field_lines();
     Segment pos_y_field_line(field.fieldLines().negXPosYCorner(),
                              field.fieldLines().posXPosYCorner());
-    *line =
-        *(createFieldLineSegment(pos_y_field_line, thickness, SSLFieldLines::POS_Y_FIELD_LINE,
-                                 SSL_FieldShapeType::TopTouchLine)
-              .release());
+    *line = *(createFieldLineSegment(pos_y_field_line, thickness,
+                                     SSLFieldLines::POS_Y_FIELD_LINE,
+                                     SSL_FieldShapeType::TopTouchLine)
+                  .release());
 
     line = geometry_field_size->add_field_lines();
     Segment neg_y_field_line(field.fieldLines().negXNegYCorner(),
@@ -181,10 +181,10 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
     line = geometry_field_size->add_field_lines();
     Segment neg_x_field_line(field.fieldLines().negXPosYCorner(),
                              field.fieldLines().negXNegYCorner());
-    *line =
-        *(createFieldLineSegment(neg_x_field_line, thickness, SSLFieldLines::NEG_X_FIELD_LINE,
-                                 SSL_FieldShapeType::LeftGoalLine)
-              .release());
+    *line = *(createFieldLineSegment(neg_x_field_line, thickness,
+                                     SSLFieldLines::NEG_X_FIELD_LINE,
+                                     SSL_FieldShapeType::LeftGoalLine)
+                  .release());
 
     line = geometry_field_size->add_field_lines();
     Segment pos_x_field_line(field.fieldLines().posXPosYCorner(),
@@ -206,17 +206,19 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
                                      SSL_FieldShapeType::CenterLine)
                   .release());
 
-    line                         = geometry_field_size->add_field_lines();
-    Segment neg_x_defense_area_front_line = Segment(field.friendlyDefenseArea().posXNegYCorner(),
-                                                    field.friendlyDefenseArea().posXPosYCorner());
+    line = geometry_field_size->add_field_lines();
+    Segment neg_x_defense_area_front_line =
+        Segment(field.friendlyDefenseArea().posXNegYCorner(),
+                field.friendlyDefenseArea().posXPosYCorner());
     *line = *(createFieldLineSegment(neg_x_defense_area_front_line, thickness,
                                      SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE,
                                      SSL_FieldShapeType::LeftPenaltyStretch)
                   .release());
 
-    line                          = geometry_field_size->add_field_lines();
-    Segment pos_x_defense_area_front_line = Segment(field.enemyDefenseArea().negXNegYCorner(),
-                                                    field.enemyDefenseArea().negXPosYCorner());
+    line = geometry_field_size->add_field_lines();
+    Segment pos_x_defense_area_front_line =
+        Segment(field.enemyDefenseArea().negXNegYCorner(),
+                field.enemyDefenseArea().negXPosYCorner());
     *line = *(createFieldLineSegment(pos_x_defense_area_front_line, thickness,
                                      SSLFieldLines::POS_X_DEFENSE_AREA_FRONT_LINE,
                                      SSL_FieldShapeType::RightPenaltyStretch)
@@ -246,15 +248,15 @@ std::unique_ptr<SSL_GeometryFieldSize> createGeometryFieldSize(const Field& fiel
                                      SSL_FieldShapeType::Undefined)
                   .release());
 
-    line                       = geometry_field_size->add_field_lines();
+    line                             = geometry_field_size->add_field_lines();
     Segment pos_y_line_of_neg_x_goal = Segment(field.friendlyGoal().negXPosYCorner(),
                                                field.friendlyGoal().posXPosYCorner());
-    *line                      = *(createFieldLineSegment(pos_y_line_of_neg_x_goal, thickness,
-                                                          SSLFieldLines::POS_Y_LINE_OF_NEG_X_GOAL,
-                                                          SSL_FieldShapeType::Undefined)
+    *line = *(createFieldLineSegment(pos_y_line_of_neg_x_goal, thickness,
+                                     SSLFieldLines::POS_Y_LINE_OF_NEG_X_GOAL,
+                                     SSL_FieldShapeType::Undefined)
                   .release());
 
-    line                          = geometry_field_size->add_field_lines();
+    line                             = geometry_field_size->add_field_lines();
     Segment neg_y_line_of_neg_x_goal = Segment(field.friendlyGoal().negXNegYCorner(),
                                                field.friendlyGoal().posXNegYCorner());
     *line = *(createFieldLineSegment(neg_y_line_of_neg_x_goal, thickness,
@@ -369,18 +371,18 @@ std::optional<Field> createField(const SSL_GeometryData& geometry_packet)
     double defense_length =
         (defense_length_p2 - defense_length_p1).length() * METERS_PER_MILLIMETER;
 
-    auto neg_x_defense_area_front_line =
-        findLineSegment(field_data.field_lines(), SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE);
+    auto neg_x_defense_area_front_line = findLineSegment(
+        field_data.field_lines(), SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE);
     if (!neg_x_defense_area_front_line)
     {
         return std::nullopt;
     }
 
     // We arbitrarily use the left side here since the left and right sides are identical
-    Point defense_width_p1 =
-        Point(neg_x_defense_area_front_line->p1().x(), neg_x_defense_area_front_line->p1().y());
-    Point defense_width_p2 =
-        Point(neg_x_defense_area_front_line->p2().x(), neg_x_defense_area_front_line->p2().y());
+    Point defense_width_p1 = Point(neg_x_defense_area_front_line->p1().x(),
+                                   neg_x_defense_area_front_line->p1().y());
+    Point defense_width_p2 = Point(neg_x_defense_area_front_line->p2().x(),
+                                   neg_x_defense_area_front_line->p2().y());
     double defense_width =
         (defense_width_p1 - defense_width_p2).length() * METERS_PER_MILLIMETER;
 

--- a/src/software/proto/message_translation/ssl_geometry.h
+++ b/src/software/proto/message_translation/ssl_geometry.h
@@ -17,48 +17,88 @@
  *
  * Several values like the various goal lines are not listed in the wiki
  * and so have been determined "experimentally" by inspecting messages
- * received from SSL Vision or Grsim
+ * received from SSL Vision or Grsim.
  *
- * Conventions and naming from the SSL
- * - "Top" refers to +y in our coordinate system. "Bottom" refers to -y
- * - "Left" refers to -x in our coordinate system. "Right" refers to +x
- * - "Penalty" really refers to the defense area
+ * We have named the enums according to our own style to be more descriptive
+ * than the SSL defaults. See the map in the .cpp file for how these map to
+ * the SSL names.
+ *
+ * See the diagram below for what names correspond to what lines. This is in
+ * the coordinate frame of the "raw" field data we would get from a camera.
+ * (ie. +/- x is not related to friendly/enemy like in our normal coordinate
+ * convention)
+ *
+ *                             N
+ *                             |
+ *                             V
+ *           C           +-------------+
+ *           |      M -> |             | <- L
+ *           V           |             |
+ *       +----------+----+------+------+----+----------+
+ *       |          |           |           |          |
+ *       |          |           |           |          |
+ *       |          |           |           |          |
+ *       |          | <- P      |      O -> |          |
+ *       |          |           |           |          |
+ *       |          |           |           |          |
+ *       |          |           |           |          |
+ *       |          +-----------------------+          |
+ *       |                      |      ^               |
+ *       |                 F -> |      |               |
+ *       |                      |      G               |
+ *  B -> |                    XXXXX                    | <- A
+ *       |      E           XXX | XXX                  |
+ *       |      |         XXX   |   XXX                |
+ *       |      V         X     |     X                |
+ *       +---------------XX-----------XX---------------+       +-----> +y
+ *       |                X     |     X                |       |
+ *       |                XXX   |   XXX  <- S          |       |
+ *       |                  XXX | XXX                  |       V
+ *       |                    XXXXXX                   |       +x
+ *       |                      |      H               |
+ *       |                      |      |               |
+ *       |                      |      V               |
+ *       |          +-----------------------+          |
+ *       |          |           |           |          |
+ *       |          |           |           |          |
+ *       |          |           |           |          |
+ *       |          |           |           |          |
+ *       |          | <- Q      |      R -> |          |
+ *       |          |           |           |          |
+ *       |          |           |           |          |
+ *       |          |           |           |          |
+ *       +----------+----+------+------+----+----------+
+ *          ^            |             |
+ *          |       J -> |             | <- I
+ *          D            +-------------+
+ *                             ^
+ *                             |
+ *                             K
  */
 // clang-format off
 MAKE_ENUM(SSLFieldLines,
-          POS_Y_FIELD_LINE,
-          NEG_Y_FIELD_LINE,
-          NEG_X_FIELD_LINE,
-          POS_X_FIELD_LINE,
-          HALFWAY_LINE,
-          // Runs perpendicular to the HALFWAY_LINE, from net to net
-          CENTER_LINE,
-          NEG_X_DEFENSE_AREA_FRONT_LINE,
-          POS_X_DEFENSE_AREA_FRONT_LINE,
-          // TOP is +y, BOTTOM is -y
-          POS_Y_LINE_OF_POS_X_GOAL,
-          NEG_Y_LINE_OF_POS_X_GOAL,
-          // The DEPTH_LINE is the back of the net
-          POS_X_GOAL_REAR_LINE,
-          // TOP is +y, BOTTOM is -y
-          POS_Y_LINE_OF_NEG_X_GOAL,
-          NEG_Y_LINE_OF_NEG_X_GOAL,
-          // The DEPTH_LINE is the back of the net
-          NEG_X_GOAL_REAR_LINE,
-          // For the LEFT_FIELD, LEFT and RIGHT are from the POV of the net
-          // on the left of the field looking in towards the center of the
-          // field. ie. LEFT is +y, RIGHT is -y
-          POS_Y_LINE_OF_NEG_X_DEFENSE_AREA,
-          NEG_Y_LINE_OF_NEG_X_DEFENSE_AREA,  // right is positive y
-          // For the RIGHT_FIELD, LEFT and RIGHT are from the POV of the net
-          // on the right of the field looking in towards the center of the
-          // field. ie. LEFT is +y, RIGHT is -y
-          NEG_Y_LINE_OF_POS_X_DEFENSE_AREA,
-          POS_Y_LINE_OF_POS_X_DEFENSE_AREA,
+          POS_Y_FIELD_LINE,                  // A
+          NEG_Y_FIELD_LINE,                  // B
+          NEG_X_FIELD_LINE,                  // C
+          POS_X_FIELD_LINE,                  // D
+          HALFWAY_LINE,                      // E
+          CENTER_LINE,                       // F
+          NEG_X_DEFENSE_AREA_FRONT_LINE,     // G
+          POS_X_DEFENSE_AREA_FRONT_LINE,     // H
+          POS_Y_LINE_OF_POS_X_GOAL,          // I
+          NEG_Y_LINE_OF_POS_X_GOAL,          // J
+          POS_X_GOAL_REAR_LINE,              // K
+          POS_Y_LINE_OF_NEG_X_GOAL,          // L
+          NEG_Y_LINE_OF_NEG_X_GOAL,          // M
+          NEG_X_GOAL_REAR_LINE,              // N
+          POS_Y_LINE_OF_NEG_X_DEFENSE_AREA,  // O
+          NEG_Y_LINE_OF_NEG_X_DEFENSE_AREA,  // P
+          NEG_Y_LINE_OF_POS_X_DEFENSE_AREA,  // Q
+          POS_Y_LINE_OF_POS_X_DEFENSE_AREA,  // R
           )
 
 MAKE_ENUM(SSLCircularArcs,
-          CENTER_CIRCLE,
+          CENTER_CIRCLE,                     // S
           )
 // clang-format on
 

--- a/src/software/proto/message_translation/ssl_geometry.h
+++ b/src/software/proto/message_translation/ssl_geometry.h
@@ -26,39 +26,41 @@
  */
 // clang-format off
 MAKE_ENUM(SSLFieldLines,
-          TOP_TOUCH_LINE,
-          BOTTOM_TOUCH_LINE,
-          LEFT_GOAL_LINE,
-          RIGHT_GOAL_LINE,
+          POS_Y_FIELD_LINE,
+          NEG_Y_FIELD_LINE,
+          NEG_X_FIELD_LINE,
+          POS_X_FIELD_LINE,
           HALFWAY_LINE,
           // Runs perpendicular to the HALFWAY_LINE, from net to net
           CENTER_LINE,
-          LEFT_PENALTY_STRETCH,
-          RIGHT_PENALTY_STRETCH,
+          NEG_X_DEFENSE_AREA_FRONT_LINE,
+          POS_X_DEFENSE_AREA_FRONT_LINE,
           // TOP is +y, BOTTOM is -y
-          RIGHT_GOAL_TOP_LINE,
-          RIGHT_GOAL_BOTTOM_LINE,
+          POS_Y_LINE_OF_POS_X_GOAL,
+          NEG_Y_LINE_OF_POS_X_GOAL,
           // The DEPTH_LINE is the back of the net
-          RIGHT_GOAL_DEPTH_LINE,
+          POS_X_GOAL_REAR_LINE,
           // TOP is +y, BOTTOM is -y
-          LEFT_GOAL_TOP_LINE,
-          LEFT_GOAL_BOTTOM_LINE,
+          POS_Y_LINE_OF_NEG_X_GOAL,
+          NEG_Y_LINE_OF_NEG_X_GOAL,
           // The DEPTH_LINE is the back of the net
-          LEFT_GOAL_DEPTH_LINE,
+          NEG_X_GOAL_REAR_LINE,
           // For the LEFT_FIELD, LEFT and RIGHT are from the POV of the net
           // on the left of the field looking in towards the center of the
           // field. ie. LEFT is +y, RIGHT is -y
-          LEFT_FIELD_LEFT_PENALTY_STRETCH,
-          LEFT_FIELD_RIGHT_PENALTY_STRETCH,  // right is positive y
+          POS_Y_LINE_OF_NEG_X_DEFENSE_AREA,
+          NEG_Y_LINE_OF_NEG_X_DEFENSE_AREA,  // right is positive y
           // For the RIGHT_FIELD, LEFT and RIGHT are from the POV of the net
           // on the right of the field looking in towards the center of the
           // field. ie. LEFT is +y, RIGHT is -y
-          RIGHT_FIELD_LEFT_PENALTY_STRETCH,
-          RIGHT_FIELD_RIGHT_PENALTY_STRETCH,
+          NEG_Y_LINE_OF_POS_X_DEFENSE_AREA,
+          POS_Y_LINE_OF_POS_X_DEFENSE_AREA,
+          )
+
+MAKE_ENUM(SSLCircularArcs,
+          CENTER_CIRCLE,
           )
 // clang-format on
-
-MAKE_ENUM(SSLCircularArcs, CENTER_CIRCLE)
 
 /**
  * Find an SSL FieldLineSegment by name. Returns the first instance of a line segment

--- a/src/software/proto/message_translation/ssl_geometry_test.cpp
+++ b/src/software/proto/message_translation/ssl_geometry_test.cpp
@@ -382,41 +382,41 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
 
     // Field lines
 
-    auto top_touch_line =
+    auto pos_y_field_line =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_Y_FIELD_LINE);
-    ASSERT_TRUE(top_touch_line);
-    EXPECT_TRUE(equalWithinTolerance(top_touch_line.value(),
+    ASSERT_TRUE(pos_y_field_line);
+    EXPECT_TRUE(equalWithinTolerance(pos_y_field_line.value(),
                                      Segment(Point(-4.5, 3), Point(4.5, 3)), thickness,
                                      tolerance));
-    ASSERT_TRUE(top_touch_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::TopTouchLine, top_touch_line->type());
+    ASSERT_TRUE(pos_y_field_line->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::TopTouchLine, pos_y_field_line->type());
 
-    auto bottom_touch_line =
+    auto neg_y_field_line =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_Y_FIELD_LINE);
-    ASSERT_TRUE(bottom_touch_line);
-    EXPECT_TRUE(equalWithinTolerance(bottom_touch_line.value(),
+    ASSERT_TRUE(neg_y_field_line);
+    EXPECT_TRUE(equalWithinTolerance(neg_y_field_line.value(),
                                      Segment(Point(-4.5, -3), Point(4.5, -3)), thickness,
                                      tolerance));
-    ASSERT_TRUE(bottom_touch_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::BottomTouchLine, bottom_touch_line->type());
+    ASSERT_TRUE(neg_y_field_line->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::BottomTouchLine, neg_y_field_line->type());
 
-    auto left_goal_line =
+    auto neg_x_field_line =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_X_FIELD_LINE);
-    ASSERT_TRUE(left_goal_line);
-    EXPECT_TRUE(equalWithinTolerance(left_goal_line.value(),
+    ASSERT_TRUE(neg_x_field_line);
+    EXPECT_TRUE(equalWithinTolerance(neg_x_field_line.value(),
                                      Segment(Point(-4.5, 3), Point(-4.5, -3)), thickness,
                                      tolerance));
-    ASSERT_TRUE(left_goal_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::LeftGoalLine, left_goal_line->type());
+    ASSERT_TRUE(neg_x_field_line->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::LeftGoalLine, neg_x_field_line->type());
 
-    auto right_goal_line =
+    auto pos_x_field_line =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_X_FIELD_LINE);
-    ASSERT_TRUE(right_goal_line);
-    EXPECT_TRUE(equalWithinTolerance(right_goal_line.value(),
+    ASSERT_TRUE(pos_x_field_line);
+    EXPECT_TRUE(equalWithinTolerance(pos_x_field_line.value(),
                                      Segment(Point(4.5, 3), Point(4.5, -3)), thickness,
                                      tolerance));
-    ASSERT_TRUE(right_goal_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::RightGoalLine, right_goal_line->type());
+    ASSERT_TRUE(pos_x_field_line->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::RightGoalLine, pos_x_field_line->type());
 
     auto halfway_line =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::HALFWAY_LINE);
@@ -435,117 +435,117 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     ASSERT_TRUE(center_line->has_type());
     EXPECT_EQ(SSL_FieldShapeType::CenterLine, center_line->type());
 
-    auto left_penalty_stretch =
+    auto neg_x_defense_area_front_line =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE);
-    ASSERT_TRUE(left_penalty_stretch);
-    EXPECT_TRUE(equalWithinTolerance(left_penalty_stretch.value(),
+    ASSERT_TRUE(neg_x_defense_area_front_line);
+    EXPECT_TRUE(equalWithinTolerance(neg_x_defense_area_front_line.value(),
                                      Segment(Point(-3.5, 1), Point(-3.5, -1)), thickness,
                                      tolerance));
-    ASSERT_TRUE(left_penalty_stretch->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::LeftPenaltyStretch, left_penalty_stretch->type());
+    ASSERT_TRUE(neg_x_defense_area_front_line->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::LeftPenaltyStretch, neg_x_defense_area_front_line->type());
 
-    auto right_penalty_stretch =
+    auto pos_x_defense_area_front_line =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_X_DEFENSE_AREA_FRONT_LINE);
-    ASSERT_TRUE(right_penalty_stretch);
-    EXPECT_TRUE(equalWithinTolerance(right_penalty_stretch.value(),
+    ASSERT_TRUE(pos_x_defense_area_front_line);
+    EXPECT_TRUE(equalWithinTolerance(pos_x_defense_area_front_line.value(),
                                      Segment(Point(3.5, 1), Point(3.5, -1)), thickness,
                                      tolerance));
-    ASSERT_TRUE(right_penalty_stretch->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::RightPenaltyStretch, right_penalty_stretch->type());
+    ASSERT_TRUE(pos_x_defense_area_front_line->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::RightPenaltyStretch, pos_x_defense_area_front_line->type());
 
-    auto right_goal_top_line =
+    auto pos_y_line_of_pos_x_goal =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_POS_X_GOAL);
-    ASSERT_TRUE(right_goal_top_line);
-    EXPECT_TRUE(equalWithinTolerance(right_goal_top_line.value(),
+    ASSERT_TRUE(pos_y_line_of_pos_x_goal);
+    EXPECT_TRUE(equalWithinTolerance(pos_y_line_of_pos_x_goal.value(),
                                      Segment(Point(4.5, 0.5), Point(4.7, 0.5)), thickness,
                                      tolerance));
-    ASSERT_TRUE(right_goal_top_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::Undefined, right_goal_top_line->type());
+    ASSERT_TRUE(pos_y_line_of_pos_x_goal->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::Undefined, pos_y_line_of_pos_x_goal->type());
 
-    auto right_goal_bottom_line =
+    auto neg_y_line_of_pos_x_goal =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_POS_X_GOAL);
-    ASSERT_TRUE(right_goal_bottom_line);
-    EXPECT_TRUE(equalWithinTolerance(right_goal_bottom_line.value(),
+    ASSERT_TRUE(neg_y_line_of_pos_x_goal);
+    EXPECT_TRUE(equalWithinTolerance(neg_y_line_of_pos_x_goal.value(),
                                      Segment(Point(4.5, -0.5), Point(4.7, -0.5)),
                                      thickness, tolerance));
-    ASSERT_TRUE(right_goal_bottom_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::Undefined, right_goal_bottom_line->type());
+    ASSERT_TRUE(neg_y_line_of_pos_x_goal->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::Undefined, neg_y_line_of_pos_x_goal->type());
 
-    auto right_goal_depth_line =
+    auto pos_x_goal_rear_line =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_X_GOAL_REAR_LINE);
-    ASSERT_TRUE(right_goal_depth_line);
-    EXPECT_TRUE(equalWithinTolerance(right_goal_depth_line.value(),
+    ASSERT_TRUE(pos_x_goal_rear_line);
+    EXPECT_TRUE(equalWithinTolerance(pos_x_goal_rear_line.value(),
                                      Segment(Point(4.7, 0.5), Point(4.7, -0.5)),
                                      thickness, tolerance));
-    ASSERT_TRUE(right_goal_depth_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::Undefined, right_goal_depth_line->type());
+    ASSERT_TRUE(pos_x_goal_rear_line->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::Undefined, pos_x_goal_rear_line->type());
 
-    auto left_goal_top_line =
+    auto pos_y_line_of_neg_x_goal =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_NEG_X_GOAL);
-    ASSERT_TRUE(left_goal_top_line);
-    EXPECT_TRUE(equalWithinTolerance(left_goal_top_line.value(),
+    ASSERT_TRUE(pos_y_line_of_neg_x_goal);
+    EXPECT_TRUE(equalWithinTolerance(pos_y_line_of_neg_x_goal.value(),
                                      Segment(Point(-4.5, 0.5), Point(-4.7, 0.5)),
                                      thickness, tolerance));
-    ASSERT_TRUE(left_goal_top_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::Undefined, left_goal_top_line->type());
+    ASSERT_TRUE(pos_y_line_of_neg_x_goal->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::Undefined, pos_y_line_of_neg_x_goal->type());
 
-    auto left_goal_bottom_line =
+    auto neg_y_line_of_neg_x_goal =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_NEG_X_GOAL);
-    ASSERT_TRUE(left_goal_bottom_line);
-    EXPECT_TRUE(equalWithinTolerance(left_goal_bottom_line.value(),
+    ASSERT_TRUE(neg_y_line_of_neg_x_goal);
+    EXPECT_TRUE(equalWithinTolerance(neg_y_line_of_neg_x_goal.value(),
                                      Segment(Point(-4.5, -0.5), Point(-4.7, -0.5)),
                                      thickness, tolerance));
-    ASSERT_TRUE(left_goal_bottom_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::Undefined, left_goal_bottom_line->type());
+    ASSERT_TRUE(neg_y_line_of_neg_x_goal->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::Undefined, neg_y_line_of_neg_x_goal->type());
 
-    auto left_goal_depth_line =
+    auto neg_x_goal_rear_line =
         findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_X_GOAL_REAR_LINE);
-    ASSERT_TRUE(left_goal_depth_line);
-    EXPECT_TRUE(equalWithinTolerance(left_goal_depth_line.value(),
+    ASSERT_TRUE(neg_x_goal_rear_line);
+    EXPECT_TRUE(equalWithinTolerance(neg_x_goal_rear_line.value(),
                                      Segment(Point(-4.7, 0.5), Point(-4.7, -0.5)),
                                      thickness, tolerance));
-    ASSERT_TRUE(left_goal_depth_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::Undefined, left_goal_depth_line->type());
+    ASSERT_TRUE(neg_x_goal_rear_line->has_type());
+    EXPECT_EQ(SSL_FieldShapeType::Undefined, neg_x_goal_rear_line->type());
 
-    auto left_field_left_penalty_stretch = findLineSegment(
+    auto pos_y_line_of_neg_x_defense_area = findLineSegment(
         field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_NEG_X_DEFENSE_AREA);
-    ASSERT_TRUE(left_field_left_penalty_stretch);
-    EXPECT_TRUE(equalWithinTolerance(left_field_left_penalty_stretch.value(),
+    ASSERT_TRUE(pos_y_line_of_neg_x_defense_area);
+    EXPECT_TRUE(equalWithinTolerance(pos_y_line_of_neg_x_defense_area.value(),
                                      Segment(Point(-4.5, 1), Point(-3.5, 1)), thickness,
                                      tolerance));
-    ASSERT_TRUE(left_field_left_penalty_stretch->has_type());
+    ASSERT_TRUE(pos_y_line_of_neg_x_defense_area->has_type());
     EXPECT_EQ(SSL_FieldShapeType::LeftFieldLeftPenaltyStretch,
-              left_field_left_penalty_stretch->type());
+              pos_y_line_of_neg_x_defense_area->type());
 
-    auto left_field_right_penalty_stretch = findLineSegment(
+    auto neg_y_line_of_neg_x_defense_area = findLineSegment(
         field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_NEG_X_DEFENSE_AREA);
-    ASSERT_TRUE(left_field_right_penalty_stretch);
-    EXPECT_TRUE(equalWithinTolerance(left_field_right_penalty_stretch.value(),
+    ASSERT_TRUE(neg_y_line_of_neg_x_defense_area);
+    EXPECT_TRUE(equalWithinTolerance(neg_y_line_of_neg_x_defense_area.value(),
                                      Segment(Point(-4.5, -1), Point(-3.5, -1)), thickness,
                                      tolerance));
-    ASSERT_TRUE(left_field_right_penalty_stretch->has_type());
+    ASSERT_TRUE(neg_y_line_of_neg_x_defense_area->has_type());
     EXPECT_EQ(SSL_FieldShapeType::LeftFieldRightPenaltyStretch,
-              left_field_right_penalty_stretch->type());
+              neg_y_line_of_neg_x_defense_area->type());
 
-    auto right_field_left_penalty_stretch = findLineSegment(
+    auto neg_y_line_of_pos_x_defense_area = findLineSegment(
         field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_POS_X_DEFENSE_AREA);
-    ASSERT_TRUE(right_field_left_penalty_stretch);
-    EXPECT_TRUE(equalWithinTolerance(right_field_left_penalty_stretch.value(),
+    ASSERT_TRUE(neg_y_line_of_pos_x_defense_area);
+    EXPECT_TRUE(equalWithinTolerance(neg_y_line_of_pos_x_defense_area.value(),
                                      Segment(Point(4.5, -1), Point(3.5, -1)), thickness,
                                      tolerance));
-    ASSERT_TRUE(right_field_left_penalty_stretch->has_type());
+    ASSERT_TRUE(neg_y_line_of_pos_x_defense_area->has_type());
     EXPECT_EQ(SSL_FieldShapeType::RightFieldLeftPenaltyStretch,
-              right_field_left_penalty_stretch->type());
+              neg_y_line_of_pos_x_defense_area->type());
 
-    auto right_field_right_penalty_stretch = findLineSegment(
+    auto pos_y_line_of_pos_x_defense_area = findLineSegment(
         field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_POS_X_DEFENSE_AREA);
-    ASSERT_TRUE(right_field_right_penalty_stretch);
-    EXPECT_TRUE(equalWithinTolerance(right_field_right_penalty_stretch.value(),
+    ASSERT_TRUE(pos_y_line_of_pos_x_defense_area);
+    EXPECT_TRUE(equalWithinTolerance(pos_y_line_of_pos_x_defense_area.value(),
                                      Segment(Point(4.5, 1), Point(3.5, 1)), thickness,
                                      tolerance));
-    ASSERT_TRUE(right_field_right_penalty_stretch->has_type());
+    ASSERT_TRUE(pos_y_line_of_pos_x_defense_area->has_type());
     EXPECT_EQ(SSL_FieldShapeType::RightFieldRightPenaltyStretch,
-              right_field_right_penalty_stretch->type());
+              pos_y_line_of_pos_x_defense_area->type());
 
     // Field arcs
 

--- a/src/software/proto/message_translation/ssl_geometry_test.cpp
+++ b/src/software/proto/message_translation/ssl_geometry_test.cpp
@@ -435,26 +435,28 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     ASSERT_TRUE(center_line->has_type());
     EXPECT_EQ(SSL_FieldShapeType::CenterLine, center_line->type());
 
-    auto neg_x_defense_area_front_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE);
+    auto neg_x_defense_area_front_line = findLineSegment(
+        field_msg->field_lines(), SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE);
     ASSERT_TRUE(neg_x_defense_area_front_line);
     EXPECT_TRUE(equalWithinTolerance(neg_x_defense_area_front_line.value(),
                                      Segment(Point(-3.5, 1), Point(-3.5, -1)), thickness,
                                      tolerance));
     ASSERT_TRUE(neg_x_defense_area_front_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::LeftPenaltyStretch, neg_x_defense_area_front_line->type());
+    EXPECT_EQ(SSL_FieldShapeType::LeftPenaltyStretch,
+              neg_x_defense_area_front_line->type());
 
-    auto pos_x_defense_area_front_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_X_DEFENSE_AREA_FRONT_LINE);
+    auto pos_x_defense_area_front_line = findLineSegment(
+        field_msg->field_lines(), SSLFieldLines::POS_X_DEFENSE_AREA_FRONT_LINE);
     ASSERT_TRUE(pos_x_defense_area_front_line);
     EXPECT_TRUE(equalWithinTolerance(pos_x_defense_area_front_line.value(),
                                      Segment(Point(3.5, 1), Point(3.5, -1)), thickness,
                                      tolerance));
     ASSERT_TRUE(pos_x_defense_area_front_line->has_type());
-    EXPECT_EQ(SSL_FieldShapeType::RightPenaltyStretch, pos_x_defense_area_front_line->type());
+    EXPECT_EQ(SSL_FieldShapeType::RightPenaltyStretch,
+              pos_x_defense_area_front_line->type());
 
-    auto pos_y_line_of_pos_x_goal =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_POS_X_GOAL);
+    auto pos_y_line_of_pos_x_goal = findLineSegment(
+        field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_POS_X_GOAL);
     ASSERT_TRUE(pos_y_line_of_pos_x_goal);
     EXPECT_TRUE(equalWithinTolerance(pos_y_line_of_pos_x_goal.value(),
                                      Segment(Point(4.5, 0.5), Point(4.7, 0.5)), thickness,
@@ -462,8 +464,8 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     ASSERT_TRUE(pos_y_line_of_pos_x_goal->has_type());
     EXPECT_EQ(SSL_FieldShapeType::Undefined, pos_y_line_of_pos_x_goal->type());
 
-    auto neg_y_line_of_pos_x_goal =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_POS_X_GOAL);
+    auto neg_y_line_of_pos_x_goal = findLineSegment(
+        field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_POS_X_GOAL);
     ASSERT_TRUE(neg_y_line_of_pos_x_goal);
     EXPECT_TRUE(equalWithinTolerance(neg_y_line_of_pos_x_goal.value(),
                                      Segment(Point(4.5, -0.5), Point(4.7, -0.5)),
@@ -480,8 +482,8 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     ASSERT_TRUE(pos_x_goal_rear_line->has_type());
     EXPECT_EQ(SSL_FieldShapeType::Undefined, pos_x_goal_rear_line->type());
 
-    auto pos_y_line_of_neg_x_goal =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_NEG_X_GOAL);
+    auto pos_y_line_of_neg_x_goal = findLineSegment(
+        field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_NEG_X_GOAL);
     ASSERT_TRUE(pos_y_line_of_neg_x_goal);
     EXPECT_TRUE(equalWithinTolerance(pos_y_line_of_neg_x_goal.value(),
                                      Segment(Point(-4.5, 0.5), Point(-4.7, 0.5)),
@@ -489,8 +491,8 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     ASSERT_TRUE(pos_y_line_of_neg_x_goal->has_type());
     EXPECT_EQ(SSL_FieldShapeType::Undefined, pos_y_line_of_neg_x_goal->type());
 
-    auto neg_y_line_of_neg_x_goal =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_NEG_X_GOAL);
+    auto neg_y_line_of_neg_x_goal = findLineSegment(
+        field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_NEG_X_GOAL);
     ASSERT_TRUE(neg_y_line_of_neg_x_goal);
     EXPECT_TRUE(equalWithinTolerance(neg_y_line_of_neg_x_goal.value(),
                                      Segment(Point(-4.5, -0.5), Point(-4.7, -0.5)),

--- a/src/software/proto/message_translation/ssl_geometry_test.cpp
+++ b/src/software/proto/message_translation/ssl_geometry_test.cpp
@@ -101,7 +101,7 @@ class SSLGeometryTest : public ::testing::Test
 TEST_F(SSLGeometryTest, test_find_line_segment_with_no_segments)
 {
     google::protobuf::RepeatedPtrField<SSL_FieldLineSegment> segments;
-    auto result = findLineSegment(segments, SSLFieldLines::LEFT_PENALTY_STRETCH);
+    auto result = findLineSegment(segments, SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE);
     EXPECT_FALSE(result);
 }
 
@@ -156,7 +156,7 @@ TEST_F(SSLGeometryTest, test_find_line_segment_with_valid_name)
     segment_2->set_thickness(0.01);
     segments.AddAllocated(segment_2.release());
 
-    auto result = findLineSegment(segments, SSLFieldLines::BOTTOM_TOUCH_LINE);
+    auto result = findLineSegment(segments, SSLFieldLines::NEG_Y_FIELD_LINE);
     ASSERT_TRUE(result);
     EXPECT_EQ("BottomTouchLine", result->name());
 }
@@ -191,7 +191,7 @@ TEST_F(SSLGeometryTest, test_find_line_segment_with_duplicate_names)
     segment_2->set_thickness(0.05);
     segments.AddAllocated(segment_2.release());
 
-    auto result = findLineSegment(segments, SSLFieldLines::TOP_TOUCH_LINE);
+    auto result = findLineSegment(segments, SSLFieldLines::POS_Y_FIELD_LINE);
     ASSERT_TRUE(result);
     EXPECT_EQ("TopTouchLine", result->name());
     // Sanity check we got the first segment
@@ -308,7 +308,7 @@ TEST_F(SSLGeometryTest, test_create_field_line_segment_with_valid_values)
 {
     const Segment segment(Point(-0.05, 1.0), Point(4, 0));
     const float thickness         = 0.005f;
-    const SSLFieldLines line_type = SSLFieldLines::TOP_TOUCH_LINE;
+    const SSLFieldLines line_type = SSLFieldLines::POS_Y_FIELD_LINE;
 
     auto field_line_msg = createFieldLineSegment(segment, thickness, line_type,
                                                  SSL_FieldShapeType::CenterLine);
@@ -326,7 +326,7 @@ TEST_F(SSLGeometryTest, test_create_field_line_segment_with_negative_thickness)
 {
     const Segment segment(Point(-0.05, 1.0), Point(4, 0));
     const float thickness         = -0.005f;
-    const SSLFieldLines line_type = SSLFieldLines::TOP_TOUCH_LINE;
+    const SSLFieldLines line_type = SSLFieldLines::POS_Y_FIELD_LINE;
 
     EXPECT_THROW(createFieldLineSegment(segment, thickness, line_type,
                                         SSL_FieldShapeType::Undefined),
@@ -383,7 +383,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     // Field lines
 
     auto top_touch_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::TOP_TOUCH_LINE);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_Y_FIELD_LINE);
     ASSERT_TRUE(top_touch_line);
     EXPECT_TRUE(equalWithinTolerance(top_touch_line.value(),
                                      Segment(Point(-4.5, 3), Point(4.5, 3)), thickness,
@@ -392,7 +392,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::TopTouchLine, top_touch_line->type());
 
     auto bottom_touch_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::BOTTOM_TOUCH_LINE);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_Y_FIELD_LINE);
     ASSERT_TRUE(bottom_touch_line);
     EXPECT_TRUE(equalWithinTolerance(bottom_touch_line.value(),
                                      Segment(Point(-4.5, -3), Point(4.5, -3)), thickness,
@@ -401,7 +401,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::BottomTouchLine, bottom_touch_line->type());
 
     auto left_goal_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::LEFT_GOAL_LINE);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_X_FIELD_LINE);
     ASSERT_TRUE(left_goal_line);
     EXPECT_TRUE(equalWithinTolerance(left_goal_line.value(),
                                      Segment(Point(-4.5, 3), Point(-4.5, -3)), thickness,
@@ -410,7 +410,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::LeftGoalLine, left_goal_line->type());
 
     auto right_goal_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::RIGHT_GOAL_LINE);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_X_FIELD_LINE);
     ASSERT_TRUE(right_goal_line);
     EXPECT_TRUE(equalWithinTolerance(right_goal_line.value(),
                                      Segment(Point(4.5, 3), Point(4.5, -3)), thickness,
@@ -436,7 +436,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::CenterLine, center_line->type());
 
     auto left_penalty_stretch =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::LEFT_PENALTY_STRETCH);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_X_DEFENSE_AREA_FRONT_LINE);
     ASSERT_TRUE(left_penalty_stretch);
     EXPECT_TRUE(equalWithinTolerance(left_penalty_stretch.value(),
                                      Segment(Point(-3.5, 1), Point(-3.5, -1)), thickness,
@@ -445,7 +445,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::LeftPenaltyStretch, left_penalty_stretch->type());
 
     auto right_penalty_stretch =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::RIGHT_PENALTY_STRETCH);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_X_DEFENSE_AREA_FRONT_LINE);
     ASSERT_TRUE(right_penalty_stretch);
     EXPECT_TRUE(equalWithinTolerance(right_penalty_stretch.value(),
                                      Segment(Point(3.5, 1), Point(3.5, -1)), thickness,
@@ -454,7 +454,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::RightPenaltyStretch, right_penalty_stretch->type());
 
     auto right_goal_top_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::RIGHT_GOAL_TOP_LINE);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_POS_X_GOAL);
     ASSERT_TRUE(right_goal_top_line);
     EXPECT_TRUE(equalWithinTolerance(right_goal_top_line.value(),
                                      Segment(Point(4.5, 0.5), Point(4.7, 0.5)), thickness,
@@ -463,7 +463,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::Undefined, right_goal_top_line->type());
 
     auto right_goal_bottom_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::RIGHT_GOAL_BOTTOM_LINE);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_POS_X_GOAL);
     ASSERT_TRUE(right_goal_bottom_line);
     EXPECT_TRUE(equalWithinTolerance(right_goal_bottom_line.value(),
                                      Segment(Point(4.5, -0.5), Point(4.7, -0.5)),
@@ -472,7 +472,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::Undefined, right_goal_bottom_line->type());
 
     auto right_goal_depth_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::RIGHT_GOAL_DEPTH_LINE);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_X_GOAL_REAR_LINE);
     ASSERT_TRUE(right_goal_depth_line);
     EXPECT_TRUE(equalWithinTolerance(right_goal_depth_line.value(),
                                      Segment(Point(4.7, 0.5), Point(4.7, -0.5)),
@@ -481,7 +481,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::Undefined, right_goal_depth_line->type());
 
     auto left_goal_top_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::LEFT_GOAL_TOP_LINE);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_NEG_X_GOAL);
     ASSERT_TRUE(left_goal_top_line);
     EXPECT_TRUE(equalWithinTolerance(left_goal_top_line.value(),
                                      Segment(Point(-4.5, 0.5), Point(-4.7, 0.5)),
@@ -490,7 +490,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::Undefined, left_goal_top_line->type());
 
     auto left_goal_bottom_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::LEFT_GOAL_BOTTOM_LINE);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_NEG_X_GOAL);
     ASSERT_TRUE(left_goal_bottom_line);
     EXPECT_TRUE(equalWithinTolerance(left_goal_bottom_line.value(),
                                      Segment(Point(-4.5, -0.5), Point(-4.7, -0.5)),
@@ -499,7 +499,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::Undefined, left_goal_bottom_line->type());
 
     auto left_goal_depth_line =
-        findLineSegment(field_msg->field_lines(), SSLFieldLines::LEFT_GOAL_DEPTH_LINE);
+        findLineSegment(field_msg->field_lines(), SSLFieldLines::NEG_X_GOAL_REAR_LINE);
     ASSERT_TRUE(left_goal_depth_line);
     EXPECT_TRUE(equalWithinTolerance(left_goal_depth_line.value(),
                                      Segment(Point(-4.7, 0.5), Point(-4.7, -0.5)),
@@ -508,7 +508,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
     EXPECT_EQ(SSL_FieldShapeType::Undefined, left_goal_depth_line->type());
 
     auto left_field_left_penalty_stretch = findLineSegment(
-        field_msg->field_lines(), SSLFieldLines::LEFT_FIELD_LEFT_PENALTY_STRETCH);
+        field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_NEG_X_DEFENSE_AREA);
     ASSERT_TRUE(left_field_left_penalty_stretch);
     EXPECT_TRUE(equalWithinTolerance(left_field_left_penalty_stretch.value(),
                                      Segment(Point(-4.5, 1), Point(-3.5, 1)), thickness,
@@ -518,7 +518,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
               left_field_left_penalty_stretch->type());
 
     auto left_field_right_penalty_stretch = findLineSegment(
-        field_msg->field_lines(), SSLFieldLines::LEFT_FIELD_RIGHT_PENALTY_STRETCH);
+        field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_NEG_X_DEFENSE_AREA);
     ASSERT_TRUE(left_field_right_penalty_stretch);
     EXPECT_TRUE(equalWithinTolerance(left_field_right_penalty_stretch.value(),
                                      Segment(Point(-4.5, -1), Point(-3.5, -1)), thickness,
@@ -528,7 +528,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
               left_field_right_penalty_stretch->type());
 
     auto right_field_left_penalty_stretch = findLineSegment(
-        field_msg->field_lines(), SSLFieldLines::RIGHT_FIELD_LEFT_PENALTY_STRETCH);
+        field_msg->field_lines(), SSLFieldLines::NEG_Y_LINE_OF_POS_X_DEFENSE_AREA);
     ASSERT_TRUE(right_field_left_penalty_stretch);
     EXPECT_TRUE(equalWithinTolerance(right_field_left_penalty_stretch.value(),
                                      Segment(Point(4.5, -1), Point(3.5, -1)), thickness,
@@ -538,7 +538,7 @@ TEST_F(SSLGeometryTest, test_create_geometry_field_size_with_valid_values)
               right_field_left_penalty_stretch->type());
 
     auto right_field_right_penalty_stretch = findLineSegment(
-        field_msg->field_lines(), SSLFieldLines::RIGHT_FIELD_RIGHT_PENALTY_STRETCH);
+        field_msg->field_lines(), SSLFieldLines::POS_Y_LINE_OF_POS_X_DEFENSE_AREA);
     ASSERT_TRUE(right_field_right_penalty_stretch);
     EXPECT_TRUE(equalWithinTolerance(right_field_right_penalty_stretch.value(),
                                      Segment(Point(4.5, 1), Point(3.5, 1)), thickness,


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Updated the names of the `SSLFieldLines` enum according to discussion in #1451. Also added an ASCII diagram to show what names are what lines.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
unit tests still pass

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #1451 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
