### PR TITLE
Added LinearDamping and Tuned Restitution of PhysicsBall

### DIFF
--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -23,6 +23,11 @@
 class SensorFusion
 {
    public:
+    /**
+     * Creates a SensorFusion with a sensor_fusion_config
+     *
+     * @param sensor_fusion_config the config to fetch parameters from
+     */
     explicit SensorFusion(std::shared_ptr<const SensorFusionConfig> sensor_fusion_config);
 
     virtual ~SensorFusion() = default;

--- a/src/software/simulation/physics/physics_ball.cpp
+++ b/src/software/simulation/physics/physics_ball.cpp
@@ -5,8 +5,11 @@
 #include "software/simulation/physics/physics_object_user_data.h"
 
 PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const BallState &ball_state,
-                         const double mass_kg)
-    : in_flight_origin(std::nullopt), in_flight_distance_meters(0.0)
+                         const double mass_kg, double restitution, double linear_damping)
+    : in_flight_origin(std::nullopt),
+      in_flight_distance_meters(0.0),
+      ball_restitution(restitution),
+      ball_linear_damping(linear_damping)
 {
     // All the BodyDef must be defined before the body is created.
     // Changes made after aren't reflected
@@ -20,8 +23,9 @@ PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const BallState &ball_s
     // helps prevent tunneling and other collision problems
     // See the "Breakdown of a collision" section of:
     // https://www.iforce2d.net/b2dtut/collision-anatomy
-    ball_body_def.bullet = true;
-    ball_body            = world->CreateBody(&ball_body_def);
+    ball_body_def.bullet        = true;
+    ball_body_def.linearDamping = static_cast<float>(ball_linear_damping);
+    ball_body                   = world->CreateBody(&ball_body_def);
 
     b2CircleShape ball_shape;
     ball_shape.m_radius = static_cast<float>(BALL_MAX_RADIUS_METERS);
@@ -33,7 +37,7 @@ PhysicsBall::PhysicsBall(std::shared_ptr<b2World> world, const BallState &ball_s
     float ball_area =
         static_cast<float>(M_PI * ball_shape.m_radius * ball_shape.m_radius);
     ball_fixture_def.density     = static_cast<float>(mass_kg / ball_area);
-    ball_fixture_def.restitution = static_cast<float>(BALL_RESTITUTION);
+    ball_fixture_def.restitution = static_cast<float>(ball_restitution);
     ball_fixture_def.friction    = static_cast<float>(BALL_FRICTION);
     ball_fixture_def.userData =
         new PhysicsObjectUserData({PhysicsObjectType::BALL, this});

--- a/src/software/simulation/physics/physics_ball.h
+++ b/src/software/simulation/physics/physics_ball.h
@@ -131,7 +131,8 @@ class PhysicsBall
     // The restitution is the amount of energy retained when bouncing off walls and
     // robots, 0.0 means perfectly inelastic and 1.0 means perfectly elastic collision.
     // The linear damping determines how the linear motion of the ball decreases over
-    // time, 0.0 means no damping and the damping increases as linear_damping increases. Linear Damping link:
+    // time, 0.0 means no damping and the damping increases as linear_damping increases.
+    // Linear Damping link:
     // https://gamedev.stackexchange.com/questions/160047/what-does-lineardamping-mean-in-box2d
     const double ball_restitution;
     const double ball_linear_damping;

--- a/src/software/simulation/physics/physics_ball.h
+++ b/src/software/simulation/physics/physics_ball.h
@@ -23,9 +23,12 @@ class PhysicsBall
      * @param world A shared_ptr to a Box2D World
      * @param ball_state The initial state of the ball
      * @param mass_kg The mass of the ball in kg
+     * @param restitution The restitution of the ball
+     * @param linear_damping The linear damping of the ball
      */
     explicit PhysicsBall(std::shared_ptr<b2World> world, const BallState& ball_state,
-                         const double mass_kg);
+                         const double mass_kg, double restitution = 1.0,
+                         double linear_damping = 0.0);
 
     PhysicsBall() = delete;
 
@@ -122,12 +125,14 @@ class PhysicsBall
     // where the ball initially became in flight
     std::optional<Point> in_flight_origin;
     double in_flight_distance_meters;
+    // friction with other objects, such as robots/wall
+    static constexpr double BALL_FRICTION = 0.0;
 
-    // These restitution and friction values are somewhat arbitrary. Because this is an
-    // "ideal" simulation, we can approximate the ball as having perfectly elastic
-    // collisions and no friction. Because we also do not generally depend on specific
-    // behaviour when the ball collides with something, getting these values to perfectly
-    // match reality isn't too important.
-    static constexpr double BALL_RESTITUTION = 1.0;
-    static constexpr double BALL_FRICTION    = 0.0;
+    // The restitution is the amount of energy retained when bouncing off walls and
+    // robots, 0.0 means perfectly inelastic and 1.0 means perfectly elastic collision.
+    // The linear damping determines how the linear motion of the ball decreases over
+    // time, 0.0 means no damping and the damping increases as linear_damping increases. Linear Damping link:
+    // https://gamedev.stackexchange.com/questions/160047/what-does-lineardamping-mean-in-box2d
+    const double ball_restitution;
+    const double ball_linear_damping;
 };

