### PR TITLE
Replaced angleWith and pointInFrontVector with acuteAngle

### DIFF
--- a/src/software/ai/evaluation/calc_best_shot.cpp
+++ b/src/software/ai/evaluation/calc_best_shot.cpp
@@ -1,6 +1,7 @@
 #include "software/ai/evaluation/calc_best_shot.h"
 
 #include "software/geom/util.h"
+#include "software/new_geom/util/acute_angle.h"
 
 std::optional<Shot> calcBestShotOnGoal(const Point &goal_post_neg,
                                        const Point &goal_post_pos, const Point &p,
@@ -126,9 +127,9 @@ std::optional<Shot> calcBestShotOnFriendlyGoal(const Field &field,
 double calcShotOpenFriendlyNetPercentage(const Field &field, const Point &shot_origin,
                                          const Shot &shot)
 {
-    Angle goal_angle = acuteVertexAngle(field.friendlyGoalpostPos(), shot_origin,
-                                        field.friendlyGoalpostNeg())
-                           .abs();
+    Angle goal_angle =
+        acuteAngle(field.friendlyGoalpostPos(), shot_origin, field.friendlyGoalpostNeg())
+            .abs();
     return shot.getOpenAngle().toDegrees() / goal_angle.toDegrees();
 }
 
@@ -136,8 +137,7 @@ double calcShotOpenEnemyNetPercentage(const Field &field, const Point &shot_orig
                                       const Shot &shot)
 {
     Angle goal_angle =
-        acuteVertexAngle(field.enemyGoalpostPos(), shot_origin, field.enemyGoalpostNeg())
-            .abs();
+        acuteAngle(field.enemyGoalpostPos(), shot_origin, field.enemyGoalpostNeg()).abs();
     return shot.getOpenAngle().toDegrees() / goal_angle.toDegrees();
 }
 

--- a/src/software/ai/hl/stp/action/intercept_ball_action.cpp
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.cpp
@@ -8,6 +8,7 @@
 #include "software/geom/util.h"
 #include "software/logger/logger.h"
 #include "software/new_geom/ray.h"
+#include "software/new_geom/util/acute_angle.h"
 #include "software/new_geom/util/closest_point.h"
 #include "software/new_geom/util/distance.h"
 #include "software/new_geom/util/intersection.h"
@@ -71,7 +72,8 @@ void InterceptBallAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         Point closest_point = closestPointOnLine(
             robot->position(), Line(ball.position(), ball.position() + ball.velocity()));
         bool point_in_front_of_ball =
-            pointInFrontVector(ball.position(), ball.velocity(), closest_point);
+            acuteAngle(ball.velocity(), closest_point - ball.position()) <
+            Angle::quarter();
 
         // We add 1e-6 to avoid division by 0 without affecting the result significantly
         Duration ball_time_to_position = Duration::fromSeconds(
@@ -97,7 +99,8 @@ void InterceptBallAction::calculateNextIntent(IntentCoroutine::push_type& yield)
                     robot->position(),
                     Line(ball.position(), ball.position() + ball.velocity()));
                 point_in_front_of_ball =
-                    pointInFrontVector(ball.position(), ball.velocity(), closest_point);
+                    acuteAngle(ball.velocity(), closest_point - ball.position()) <
+                    Angle::quarter();
             }
         }
         else if (point_ball_leaves_field)
