### PR TITLE
Pass network interface as command line argument

### DIFF
--- a/src/software/full_system_main.cpp
+++ b/src/software/full_system_main.cpp
@@ -110,13 +110,14 @@ int main(int argc, char **argv)
         std::shared_ptr<const AIControlConfig> ai_control_config =
             DynamicParameters->getAIControlConfig();
 
-        std::shared_ptr<Backend> backend =
-            GenericFactory<std::string, Backend>::create(args.backend_name);
-
         // TODO remove this when we move to non-generic factories for backends
         // https://github.com/UBC-Thunderbots/Software/issues/1452
-        MutableDynamicParameters->getNetworkConfig()->NetworkInterface->setValue(
-            args.network_interface_name);
+        MutableDynamicParameters->getMutableNetworkConfig()
+            ->mutableNetworkInterface()
+            ->setValue(args.network_interface_name);
+
+        std::shared_ptr<Backend> backend =
+            GenericFactory<std::string, Backend>::create(args.backend_name);
 
         auto ai = std::make_shared<AIWrapper>(ai_config, ai_control_config);
         std::shared_ptr<ThreadedFullSystemGUI> visualizer;

--- a/src/software/full_system_main.cpp
+++ b/src/software/full_system_main.cpp
@@ -12,10 +12,11 @@
 
 struct commandLineArgs
 {
-    bool help                = false;
-    std::string backend_name = "";
-    bool headless            = false;
-    bool err                 = false;
+    bool help                          = false;
+    std::string backend_name           = "";
+    std::string network_interface_name = "";
+    bool headless                      = false;
+    bool err                           = false;
 };
 
 // clang-format off
@@ -52,14 +53,23 @@ commandLineArgs parseCommandLineArgs(int argc, char **argv)
     std::string backend_help_str =
         "The backend that you would like to use, one of: " + all_backend_names;
 
+    std::string interface_help_str =
+        "The interface to send and receive packets over, ifconfig to get an idea";
+
     boost::program_options::options_description desc{"Options"};
     desc.add_options()("help,h", boost::program_options::bool_switch(&args.help),
-                       "Help screen")(
+                       "Help screen");
+    desc.add_options()(
         "backend",
         boost::program_options::value<std::string>(&args.backend_name)->required(),
-        backend_help_str.c_str())("headless",
-                                  boost::program_options::bool_switch(&args.headless),
-                                  "Run without the FullSystemGUI");
+        backend_help_str.c_str());
+    desc.add_options()(
+        "interface",
+        boost::program_options::value<std::string>(&args.network_interface_name)
+            ->required(),
+        interface_help_str.c_str());
+    desc.add_options()("headless", boost::program_options::bool_switch(&args.headless),
+                       "Run without the FullSystemGUI");
 
     boost::program_options::variables_map vm;
     try
@@ -102,6 +112,12 @@ int main(int argc, char **argv)
 
         std::shared_ptr<Backend> backend =
             GenericFactory<std::string, Backend>::create(args.backend_name);
+
+        // TODO remove this when we move to non-generic factories for backends
+        // https://github.com/UBC-Thunderbots/Software/issues/1452
+        MutableDynamicParameters->getNetworkConfig()->NetworkInterface->setValue(
+            args.network_interface_name);
+
         auto ai = std::make_shared<AIWrapper>(ai_config, ai_control_config);
         std::shared_ptr<ThreadedFullSystemGUI> visualizer;
 