--- a/src/software/simulation/physics/physics_field.h
+++ b/src/software/simulation/physics/physics_field.h
@@ -94,6 +94,10 @@ class PhysicsField
     b2ChainShape friendly_goal_shape;
     b2FixtureDef friendly_goal_fixture_def;
 
+    // We set the field restitution to 0 so that behavioiur of bouncing off walls is
+    // completely determined by the ball's restitution
+    const float field_restitution = 0.0f;
+
     // Since the field never changes during simulation, we store the initial field
     // used during construction to make it easy to return Field objects when requested
     Field field;

--- a/src/software/simulation/physics/physics_world.cpp
+++ b/src/software/simulation/physics/physics_world.cpp
@@ -5,12 +5,15 @@
 #include "shared/constants.h"
 #include "software/logger/logger.h"
 
-PhysicsWorld::PhysicsWorld(const Field& field, double ball_restitution, double ball_linear_damping)
+PhysicsWorld::PhysicsWorld(const Field& field, double ball_restitution,
+                           double ball_linear_damping)
     : b2_world(std::make_shared<b2World>(b2Vec2{0, 0})),
       current_timestamp(Timestamp::fromSeconds(0)),
       contact_listener(std::make_unique<SimulationContactListener>()),
       physics_field(b2_world, field),
-      physics_ball(nullptr), ball_restitution(ball_restitution), ball_linear_damping(ball_linear_damping)
+      physics_ball(nullptr),
+      ball_restitution(ball_restitution),
+      ball_linear_damping(ball_linear_damping)
 {
     b2_world->SetContactListener(contact_listener.get());
 }
@@ -73,7 +76,8 @@ const Timestamp PhysicsWorld::getTimestamp() const
 
 void PhysicsWorld::setBallState(const BallState& ball_state)
 {
-    physics_ball = std::make_shared<PhysicsBall>(b2_world, ball_state, BALL_MASS_KG, ball_restitution, ball_linear_damping);
+    physics_ball = std::make_shared<PhysicsBall>(b2_world, ball_state, BALL_MASS_KG,
+                                                 ball_restitution, ball_linear_damping);
 }
 
 void PhysicsWorld::removeBall()

--- a/src/software/simulation/physics/physics_world.cpp
+++ b/src/software/simulation/physics/physics_world.cpp
@@ -5,12 +5,12 @@
 #include "shared/constants.h"
 #include "software/logger/logger.h"
 
-PhysicsWorld::PhysicsWorld(const Field& field)
+PhysicsWorld::PhysicsWorld(const Field& field, double ball_restitution, double ball_linear_damping)
     : b2_world(std::make_shared<b2World>(b2Vec2{0, 0})),
       current_timestamp(Timestamp::fromSeconds(0)),
       contact_listener(std::make_unique<SimulationContactListener>()),
       physics_field(b2_world, field),
-      physics_ball(nullptr)
+      physics_ball(nullptr), ball_restitution(ball_restitution), ball_linear_damping(ball_linear_damping)
 {
     b2_world->SetContactListener(contact_listener.get());
 }
