### PR TITLE
Reduce clutter from CI logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ jobs:
         # Run tests and collect coverage
         - >
           bazel coverage //...     \
+            --noshow_progress \
+            --noshow_loading_progress \
             --compilation_mode=fastbuild    \
             --verbose_test_summary          \
             --instrumentation_filter=//...  \

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ jobs:
         - >
           bazel coverage //...     \
             --noshow_progress \
-            --noshow_loading_progress \
             --compilation_mode=fastbuild    \
             --verbose_test_summary          \
             --instrumentation_filter=//...  \
@@ -22,9 +21,9 @@ jobs:
         # Collect Code Coverage Results
         - bash <(curl -s https://codecov.io/bash) -s bazel-testlogs/ | (head -n100 && tail -n100)
         # Build ARM Targets For Firmware
-        - bazel build --cpu=stm32h7 //firmware_new/boards/frankie_v1:frankie_v1_main 
-        - bazel build --cpu=stm32f4 //firmware/boards/legacy_robot_stm32f4:bin 
-        - bazel build --cpu=stm32f4 //firmware/boards/legacy_dongle_stm32f4:bin 
+        - bazel build --cpu=stm32h7 --noshow_progress //firmware_new/boards/frankie_v1:frankie_v1_main 
+        - bazel build --cpu=stm32f4 --noshow_progress //firmware/boards/legacy_robot_stm32f4:bin 
+        - bazel build --cpu=stm32f4 --noshow_progress //firmware/boards/legacy_dongle_stm32f4:bin 
     - name: "Check Formatting"
       script:
         - ./formatting_scripts/check_formatting_ci.sh


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Its really hard to figure out what went wrong because the build logs for travis are incredibly long
Travis doesn't support ANSI escape characters so every time bazel does a carriage return and rewrites the same line, it shows up as a new line causing the logs to flood

We can suppress the loading progress, and the progress, which makes it significantly less cluttered

Removes ~120 thousand lines before the test output
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Testing w/ this PR
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
pet peeve
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
