### PR TITLE
Reset variables before calling accept

### DIFF
--- a/src/software/ai/motion_constraint/motion_constraint_manager.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_manager.cpp
@@ -5,9 +5,9 @@
 std::set<MotionConstraint> MotionConstraintManager::getMotionConstraints(
     const GameState &game_state, Tactic &tactic)
 {
+    current_whitelisted_constraints.clear();
     std::set<MotionConstraint> current_motion_constraints =
         getMotionConstraintsFromGameState(game_state);
-
     try
     {
         // updates current_whitelisted_constraints

--- a/src/software/ai/navigator/navigator.cpp
+++ b/src/software/ai/navigator/navigator.cpp
@@ -91,6 +91,8 @@ std::vector<std::unique_ptr<Primitive>> Navigator::getAssignedPrimitives(
     auto assigned_primitives = std::vector<std::unique_ptr<Primitive>>();
     for (const auto &intent : assignedIntents)
     {
+        current_primitive.reset(nullptr);
+        current_robot_id.reset();
         intent->accept(*this);
         if (current_primitive)
         {

--- a/src/software/proto/message_translation/tbots_protobuf_primitive_visitor.cpp
+++ b/src/software/proto/message_translation/tbots_protobuf_primitive_visitor.cpp
@@ -7,6 +7,7 @@
 std::unique_ptr<RadioPrimitiveMsg> ProtobufPrimitiveVisitor::getRadioPrimitiveMsg(
     const Primitive &primitive)
 {
+    prim_msg_ptr.reset(nullptr);
     primitive.accept(*this);
     return std::move(prim_msg_ptr);
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Found some fixes for visitors
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
visual testing for kickoffplaytest
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