@@ -73,7 +73,7 @@ const Timestamp PhysicsWorld::getTimestamp() const
 
 void PhysicsWorld::setBallState(const BallState& ball_state)
 {
-    physics_ball = std::make_shared<PhysicsBall>(b2_world, ball_state, BALL_MASS_KG);
+    physics_ball = std::make_shared<PhysicsBall>(b2_world, ball_state, BALL_MASS_KG, ball_restitution, ball_linear_damping);
 }
 
 void PhysicsWorld::removeBall()

--- a/src/software/simulation/physics/physics_world.h
+++ b/src/software/simulation/physics/physics_world.h
@@ -27,7 +27,8 @@ class PhysicsWorld
      * @param ball_restitution The restitution for ball collisions
      * @param ball_linear_damping The damping on the ball's linear motion
      */
-    explicit PhysicsWorld(const Field& field, double ball_restitution = 1.0, double ball_linear_damping = 0.0);
+    explicit PhysicsWorld(const Field& field, double ball_restitution = 1.0,
+                          double ball_linear_damping = 0.0);
     PhysicsWorld() = delete;
 
     // Delete the copy and assignment operators because copying this class causes

--- a/src/software/simulation/physics/physics_world.h
+++ b/src/software/simulation/physics/physics_world.h
@@ -24,8 +24,10 @@ class PhysicsWorld
      * Creates a new PhysicsWorld that will contain no robots and no ball.
      *
      * @param field The initial state of the field
+     * @param ball_restitution The restitution for ball collisions
+     * @param ball_linear_damping The damping on the ball's linear motion
      */
-    explicit PhysicsWorld(const Field& field);
+    explicit PhysicsWorld(const Field& field, double ball_restitution = 1.0, double ball_linear_damping = 0.0);
     PhysicsWorld() = delete;
 
     // Delete the copy and assignment operators because copying this class causes
@@ -206,6 +208,8 @@ class PhysicsWorld
 
     PhysicsField physics_field;
     std::shared_ptr<PhysicsBall> physics_ball;
+    const double ball_restitution;
+    const double ball_linear_damping;
     std::vector<std::shared_ptr<PhysicsRobot>> yellow_physics_robots;
     std::vector<std::shared_ptr<PhysicsRobot>> blue_physics_robots;
 };

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -15,7 +15,12 @@ extern "C"
 }
 
 Simulator::Simulator(const Field& field, const Duration& physics_time_step)
-    : physics_world(field), frame_number(0), physics_time_step(physics_time_step)
+    : Simulator(field, 1.0, 0.0, physics_time_step)
+{
+}
+
+Simulator::Simulator(const Field& field, double ball_restitution, double ball_linear_damping, const Duration& physics_time_step)
+    : physics_world(field, ball_restitution, ball_linear_damping), frame_number(0), physics_time_step(physics_time_step)
 {
 }
 

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -19,8 +19,11 @@ Simulator::Simulator(const Field& field, const Duration& physics_time_step)
 {
 }
 
-Simulator::Simulator(const Field& field, double ball_restitution, double ball_linear_damping, const Duration& physics_time_step)
-    : physics_world(field, ball_restitution, ball_linear_damping), frame_number(0), physics_time_step(physics_time_step)
+Simulator::Simulator(const Field& field, double ball_restitution,
+                     double ball_linear_damping, const Duration& physics_time_step)
+    : physics_world(field, ball_restitution, ball_linear_damping),
+      frame_number(0),
+      physics_time_step(physics_time_step)
 {
 }
 

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -81,7 +81,9 @@ class Simulator
      * @param physics_time_step The time step used to simulated physics
      * and robot primitives.
      */
