### PR TITLE
Assign StopTactic to Unassigned Robots in STP

### DIFF
--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -202,6 +202,7 @@ void STP::assignRobotsToTactics(const World& world,
             (*iter)->updateRobot(*goalie);
         }
     }
+    std::cout << tactics.size() << std::endl;
 
     // Discard all goalie tactics, since we have already assigned the goalie robot (if
     // there is one) to the first goalie tactic, and there should only ever be one goalie
@@ -215,6 +216,22 @@ void STP::assignRobotsToTactics(const World& world,
         // considered lower priority
         tactics.resize(non_goalie_robots.size());
     }
+    else
+    {
+        // Assign rest of robots with StopTactic
+        for (auto i = tactics.size(); i < non_goalie_robots.size(); i++)
+        {
+            tactics.push_back(std::make_shared<StopTactic>(false));
+        }
+    }
+
+    for (auto tactic : tactics)
+    {
+        std::cout << tactic->getName() << std::endl;
+    }
+
+    std::cout << tactics.size() << std::endl;
+    std::cout << non_goalie_robots.size() << std::endl;
 
     size_t num_rows = non_goalie_robots.size();
     size_t num_cols = tactics.size();
@@ -237,6 +254,9 @@ void STP::assignRobotsToTactics(const World& world,
         for (size_t col = 0; col < num_cols; col++)
         {
             Robot robot                     = non_goalie_robots.at(row);
+
+            std::cout << "ROBOT ID: " << robot.id() << std::endl;
+
             std::shared_ptr<Tactic>& tactic = tactics.at(col);
             double robot_cost_for_tactic    = tactic->calculateRobotCost(robot, world);
 
@@ -249,16 +269,29 @@ void STP::assignRobotsToTactics(const World& world,
                 required_capabilities.begin(), required_capabilities.end(),
                 robot_capabilities.begin(), robot_capabilities.end(),
                 std::inserter(missing_capabilities, missing_capabilities.begin()));
+            // TODO missing_capabilities for robot_0 and stoptactic isn't working
+            std::cout << tactic->getName() << std::endl;
+            std::cout << missing_capabilities.size() << std::endl;
+            std::cout << "req_cap: " << required_capabilities.size() << std::endl;
+            std::cout << "rob_cap: " << robot_capabilities.size() << std::endl;
+
+            for (auto req : required_capabilities)
+            {
+                std::cout << "req_cap requires: " << static_cast<int>(req) << std::endl;
+            }
 
             if (missing_capabilities.size() > 0)
             {
+                std::cout << "REQ NOT MET" << std::endl;
                 matrix(row, col) = robot_cost_for_tactic + 10.0f;
             }
             else
             {
+                std::cout << "REQ MET" << std::endl;
                 // capability requirements are satisfied, use real cost
                 matrix(row, col) = robot_cost_for_tactic;
             }
+            std::cout << "----" << std::endl;
         }
     }
 
