### PR TITLE
Updated sizes and size policies so text boxes don't get cutoff in RobotDiagnosticsGUI

### DIFF
--- a/src/software/gui/robot_diagnostics/ui/main_widget.ui
+++ b/src/software/gui/robot_diagnostics/ui/main_widget.ui
@@ -28,7 +28,7 @@
            <widget class="QLabel" name="label_robot_selection">
             <property name="maximumSize">
              <size>
-              <width>120</width>
+              <width>16777215</width>
               <height>16777215</height>
              </size>
             </property>
@@ -75,7 +75,7 @@
              <widget class="QLabel" name="label_sensor_status">
               <property name="maximumSize">
                <size>
-                <width>135</width>
+                <width>16777215</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -91,6 +91,12 @@
             </item>
             <item>
              <widget class="Line" name="line_2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -112,7 +118,7 @@
                <widget class="QLabel" name="label_status">
                 <property name="maximumSize">
                  <size>
-                  <width>50</width>
+                  <width>16777215</width>
                   <height>16777215</height>
                  </size>
                 </property>
@@ -128,6 +134,12 @@
               </item>
               <item>
                <widget class="Line" name="line_6">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
@@ -269,7 +281,7 @@
                <widget class="QLabel" name="label_temperature">
                 <property name="maximumSize">
                  <size>
-                  <width>100</width>
+                  <width>16777215</width>
                   <height>16777215</height>
                  </size>
                 </property>
@@ -285,6 +297,12 @@
               </item>
               <item>
                <widget class="Line" name="line_7">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
@@ -372,7 +390,7 @@
              <widget class="QLabel" name="label_leds">
               <property name="maximumSize">
                <size>
-                <width>45</width>
+                <width>16777215</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -388,6 +406,12 @@
             </item>
             <item>
              <widget class="Line" name="line_3">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -431,7 +455,7 @@
              <widget class="QLabel" name="label_drive">
               <property name="maximumSize">
                <size>
-                <width>50</width>
+                <width>16777215</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -447,6 +471,12 @@
             </item>
             <item>
              <widget class="Line" name="line">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -776,7 +806,7 @@
              <widget class="QLabel" name="label_chicker">
               <property name="maximumSize">
                <size>
-                <width>68</width>
+                <width>16777215</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -792,6 +822,12 @@
             </item>
             <item>
              <widget class="Line" name="line_4">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -867,6 +903,12 @@
                 </item>
                 <item>
                  <widget class="QLineEdit" name="lineEdit_chicker_power">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
                   <property name="maximumSize">
                    <size>
                     <width>60</width>
@@ -943,7 +985,7 @@
              <widget class="QLabel" name="label_dribbler_2">
               <property name="maximumSize">
                <size>
-                <width>80</width>
+                <width>16777215</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -959,6 +1001,12 @@
             </item>
             <item>
              <widget class="Line" name="line_5">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -989,9 +1037,15 @@
             </item>
             <item>
              <widget class="QLineEdit" name="lineEdit_dribbler_power">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="maximumSize">
                <size>
-                <width>60</width>
+                <width>16777215</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -999,6 +1053,12 @@
             </item>
             <item>
              <widget class="QPushButton" name="pushButton_dribbler_stop">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Stop and Reset</string>
               </property>
@@ -1051,7 +1111,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup_charge_state"/>
   <buttongroup name="buttonGroup_autochick"/>
+  <buttongroup name="buttonGroup_charge_state"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION

<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
* Some text boxes had small fixed max sizes. Changed to MAX_INT
* Changed size policies of horizontal spacers and lines to EXPANDING
instead of MINIMUM so they can shrink if needed

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Manual verification

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