-    explicit Simulator(const Field& field, double ball_restitution , double ball_linear_damping, const Duration& physics_time_step =
+    explicit Simulator(const Field& field, double ball_restitution,
+                       double ball_linear_damping,
+                       const Duration& physics_time_step =
                            Duration::fromSeconds(DEFAULT_PHYSICS_TIME_STEP_SECONDS));
     Simulator() = delete;
 

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -70,6 +70,19 @@ class Simulator
     explicit Simulator(const Field& field,
                        const Duration& physics_time_step =
                            Duration::fromSeconds(DEFAULT_PHYSICS_TIME_STEP_SECONDS));
+
+    /**
+     * Creates a new Simulator. The starting state of the simulation
+     * will have the given field, with no robots or ball.
+     *
+     * @param field The field to initialize the simulation with
+     * @param ball_restitution The restitution for ball collisions
+     * @param ball_linear_damping The damping on the ball's linear motion
+     * @param physics_time_step The time step used to simulated physics
+     * and robot primitives.
+     */
+    explicit Simulator(const Field& field, double ball_restitution , double ball_linear_damping, const Duration& physics_time_step =
+                           Duration::fromSeconds(DEFAULT_PHYSICS_TIME_STEP_SECONDS));
     Simulator() = delete;
 
     /**

--- a/src/software/simulation/standalone_simulator.cpp
+++ b/src/software/simulation/standalone_simulator.cpp
@@ -9,7 +9,7 @@ extern "C"
 StandaloneSimulator::StandaloneSimulator(
     std::shared_ptr<StandaloneSimulatorConfig> standalone_simulator_config)
     : standalone_simulator_config(standalone_simulator_config),
-      simulator(Field::createSSLDivisionBField())
+      simulator(Field::createSSLDivisionBField(), 0.8, 0.2)
 {
     standalone_simulator_config->mutableBlueTeamChannel()->registerCallbackFunction(
         [this](int) { this->initNetworking(); });
@@ -29,7 +29,7 @@ StandaloneSimulator::StandaloneSimulator(
             this->wrapper_packet_sender->sendProto(wrapper_packet);
         });
 
-    simulator.setBallState(BallState(Point(0, 0), Vector(0, 0)));
+    simulator.setBallState(BallState(Point(0, 0), Vector(5, 2)));
 
     simulator.startSimulation();
 }

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -1,7 +1,10 @@
 #include "software/simulation/threaded_simulator.h"
 
-ThreadedSimulator::ThreadedSimulator(const Field &field, double ball_restitution, double ball_linear_damping)
-    : simulator(field, ball_restitution, ball_linear_damping), simulation_thread_started(false), stopping_simulation(false)
+ThreadedSimulator::ThreadedSimulator(const Field &field, double ball_restitution,
+                                     double ball_linear_damping)
+    : simulator(field, ball_restitution, ball_linear_damping),
+      simulation_thread_started(false),
+      stopping_simulation(false)
 {
 }
 

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -1,7 +1,7 @@
 #include "software/simulation/threaded_simulator.h"
 
-ThreadedSimulator::ThreadedSimulator(const Field &field)
-    : simulator(field), simulation_thread_started(false), stopping_simulation(false)
+ThreadedSimulator::ThreadedSimulator(const Field &field, double ball_restitution, double ball_linear_damping)
+    : simulator(field, ball_restitution, ball_linear_damping), simulation_thread_started(false), stopping_simulation(false)
 {
 }
 

--- a/src/software/simulation/threaded_simulator.h
+++ b/src/software/simulation/threaded_simulator.h
@@ -17,8 +17,10 @@ class ThreadedSimulator
      * will have the given field, with no robots or ball.
      *
      * @param field The field to initialize the simulation with
+     * @param ball_restitution The restitution for ball collisions
+     * @param ball_linear_damping The damping on the ball's linear motion
      */
-    explicit ThreadedSimulator(const Field& field);
+    explicit ThreadedSimulator(const Field& field, double ball_restitution = 1.0, double ball_linear_damping = 0.0);
     ~ThreadedSimulator();
 
     /**

--- a/src/software/simulation/threaded_simulator.h
+++ b/src/software/simulation/threaded_simulator.h
@@ -20,7 +20,8 @@ class ThreadedSimulator
      * @param ball_restitution The restitution for ball collisions
      * @param ball_linear_damping The damping on the ball's linear motion
      */
-    explicit ThreadedSimulator(const Field& field, double ball_restitution = 1.0, double ball_linear_damping = 0.0);
+    explicit ThreadedSimulator(const Field& field, double ball_restitution = 1.0,
+                               double ball_linear_damping = 0.0);
     ~ThreadedSimulator();
 
     /**


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
* Added LinearDamping and Tuned Restitution of PhysicsBall
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
visual inspection
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
