### PR TITLE
Trajectory Planner Bug Fix: Speed accumulation during rebalancing

### DIFF
--- a/src/firmware/app/control/trajectory_planner_impl.c
+++ b/src/firmware/app/control/trajectory_planner_impl.c
@@ -112,7 +112,7 @@ float app_trajectory_planner_impl_modifySpeedToMatchDuration(float initial_speed
 {
     // Calculate the new final speed based on the initial speed, displacement, and
     // the desired duration in time
-    return (2 * displacement / duration) + initial_speed;
+    return (2 * displacement - initial_speed * duration) / duration;
 }
 
 
@@ -131,29 +131,37 @@ void app_trajectory_planner_impl_modifySpeedsToMatchLongestSegmentDuration(
     for (unsigned int i = 0; i < num_elements - 1; i++)
     {
         // Check for the case that each segment duration isn't equal, so that they can be
-        // modifed to have the same duration
+        // modified to have the same duration
         if (durations1[i] > durations2[i] && displacement1[i] != 0)
         {
             const float current_speed    = speeds2[i];
-            const float displacement     = displacement2[i];
             const float desired_duration = durations1[i];
             float *final_speed_to_change = &speeds2[i + 1];
+            const float displacement     = displacement2[i];
 
             *final_speed_to_change =
                 app_trajectory_planner_impl_modifySpeedToMatchDuration(
                     current_speed, desired_duration, displacement);
+            if (*final_speed_to_change < 0)
+            {
+                *final_speed_to_change = 0;
+            }
             complete_time_profile[i + 1] = complete_time_profile[i] + desired_duration;
         }
         else if (durations2[i] > durations1[i] && displacement2[i] != 0)
         {
             const float current_speed    = speeds1[i];
-            const float displacement     = displacement1[i];
             const float desired_duration = durations2[i];
             float *final_speed_to_change = &speeds1[i + 1];
+            const float displacement     = displacement1[i];
 
             *final_speed_to_change =
                 app_trajectory_planner_impl_modifySpeedToMatchDuration(
                     current_speed, desired_duration, displacement);
+            if (*final_speed_to_change < 0)
+            {
+                *final_speed_to_change = 0;
+            }
             complete_time_profile[i + 1] = complete_time_profile[i] + desired_duration;
         }
         else

--- a/src/firmware/app/control/trajectory_planner_impl.c
+++ b/src/firmware/app/control/trajectory_planner_impl.c
@@ -112,7 +112,17 @@ float app_trajectory_planner_impl_modifySpeedToMatchDuration(float initial_speed
 {
     // Calculate the new final speed based on the initial speed, displacement, and
     // the desired duration in time
-    return (2 * displacement - initial_speed * duration) / duration;
+    float next_speed = (2.0f * displacement - initial_speed * duration) / duration;
+
+    // Since speed is absolute here, we want to prevent returning negative speed that
+    // would make us go backwards along the path The case where next_speed < 0 shouldn't
+    // happen under normal circumstances, but this check exists just in case.
+    if (next_speed < 0.0f)
+    {
+        next_speed = 0.0f;
+    }
+
+    return next_speed;
 }
 
 
@@ -142,10 +152,7 @@ void app_trajectory_planner_impl_modifySpeedsToMatchLongestSegmentDuration(
             *final_speed_to_change =
                 app_trajectory_planner_impl_modifySpeedToMatchDuration(
                     current_speed, desired_duration, displacement);
-            if (*final_speed_to_change < 0)
-            {
-                *final_speed_to_change = 0;
-            }
+
             complete_time_profile[i + 1] = complete_time_profile[i] + desired_duration;
         }
         else if (durations2[i] > durations1[i] && displacement2[i] != 0)
@@ -158,10 +165,7 @@ void app_trajectory_planner_impl_modifySpeedsToMatchLongestSegmentDuration(
             *final_speed_to_change =
                 app_trajectory_planner_impl_modifySpeedToMatchDuration(
                     current_speed, desired_duration, displacement);
-            if (*final_speed_to_change < 0)
-            {
-                *final_speed_to_change = 0;
-            }
+
             complete_time_profile[i + 1] = complete_time_profile[i] + desired_duration;
         }
         else

--- a/src/firmware/app/control/trajectory_planner_impl.c
+++ b/src/firmware/app/control/trajectory_planner_impl.c
@@ -106,9 +106,9 @@ void app_trajectory_planner_impl_generatePositionTrajectoryTimeProfile(
     }
 }
 
-float app_trajectory_planner_impl_modifySpeedToMatchDuration(float initial_speed,
-                                                             float duration,
-                                                             float displacement)
+float app_trajectory_planner_impl_calculateSpeedToMatchDuration(float initial_speed,
+                                                                float duration,
+                                                                float displacement)
 {
     // Calculate the new final speed based on the initial speed, displacement, and
     // the desired duration in time
@@ -150,10 +150,8 @@ void app_trajectory_planner_impl_modifySpeedsToMatchLongestSegmentDuration(
             const float displacement     = displacement2[i];
 
             *final_speed_to_change =
-                app_trajectory_planner_impl_modifySpeedToMatchDuration(
+                app_trajectory_planner_impl_calculateSpeedToMatchDuration(
                     current_speed, desired_duration, displacement);
-
-            complete_time_profile[i + 1] = complete_time_profile[i] + desired_duration;
         }
         else if (durations2[i] > durations1[i] && displacement2[i] != 0)
         {
@@ -163,7 +161,7 @@ void app_trajectory_planner_impl_modifySpeedsToMatchLongestSegmentDuration(
             const float displacement     = displacement1[i];
 
             *final_speed_to_change =
-                app_trajectory_planner_impl_modifySpeedToMatchDuration(
+                app_trajectory_planner_impl_calculateSpeedToMatchDuration(
                     current_speed, desired_duration, displacement);
 
             complete_time_profile[i + 1] = complete_time_profile[i] + desired_duration;

--- a/src/firmware/app/control/trajectory_planner_impl.c
+++ b/src/firmware/app/control/trajectory_planner_impl.c
@@ -151,6 +151,8 @@ void app_trajectory_planner_impl_modifySpeedsToMatchLongestSegmentDuration(
 
             *next_speed = app_trajectory_planner_impl_calculateSpeedToMatchDuration(
                 current_speed, desired_duration, displacement);
+
+            complete_time_profile[i + 1] = complete_time_profile[i] + desired_duration;
         }
         else if (durations2[i] > durations1[i] && displacement2[i] != 0)
         {
@@ -168,7 +170,6 @@ void app_trajectory_planner_impl_modifySpeedsToMatchLongestSegmentDuration(
         {
             // This means that the durations are equal and nothing needs to be changed
             complete_time_profile[i + 1] = complete_time_profile[i] + durations1[i];
-            continue;
         }
     }
 }

--- a/src/firmware/app/control/trajectory_planner_impl.c
+++ b/src/firmware/app/control/trajectory_planner_impl.c
@@ -146,23 +146,21 @@ void app_trajectory_planner_impl_modifySpeedsToMatchLongestSegmentDuration(
         {
             const float current_speed    = speeds2[i];
             const float desired_duration = durations1[i];
-            float *final_speed_to_change = &speeds2[i + 1];
+            float *next_speed            = &speeds2[i + 1];
             const float displacement     = displacement2[i];
 
-            *final_speed_to_change =
-                app_trajectory_planner_impl_calculateSpeedToMatchDuration(
-                    current_speed, desired_duration, displacement);
+            *next_speed = app_trajectory_planner_impl_calculateSpeedToMatchDuration(
+                current_speed, desired_duration, displacement);
         }
         else if (durations2[i] > durations1[i] && displacement2[i] != 0)
         {
             const float current_speed    = speeds1[i];
             const float desired_duration = durations2[i];
-            float *final_speed_to_change = &speeds1[i + 1];
+            float *next_speed            = &speeds1[i + 1];
             const float displacement     = displacement1[i];
 
-            *final_speed_to_change =
-                app_trajectory_planner_impl_calculateSpeedToMatchDuration(
-                    current_speed, desired_duration, displacement);
+            *next_speed = app_trajectory_planner_impl_calculateSpeedToMatchDuration(
+                current_speed, desired_duration, displacement);
 
             complete_time_profile[i + 1] = complete_time_profile[i] + desired_duration;
         }

--- a/src/firmware/app/control/trajectory_planner_impl.c
+++ b/src/firmware/app/control/trajectory_planner_impl.c
@@ -115,7 +115,7 @@ float app_trajectory_planner_impl_calculateSpeedToMatchDuration(float initial_sp
     float next_speed = (2.0f * displacement - initial_speed * duration) / duration;
 
     // Since speed is absolute here, we want to prevent returning negative speed that
-    // would make us go backwards along the path The case where next_speed < 0 shouldn't
+    // would make us go backwards along the path. The case where next_speed < 0 shouldn't
     // happen under normal circumstances, but this check exists just in case.
     if (next_speed < 0.0f)
     {

--- a/src/firmware/app/control/trajectory_planner_impl.h
+++ b/src/firmware/app/control/trajectory_planner_impl.h
@@ -263,6 +263,6 @@ void app_trajectory_planner_impl_modifySpeedsToMatchLongestSegmentDuration(
  *
  * @return final_speed The final speed at the end of the segment.
  */
-float app_trajectory_planner_impl_modifySpeedToMatchDuration(float initial_speed,
-                                                             float duration,
-                                                             float displacement);
+float app_trajectory_planner_impl_calculateSpeedToMatchDuration(float initial_speed,
+                                                                float duration,
+                                                                float displacement);

--- a/src/firmware/app/control/trajectory_planner_impl_test.cpp
+++ b/src/firmware/app/control/trajectory_planner_impl_test.cpp
@@ -734,6 +734,28 @@ TEST(TrajectoryPlannerImplTest, test_rebalance_trajectory_segment_to_mach_durati
 
     speeds[1] = app_trajectory_planner_impl_modifySpeedToMatchDuration(
         speeds[0], desired_time_seconds, segment_lengths_meters[0]);
-    EXPECT_FLOAT_EQ(speeds[1], 201);
+    EXPECT_FLOAT_EQ(speeds[1], 199);
     EXPECT_FLOAT_EQ(speeds[0], 1);
+}
+
+TEST(TrajectoryPlannerImplTest,
+     test_rebalance_trajectory_segment_to_mach_duration_decreasing_speed)
+{
+    // This test was added to address a bug where the trajectory rebalancing could not
+    // account for decreasing speeds this led to the accumulation of speed where it was
+    // supposed to be decreasing
+    float segment_lengths_meters[TRAJECTORY_PLANNER_MAX_NUM_ELEMENTS];
+    float speeds[TRAJECTORY_PLANNER_MAX_NUM_ELEMENTS];
+
+    // Create an artificial trajectory here for testing
+    speeds[0]                  = 4;
+    speeds[1]                  = 3;
+    float desired_time_seconds = 0.15f;
+
+    segment_lengths_meters[0] = 0.35f;
+
+    speeds[1] = app_trajectory_planner_impl_modifySpeedToMatchDuration(
+        speeds[0], desired_time_seconds, segment_lengths_meters[0]);
+    EXPECT_NEAR(speeds[1], 0.666666f, 0.0001f);
+    EXPECT_FLOAT_EQ(speeds[0], 4.0f);
 }

--- a/src/firmware/app/control/trajectory_planner_impl_test.cpp
+++ b/src/firmware/app/control/trajectory_planner_impl_test.cpp
@@ -732,7 +732,7 @@ TEST(TrajectoryPlannerImplTest, test_rebalance_trajectory_segment_to_mach_durati
 
     segment_lengths_meters[0] = 1.0;
 
-    speeds[1] = app_trajectory_planner_impl_modifySpeedToMatchDuration(
+    speeds[1] = app_trajectory_planner_impl_calculateSpeedToMatchDuration(
         speeds[0], desired_time_seconds, segment_lengths_meters[0]);
     EXPECT_FLOAT_EQ(speeds[1], 199);
     EXPECT_FLOAT_EQ(speeds[0], 1);
@@ -754,7 +754,7 @@ TEST(TrajectoryPlannerImplTest,
 
     segment_lengths_meters[0] = 0.35f;
 
-    speeds[1] = app_trajectory_planner_impl_modifySpeedToMatchDuration(
+    speeds[1] = app_trajectory_planner_impl_calculateSpeedToMatchDuration(
         speeds[0], desired_time_seconds, segment_lengths_meters[0]);
     EXPECT_NEAR(speeds[1], 0.666666f, 0.0001f);
     EXPECT_FLOAT_EQ(speeds[0], 4.0f);

--- a/src/firmware/app/control/trajectory_planner_impl_test.cpp
+++ b/src/firmware/app/control/trajectory_planner_impl_test.cpp
@@ -739,7 +739,7 @@ TEST(TrajectoryPlannerImplTest, test_rebalance_trajectory_segment_to_mach_durati
 }
 
 TEST(TrajectoryPlannerImplTest,
-     test_rebalance_trajectory_segment_to_mach_duration_decreasing_speed)
+     test_rebalance_trajectory_segment_to_match_duration_decreasing_speed)
 {
     // This test was added to address a bug where the trajectory rebalancing could not
     // account for decreasing speeds. This led to the accumulation of speed when it was

--- a/src/firmware/app/control/trajectory_planner_impl_test.cpp
+++ b/src/firmware/app/control/trajectory_planner_impl_test.cpp
@@ -742,7 +742,7 @@ TEST(TrajectoryPlannerImplTest,
      test_rebalance_trajectory_segment_to_mach_duration_decreasing_speed)
 {
     // This test was added to address a bug where the trajectory rebalancing could not
-    // account for decreasing speeds this led to the accumulation of speed where it was
+    // account for decreasing speeds. This led to the accumulation of speed when it was
     // supposed to be decreasing
     float segment_lengths_meters[TRAJECTORY_PLANNER_MAX_NUM_ELEMENTS];
     float speeds[TRAJECTORY_PLANNER_MAX_NUM_ELEMENTS];

--- a/src/firmware/app/control/trajectory_planner_test.cpp
+++ b/src/firmware/app/control/trajectory_planner_test.cpp
@@ -1210,3 +1210,39 @@ TEST_F(
     EXPECT_FLOAT_EQ(
         velocity_trajectory.angular_velocity[path_parameters.num_elements - 1], 0);
 }
+
+// A robot with very little linear motion required, rotates just under 180 deg.
+TEST_F(TrajectoryPlannerTest,
+       test_angular_limiting_the_trajectory_with_large_linear_slowdown)
+{
+    // This test was created to address a bug that was found where the corrected linear
+    // speeds where too great it was caused by the speed correction only adding speed vs
+    // taking it away when the speed is decreasing.
+    FirmwareRobotPathParameters_t path_parameters = {
+        .path                = {.x = {.coefficients = {0.0f, 0.0f, 0.05f, 4.6f}},
+                 .y = {.coefficients = {0.0f, 0.0f, 0.0f, -3.09f}}},
+        .orientation_profile = {.coefficients = {0.0f, 0.0f, 2.55f, 0.0f}},
+        .t_start             = 0.0f,
+        .t_end               = 1.0f,
+        .num_elements        = 10,
+        .max_allowable_linear_acceleration  = 1.5f,
+        .max_allowable_linear_speed         = 1.0f,
+        .max_allowable_angular_acceleration = 5.0f,
+        .max_allowable_angular_speed        = 6.28f,
+        .initial_linear_speed               = 0.0f,
+        .final_linear_speed                 = 0.0f};
+
+    PositionTrajectory_t position_trajectory;
+    auto status =
+        app_trajectory_planner_generateConstantParameterizationPositionTrajectory(
+            path_parameters, &position_trajectory);
+    EXPECT_EQ(status, OK);
+
+    // Check that the speeds meet the start and end conditions and did not accumulate
+    EXPECT_NEAR(position_trajectory.linear_speed[0], path_parameters.initial_linear_speed,
+                0.0001f);
+    EXPECT_NEAR(position_trajectory.linear_speed[9], path_parameters.final_linear_speed,
+                0.0001f);
+    EXPECT_NEAR(position_trajectory.angular_speed[0], 0.0f, 0.0001f);
+    EXPECT_NEAR(position_trajectory.angular_speed[9], 0.0f, 0.0001f);
+}

--- a/src/firmware/app/control/trajectory_planner_test.cpp
+++ b/src/firmware/app/control/trajectory_planner_test.cpp
@@ -1216,8 +1216,8 @@ TEST_F(TrajectoryPlannerTest,
        test_angular_limiting_the_trajectory_with_large_linear_slowdown)
 {
     // This test was created to address a bug that was found where the corrected linear
-    // speeds where too great it was caused by the speed correction only adding speed vs
-    // taking it away when the speed is decreasing.
+    // speeds accumulated instead of decreasing to the final value. It was caused by the
+    // speed correction only adding speed vs taking it away when the speed is decreasing.
     FirmwareRobotPathParameters_t path_parameters = {
         .path                = {.x = {.coefficients = {0.0f, 0.0f, 0.05f, 4.6f}},
                  .y = {.coefficients = {0.0f, 0.0f, 0.0f, -3.09f}}},


### PR DESCRIPTION
### Description
It was found during simulator testing that the trajectory planner behaved strangely when the robot was asked to move a small linear distance and a large angular distance.

It was found through debugging that the linear speed was accumulating over the profile instead of increasing then decreasing near the destination.

I found that the bug was caused by a incorrect formula in the rebalancing function.
### Testing Done
Unit test for the _impl_ function in question, and a high-level test using the parameters from the initial bug.
### Review Checklist
- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [X] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.