@@ -275,11 +308,13 @@ void STP::assignRobotsToTactics(const World& world,
     //        -1, 0,-1,         and            0,-1,
     //         0,-1,-1,                       -1, 0,
     //        -1,-1, 0,
+    std::cout << "MATRIX of " << num_rows << " and " << num_cols << std::endl;
     for (size_t row = 0; row < num_rows; row++)
     {
         for (size_t col = 0; col < num_cols; col++)
         {
             auto val = matrix(row, col);
+            std::cout << val << " at (" << row << ", " << col << ")" << std::endl;
             if (val == 0)
             {
                 tactics.at(col)->updateRobot(non_goalie_robots.at(row));

--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -245,8 +245,7 @@ std::vector<std::shared_ptr<Tactic>> STP::assignRobotsToTactics(
     {
         for (size_t col = 0; col < num_cols; col++)
         {
-            Robot robot = non_goalie_robots.at(row);
-
+            Robot robot                     = non_goalie_robots.at(row);
             std::shared_ptr<Tactic>& tactic = tactics.at(col);
             double robot_cost_for_tactic    = tactic->calculateRobotCost(robot, world);
 

--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -118,7 +118,7 @@ std::vector<std::unique_ptr<Intent>> STP::getIntentsFromCurrentPlay(const World&
     std::vector<std::unique_ptr<Intent>> intents;
     if (current_tactics)
     {
-        assignRobotsToTactics(world, &(*current_tactics));
+        assignRobotsToTactics(world, *current_tactics);
 
         ActionWorldParamsUpdateVisitor action_world_params_update_visitor(world);
         TacticWorldParamsUpdateVisitor tactic_world_params_update_visitor(world);
@@ -169,7 +169,7 @@ std::vector<std::unique_ptr<Intent>> STP::getIntents(const World& world)
 }
 
 void STP::assignRobotsToTactics(const World& world,
-                                std::vector<std::shared_ptr<Tactic>>* tactics) const
+                                std::vector<std::shared_ptr<Tactic>> &tactics) const
 {
     // This functions optimizes the assignment of robots to tactics by minimizing
     // the total cost of assignment using the Hungarian algorithm
@@ -196,8 +196,8 @@ void STP::assignRobotsToTactics(const World& world,
             std::find(non_goalie_robots.begin(), non_goalie_robots.end(), *goalie));
 
         // Assign the goalie to the first goalie tactic
-        auto iter = std::find_if(tactics->begin(), tactics->end(), isGoalieTactic);
-        if (iter != tactics->end())
+        auto iter = std::find_if(tactics.begin(), tactics.end(), isGoalieTactic);
+        if (iter != tactics.end())
         {
             (*iter)->updateRobot(*goalie);
         }
@@ -205,27 +205,27 @@ void STP::assignRobotsToTactics(const World& world,
 
     // Discard all goalie tactics, since we have already assigned the goalie robot (if
     // there is one) to the first goalie tactic, and there should only ever be one goalie
-    tactics->erase(std::remove_if(tactics->begin(), tactics->end(), isGoalieTactic),
-                   tactics->end());
+    tactics.erase(std::remove_if(tactics.begin(), tactics.end(), isGoalieTactic),
+                   tactics.end());
 
-    if (non_goalie_robots.size() < tactics->size())
+    if (non_goalie_robots.size() < tactics.size())
     {
         // We do not have enough robots to assign all the tactics to. We "drop"
         // (aka don't assign) the tactics at the end of the vector since they are
         // considered lower priority
-        tactics->resize(non_goalie_robots.size());
+        tactics.resize(non_goalie_robots.size());
     }
     else
     {
         // Assign rest of robots with StopTactic
-        for (auto i = tactics->size(); i < non_goalie_robots.size(); i++)
+        for (auto i = tactics.size(); i < non_goalie_robots.size(); i++)
         {
-            tactics->push_back(std::make_shared<StopTactic>(false));
+            tactics.push_back(std::make_shared<StopTactic>(false));
         }
     }
 
     size_t num_rows = non_goalie_robots.size();
-    size_t num_cols = tactics->size();
+    size_t num_cols = tactics.size();
 
     // The Matrix constructor will assert if the rows and columns of the matrix are
     // not >= 1, so we perform that check first and return an empty vector of tactics.
@@ -246,7 +246,7 @@ void STP::assignRobotsToTactics(const World& world,
         {
             Robot robot = non_goalie_robots.at(row);
 
-            std::shared_ptr<Tactic>& tactic = tactics->at(col);
+            std::shared_ptr<Tactic>& tactic = tactics.at(col);
             double robot_cost_for_tactic    = tactic->calculateRobotCost(robot, world);
 
             std::set<RobotCapability> required_capabilities =
@@ -291,7 +291,7 @@ void STP::assignRobotsToTactics(const World& world,
             auto val = matrix(row, col);
             if (val == 0)
             {
-                tactics->at(col)->updateRobot(non_goalie_robots.at(row));
+                tactics.at(col)->updateRobot(non_goalie_robots.at(row));
                 break;
             }
         }

--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -202,7 +202,8 @@ void STP::assignRobotsToTactics(const World& world,
             (*iter)->updateRobot(*goalie);
         }
     }
-    std::cout << tactics.size() << std::endl;
+    std::cout << "Tactics Size: " << tactics.size() << std::endl;
+    std::cout << "Non-Goalie Size: " << non_goalie_robots.size() << std::endl;
 
     // Discard all goalie tactics, since we have already assigned the goalie robot (if
     // there is one) to the first goalie tactic, and there should only ever be one goalie
@@ -218,6 +219,7 @@ void STP::assignRobotsToTactics(const World& world,
     }
     else
     {
+        std::cout << "Adding StopTactics" << std::endl;
         // Assign rest of robots with StopTactic
         for (auto i = tactics.size(); i < non_goalie_robots.size(); i++)
         {
@@ -225,13 +227,11 @@ void STP::assignRobotsToTactics(const World& world,
         }
     }
 
+    std::cout << "Printing Tactics in tactic queue" << std::endl;
     for (auto tactic : tactics)
     {
         std::cout << tactic->getName() << std::endl;
     }
-
-    std::cout << tactics.size() << std::endl;
-    std::cout << non_goalie_robots.size() << std::endl;
 
     size_t num_rows = non_goalie_robots.size();
     size_t num_cols = tactics.size();
@@ -253,9 +253,7 @@ void STP::assignRobotsToTactics(const World& world,
     {
         for (size_t col = 0; col < num_cols; col++)
         {
-            Robot robot                     = non_goalie_robots.at(row);
-
-            std::cout << "ROBOT ID: " << robot.id() << std::endl;
+            Robot robot = non_goalie_robots.at(row);
 
             std::shared_ptr<Tactic>& tactic = tactics.at(col);
             double robot_cost_for_tactic    = tactic->calculateRobotCost(robot, world);
@@ -269,29 +267,16 @@ void STP::assignRobotsToTactics(const World& world,
                 required_capabilities.begin(), required_capabilities.end(),
                 robot_capabilities.begin(), robot_capabilities.end(),
                 std::inserter(missing_capabilities, missing_capabilities.begin()));
-            // TODO missing_capabilities for robot_0 and stoptactic isn't working
-            std::cout << tactic->getName() << std::endl;
-            std::cout << missing_capabilities.size() << std::endl;
-            std::cout << "req_cap: " << required_capabilities.size() << std::endl;
-            std::cout << "rob_cap: " << robot_capabilities.size() << std::endl;
-
-            for (auto req : required_capabilities)
-            {
-                std::cout << "req_cap requires: " << static_cast<int>(req) << std::endl;
-            }
 
             if (missing_capabilities.size() > 0)
             {
-                std::cout << "REQ NOT MET" << std::endl;
                 matrix(row, col) = robot_cost_for_tactic + 10.0f;
             }
             else
             {
-                std::cout << "REQ MET" << std::endl;
                 // capability requirements are satisfied, use real cost
                 matrix(row, col) = robot_cost_for_tactic;
             }
-            std::cout << "----" << std::endl;
         }
     }
 
@@ -318,6 +303,8 @@ void STP::assignRobotsToTactics(const World& world,
             if (val == 0)
             {
                 tactics.at(col)->updateRobot(non_goalie_robots.at(row));
+                std::cout << tactics.at(col)->getName() << std::endl;
+                std::cout << tactics.at(col)->getAssignedRobot().has_value() << std::endl;
                 break;
             }
         }

--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -190,6 +190,7 @@ std::vector<std::shared_ptr<Tactic>> STP::assignRobotsToTactics(
     auto isGoalieTactic                  = [](std::shared_ptr<Tactic> tactic) {
         return tactic->isGoalieTactic();
     };
+    std::vector<std::shared_ptr<Tactic>> goalie_tactics;
 
     if (goalie)
     {
@@ -203,6 +204,10 @@ std::vector<std::shared_ptr<Tactic>> STP::assignRobotsToTactics(
             (*iter)->updateRobot(*goalie);
         }
     }
+
+    // Store goalie tactics, which will be added at the end
+    std::copy_if(tactics.begin(), tactics.end(), back_inserter(goalie_tactics),
+                 isGoalieTactic);
 
     // Discard all goalie tactics, since we have already assigned the goalie robot (if
     // there is one) to the first goalie tactic, and there should only ever be one goalie
@@ -296,6 +301,9 @@ std::vector<std::shared_ptr<Tactic>> STP::assignRobotsToTactics(
             }
         }
     }
+
+    // Re-insert goalie tactics to returned tactics
+    tactics.insert(tactics.begin(), goalie_tactics.begin(), goalie_tactics.end());
 
     return tactics;
 }

--- a/src/software/ai/hl/stp/stp.h
+++ b/src/software/ai/hl/stp/stp.h
@@ -50,9 +50,11 @@ class STP : public HL
      * @param world The state of the world, which contains the friendly Robots that will
      * be assigned to each tactic
      * @param tactics The list of tactics that should be assigned a robot
+     *
+     * @return The list of tactics that were assigned to the robots
      */
-    void assignRobotsToTactics(const World &world,
-                               std::vector<std::shared_ptr<Tactic>> &tactics) const;
+    std::vector<std::shared_ptr<Tactic>> assignRobotsToTactics(
+        const World &world, std::vector<std::shared_ptr<Tactic>> tactics) const;
 
     /**
      * Given the state of the world, returns a unique_ptr to the Play that should be run

--- a/src/software/ai/hl/stp/stp.h
+++ b/src/software/ai/hl/stp/stp.h
@@ -52,7 +52,7 @@ class STP : public HL
      * @param tactics The list of tactics that should be assigned a robot
      */
     void assignRobotsToTactics(const World &world,
-                               std::vector<std::shared_ptr<Tactic>> *tactics) const;
+                               std::vector<std::shared_ptr<Tactic>> &tactics) const;
 
     /**
      * Given the state of the world, returns a unique_ptr to the Play that should be run

--- a/src/software/ai/hl/stp/stp.h
+++ b/src/software/ai/hl/stp/stp.h
@@ -52,7 +52,7 @@ class STP : public HL
      * @param tactics The list of tactics that should be assigned a robot
      */
     void assignRobotsToTactics(const World &world,
-                               std::vector<std::shared_ptr<Tactic>> tactics) const;
+                               std::vector<std::shared_ptr<Tactic>> *tactics) const;
 
     /**
      * Given the state of the world, returns a unique_ptr to the Play that should be run

--- a/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
+++ b/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
@@ -374,6 +374,8 @@ TEST_F(STPTacticAssignmentTest,
     // this robot has no capabilities
     Robot robot_0(0, Point(0.1, 0.1), Vector(), Angle::zero(), AngularVelocity::zero(),
                   Timestamp::fromSeconds(0), 10, allRobotCapabilities());
+    // TODO robot_0 needs move for stop tactic?
+    // TODO it does because all tactics do
     Robot robot_1(1, Point(-10, -10), Vector(), Angle::zero(), AngularVelocity::zero(),
                   Timestamp::fromSeconds(0));
     friendly_team.updateRobots({robot_0, robot_1});
@@ -384,7 +386,6 @@ TEST_F(STPTacticAssignmentTest,
     move_tactic_1->updateControlParams(Point(0, 0));
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
-
 
     stp.assignRobotsToTactics(world, tactics);
 

--- a/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
+++ b/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
@@ -411,10 +411,13 @@ TEST_F(STPTacticAssignmentTest,
     auto goalie_tactic_2                         = std::make_shared<GoalieTestTactic>();
     std::vector<std::shared_ptr<Tactic>> tactics = {goalie_tactic_1, goalie_tactic_2};
 
-    stp.assignRobotsToTactics(world, tactics);
+    std::vector<std::shared_ptr<Tactic>> assigned_tactics =
+        stp.assignRobotsToTactics(world, tactics);
 
     EXPECT_FALSE(goalie_tactic_1->getAssignedRobot().has_value());
     EXPECT_FALSE(goalie_tactic_2->getAssignedRobot().has_value());
+    ASSERT_FALSE(assigned_tactics[0]->getAssignedRobot().has_value());
+    ASSERT_FALSE(assigned_tactics[1]->getAssignedRobot().has_value());
 }
 
 TEST_F(STPTacticAssignmentTest,
@@ -445,18 +448,16 @@ TEST_F(STPTacticAssignmentTest,
     EXPECT_EQ(goalie_tactic_1->getAssignedRobot().value(), robot_0);
 
     // Change the goalie and perform the same check in case we have a fluke bug
-    // Re-insert goalie tactic into queue since goalie tactics are removed after
-    // assignment
-    tactics.insert(tactics.begin(), goalie_tactic_1);
-
     friendly_team.assignGoalie(1);
     world.updateFriendlyTeamState(friendly_team);
 
-    stp.assignRobotsToTactics(world, tactics);
+    std::vector<std::shared_ptr<Tactic>> assigned_tactics =
+        stp.assignRobotsToTactics(world, tactics);
 
     EXPECT_TRUE(allTacticsAssigned(tactics));
     ASSERT_TRUE(goalie_tactic_1->getAssignedRobot().has_value());
     EXPECT_EQ(goalie_tactic_1->getAssignedRobot().value(), robot_1);
+    ASSERT_TRUE(assigned_tactics[0]->getAssignedRobot().has_value());
 }
 
 TEST_F(STPTacticAssignmentTest,
@@ -477,11 +478,14 @@ TEST_F(STPTacticAssignmentTest,
     auto goalie_tactic_2                         = std::make_shared<GoalieTestTactic>();
     std::vector<std::shared_ptr<Tactic>> tactics = {goalie_tactic_1, goalie_tactic_2};
 
-    stp.assignRobotsToTactics(world, tactics);
+    std::vector<std::shared_ptr<Tactic>> assigned_tactics =
+        stp.assignRobotsToTactics(world, tactics);
 
     ASSERT_TRUE(goalie_tactic_1->getAssignedRobot().has_value());
     EXPECT_FALSE(goalie_tactic_2->getAssignedRobot().has_value());
     EXPECT_EQ(goalie_tactic_1->getAssignedRobot().value(), robot_0);
+    ASSERT_TRUE(assigned_tactics[0]->getAssignedRobot().has_value());
+    ASSERT_FALSE(assigned_tactics[1]->getAssignedRobot().has_value());
 }
 
 TEST_F(STPTacticAssignmentTest,

--- a/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
+++ b/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
@@ -76,7 +76,7 @@ TEST_F(STPTacticAssignmentTest,
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1, move_tactic_2};
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     EXPECT_TRUE(allTacticsAssigned(tactics));
 }
@@ -98,7 +98,7 @@ TEST_F(STPTacticAssignmentTest,
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1, move_tactic_2};
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     EXPECT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     EXPECT_FALSE(move_tactic_2->getAssignedRobot().has_value());
@@ -121,7 +121,7 @@ TEST_F(STPTacticAssignmentTest,
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     EXPECT_TRUE(move_tactic_1->getAssignedRobot().has_value());
 }
@@ -138,7 +138,7 @@ TEST_F(STPTacticAssignmentTest, test_0_tactics_returned_when_there_are_no_robots
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     EXPECT_FALSE(move_tactic_1->getAssignedRobot().has_value());
 }
@@ -164,7 +164,7 @@ TEST_F(STPTacticAssignmentTest,
     // way around to move_tactic_2. What we expect is that robot_0 will be assigned to
     // move_tactic_2 and "slide over" to make room for robot_1
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     // move_tactic_1 should be the only Tactic assigned a robot, since stop_tactic_1 is a
     // lower priority than move_tactic_1 so it should be dropped since there's only 1
@@ -188,7 +188,7 @@ TEST_F(STPTacticAssignmentTest, test_assigning_1_tactic_to_1_robot)
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     EXPECT_EQ(move_tactic_1->getAssignedRobot().value(), robot_0);
@@ -219,7 +219,7 @@ TEST_F(STPTacticAssignmentTest, test_assigning_2_robots_to_2_tactics_no_overlap)
     // Each robot is close to separate tactic destinations. They should each be trivially
     // assigned to the tactic with the destination closest to their position
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     ASSERT_TRUE(move_tactic_2->getAssignedRobot().has_value());
@@ -260,7 +260,7 @@ TEST_F(STPTacticAssignmentTest, test_assigning_2_robots_to_2_tactics_with_overla
     // way around to move_tactic_2. What we expect is that robot_0 will be assigned to
     // move_tactic_2 and "slide over" to make room for robot_1
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     ASSERT_TRUE(move_tactic_2->getAssignedRobot().has_value());
@@ -291,7 +291,7 @@ TEST_F(STPTacticAssignmentTest, test_assigning_3_robots_to_2_tactics)
     // robot_2 should not be assigned since both robot_0 and robot_1 are more optimal
     // to assign to the tactics. robot_2 is too far away
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     ASSERT_TRUE(move_tactic_2->getAssignedRobot().has_value());
@@ -320,7 +320,7 @@ TEST_F(STPTacticAssignmentTest,
                                                     stop_tactic_3};
 
     // If all costs are equal, the robots and tactics are simply paired in order
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     ASSERT_TRUE(stop_tactic_1->getAssignedRobot().has_value());
     ASSERT_TRUE(stop_tactic_2->getAssignedRobot().has_value());
@@ -355,7 +355,7 @@ TEST_F(STPTacticAssignmentTest,
     std::vector<std::shared_ptr<Tactic>> tactics = {stop_tactic_1, move_tactic_1,
                                                     stop_tactic_2};
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     ASSERT_TRUE(stop_tactic_1->getAssignedRobot().has_value());
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
@@ -385,13 +385,7 @@ TEST_F(STPTacticAssignmentTest,
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
 
-    stp.assignRobotsToTactics(world, tactics);
-
-    std::cout << "Printing Tactics" << std::endl;
-    for (auto tactic : tactics)
-    {
-        std::cout << tactic->getName() << std::endl;
-    }
+    stp.assignRobotsToTactics(world, &tactics);
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     EXPECT_EQ(move_tactic_1->getAssignedRobot().value(), robot_1);
@@ -416,7 +410,7 @@ TEST_F(STPTacticAssignmentTest,
     auto goalie_tactic_2                         = std::make_shared<GoalieTestTactic>();
     std::vector<std::shared_ptr<Tactic>> tactics = {goalie_tactic_1, goalie_tactic_2};
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     EXPECT_FALSE(goalie_tactic_1->getAssignedRobot().has_value());
     EXPECT_FALSE(goalie_tactic_2->getAssignedRobot().has_value());
@@ -443,18 +437,23 @@ TEST_F(STPTacticAssignmentTest,
     auto goalie_tactic_1                         = std::make_shared<GoalieTestTactic>();
     std::vector<std::shared_ptr<Tactic>> tactics = {goalie_tactic_1};
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
+    EXPECT_TRUE(allTacticsAssigned(tactics));
     ASSERT_TRUE(goalie_tactic_1->getAssignedRobot().has_value());
     EXPECT_EQ(goalie_tactic_1->getAssignedRobot().value(), robot_0);
 
     // Change the goalie and perform the same check in case we have a fluke bug
+    // Re-insert goalie tactic into queue since goalie tactics are removed after
+    // assignment
+    tactics.insert(tactics.begin(), goalie_tactic_1);
 
     friendly_team.assignGoalie(1);
     world.updateFriendlyTeamState(friendly_team);
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
+    EXPECT_TRUE(allTacticsAssigned(tactics));
     ASSERT_TRUE(goalie_tactic_1->getAssignedRobot().has_value());
     EXPECT_EQ(goalie_tactic_1->getAssignedRobot().value(), robot_1);
 }
@@ -477,7 +476,7 @@ TEST_F(STPTacticAssignmentTest,
     auto goalie_tactic_2                         = std::make_shared<GoalieTestTactic>();
     std::vector<std::shared_ptr<Tactic>> tactics = {goalie_tactic_1, goalie_tactic_2};
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
     ASSERT_TRUE(goalie_tactic_1->getAssignedRobot().has_value());
     EXPECT_FALSE(goalie_tactic_2->getAssignedRobot().has_value());
@@ -485,8 +484,10 @@ TEST_F(STPTacticAssignmentTest,
 }
 
 TEST_F(STPTacticAssignmentTest,
-       test_assigning_stop_tactics_to_non_assigned_non_goalie_robots)
+       test_assigning_stop_tactics_to_unassigned_non_goalie_robots)
 {
+    // Test that StopTactic is assigned to remaining robots without tactics
+
     Team friendly_team(Duration::fromSeconds(0));
     Robot robot_0(0, Point(-1, 1), Vector(), Angle::zero(), AngularVelocity::zero(),
                   Timestamp::fromSeconds(0));
@@ -502,8 +503,15 @@ TEST_F(STPTacticAssignmentTest,
     move_tactic_1->updateControlParams(Point(-1, 0));
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
+    std::vector<Robot> expected_robots_assigned  = {robot_0, robot_1, robot_2};
+    std::vector<std::string> expected_tactics    = {"Move Test Tactic", "Stop Tactic",
+                                                 "Stop Tactic"};
 
-    stp.assignRobotsToTactics(world, tactics);
+    stp.assignRobotsToTactics(world, &tactics);
 
-    EXPECT_TRUE(move_tactic_1->getAssignedRobot().has_value());
+    for (unsigned int i = 0; i < tactics.size(); i++)
+    {
+        EXPECT_EQ(tactics[i]->getAssignedRobot().value(), expected_robots_assigned[i]);
+        EXPECT_EQ(tactics[i]->getName(), expected_tactics[i]);
+    }
 }

--- a/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
+++ b/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
@@ -76,7 +76,7 @@ TEST_F(STPTacticAssignmentTest,
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1, move_tactic_2};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     EXPECT_TRUE(allTacticsAssigned(tactics));
 }
@@ -98,7 +98,7 @@ TEST_F(STPTacticAssignmentTest,
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1, move_tactic_2};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     EXPECT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     EXPECT_FALSE(move_tactic_2->getAssignedRobot().has_value());
@@ -121,7 +121,7 @@ TEST_F(STPTacticAssignmentTest,
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     EXPECT_TRUE(move_tactic_1->getAssignedRobot().has_value());
 }
@@ -138,7 +138,7 @@ TEST_F(STPTacticAssignmentTest, test_0_tactics_returned_when_there_are_no_robots
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     EXPECT_FALSE(move_tactic_1->getAssignedRobot().has_value());
 }
@@ -164,7 +164,7 @@ TEST_F(STPTacticAssignmentTest,
     // way around to move_tactic_2. What we expect is that robot_0 will be assigned to
     // move_tactic_2 and "slide over" to make room for robot_1
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     // move_tactic_1 should be the only Tactic assigned a robot, since stop_tactic_1 is a
     // lower priority than move_tactic_1 so it should be dropped since there's only 1
@@ -188,7 +188,7 @@ TEST_F(STPTacticAssignmentTest, test_assigning_1_tactic_to_1_robot)
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     EXPECT_EQ(move_tactic_1->getAssignedRobot().value(), robot_0);
@@ -219,7 +219,7 @@ TEST_F(STPTacticAssignmentTest, test_assigning_2_robots_to_2_tactics_no_overlap)
     // Each robot is close to separate tactic destinations. They should each be trivially
     // assigned to the tactic with the destination closest to their position
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     ASSERT_TRUE(move_tactic_2->getAssignedRobot().has_value());
@@ -260,7 +260,7 @@ TEST_F(STPTacticAssignmentTest, test_assigning_2_robots_to_2_tactics_with_overla
     // way around to move_tactic_2. What we expect is that robot_0 will be assigned to
     // move_tactic_2 and "slide over" to make room for robot_1
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     ASSERT_TRUE(move_tactic_2->getAssignedRobot().has_value());
@@ -291,7 +291,7 @@ TEST_F(STPTacticAssignmentTest, test_assigning_3_robots_to_2_tactics)
     // robot_2 should not be assigned since both robot_0 and robot_1 are more optimal
     // to assign to the tactics. robot_2 is too far away
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     ASSERT_TRUE(move_tactic_2->getAssignedRobot().has_value());
@@ -320,7 +320,7 @@ TEST_F(STPTacticAssignmentTest,
                                                     stop_tactic_3};
 
     // If all costs are equal, the robots and tactics are simply paired in order
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     ASSERT_TRUE(stop_tactic_1->getAssignedRobot().has_value());
     ASSERT_TRUE(stop_tactic_2->getAssignedRobot().has_value());
@@ -355,7 +355,7 @@ TEST_F(STPTacticAssignmentTest,
     std::vector<std::shared_ptr<Tactic>> tactics = {stop_tactic_1, move_tactic_1,
                                                     stop_tactic_2};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     ASSERT_TRUE(stop_tactic_1->getAssignedRobot().has_value());
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
@@ -385,7 +385,7 @@ TEST_F(STPTacticAssignmentTest,
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     EXPECT_EQ(move_tactic_1->getAssignedRobot().value(), robot_1);
@@ -410,7 +410,7 @@ TEST_F(STPTacticAssignmentTest,
     auto goalie_tactic_2                         = std::make_shared<GoalieTestTactic>();
     std::vector<std::shared_ptr<Tactic>> tactics = {goalie_tactic_1, goalie_tactic_2};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     EXPECT_FALSE(goalie_tactic_1->getAssignedRobot().has_value());
     EXPECT_FALSE(goalie_tactic_2->getAssignedRobot().has_value());
@@ -437,7 +437,7 @@ TEST_F(STPTacticAssignmentTest,
     auto goalie_tactic_1                         = std::make_shared<GoalieTestTactic>();
     std::vector<std::shared_ptr<Tactic>> tactics = {goalie_tactic_1};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     EXPECT_TRUE(allTacticsAssigned(tactics));
     ASSERT_TRUE(goalie_tactic_1->getAssignedRobot().has_value());
@@ -451,7 +451,7 @@ TEST_F(STPTacticAssignmentTest,
     friendly_team.assignGoalie(1);
     world.updateFriendlyTeamState(friendly_team);
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     EXPECT_TRUE(allTacticsAssigned(tactics));
     ASSERT_TRUE(goalie_tactic_1->getAssignedRobot().has_value());
@@ -476,7 +476,7 @@ TEST_F(STPTacticAssignmentTest,
     auto goalie_tactic_2                         = std::make_shared<GoalieTestTactic>();
     std::vector<std::shared_ptr<Tactic>> tactics = {goalie_tactic_1, goalie_tactic_2};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
     ASSERT_TRUE(goalie_tactic_1->getAssignedRobot().has_value());
     EXPECT_FALSE(goalie_tactic_2->getAssignedRobot().has_value());
@@ -507,11 +507,12 @@ TEST_F(STPTacticAssignmentTest,
     std::vector<std::string> expected_tactics    = {"Move Test Tactic", "Stop Tactic",
                                                  "Stop Tactic"};
 
-    stp.assignRobotsToTactics(world, &tactics);
+    stp.assignRobotsToTactics(world, tactics);
 
-    for (unsigned int i = 0; i < tactics.size(); i++)
-    {
+    for (unsigned int i = 0; i < tactics.size(); i++) {
         EXPECT_EQ(tactics[i]->getAssignedRobot().value(), expected_robots_assigned[i]);
-        EXPECT_EQ(tactics[i]->getName(), expected_tactics[i]);
     }
+
+    auto tactic1 = dynamic_cast<MoveTestTactic>(*move_tactic_1);
+    ASSERT_TRUE(tactic1);
 }

--- a/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
+++ b/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
@@ -507,12 +507,16 @@ TEST_F(STPTacticAssignmentTest,
     std::vector<std::string> expected_tactics    = {"Move Test Tactic", "Stop Tactic",
                                                  "Stop Tactic"};
 
-    stp.assignRobotsToTactics(world, tactics);
+    std::vector<std::shared_ptr<Tactic>> assigned_tactics =
+        stp.assignRobotsToTactics(world, tactics);
 
-    for (unsigned int i = 0; i < tactics.size(); i++) {
-        EXPECT_EQ(tactics[i]->getAssignedRobot().value(), expected_robots_assigned[i]);
+    for (unsigned int i = 0; i < assigned_tactics.size(); i++)
+    {
+        EXPECT_EQ(assigned_tactics[i]->getAssignedRobot().value(),
+                  expected_robots_assigned[i]);
     }
 
-    auto tactic1 = dynamic_cast<MoveTestTactic>(*move_tactic_1);
-    ASSERT_TRUE(tactic1);
+    // TODO add tactic dynamic_cast check
+    //    auto tactic1 = dynamic_cast<MoveTestTactic>(*move_tactic_1);
+    //    ASSERT_TRUE(tactic1);
 }

--- a/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
+++ b/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
@@ -374,8 +374,6 @@ TEST_F(STPTacticAssignmentTest,
     // this robot has no capabilities
     Robot robot_0(0, Point(0.1, 0.1), Vector(), Angle::zero(), AngularVelocity::zero(),
                   Timestamp::fromSeconds(0), 10, allRobotCapabilities());
-    // TODO robot_0 needs move for stop tactic?
-    // TODO it does because all tactics do
     Robot robot_1(1, Point(-10, -10), Vector(), Angle::zero(), AngularVelocity::zero(),
                   Timestamp::fromSeconds(0));
     friendly_team.updateRobots({robot_0, robot_1});
@@ -388,6 +386,12 @@ TEST_F(STPTacticAssignmentTest,
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
 
     stp.assignRobotsToTactics(world, tactics);
+
+    std::cout << "Printing Tactics" << std::endl;
+    for (auto tactic : tactics)
+    {
+        std::cout << tactic->getName() << std::endl;
+    }
 
     ASSERT_TRUE(move_tactic_1->getAssignedRobot().has_value());
     EXPECT_EQ(move_tactic_1->getAssignedRobot().value(), robot_1);
@@ -478,4 +482,28 @@ TEST_F(STPTacticAssignmentTest,
     ASSERT_TRUE(goalie_tactic_1->getAssignedRobot().has_value());
     EXPECT_FALSE(goalie_tactic_2->getAssignedRobot().has_value());
     EXPECT_EQ(goalie_tactic_1->getAssignedRobot().value(), robot_0);
+}
+
+TEST_F(STPTacticAssignmentTest,
+       test_assigning_stop_tactics_to_non_assigned_non_goalie_robots)
+{
+    Team friendly_team(Duration::fromSeconds(0));
+    Robot robot_0(0, Point(-1, 1), Vector(), Angle::zero(), AngularVelocity::zero(),
+                  Timestamp::fromSeconds(0));
+    Robot robot_1(1, Point(-3, 5), Vector(), Angle::zero(), AngularVelocity::zero(),
+                  Timestamp::fromSeconds(0));
+    Robot robot_2(2, Point(6, 7), Vector(), Angle::zero(), AngularVelocity::zero(),
+                  Timestamp::fromSeconds(0));
+    friendly_team.updateRobots({robot_0, robot_1, robot_2});
+    world.updateFriendlyTeamState(friendly_team);
+
+    auto move_tactic_1 = std::make_shared<MoveTestTactic>();
+
+    move_tactic_1->updateControlParams(Point(-1, 0));
+
+    std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
+
+    stp.assignRobotsToTactics(world, tactics);
+
+    EXPECT_TRUE(move_tactic_1->getAssignedRobot().has_value());
 }

--- a/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
+++ b/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
@@ -4,6 +4,7 @@
 
 #include "software/ai/hl/stp/play/test_plays/halt_test_play.h"
 #include "software/ai/hl/stp/stp.h"
+#include "software/ai/hl/stp/tactic/stop_tactic.h"
 #include "software/ai/hl/stp/tactic/test_tactics/goalie_test_tactic.h"
 #include "software/ai/hl/stp/tactic/test_tactics/move_test_tactic.h"
 #include "software/ai/hl/stp/tactic/test_tactics/stop_test_tactic.h"
@@ -504,19 +505,19 @@ TEST_F(STPTacticAssignmentTest,
 
     std::vector<std::shared_ptr<Tactic>> tactics = {move_tactic_1};
     std::vector<Robot> expected_robots_assigned  = {robot_0, robot_1, robot_2};
-    std::vector<std::string> expected_tactics    = {"Move Test Tactic", "Stop Tactic",
-                                                 "Stop Tactic"};
 
     std::vector<std::shared_ptr<Tactic>> assigned_tactics =
         stp.assignRobotsToTactics(world, tactics);
 
+    // Check each tactic is assigned to the intended robot
     for (unsigned int i = 0; i < assigned_tactics.size(); i++)
     {
         EXPECT_EQ(assigned_tactics[i]->getAssignedRobot().value(),
                   expected_robots_assigned[i]);
     }
 
-    // TODO add tactic dynamic_cast check
-    //    auto tactic1 = dynamic_cast<MoveTestTactic>(*move_tactic_1);
-    //    ASSERT_TRUE(tactic1);
+    // Check that StopTactics are added
+    ASSERT_TRUE(dynamic_cast<MoveTestTactic*>(assigned_tactics[0].get()));
+    ASSERT_TRUE(dynamic_cast<StopTactic*>(assigned_tactics[1].get()));
+    ASSERT_TRUE(dynamic_cast<StopTactic*>(assigned_tactics[2].get()));
 }

--- a/src/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -4,7 +4,7 @@
 #include "software/geom/algorithms/distance.h"
 
 CherryPickTactic::CherryPickTactic(const World& world, const Rectangle& target_region)
-    : Tactic(true),
+    : Tactic(true, {RobotCapability::Move}),
       pass_generator(world, world.ball().position(), PassType::ONE_TOUCH_SHOT),
       world(world),
       target_region(target_region)

--- a/src/software/ai/hl/stp/tactic/chip_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/chip_tactic.cpp
@@ -5,7 +5,7 @@
 #include "software/ai/hl/stp/action/chip_action.h"
 
 ChipTactic::ChipTactic(const Ball &ball, bool loop_forever)
-    : Tactic(loop_forever, {RobotCapability::Chip}), ball(ball)
+    : Tactic(loop_forever, {RobotCapability::Chip, RobotCapability::Move}), ball(ball)
 {
 }
 

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
@@ -14,7 +14,7 @@
 CreaseDefenderTactic::CreaseDefenderTactic(
     const Field &field, const Ball &ball, const Team &friendly_team,
     const Team &enemy_team, CreaseDefenderTactic::LeftOrRight left_or_right)
-    : Tactic(true),
+    : Tactic(true, {RobotCapability::Move}),
       field(field),
       ball(ball),
       friendly_team(friendly_team),

--- a/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
@@ -12,7 +12,7 @@ DefenseShadowEnemyTactic::DefenseShadowEnemyTactic(const Field &field,
                                                    const Team &enemy_team,
                                                    const Ball &ball, bool ignore_goalie,
                                                    double shadow_distance)
-    : Tactic(true),
+    : Tactic(true, {RobotCapability::Move}),
       field(field),
       friendly_team(friendly_team),
       enemy_team(enemy_team),

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -17,7 +17,7 @@
 
 GoalieTactic::GoalieTactic(const Ball &ball, const Field &field,
                            const Team &friendly_team, const Team &enemy_team)
-    : Tactic(true),
+    : Tactic(true, {RobotCapability::Move}),
       ball(ball),
       field(field),
       friendly_team(friendly_team),

--- a/src/software/ai/hl/stp/tactic/move_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/move_tactic.cpp
@@ -3,7 +3,9 @@
 #include <algorithm>
 
 
-MoveTactic::MoveTactic(bool loop_forever) : Tactic(loop_forever) {}
+MoveTactic::MoveTactic(bool loop_forever) : Tactic(loop_forever, {RobotCapability::Move})
+{
+}
 
 std::string MoveTactic::getName() const
 {

--- a/src/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -6,7 +6,9 @@
 #include "software/logger/logger.h"
 
 PasserTactic::PasserTactic(Pass pass, const Ball& ball, bool loop_forever)
-    : Tactic(loop_forever, {RobotCapability::Kick}), pass(std::move(pass)), ball(ball)
+    : Tactic(loop_forever, {RobotCapability::Kick, RobotCapability::Move}),
+      pass(std::move(pass)),
+      ball(ball)
 {
 }
 

--- a/src/software/ai/hl/stp/tactic/patrol_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/patrol_tactic.cpp
@@ -9,7 +9,7 @@ PatrolTactic::PatrolTactic(const std::vector<Point> &points,
                            double at_patrol_point_tolerance,
                            Angle orientation_at_patrol_points,
                            double linear_speed_at_patrol_points)
-    : Tactic(true),
+    : Tactic(true, {RobotCapability::Move}),
       patrol_points(points),
       at_patrol_point_tolerance(at_patrol_point_tolerance),
       orientation_at_patrol_points(orientation_at_patrol_points),

--- a/src/software/ai/hl/stp/tactic/penalty_kick_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/penalty_kick_tactic.cpp
@@ -14,7 +14,10 @@
 PenaltyKickTactic::PenaltyKickTactic(const Ball& ball, const Field& field,
                                      const std::optional<Robot>& enemy_goalie,
                                      bool loop_forever)
-    : Tactic(loop_forever), ball(ball), field(field), enemy_goalie(enemy_goalie)
+    : Tactic(loop_forever, {RobotCapability::Move}),
+      ball(ball),
+      field(field),
+      enemy_goalie(enemy_goalie)
 {
 }
 

--- a/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -10,7 +10,7 @@
 ReceiverTactic::ReceiverTactic(const Field& field, const Team& friendly_team,
                                const Team& enemy_team, const Pass pass, const Ball& ball,
                                bool loop_forever)
-    : Tactic(loop_forever),
+    : Tactic(loop_forever, {RobotCapability::Move}),
       field(field),
       pass(pass),
       ball(ball),

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -9,7 +9,7 @@ ShadowEnemyTactic::ShadowEnemyTactic(const Field &field, const Team &friendly_te
                                      const Team &enemy_team, bool ignore_goalie,
                                      const Ball &ball, const double ball_steal_speed,
                                      bool enemy_team_can_pass, bool loop_forever)
-    : Tactic(loop_forever),
+    : Tactic(loop_forever, {RobotCapability::Move}),
       field(field),
       friendly_team(friendly_team),
       enemy_team(enemy_team),

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
@@ -9,7 +9,7 @@
 ShadowFreekickerTactic::ShadowFreekickerTactic(FreekickShadower free_kick_shadower,
                                                Team enemy_team, Ball ball, Field field,
                                                bool loop_forever)
-    : Tactic(loop_forever),
+    : Tactic(loop_forever, {RobotCapability::Move}),
       free_kick_shadower(free_kick_shadower),
       enemy_team(enemy_team),
       ball(ball),

--- a/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shoot_goal_tactic.cpp
@@ -11,7 +11,7 @@ ShootGoalTactic::ShootGoalTactic(const Field &field, const Team &friendly_team,
                                  const Team &enemy_team, const Ball &ball,
                                  Angle min_net_open_angle,
                                  std::optional<Point> chip_target, bool loop_forever)
-    : Tactic(loop_forever, {RobotCapability::Kick}),
+    : Tactic(loop_forever, {RobotCapability::Kick, RobotCapability::Move}),
       field(field),
       friendly_team(friendly_team),
       enemy_team(enemy_team),

--- a/src/software/ai/hl/stp/tactic/stop_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/stop_tactic.cpp
@@ -4,7 +4,7 @@
 
 #include "software/ai/hl/stp/action/stop_action.h"
 
-StopTactic::StopTactic(bool coast) : Tactic(true), coast(coast) {}
+StopTactic::StopTactic(bool coast) : Tactic(true, {}), coast(coast) {}
 
 std::string StopTactic::getName() const
 {

--- a/src/software/ai/hl/stp/tactic/tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/tactic.cpp
@@ -8,8 +8,6 @@ Tactic::Tactic(bool loop_forever, const std::set<RobotCapability> &capability_re
       loop_forever(loop_forever),
       capability_reqs(capability_reqs_)
 {
-    // require movement capability by default
-    capability_reqs.emplace(RobotCapability::Move);
 }
 
 bool Tactic::done() const

--- a/src/software/ai/hl/stp/tactic/tactic.h
+++ b/src/software/ai/hl/stp/tactic/tactic.h
@@ -44,8 +44,7 @@ class Tactic
      * @param loop_forever Whether or not this Tactic should never complete. If true, the
      * tactic will be restarted every time it completes and will never report done
      */
-    explicit Tactic(bool loop_forever,
-                    const std::set<RobotCapability> &capability_reqs_ = {});
+    explicit Tactic(bool loop_forever, const std::set<RobotCapability> &capability_reqs_);
 
     /**
      * Returns true if the Tactic is done and false otherwise. If the Tactic is supposed

--- a/src/software/ai/hl/stp/tactic/test_tactics/goalie_test_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/test_tactics/goalie_test_tactic.cpp
@@ -1,6 +1,9 @@
 #include "software/ai/hl/stp/tactic/test_tactics/goalie_test_tactic.h"
 
-GoalieTestTactic::GoalieTestTactic(bool loop_forever) : Tactic(loop_forever) {}
+GoalieTestTactic::GoalieTestTactic(bool loop_forever)
+    : Tactic(loop_forever, {RobotCapability::Move})
+{
+}
 
 std::string GoalieTestTactic::getName() const
 {

--- a/src/software/ai/hl/stp/tactic/test_tactics/move_test_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/test_tactics/move_test_tactic.cpp
@@ -5,8 +5,8 @@
 #include "software/ai/hl/stp/action/move_action.h"
 
 MoveTestTactic::MoveTestTactic(bool loop_forever)
-    : Tactic(loop_forever,
-             {RobotCapability::Dribble, RobotCapability::Kick, RobotCapability::Chip})
+    : Tactic(loop_forever, {RobotCapability::Dribble, RobotCapability::Kick,
+                            RobotCapability::Chip, RobotCapability::Move})
 {
 }
 

--- a/src/software/ai/hl/stp/tactic/test_tactics/move_test_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/test_tactics/move_test_tactic.cpp
@@ -5,8 +5,7 @@
 #include "software/ai/hl/stp/action/move_action.h"
 
 MoveTestTactic::MoveTestTactic(bool loop_forever)
-    : Tactic(loop_forever, {RobotCapability::Dribble, RobotCapability::Kick,
-                            RobotCapability::Chip, RobotCapability::Move})
+    : Tactic(loop_forever, allRobotCapabilities())
 {
 }
 

--- a/src/software/ai/hl/stp/tactic/test_tactics/stop_test_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/test_tactics/stop_test_tactic.cpp
@@ -2,7 +2,7 @@
 
 #include "software/ai/hl/stp/action/stop_action.h"
 
-StopTestTactic::StopTestTactic(bool loop_forever) : Tactic(loop_forever) {}
+StopTestTactic::StopTestTactic(bool loop_forever) : Tactic(loop_forever, {}) {}
 
 std::string StopTestTactic::getName() const
 {


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

Assign robots that do not have plays with `StopTactic` to prevent unintended behaviour.
Changes for this PR include:
- Removing the default `RobotCapability::Move` requirement for all tactics (mostly because `StopTactic` does not need it)
- Changing `assignRobotsToTactics` to take in a pointer `tactics` so we can add/remove tactics during assignment

### Testing Done

Added a test in `stp_tactic_assignment_test.cpp` for `test_assigning_stop_tactics_to_unassigned_non_goalie_robots` which verifies non-assigned robots get `StopTactic`.

### Resolved Issues

Resolves #1107 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