@@ -128,7 +131,8 @@ void InterceptBallAction::moveToInterceptPosition(IntentCoroutine::push_type& yi
                                                   Point closest_point_on_ball_trajectory)
 {
     bool robot_on_ball_line =
-        pointInFrontVector(ball.position(), ball.velocity(), robot->position()) &&
+        acuteAngle(ball.velocity(), robot->position() - ball.position()) <
+            Angle::quarter() &&
         distance(robot->position(),
                  Line(ball.position(), ball.position() + ball.velocity())) <
             ROBOT_CLOSE_TO_BALL_TRAJECTORY_LINE_THRESHOLD;

--- a/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -5,6 +5,7 @@
 #include "software/ai/hl/stp/action/move_action.h"
 #include "software/geom/util.h"
 #include "software/logger/logger.h"
+#include "software/new_geom/util/acute_angle.h"
 #include "software/new_geom/util/closest_point.h"
 
 ReceiverTactic::ReceiverTactic(const Field& field, const Team& friendly_team,
@@ -192,10 +193,9 @@ std::optional<Shot> ReceiverTactic::findFeasibleShot()
                 .clamp()
                 .abs();
 
-        Angle goal_angle =
-            acuteVertexAngle(field.friendlyGoalpostPos(), robot->position(),
-                             field.friendlyGoalpostNeg())
-                .abs();
+        Angle goal_angle = acuteAngle(field.friendlyGoalpostPos(), robot->position(),
+                                      field.friendlyGoalpostNeg())
+                               .abs();
         net_percent_open =
             best_shot_opt->getOpenAngle().toDegrees() / goal_angle.toDegrees();
     }

--- a/src/software/ai/passing/cost_function.cpp
+++ b/src/software/ai/passing/cost_function.cpp
@@ -7,6 +7,7 @@
 #include "software/ai/evaluation/pass.h"
 #include "software/geom/util.h"
 #include "software/logger/logger.h"
+#include "software/new_geom/util/acute_angle.h"
 #include "software/parameter/dynamic_parameters.h"
 
 double ratePass(const World& world, const Pass& pass,
@@ -101,8 +102,8 @@ double ratePassShootScore(const Field& field, const Team& enemy_team, const Pass
     }
 
     // Figure out what the maximum open angle of the goal could be from the receiver pos.
-    Angle goal_angle = acuteVertexAngle(field.enemyGoalpostNeg(), pass.receiverPoint(),
-                                        field.enemyGoalpostPos())
+    Angle goal_angle = acuteAngle(field.enemyGoalpostNeg(), pass.receiverPoint(),
+                                  field.enemyGoalpostPos())
                            .abs();
     double net_percent_open = 0;
     if (goal_angle > Angle::zero())

--- a/src/software/geom/util.cpp
+++ b/src/software/geom/util.cpp
@@ -167,25 +167,6 @@ double offsetToLine(Point x0, Point x1, Point p)
     return fabs(n.dot(p - x0));
 }
 
-Angle acuteVertexAngle(Vector v1, Vector v2)
-{
-    return v1.orientation().minDiff(v2.orientation());
-}
-
-Angle acuteVertexAngle(Point p1, Point p2, Point p3)
-{
-    return acuteVertexAngle(p1 - p2, p3 - p2);
-}
-
-bool pointInFrontVector(Point offset, Vector direction, Point p)
-{
-    // compare angle different
-    Angle a1   = direction.orientation();
-    Angle a2   = (p - offset).orientation();
-    Angle diff = (a1 - a2).clamp();
-    return diff < Angle::quarter() && diff > -Angle::quarter();
-}
-
 std::pair<Point, Point> getCircleTangentPoints(const Point &start, const Circle &circle,
                                                double buffer)
 {

--- a/src/software/geom/util.h
+++ b/src/software/geom/util.h
@@ -112,39 +112,6 @@ Point calcBlockCone(const Point &a, const Point &b, const Point &p, const double
 double offsetToLine(Point x0, Point x1, Point p);
 
 /**
- * Calculates the acute angle formed by the two given vectors
- *
- * @param v1
- * @param v2
- *
- * @return The acute angle formed by v1 and v2
- */
-Angle acuteVertexAngle(Vector v1, Vector v2);
-
-/**
- * Calculates the acute angle formed by the vector p2->p1 and p2->p3
- *
- * @param p1
- * @param p2
- * @param p3
- *
- * @return the acute angle formed by the vector p2->p1 and p2->p3
- */
-Angle acuteVertexAngle(Point p1, Point p2, Point p3);
-
-/**
- * found out if a point is in the vector's direction or against it
- * if the point normal to the vector, return false
- *
- * @param offset is the position of the origin of the vector
- *
- * @param dir is the direction of the vector
- *
- * @param p is the point is question
- */
-bool pointInFrontVector(Point offset, Vector dir, Point p);
-
-/**
  * Returns the circle's tangent points.
  *
  * Returns the points on the circle that form tangent lines with the start point

--- a/src/software/geom/util_test.cpp
+++ b/src/software/geom/util_test.cpp
@@ -113,50 +113,6 @@ TEST(GeomUtilTest, test_offset_to_line)
     EXPECT_NEAR(2, offsetToLine(x0, x1, p), 1e-5);
 }
 
-TEST(GeomUtilTest, test_acuteVertexAngle_angle_over_neg_y_axis)
-{
-    // Two vectors that form an acute angle over the negative y-axis
-
-    Vector v1 = Vector::createFromAngle(Angle::fromDegrees((-70)));
-    Vector v2 = Vector::createFromAngle(Angle::fromDegrees((-120)));
-
-    EXPECT_DOUBLE_EQ(50, acuteVertexAngle(v1, v2).toDegrees());
-}
-
-TEST(GeomUtilTest, test_acuteVertexAngle_angle_over_pos_y_axis)
-{
-    // Two vectors that form an acute angle over the positive y-axis
-
-    Vector v1 = Vector::createFromAngle(Angle::fromDegrees((70)));
-    Vector v2 = Vector::createFromAngle(Angle::fromDegrees((120)));
-
-    EXPECT_DOUBLE_EQ(50, acuteVertexAngle(v1, v2).toDegrees());
-}
-
-TEST(GeomUtilTest, test_acuteVertexAngle_180_degrees)
-{
-    Vector v1 = Vector::createFromAngle(Angle::fromDegrees((-90)));
-    Vector v2 = Vector::createFromAngle(Angle::fromDegrees((90)));
-
-    EXPECT_DOUBLE_EQ(180, acuteVertexAngle(v1, v2).toDegrees());
-}
-
-TEST(GeomUtilTest, test_acuteVertexAngle_large_angle_over_neg_x_axis)
-{
-    Vector v1 = Vector::createFromAngle(Angle::fromDegrees((-95)));
-    Vector v2 = Vector::createFromAngle(Angle::fromDegrees((99)));
-
-    EXPECT_DOUBLE_EQ(166, acuteVertexAngle(v1, v2).toDegrees());
-}
-
-TEST(GeomUtilTest, test_acuteVertex_angle_between_points)
-{
-    Point p1(2, 0.5);
-    Point p2(1, -0.5);
-    Point p3(1, 0.5);
-    EXPECT_DOUBLE_EQ(45, acuteVertexAngle(p1, p2, p3).toDegrees());
-}
-
 // Check the case where both rays intersect the segment only once (forming an intersection
 // segment within the segment)
 TEST(GeomUtilTest, test_segment_intersect_with_existing_segment)

--- a/src/software/new_geom/BUILD
+++ b/src/software/new_geom/BUILD
@@ -351,6 +351,7 @@ cc_test(
     srcs = ["bezier_curve2d_test.cpp"],
     deps = [
         ":bezier_curve2d",
+        "//software/new_geom/util:algorithms",
         "//software/test_util",
         "@gtest//:gtest_main",
     ],

--- a/src/software/new_geom/cubic_bezier_spline2d_test.cpp
+++ b/src/software/new_geom/cubic_bezier_spline2d_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "software/new_geom/bezier_curve2d.h"
+#include "software/new_geom/util/acute_angle.h"
 #include "software/test_util/test_util.h"
 
 class CubicBezierSplineTest : public ::testing::Test
@@ -65,7 +66,7 @@ TEST_F(CubicBezierSplineTest, getValueAt__start_point)
     // as well.
     const Point just_after_start_point   = test_spline_1.getValueAt(1e-9);
     const Vector approx_tangent_at_start = just_after_start_point - start_point;
-    const Angle tangent_error_angle = approx_tangent_at_start.angleWith(Vector(-3, -4));
+    const Angle tangent_error_angle = acuteAngle(approx_tangent_at_start, Vector(-3, -4));
 
     EXPECT_NEAR(0, tangent_error_angle.toRadians(), 1e-9);
 }
@@ -81,9 +82,10 @@ TEST_F(CubicBezierSplineTest, getValueAt__end_point)
     // as well.
     const Point just_before_end_point  = test_spline_1.getValueAt(1 - 1e-9);
     const Vector approx_tangent_at_end = just_before_end_point - end_point;
-    const Angle tangent_error_angle    = approx_tangent_at_end.angleWith(Vector(-2, -5));
+    const Angle tangent_error_angle = acuteAngle(approx_tangent_at_end, Vector(-2, -5));
 
-    EXPECT_NEAR(0, tangent_error_angle.toRadians(), 1e-9);
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(Angle::zero(), tangent_error_angle,
+                                               Angle::fromRadians(1e-6)));
 }
 
 TEST_F(CubicBezierSplineTest, getStartPoint)

--- a/src/software/new_geom/util/BUILD
+++ b/src/software/new_geom/util/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "algorithms",
     srcs = [
+        "acute_angle.cpp",
         "almost_equal.cpp",
         "closest_point.cpp",
         "collinear.cpp",
@@ -15,6 +16,7 @@ cc_library(
         "voronoi_diagram.cpp",
     ],
     hdrs = [
+        "acute_angle.h",
         "almost_equal.h",
         "closest_point.h",
         "collinear.h",
@@ -150,6 +152,15 @@ cc_test(
 cc_test(
     name = "furthest_point_test",
     srcs = ["furthest_point_test.cpp"],
+    deps = [
+        ":algorithms",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "acute_angle_test",
+    srcs = ["acute_angle_test.cpp"],
     deps = [
         ":algorithms",
         "@gtest//:gtest_main",

--- a/src/software/new_geom/util/acute_angle.cpp
+++ b/src/software/new_geom/util/acute_angle.cpp
@@ -1,0 +1,11 @@
+#include "software/new_geom/util/acute_angle.h"
+
+Angle acuteAngle(Vector v1, Vector v2)
+{
+    return v1.orientation().minDiff(v2.orientation());
+}
+
+Angle acuteAngle(Point p1, Point p2, Point p3)
+{
+    return acuteAngle(p1 - p2, p3 - p2);
+}

--- a/src/software/new_geom/util/acute_angle.h
+++ b/src/software/new_geom/util/acute_angle.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "software/new_geom/point.h"
+
+/**
+ * Calculates the acute angle formed by the two given vectors
+ *
+ * @param v1
+ * @param v2
+ *
+ * @return The acute angle formed by v1 and v2
+ */
+Angle acuteAngle(Vector v1, Vector v2);
+
+/**
+ * Calculates the acute angle formed by the vector p2->p1 and p2->p3
+ *
+ * @param p1
+ * @param p2
+ * @param p3
+ *
+ * @return the acute angle formed by the vector p2->p1 and p2->p3
+ */
+Angle acuteAngle(Point p1, Point p2, Point p3);

--- a/src/software/new_geom/util/acute_angle_test.cpp
+++ b/src/software/new_geom/util/acute_angle_test.cpp
@@ -1,0 +1,47 @@
+#include "software/new_geom/util/acute_angle.h"
+
+#include <gtest/gtest.h>
+
+TEST(GeomUtilTest, test_acuteAngle_angle_over_neg_y_axis)
+{
+    // Two vectors that form an acute angle over the negative y-axis
+
+    Vector v1 = Vector::createFromAngle(Angle::fromDegrees((-70)));
+    Vector v2 = Vector::createFromAngle(Angle::fromDegrees((-120)));
+
+    EXPECT_DOUBLE_EQ(50, acuteAngle(v1, v2).toDegrees());
+}
+
+TEST(GeomUtilTest, test_acuteAngle_angle_over_pos_y_axis)
+{
+    // Two vectors that form an acute angle over the positive y-axis
+
+    Vector v1 = Vector::createFromAngle(Angle::fromDegrees((70)));
+    Vector v2 = Vector::createFromAngle(Angle::fromDegrees((120)));
+
+    EXPECT_DOUBLE_EQ(50, acuteAngle(v1, v2).toDegrees());
+}
+
+TEST(GeomUtilTest, test_acuteAngle_180_degrees)
+{
+    Vector v1 = Vector::createFromAngle(Angle::fromDegrees((-90)));
+    Vector v2 = Vector::createFromAngle(Angle::fromDegrees((90)));
+
+    EXPECT_DOUBLE_EQ(180, acuteAngle(v1, v2).toDegrees());
+}
+
+TEST(GeomUtilTest, test_acuteAngle_large_angle_over_neg_x_axis)
+{
+    Vector v1 = Vector::createFromAngle(Angle::fromDegrees((-95)));
+    Vector v2 = Vector::createFromAngle(Angle::fromDegrees((99)));
+
+    EXPECT_DOUBLE_EQ(166, acuteAngle(v1, v2).toDegrees());
+}
+
+TEST(GeomUtilTest, test_acuteVertex_angle_between_points)
+{
+    Point p1(2, 0.5);
+    Point p2(1, -0.5);
+    Point p3(1, 0.5);
+    EXPECT_DOUBLE_EQ(45, acuteAngle(p1, p2, p3).toDegrees());
+}

--- a/src/software/new_geom/vector.cpp
+++ b/src/software/new_geom/vector.cpp
@@ -84,11 +84,6 @@ double Vector::cross(const Vector &other) const
     return x_ * other.y() - y_ * other.x();
 }
 
-Angle Vector::angleWith(const Vector &other) const
-{
-    return Angle::fromRadians(acos(dot(other) / (length() * other.length())));
-}
-
 Vector &Vector::operator=(const Vector &q)
 {
     x_ = q.x();

--- a/src/software/new_geom/vector.h
+++ b/src/software/new_geom/vector.h
@@ -183,15 +183,6 @@ class Vector final
      */
     Vector &operator=(const Vector &other);
 
-    /**
-     * Calculate the angle between this and another Vector
-     *
-     * @param other the other Vector to calculate the angle with
-     *
-     * @return the Angle between this vector and the other vector
-     */
-    Angle angleWith(const Vector &other) const;
-
    private:
     /**
      * The magnitude in the X coordinate of the Vector. The variable name starts with an

--- a/src/software/new_geom/vector_test.cpp
+++ b/src/software/new_geom/vector_test.cpp
@@ -235,27 +235,3 @@ TEST(VectorOperatorTests, vector_equality_inequality_test)
     EXPECT_FALSE(u == v);
     EXPECT_TRUE(u != v);
 }
-
-TEST(VectorAngleWithTests, vector_right_angle_with_other_test)
-{
-    Vector u = Vector(0, 5);
-    Vector v = Vector(4, 0);
-
-    EXPECT_EQ(v.angleWith(u), Angle::fromDegrees(90));
-}
-
-TEST(VectorAngleWithTests, vector_acute_angle_with_other_test)
-{
-    Vector u = Vector(0, -1);
-    Vector v = Vector(-1, -1);
-
-    EXPECT_EQ(v.angleWith(u), Angle::fromDegrees(45));
-}
-
-TEST(VectorAngleWithTests, vector_obtuse_angle_with_other_test)
-{
-    Vector u = Vector(1, 0);
-    Vector v = Vector(-1, -1);
-
-    EXPECT_EQ(v.angleWith(u), Angle::fromDegrees(135));
-}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Replace `acuteVertexAngle` with `angleWith` and `pointInFrontVector` with `similar`
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
added unit tests
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #1146
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