--- a/src/software/full_system_main.cpp
+++ b/src/software/full_system_main.cpp
@@ -33,7 +33,7 @@ std::string BANNER =
 // clang-format on
 
 /**
- * Parses Arguments and Indicates which arguments were received
+ * Parses arguments and indicates which arguments were received
  *
  * @param argc
  * @param argv

--- a/src/software/full_system_main.cpp
+++ b/src/software/full_system_main.cpp
@@ -54,7 +54,7 @@ commandLineArgs parseCommandLineArgs(int argc, char **argv)
         "The backend that you would like to use, one of: " + all_backend_names;
 
     std::string interface_help_str =
-        "The interface to send and receive packets over, ifconfig to get an idea";
+        "The interface to send and receive packets over (can be found through ifconfig)";
 
     boost::program_options::options_description desc{"Options"};
     desc.add_options()("help,h", boost::program_options::bool_switch(&args.help),

--- a/src/software/full_system_main.cpp
+++ b/src/software/full_system_main.cpp
@@ -65,8 +65,7 @@ commandLineArgs parseCommandLineArgs(int argc, char **argv)
         backend_help_str.c_str());
     desc.add_options()(
         "interface",
-        boost::program_options::value<std::string>(&args.network_interface_name)
-            ->required(),
+        boost::program_options::value<std::string>(&args.network_interface_name),
         interface_help_str.c_str());
     desc.add_options()("headless", boost::program_options::bool_switch(&args.headless),
                        "Run without the FullSystemGUI");
@@ -112,9 +111,12 @@ int main(int argc, char **argv)
 
         // TODO remove this when we move to non-generic factories for backends
         // https://github.com/UBC-Thunderbots/Software/issues/1452
-        MutableDynamicParameters->getMutableNetworkConfig()
-            ->mutableNetworkInterface()
-            ->setValue(args.network_interface_name);
+        if (!args.network_interface_name.empty())
+        {
+            MutableDynamicParameters->getMutableNetworkConfig()
+                ->mutableNetworkInterface()
+                ->setValue(args.network_interface_name);
+        }
 
         std::shared_ptr<Backend> backend =
             GenericFactory<std::string, Backend>::create(args.backend_name);

--- a/src/software/simulation/BUILD
+++ b/src/software/simulation/BUILD
@@ -189,5 +189,6 @@ cc_binary(
         "//software/gui/standalone_simulator:threaded_standalone_simulator_gui",
         "//software/logger",
         "//software/parameter:dynamic_parameters",
+        "@boost//:program_options",
     ],
 )

--- a/src/software/simulation/standalone_simulator_main.cpp
+++ b/src/software/simulation/standalone_simulator_main.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
     {
         // TODO remove this when we move to non-generic factories for backends
         // https://github.com/UBC-Thunderbots/Software/issues/1452
-        MutableDynamicParameters->getMutableNetworkConfig()
+        MutableDynamicParameters->getMutableStandaloneSimulatorConfig()
             ->mutableNetworkInterface()
             ->setValue(args.network_interface_name);
 

--- a/src/software/simulation/standalone_simulator_main.cpp
+++ b/src/software/simulation/standalone_simulator_main.cpp
@@ -32,8 +32,7 @@ commandLineArgs parseCommandLineArgs(int argc, char **argv)
                        "Help screen");
     desc.add_options()(
         "interface",
-        boost::program_options::value<std::string>(&args.network_interface_name)
-            ->required(),
+        boost::program_options::value<std::string>(&args.network_interface_name),
         interface_help_str.c_str());
 
     boost::program_options::variables_map vm;
@@ -68,9 +67,12 @@ int main(int argc, char **argv)
     {
         // TODO remove this when we move to non-generic factories for backends
         // https://github.com/UBC-Thunderbots/Software/issues/1452
-        MutableDynamicParameters->getMutableStandaloneSimulatorConfig()
-            ->mutableNetworkInterface()
-            ->setValue(args.network_interface_name);
+        if (!args.network_interface_name.empty())
+        {
+            MutableDynamicParameters->getMutableStandaloneSimulatorConfig()
+                ->mutableNetworkInterface()
+                ->setValue(args.network_interface_name);
+        }
 
         ThreadedStandaloneSimulatorGUI standalone_simulator_gui_wrapper;
         StandaloneSimulator standalone_simulator(

--- a/src/software/simulation/standalone_simulator_main.cpp
+++ b/src/software/simulation/standalone_simulator_main.cpp
@@ -1,24 +1,90 @@
+#include <boost/program_options.hpp>
+
 #include "software/gui/standalone_simulator/threaded_standalone_simulator_gui.h"
 #include "software/logger/logger.h"
 #include "software/parameter/dynamic_parameters.h"
 #include "software/simulation/standalone_simulator.h"
 
-int main()
+struct commandLineArgs
+{
+    bool help                          = false;
+    std::string network_interface_name = "";
+    bool err                           = false;
+};
+
+/**
+ * Parses arguments and indicates which arguments were received
+ *
+ * @param argc
+ * @param argv
+ *
+ * @return a struct of which arguments are passed
+ */
+commandLineArgs parseCommandLineArgs(int argc, char **argv)
+{
+    commandLineArgs args;
+
+    std::string interface_help_str =
+        "The interface to send and receive packets over (can be found through ifconfig)";
+
+    boost::program_options::options_description desc{"Options"};
+    desc.add_options()("help,h", boost::program_options::bool_switch(&args.help),
+                       "Help screen");
+    desc.add_options()(
+        "interface",
+        boost::program_options::value<std::string>(&args.network_interface_name)
+            ->required(),
+        interface_help_str.c_str());
+
+    boost::program_options::variables_map vm;
+
+    try
+    {
+        boost::program_options::store(parse_command_line(argc, argv, desc), vm);
+        boost::program_options::notify(vm);
+
+        if (args.help)
+        {
+            std::cout << desc << std::endl;
+        }
+    }
+    catch (const boost::program_options::error &ex)
+    {
+        std::cerr << ex.what() << '\n';
+        args.err = true;
+        return args;
+    }
+
+    return args;
+}
+
+int main(int argc, char **argv)
 {
     LoggerSingleton::initializeLogger();
 
-    ThreadedStandaloneSimulatorGUI standalone_simulator_gui_wrapper;
-    StandaloneSimulator standalone_simulator(
-        MutableDynamicParameters->getMutableStandaloneSimulatorConfig());
-    standalone_simulator.registerOnSSLWrapperPacketReadyCallback(
-        [&standalone_simulator_gui_wrapper](SSL_WrapperPacket packet) {
-            standalone_simulator_gui_wrapper.onValueReceived(packet);
-        });
+    commandLineArgs args = parseCommandLineArgs(argc, argv);
 
-    // This blocks forever without using the CPU.
-    // Wait for the Simulator GUI to shut down before shutting
-    // down the rest of the system
-    standalone_simulator_gui_wrapper.getTerminationPromise()->get_future().wait();
+    if (!args.help && !args.err)
+    {
+        // TODO remove this when we move to non-generic factories for backends
+        // https://github.com/UBC-Thunderbots/Software/issues/1452
+        MutableDynamicParameters->getMutableNetworkConfig()
+            ->mutableNetworkInterface()
+            ->setValue(args.network_interface_name);
+
+        ThreadedStandaloneSimulatorGUI standalone_simulator_gui_wrapper;
+        StandaloneSimulator standalone_simulator(
+            MutableDynamicParameters->getMutableStandaloneSimulatorConfig());
+        standalone_simulator.registerOnSSLWrapperPacketReadyCallback(
+            [&standalone_simulator_gui_wrapper](SSL_WrapperPacket packet) {
+                standalone_simulator_gui_wrapper.onValueReceived(packet);
+            });
+
+        // This blocks forever without using the CPU.
+        // Wait for the Simulator GUI to shut down before shutting
+        // down the rest of the system
+        standalone_simulator_gui_wrapper.getTerminationPromise()->get_future().wait();
+    }
 
     return 0;
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
We have way too many different interfaces, it doesn't belong in the dynamic parameters, made it a command line argument
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Tested manually that it works
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
#1510 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
N/A
### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
