### PR TITLE
Virtual Interfaces

### DIFF
--- a/environment_setup/setup_networking.sh
+++ b/environment_setup/setup_networking.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# At the time of creating this script, we have team members with enp3s0f1,
+# wlp3s0, wlp7s0, eth1, eth0 and a plethora of other network interfaces 
+#
+# This script will create two virtual interfaces tbots_wifi and tbots_eth
+# and then bridge those with the appropriate physical interfaces on the users
+# system.
+#
+# This script can be rerun to reconfigure the interfaces.
+echo "================================================================"
+echo " Networking Interface Setup"
+echo "================================================================"
+
+TBOTS_WIFI_INTERFACE=tbots_wifi
+TBOTS_ETHERNET_INTERFACE=tbots_eth
+
+echo "Removing tbots network interfaces, if they exist"
+sudo ip link set dev $TBOTS_WIFI_INTERFACE down
+sudo ip link set dev $TBOTS_ETHERNET_INTERFACE down
+sudo brctl delbr $TBOTS_WIFI_INTERFACE
+sudo brctl delbr $TBOTS_ETHERNET_INTERFACE
+
+# get the "suggested" interface(s). The first interface is usually the correct
+# one but we provide the option to select other interfaces, which is useful for VM users
+SUGGESTED_INTERFACE=$(route | grep '^default' | grep -o '[^ ]*$')
+
+PS3="Suggested interfaces(s):
+$SUGGESTED_INTERFACE
+Select wifi interface (input 0 to skip): "
+
+echo "==================================================="
+echo " Configure WiFi interface ($TBOTS_WIFI_INTERFACE)"
+echo "==================================================="
+
+select INTERFACE in $(ls /sys/class/net);
+do
+    case $INTERFACE in
+        "")
+            echo "WiFi interface not configured"
+            break
+            ;;
+        *)
+            echo "> Selected interface $INTERFACE ($REPLY)"
+            sudo brctl addbr $TBOTS_WIFI_INTERFACE && \
+            sudo brctl addif $TBOTS_WIFI_INTERFACE $INTERFACE && \
+            sudo ip link set dev $TBOTS_WIFI_INTERFACE up && \
+            echo "> WiFi Interface Configured"
+            break
+            ;;
+    esac
+done
+
+PS3="Select ethernet interface (input 0 to skip): "
+
+echo "==================================================="
+echo " Configure WiFi interface ($TBOTS_ETHERNET_INTERFACE)"
+echo "==================================================="
+select INTERFACE in $(ls -I $TBOTS_WIFI_INTERFACE /sys/class/net );
+do
+    case $INTERFACE in
+        "")
+            echo "Ethernet interface not configured"
+            break
+            ;;
+        *)
+            echo "> Selected interface $INTERFACE ($REPLY)"
+            sudo brctl addbr $TBOTS_ETHERNET_INTERFACE && \
+            sudo brctl addif $TBOTS_ETHERNET_INTERFACE $INTERFACE && \
+            sudo ip link set dev $TBOTS_ETHERNET_INTERFACE up && \
+            echo "> Ethernet Interface Configured"
+            break
+            ;;
+    esac
+done

--- a/environment_setup/setup_networking.sh
+++ b/environment_setup/setup_networking.sh
@@ -53,7 +53,7 @@ done
 PS3="Select ethernet interface (input 0 to skip): "
 
 echo "==================================================="
-echo " Configure WiFi interface ($TBOTS_ETHERNET_INTERFACE)"
+echo " Configure Ethernet interface ($TBOTS_ETHERNET_INTERFACE)"
 echo "==================================================="
 select INTERFACE in $(ls -I $TBOTS_WIFI_INTERFACE /sys/class/net );
 do

--- a/environment_setup/setup_software.sh
+++ b/environment_setup/setup_software.sh
@@ -56,6 +56,7 @@ host_software_packages=(
                       # to manually install it ourselves
     kcachegrind # This lets us view the profiles output by callgrind
     codespell # Fixes typos
+    bridge-utils # Used to configure network in setup_networking.sh
 )
 
 if ! sudo apt-get install "${host_software_packages[@]}" -y ; then

--- a/src/software/parameter/config/network.yaml
+++ b/src/software/parameter/config/network.yaml
@@ -7,8 +7,7 @@ NetworkConfig:
       description: >-
           The multicast channel to join to communicate with the robots
     NetworkInterface:
-      default: "eth0"
+      default: "tbots_wifi"
       type: "std::string"
       description: >-
           The network interface that is connected to the thunderbots router.
-          Can be found using ifconfig on ubuntu.


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Bridges user interfaces to known interfaces so that we can configure the interfaces once and forget about it.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Tested manually on my computer, made sure wifi backend runs w/ grsim
Robots can send/recv over bridged network as well

⚠️  please try this script out locally, make sure to run `setup_software.sh` again or install `bridge-utils`
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
#1510 
### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
