### PR TITLE
Made simulated test timing more smooth

### DIFF
--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -144,15 +144,17 @@ void SimulatedTestFixture::updateSensorFusion()
     sensor_fusion.updateWorld(sensor_msg);
 }
 
-void SimulatedTestFixture::sleep(const std::chrono::steady_clock::time_point &wall_start_time,
-                                 const Duration &desired_wall_tick_time) {
+void SimulatedTestFixture::sleep(
+    const std::chrono::steady_clock::time_point &wall_start_time,
+    const Duration &desired_wall_tick_time)
+{
     auto wall_time_now = std::chrono::steady_clock::now();
     auto current_tick_wall_time_duration =
         std::chrono::duration_cast<std::chrono::milliseconds>(wall_time_now -
                                                               wall_start_time);
-    auto ms_to_sleep =
-            std::chrono::milliseconds(static_cast<int>(desired_wall_tick_time.getMilliseconds())) -
-            current_tick_wall_time_duration;
+    auto ms_to_sleep = std::chrono::milliseconds(
+                           static_cast<int>(desired_wall_tick_time.getMilliseconds())) -
+                       current_tick_wall_time_duration;
     std::cout << "sleeping for " << ms_to_sleep.count() << std::endl;
     if (ms_to_sleep > std::chrono::milliseconds(0))
     {
@@ -188,13 +190,15 @@ void SimulatedTestFixture::runTest(
             NonTerminatingFunctionValidator(validation_function, world));
     }
 
-    const Timestamp timeout_time         = simulator->getTimestamp() + timeout;
-    const Duration simulation_time_step             = Duration::fromSeconds(1.0 / SIMULATED_CAMERA_FPS);
-    const Duration ai_time_step             = Duration::fromSeconds(simulation_time_step.getSeconds() * CAMERA_FRAMES_PER_AI_TICK);
+    const Timestamp timeout_time = simulator->getTimestamp() + timeout;
+    const Duration simulation_time_step =
+        Duration::fromSeconds(1.0 / SIMULATED_CAMERA_FPS);
+    const Duration ai_time_step = Duration::fromSeconds(
+        simulation_time_step.getSeconds() * CAMERA_FRAMES_PER_AI_TICK);
     bool validation_functions_done = false;
     while (simulator->getTimestamp() < timeout_time)
     {
-        auto wall_start_time           = std::chrono::steady_clock::now();
+        auto wall_start_time = std::chrono::steady_clock::now();
         for (size_t i = 0; i < CAMERA_FRAMES_PER_AI_TICK; i++)
         {
             simulator->stepSimulation(simulation_time_step);

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -144,19 +144,16 @@ void SimulatedTestFixture::updateSensorFusion()
     sensor_fusion.updateWorld(sensor_msg);
 }
 
-void SimulatedTestFixture::sleep(
-    const std::chrono::steady_clock::time_point &wall_start_time,
-    const Timestamp &current_time)
-{
-    // How long to wait for the wall-clock time to match the
-    // current simulation time
+void SimulatedTestFixture::sleep(const std::chrono::steady_clock::time_point &wall_start_time,
+                                 const Duration &desired_wall_tick_time) {
     auto wall_time_now = std::chrono::steady_clock::now();
-    auto wall_time_since_sim_start =
+    auto current_tick_wall_time_duration =
         std::chrono::duration_cast<std::chrono::milliseconds>(wall_time_now -
                                                               wall_start_time);
     auto ms_to_sleep =
-        std::chrono::milliseconds(static_cast<int>(current_time.getMilliseconds())) -
-        wall_time_since_sim_start;
+            std::chrono::milliseconds(static_cast<int>(desired_wall_tick_time.getMilliseconds())) -
+            current_tick_wall_time_duration;
+    std::cout << "sleeping for " << ms_to_sleep.count() << std::endl;
     if (ms_to_sleep > std::chrono::milliseconds(0))
     {
         std::this_thread::sleep_for(ms_to_sleep);
@@ -191,15 +188,16 @@ void SimulatedTestFixture::runTest(
             NonTerminatingFunctionValidator(validation_function, world));
     }
 
-    Timestamp timeout_time         = simulator->getTimestamp() + timeout;
-    Duration time_step             = Duration::fromSeconds(1.0 / SIMULATED_CAMERA_FPS);
-    auto wall_start_time           = std::chrono::steady_clock::now();
+    const Timestamp timeout_time         = simulator->getTimestamp() + timeout;
+    const Duration simulation_time_step             = Duration::fromSeconds(1.0 / SIMULATED_CAMERA_FPS);
+    const Duration ai_time_step             = Duration::fromSeconds(simulation_time_step.getSeconds() * CAMERA_FRAMES_PER_AI_TICK);
     bool validation_functions_done = false;
     while (simulator->getTimestamp() < timeout_time)
     {
+        auto wall_start_time           = std::chrono::steady_clock::now();
         for (size_t i = 0; i < CAMERA_FRAMES_PER_AI_TICK; i++)
         {
-            simulator->stepSimulation(time_step);
+            simulator->stepSimulation(simulation_time_step);
             updateSensorFusion();
         }
 
@@ -220,6 +218,11 @@ void SimulatedTestFixture::runTest(
                     std::move(primitives));
             simulator->setYellowRobotPrimitives(primitives_ptr);
 
+            if (run_simulation_in_realtime)
+            {
+                sleep(wall_start_time, ai_time_step);
+            }
+
             if (full_system_gui)
             {
                 full_system_gui->onValueReceived(*world);
@@ -230,11 +233,6 @@ void SimulatedTestFixture::runTest(
         else
         {
             LOG(WARNING) << "SensorFusion did not output a valid World";
-        }
-
-        if (run_simulation_in_realtime)
-        {
-            sleep(wall_start_time, simulator->getTimestamp());
         }
     }
 

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -155,7 +155,6 @@ void SimulatedTestFixture::sleep(
     auto ms_to_sleep = std::chrono::milliseconds(
                            static_cast<int>(desired_wall_tick_time.getMilliseconds())) -
                        current_tick_wall_time_duration;
-    std::cout << "sleeping for " << ms_to_sleep.count() << std::endl;
     if (ms_to_sleep > std::chrono::milliseconds(0))
     {
         std::this_thread::sleep_for(ms_to_sleep);

--- a/src/software/simulated_tests/simulated_test_fixture.h
+++ b/src/software/simulated_tests/simulated_test_fixture.h
@@ -138,15 +138,16 @@ class SimulatedTestFixture : public ::testing::Test
             non_terminating_function_validators);
 
     /**
-     * Puts the current thread to sleep until the difference between the current wall time
-     * and the wall_start_time is >= the difference between current_time and zero. This
-     * "synchronizes" wall time with simulation time by slowing down execution if needed.
+     * Puts the current thread to sleep such that each simulation step will take
+     * the desired about of real-world "wall" time.
      *
-     * @param wall_start_time The time at which the simulated test started, in wall time
-     * @param current_time The current time in the simulated test
+     * @param wall_start_time The time at which the most recent simulation step started,
+     * in wall time
+     * @param desired_wall_tick_time How long each simulation step should take
+     * in wall-clock time
      */
     static void sleep(const std::chrono::steady_clock::time_point& wall_start_time,
-                      const Timestamp& current_time);
+                      const Duration& desired_wall_tick_time);
 
     // The simulator needs to be a pointer so that we can destroy and re-create
     // the object in the SetUp function. Because the simulator has no

--- a/src/software/simulated_tests/simulated_test_fixture.h
+++ b/src/software/simulated_tests/simulated_test_fixture.h
@@ -139,7 +139,7 @@ class SimulatedTestFixture : public ::testing::Test
 
     /**
      * Puts the current thread to sleep such that each simulation step will take
-     * the desired about of real-world "wall" time.
+     * the desired amount of real-world "wall" time.
      *
      * @param wall_start_time The time at which the most recent simulation step started,
      * in wall time


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Previously the simulated tests used absolute simulated time to determine how long to sleep if it needed to in order to make things appear "real-time". However if things ran slowly for a bit, things later could run extremely fast because they wouldn't sleep at all (because the time was "lagging behind" so much of where we thought we should be).

I changed the system to use relative timings, and also fixed a small bug where we only slept half as long as we needed to. Everything now runs at a much more consistent and realistic speed.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
manual verification

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
