### PR TITLE
Replaced ConstPrimitiveVectorPtr with PrimitiveSetMsg outside of AI and tests

### DIFF
--- a/src/firmware_new/tools/send_proto_over_udp.cpp
+++ b/src/firmware_new/tools/send_proto_over_udp.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
     {
         // primitive and vision sender
         primitive_sender->sendProto(test_primitive_msg);
-        *(test_vision_msg.mutable_time_sent()) = *createCurrentTimestampMsg();
+        test_vision_msg.set_timestamp_seconds(createCurrentTime());
         vision_sender->sendProto(test_vision_msg);
 
         // 100 hz test

--- a/src/shared/proto/tbots_software_msgs.proto
+++ b/src/shared/proto/tbots_software_msgs.proto
@@ -2,13 +2,12 @@ syntax = "proto3";
 
 import "shared/proto/vision.proto";
 import "shared/proto/primitive.proto";
-import "shared/proto/tbots_timestamp_msg.proto";
 import "nanopb/options.proto";
 
 message VisionMsg
 {
     // Epoch timestamp of captured vision data
-    TimestampMsg time_sent = 1;
+    double timestamp_seconds = 1;
 
     // Robot ID to RobotState map
     map<uint32, RobotStateMsg> robot_states = 2;
@@ -20,7 +19,7 @@ message VisionMsg
 message PrimitiveSetMsg
 {
     // Epoch timestamp when primitives were assigned
-    TimestampMsg time_sent = 1;
+    double timestamp_seconds = 1;
 
     // Robot ID to RadioPrimitive map
     // NOTE: The `max_count` for this field should be set to a number that is less then

--- a/src/software/ai/ai.cpp
+++ b/src/software/ai/ai.cpp
@@ -26,12 +26,19 @@ AI::AI(std::shared_ptr<const AIConfig> ai_config,
 
 std::vector<std::unique_ptr<Primitive>> AI::getPrimitives(const World &world) const
 {
-    std::vector<std::unique_ptr<Intent>> assignedIntents = high_level->getIntents(world);
+    std::vector<std::unique_ptr<Intent>> assigned_intents = high_level->getIntents(world);
 
-    std::vector<std::unique_ptr<Primitive>> assignedPrimitives =
-        navigator->getAssignedPrimitives(world, assignedIntents);
+    std::vector<std::unique_ptr<Primitive>> assigned_primitives =
+        navigator->getAssignedPrimitives(world, assigned_intents);
 
-    return assignedPrimitives;
+    return assigned_primitives;
+}
+
+std::unique_ptr<PrimitiveSetMsg> AI::getPrimitiveSetMsg(const World &world) const
+{
+    std::vector<std::unique_ptr<Intent>> assigned_intents = high_level->getIntents(world);
+
+    return navigator->getAssignedPrimitiveSetMsg(world, assigned_intents);
 }
 
 PlayInfo AI::getPlayInfo() const

--- a/src/software/ai/ai.cpp
+++ b/src/software/ai/ai.cpp
@@ -24,16 +24,6 @@ AI::AI(std::shared_ptr<const AIConfig> ai_config,
 {
 }
 
-std::vector<std::unique_ptr<Primitive>> AI::getPrimitives(const World &world) const
-{
-    std::vector<std::unique_ptr<Intent>> assigned_intents = high_level->getIntents(world);
-
-    std::vector<std::unique_ptr<Primitive>> assigned_primitives =
-        navigator->getAssignedPrimitives(world, assigned_intents);
-
-    return assigned_primitives;
-}
-
 std::unique_ptr<PrimitiveSetMsg> AI::getPrimitiveSetMsg(const World &world) const
 {
     std::vector<std::unique_ptr<Intent>> assigned_intents = high_level->getIntents(world);

--- a/src/software/ai/ai.h
+++ b/src/software/ai/ai.h
@@ -35,6 +35,17 @@ class AI final
     std::vector<std::unique_ptr<Primitive>> getPrimitives(const World& world) const;
 
     /**
+     * Calculates the PrimitiveSetMsg that should be run by our Robots given the current
+     * state of the world.
+     *
+     * @param world The state of the World with which to make the decisions
+     *
+     * @return the PrimitiveSetMsg that should be run by our Robots given the current
+     * state of the world.
+     */
+    std::unique_ptr<PrimitiveSetMsg> getPrimitiveSetMsg(const World& world) const;
+
+    /**
      * Returns information about the currently running plays and tactics, including the
      * name of the play, and which robots are running which tactics
      *

--- a/src/software/ai/ai.h
+++ b/src/software/ai/ai.h
@@ -24,17 +24,6 @@ class AI final
                 std::shared_ptr<const AIControlConfig> control_config);
 
     /**
-     * Calculates the Primitives that should be run by our Robots given the current
-     * state of the world.
-     *
-     * @param world The state of the World with which to make the decisions
-     *
-     * @return the Primitives that should be run by our Robots given the current state
-     * of the world.
-     */
-    std::vector<std::unique_ptr<Primitive>> getPrimitives(const World& world) const;
-
-    /**
      * Calculates the PrimitiveSetMsg that should be run by our Robots given the current
      * state of the world.
      *

--- a/src/software/ai/ai_wrapper.cpp
+++ b/src/software/ai/ai_wrapper.cpp
@@ -21,8 +21,7 @@ void AIWrapper::runAIAndSendPrimitives()
 {
     if (most_recent_world && control_config->RunAI()->value())
     {
-        auto new_primitives =
-            ai.getPrimitiveSetMsg(*most_recent_world);
+        auto new_primitives = ai.getPrimitiveSetMsg(*most_recent_world);
 
         PlayInfo play_info = ai.getPlayInfo();
         Subject<PlayInfo>::sendValueToObservers(play_info);

--- a/src/software/ai/ai_wrapper.cpp
+++ b/src/software/ai/ai_wrapper.cpp
@@ -21,16 +21,13 @@ void AIWrapper::runAIAndSendPrimitives()
 {
     if (most_recent_world && control_config->RunAI()->value())
     {
-        std::vector<std::unique_ptr<Primitive>> new_primitives =
-            ai.getPrimitives(*most_recent_world);
+        auto new_primitives =
+            ai.getPrimitiveSetMsg(*most_recent_world);
 
         PlayInfo play_info = ai.getPlayInfo();
         Subject<PlayInfo>::sendValueToObservers(play_info);
 
-        auto new_primitives_ptr =
-            std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
-                std::move(new_primitives));
-        Subject<ConstPrimitiveVectorPtr>::sendValueToObservers(new_primitives_ptr);
+        Subject<PrimitiveSetMsg>::sendValueToObservers(*new_primitives);
     }
     drawAI();
 }

--- a/src/software/ai/ai_wrapper.h
+++ b/src/software/ai/ai_wrapper.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/ai/ai.h"
 #include "software/ai/hl/stp/play_info.h"
 #include "software/gui/drawing/draw_functions.h"
 #include "software/multithreading/first_in_first_out_threaded_observer.h"
 #include "software/multithreading/subject.h"
-#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/world/world.h"
 
 /**

--- a/src/software/ai/ai_wrapper.h
+++ b/src/software/ai/ai_wrapper.h
@@ -5,6 +5,7 @@
 #include "software/gui/drawing/draw_functions.h"
 #include "software/multithreading/first_in_first_out_threaded_observer.h"
 #include "software/multithreading/subject.h"
+#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/world/world.h"
 
 /**
@@ -13,7 +14,7 @@
  * robots based on the World state, and sending them out.
  */
 class AIWrapper : public FirstInFirstOutThreadedObserver<World>,
-                  public Subject<ConstPrimitiveVectorPtr>,
+                  public Subject<PrimitiveSetMsg>,
                   public Subject<AIDrawFunction>,
                   public Subject<PlayInfo>
 {

--- a/src/software/ai/navigator/BUILD
+++ b/src/software/ai/navigator/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "//software/logger",
         "//software/parameter:dynamic_parameters",
         "//software/primitive:all_primitives",
+        "//software/proto/message_translation:tbots_protobuf",
         "//software/world",
     ],
 )

--- a/src/software/ai/navigator/navigator.cpp
+++ b/src/software/ai/navigator/navigator.cpp
@@ -2,6 +2,7 @@
 
 #include "software/geom/algorithms/distance.h"
 #include "software/logger/logger.h"
+#include "software/proto/message_translation/tbots_protobuf.h"
 
 Navigator::Navigator(std::unique_ptr<PathManager> path_manager,
                      RobotNavigationObstacleFactory robot_navigation_obstacle_factory,
@@ -60,15 +61,25 @@ void Navigator::visit(const StopIntent &intent)
     current_robot_id  = intent.getRobotId();
 }
 
+std::unique_ptr<PrimitiveSetMsg> Navigator::getAssignedPrimitiveSetMsg(
+    const World &world, const std::vector<std::unique_ptr<Intent>> &assigned_intents)
+{
+    auto primitives     = getAssignedPrimitives(world, assigned_intents);
+    auto primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
+        std::move(primitives));
+
+    return createPrimitiveSetMsg(primitives_ptr);
+}
+
 std::vector<std::unique_ptr<Primitive>> Navigator::getAssignedPrimitives(
-    const World &world, const std::vector<std::unique_ptr<Intent>> &assignedIntents)
+    const World &world, const std::vector<std::unique_ptr<Intent>> &assigned_intents)
 {
     planned_paths.clear();
     move_intents_for_path_planning.clear();
     friendly_non_move_intent_robot_obstacles.clear();
 
     auto assigned_primitives = std::vector<std::unique_ptr<Primitive>>();
-    for (const auto &intent : assignedIntents)
+    for (const auto &intent : assigned_intents)
     {
         current_primitive.reset(nullptr);
         current_robot_id.reset();

--- a/src/software/ai/navigator/navigator.h
+++ b/src/software/ai/navigator/navigator.h
@@ -2,6 +2,7 @@
 
 #include <unordered_set>
 
+#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/ai/intent/all_intents.h"
 #include "software/ai/intent/intent.h"
 #include "software/ai/intent/intent_visitor.h"
@@ -41,6 +42,17 @@ class Navigator : public IntentVisitor
      * @return vector of primitives for the given intents
      */
     std::vector<std::unique_ptr<Primitive>> getAssignedPrimitives(
+        const World &world, const std::vector<std::unique_ptr<Intent>> &assignedIntents);
+
+    /**
+     * Get PrimitiveSetMsg for given assigned intents
+     *
+     * @param world World to navigate around
+     * @assignedIntents intents to process into primitives
+     *
+     * @return PrimitiveSetMsg
+     */
+    std::unique_ptr<PrimitiveSetMsg> getAssignedPrimitiveSetMsg(
         const World &world, const std::vector<std::unique_ptr<Intent>> &assignedIntents);
 
     /**

--- a/src/software/backend/backend.h
+++ b/src/software/backend/backend.h
@@ -2,6 +2,7 @@
 
 #include "software/multithreading/first_in_first_out_threaded_observer.h"
 #include "software/multithreading/subject.h"
+#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/primitive/primitive.h"
 #include "software/proto/sensor_msg.pb.h"
 #include "software/world/world.h"
@@ -15,7 +16,7 @@
  */
 class Backend : public Subject<SensorMsg>,
                 public FirstInFirstOutThreadedObserver<World>,
-                public FirstInFirstOutThreadedObserver<ConstPrimitiveVectorPtr>
+                public FirstInFirstOutThreadedObserver<PrimitiveSetMsg>
 {
    public:
     Backend() = default;

--- a/src/software/backend/backend.h
+++ b/src/software/backend/backend.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/multithreading/first_in_first_out_threaded_observer.h"
 #include "software/multithreading/subject.h"
-#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/primitive/primitive.h"
 #include "software/proto/sensor_msg.pb.h"
 #include "software/world/world.h"

--- a/src/software/backend/radio/mrf/dongle.cpp
+++ b/src/software/backend/radio/mrf/dongle.cpp
@@ -413,15 +413,15 @@ void MRFDongle::send_camera_packet(std::vector<std::tuple<uint8_t, Point, Angle>
     annunciator.update_vision_detections(robot_ids);
 };
 
-void MRFDongle::send_drive_packet(const std::vector<std::unique_ptr<Primitive>> &prims)
+void MRFDongle::send_drive_packet(const PrimitiveSetMsg &prims)
 {
-    for (auto &prim : prims)
+    for (auto &[robot_id,prim_proto] : prims.robot_primitives())
     {
-        std::vector<uint8_t> encoded_primitive = encode_primitive(prim);
+        std::vector<uint8_t> encoded_primitive = encode_primitive(robot_id, prim_proto);
         if (encoded_primitive.size() > MAX_RADIO_PACKET_SIZE)
         {
-            LOG(WARNING) << "Failed to send " << prim->getPrimitiveName()
-                         << ", it had an encoded length of" << encoded_primitive.size()
+            LOG(WARNING) << "Failed to send a primitive, because it had an encoded length of"
+                << encoded_primitive.size()
                          << ", max is  " << MAX_RADIO_PACKET_SIZE;
         }
         else
@@ -454,11 +454,8 @@ void MRFDongle::submit_drive_transfer(std::vector<uint8_t> data)
     }
 }
 
-std::vector<uint8_t> MRFDongle::encode_primitive(const std::unique_ptr<Primitive> &prim)
+std::vector<uint8_t> MRFDongle::encode_primitive(unsigned int robot_id, PrimitiveMsg prim_proto)
 {
-    // Get the proto representation of the primitive
-    PrimitiveMsg prim_proto = ProtoCreatorPrimitiveVisitor().createPrimitiveMsg(*prim);
-
     // Serialize the proto representation
     std::vector<uint8_t> serialized_proto(prim_proto.ByteSizeLong());
     prim_proto.SerializeToArray(serialized_proto.data(),
@@ -466,8 +463,7 @@ std::vector<uint8_t> MRFDongle::encode_primitive(const std::unique_ptr<Primitive
     // Prepend the robot id
     // We place this outside the proto so that we can check on the robot if the message
     // was intended for that robot with de-serializing the message
-    serialized_proto.insert(serialized_proto.begin(),
-                            static_cast<uint8_t>(prim->getRobotId()));
+    serialized_proto.insert(serialized_proto.begin(), static_cast<uint8_t>(robot_id));
 
 
     return serialized_proto;

--- a/src/software/backend/radio/mrf/dongle.cpp
+++ b/src/software/backend/radio/mrf/dongle.cpp
@@ -415,14 +415,14 @@ void MRFDongle::send_camera_packet(std::vector<std::tuple<uint8_t, Point, Angle>
 
 void MRFDongle::send_drive_packet(const PrimitiveSetMsg &prims)
 {
-    for (auto &[robot_id,prim_proto] : prims.robot_primitives())
+    for (auto &[robot_id, prim_proto] : prims.robot_primitives())
     {
         std::vector<uint8_t> encoded_primitive = encode_primitive(robot_id, prim_proto);
         if (encoded_primitive.size() > MAX_RADIO_PACKET_SIZE)
         {
-            LOG(WARNING) << "Failed to send a primitive, because it had an encoded length of"
-                << encoded_primitive.size()
-                         << ", max is  " << MAX_RADIO_PACKET_SIZE;
+            LOG(WARNING)
+                << "Failed to send a primitive, because it had an encoded length of"
+                << encoded_primitive.size() << ", max is  " << MAX_RADIO_PACKET_SIZE;
         }
         else
         {
@@ -454,7 +454,8 @@ void MRFDongle::submit_drive_transfer(std::vector<uint8_t> data)
     }
 }
 
-std::vector<uint8_t> MRFDongle::encode_primitive(unsigned int robot_id, PrimitiveMsg prim_proto)
+std::vector<uint8_t> MRFDongle::encode_primitive(unsigned int robot_id,
+                                                 PrimitiveMsg prim_proto)
 {
     // Serialize the proto representation
     std::vector<uint8_t> serialized_proto(prim_proto.ByteSizeLong());

--- a/src/software/backend/radio/mrf/dongle.h
+++ b/src/software/backend/radio/mrf/dongle.h
@@ -19,6 +19,7 @@
 #include "software/backend/radio/mrf/send_reliable_message_operation.h"
 #include "software/backend/radio/mrf/usb/libusb.h"
 #include "software/backend/radio/mrf/util/async_operation.h"
+#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/backend/radio/mrf/util/noncopyable.h"
 #include "software/geom/angle.h"
 #include "software/geom/point.h"
@@ -49,12 +50,12 @@ class MRFDongle final
     ~MRFDongle();
 
     /**
-     * Given a vector of primitives, constructs a single drive packet to send over radio
+     * Given a PrimitiveSetMsg, constructs a single drive packet to send over radio
      * to all robots.
      *
-     * @param prims vector of primitives from HL
+     * @param prims PrimitiveSetMsg from HL
      */
-    void send_drive_packet(const std::vector<std::unique_ptr<Primitive>> &prims);
+    void send_drive_packet(const PrimitiveSetMsg &prims);
 
     /**
      * Sends a camera packet over radio to all robots, including vision coordinates of
@@ -126,13 +127,14 @@ class MRFDongle final
     uint16_t pan_;
 
     /**
-     * Encode the given primitive for transmission over radio
+     * Encode the given primitive and robot id for transmission over radio
      *
-     * @param prim The primitive to encode
+     * @param robot_id The robot id to encode for
+     * @param prim_proto The primitive to encode
      *
-     * @return The serialization of the proto equivalent of the primitive
+     * @return The serialization of the primitive proto
      */
-    std::vector<uint8_t> encode_primitive(const std::unique_ptr<Primitive> &prim);
+    std::vector<uint8_t> encode_primitive(unsigned int robot_id, PrimitiveMsg prim_proto);
 
     /**
      * Attempt to pack and send the given data over libusb to the radio

--- a/src/software/backend/radio/mrf/dongle.h
+++ b/src/software/backend/radio/mrf/dongle.h
@@ -15,11 +15,11 @@
 #include <utility>
 #include <vector>
 
+#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/backend/radio/mrf/annunciator.h"
 #include "software/backend/radio/mrf/send_reliable_message_operation.h"
 #include "software/backend/radio/mrf/usb/libusb.h"
 #include "software/backend/radio/mrf/util/async_operation.h"
-#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/backend/radio/mrf/util/noncopyable.h"
 #include "software/geom/angle.h"
 #include "software/geom/point.h"

--- a/src/software/backend/radio/radio_output.cpp
+++ b/src/software/backend/radio/radio_output.cpp
@@ -12,8 +12,7 @@ RadioOutput::RadioOutput(unsigned int config,
 {
 }
 
-void RadioOutput::sendPrimitives(
-    const std::vector<std::unique_ptr<Primitive>> &primitives)
+void RadioOutput::sendPrimitives( const PrimitiveSetMsg &primitives)
 {
     dongle.send_drive_packet(primitives);
 }

--- a/src/software/backend/radio/radio_output.cpp
+++ b/src/software/backend/radio/radio_output.cpp
@@ -12,7 +12,7 @@ RadioOutput::RadioOutput(unsigned int config,
 {
 }
 
-void RadioOutput::sendPrimitives( const PrimitiveSetMsg &primitives)
+void RadioOutput::sendPrimitives(const PrimitiveSetMsg &primitives)
 {
     dongle.send_drive_packet(primitives);
 }

--- a/src/software/backend/radio/radio_output.h
+++ b/src/software/backend/radio/radio_output.h
@@ -2,8 +2,8 @@
 
 #include <limits>
 
-#include "software/backend/radio/mrf/dongle.h"
 #include "shared/proto/tbots_software_msgs.pb.h"
+#include "software/backend/radio/mrf/dongle.h"
 #include "software/backend/radio/robot_status.h"
 #include "software/world/ball.h"
 #include "software/world/team.h"
@@ -27,7 +27,7 @@ class RadioOutput
      *
      * @param primitives the PrimitiveSetMsg to send
      */
-    void sendPrimitives( const PrimitiveSetMsg &primitives);
+    void sendPrimitives(const PrimitiveSetMsg& primitives);
 
     /**
      * Sends a camera packet with the detected robots and ball.

--- a/src/software/backend/radio/radio_output.h
+++ b/src/software/backend/radio/radio_output.h
@@ -3,6 +3,7 @@
 #include <limits>
 
 #include "software/backend/radio/mrf/dongle.h"
+#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/backend/radio/robot_status.h"
 #include "software/world/ball.h"
 #include "software/world/team.h"
@@ -24,9 +25,9 @@ class RadioOutput
     /**
      * Sends the given primitives to the backend to control the robots
      *
-     * @param primitives the list of primitives to send
+     * @param primitives the PrimitiveSetMsg to send
      */
-    void sendPrimitives(const std::vector<std::unique_ptr<Primitive>>& primitives);
+    void sendPrimitives( const PrimitiveSetMsg &primitives);
 
     /**
      * Sends a camera packet with the detected robots and ball.

--- a/src/software/backend/radio_backend.cpp
+++ b/src/software/backend/radio_backend.cpp
@@ -18,9 +18,9 @@ RadioBackend::RadioBackend(
 {
 }
 
-void RadioBackend::onValueReceived(ConstPrimitiveVectorPtr primitives_ptr)
+void RadioBackend::onValueReceived(PrimitiveSetMsg primitives)
 {
-    radio_output.sendPrimitives(*primitives_ptr);
+    radio_output.sendPrimitives(primitives);
 }
 
 void RadioBackend::onValueReceived(World world)

--- a/src/software/backend/radio_backend.h
+++ b/src/software/backend/radio_backend.h
@@ -16,7 +16,7 @@ class RadioBackend : public Backend
    private:
     static const int DEFAULT_RADIO_CONFIG = 0;
 
-    void onValueReceived(ConstPrimitiveVectorPtr primitives) override;
+    void onValueReceived(PrimitiveSetMsg primitives) override;
     void onValueReceived(World world) override;
 
     /**
@@ -37,6 +37,6 @@ class RadioBackend : public Backend
     std::optional<World> most_recently_received_world;
     std::mutex most_recently_received_world_mutex;
 
-    ConstPrimitiveVectorPtr most_recently_received_primitives;
+    PrimitiveSetMsg most_recently_received_primitives;
     std::mutex most_recently_received_primitives_mutex;
 };

--- a/src/software/backend/wifi_backend.cpp
+++ b/src/software/backend/wifi_backend.cpp
@@ -30,9 +30,9 @@ WifiBackend::WifiBackend(std::shared_ptr<const NetworkConfig> network_config)
     joinMulticastChannel(channel, network_interface);
 }
 
-void WifiBackend::onValueReceived(ConstPrimitiveVectorPtr primitives_ptr)
+void WifiBackend::onValueReceived(PrimitiveSetMsg primitives)
 {
-    primitive_output->sendProto(*createPrimitiveSetMsg(primitives_ptr));
+    primitive_output->sendProto(primitives);
 }
 
 void WifiBackend::onValueReceived(World world)

--- a/src/software/backend/wifi_backend.h
+++ b/src/software/backend/wifi_backend.h
@@ -17,7 +17,7 @@ class WifiBackend : public Backend
     static const std::string name;
 
    private:
-    void onValueReceived(ConstPrimitiveVectorPtr primitives) override;
+    void onValueReceived(PrimitiveSetMsg primitives) override;
     void onValueReceived(World world) override;
 
     /**

--- a/src/software/full_system_main.cpp
+++ b/src/software/full_system_main.cpp
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
         std::shared_ptr<ThreadedFullSystemGUI> visualizer;
 
         // Connect observers
-        ai->Subject<ConstPrimitiveVectorPtr>::registerObserver(backend);
+        ai->Subject<PrimitiveSetMsg>::registerObserver(backend);
         sensor_fusion->Subject<World>::registerObserver(ai);
         backend->Subject<SensorMsg>::registerObserver(sensor_fusion);
         if (!args.headless)

--- a/src/software/handheld_controller/BUILD
+++ b/src/software/handheld_controller/BUILD
@@ -45,6 +45,7 @@ cc_library(
         "//software/multithreading:subject",
         "//software/multithreading:threaded_observer",
         "//software/primitive",
+        "//software/proto/message_translation:tbots_protobuf",
         "//software/primitive:chip_primitive",
         "//software/primitive:direct_velocity_primitive",
         "//software/primitive:kick_primitive",

--- a/src/software/handheld_controller/BUILD
+++ b/src/software/handheld_controller/BUILD
@@ -45,10 +45,10 @@ cc_library(
         "//software/multithreading:subject",
         "//software/multithreading:threaded_observer",
         "//software/primitive",
-        "//software/proto/message_translation:tbots_protobuf",
         "//software/primitive:chip_primitive",
         "//software/primitive:direct_velocity_primitive",
         "//software/primitive:kick_primitive",
+        "//software/proto/message_translation:tbots_protobuf",
     ],
 )
 

--- a/src/software/handheld_controller/controller_primitive_generator.cpp
+++ b/src/software/handheld_controller/controller_primitive_generator.cpp
@@ -2,8 +2,8 @@
 
 #include "software/primitive/chip_primitive.h"
 #include "software/primitive/direct_velocity_primitive.h"
-#include "software/proto/message_translation/tbots_protobuf.h"
 #include "software/primitive/kick_primitive.h"
+#include "software/proto/message_translation/tbots_protobuf.h"
 
 ControllerPrimitiveGenerator::ControllerPrimitiveGenerator(
     std::shared_ptr<const HandheldControllerConfig> controller_input_config)
@@ -17,7 +17,8 @@ void ControllerPrimitiveGenerator::onValueReceived(ControllerInput controller_in
     primitives.emplace_back(createPrimitiveFromControllerInput(controller_input));
     auto primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
         std::move(primitives));
-    Subject<PrimitiveSetMsg>::sendValueToObservers(*createPrimitiveSetMsg(primitives_ptr));
+    Subject<PrimitiveSetMsg>::sendValueToObservers(
+        *createPrimitiveSetMsg(primitives_ptr));
 }
 
 std::unique_ptr<Primitive>

--- a/src/software/handheld_controller/controller_primitive_generator.cpp
+++ b/src/software/handheld_controller/controller_primitive_generator.cpp
@@ -2,6 +2,7 @@
 
 #include "software/primitive/chip_primitive.h"
 #include "software/primitive/direct_velocity_primitive.h"
+#include "software/proto/message_translation/tbots_protobuf.h"
 #include "software/primitive/kick_primitive.h"
 
 ControllerPrimitiveGenerator::ControllerPrimitiveGenerator(
@@ -16,7 +17,7 @@ void ControllerPrimitiveGenerator::onValueReceived(ControllerInput controller_in
     primitives.emplace_back(createPrimitiveFromControllerInput(controller_input));
     auto primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
         std::move(primitives));
-    Subject<ConstPrimitiveVectorPtr>::sendValueToObservers(primitives_ptr);
+    Subject<PrimitiveSetMsg>::sendValueToObservers(*createPrimitiveSetMsg(primitives_ptr));
 }
 
 std::unique_ptr<Primitive>

--- a/src/software/handheld_controller/controller_primitive_generator.h
+++ b/src/software/handheld_controller/controller_primitive_generator.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/handheld_controller/controller.h"
 #include "software/multithreading/first_in_first_out_threaded_observer.h"
 #include "software/multithreading/subject.h"
-#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/primitive/primitive.h"
 
 /**

--- a/src/software/handheld_controller/controller_primitive_generator.h
+++ b/src/software/handheld_controller/controller_primitive_generator.h
@@ -3,6 +3,7 @@
 #include "software/handheld_controller/controller.h"
 #include "software/multithreading/first_in_first_out_threaded_observer.h"
 #include "software/multithreading/subject.h"
+#include "shared/proto/tbots_software_msgs.pb.h"
 #include "software/primitive/primitive.h"
 
 /**
@@ -10,7 +11,7 @@
  */
 class ControllerPrimitiveGenerator
     : public FirstInFirstOutThreadedObserver<ControllerInput>,
-      public Subject<ConstPrimitiveVectorPtr>
+      public Subject<PrimitiveSetMsg>
 {
    public:
     /**

--- a/src/software/handheld_controller/handheld_control_main.cpp
+++ b/src/software/handheld_controller/handheld_control_main.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
     auto backend = std::make_shared<RadioBackend>();
 
     controller->Subject<ControllerInput>::registerObserver(primitive_generator);
-    primitive_generator->Subject<ConstPrimitiveVectorPtr>::registerObserver(backend);
+    primitive_generator->Subject<PrimitiveSetMsg>::registerObserver(backend);
 
     // This blocks forever without using the CPU
     std::promise<void>().get_future().wait();

--- a/src/software/proto/message_translation/tbots_protobuf.cpp
+++ b/src/software/proto/message_translation/tbots_protobuf.cpp
@@ -11,8 +11,9 @@
 std::unique_ptr<VisionMsg> createVisionMsg(const World& world)
 {
     // create msg and set timestamp
-    auto vision_msg                    = std::make_unique<VisionMsg>();
-    *(vision_msg->mutable_time_sent()) = *createCurrentTimestampMsg();
+    auto vision_msg = std::make_unique<VisionMsg>();
+
+    vision_msg->set_timestamp_seconds(createCurrentTime());
 
     // set robot_states map
     auto& robot_states_map = *vision_msg->mutable_robot_states();
@@ -38,8 +39,8 @@ std::unique_ptr<PrimitiveSetMsg> createPrimitiveSetMsg(
     const ConstPrimitiveVectorPtr& primitives)
 {
     // create msg and update timestamp
-    auto primitive_set_msg                    = std::make_unique<PrimitiveSetMsg>();
-    *(primitive_set_msg->mutable_time_sent()) = *createCurrentTimestampMsg();
+    auto primitive_set_msg = std::make_unique<PrimitiveSetMsg>();
+    primitive_set_msg->set_timestamp_seconds(createCurrentTime());
 
     // set robot primitives
     auto& robot_primitives_map = *primitive_set_msg->mutable_robot_primitives();
@@ -111,9 +112,8 @@ std::unique_ptr<VectorMsg> createVectorMsg(const Vector& vector)
     return std::move(vector_msg);
 }
 
-std::unique_ptr<TimestampMsg> createCurrentTimestampMsg()
+double createCurrentTime()
 {
-    auto timestamp_msg    = std::make_unique<TimestampMsg>();
     const auto clock_time = std::chrono::system_clock::now();
     double time_in_seconds =
         static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(
@@ -121,6 +121,5 @@ std::unique_ptr<TimestampMsg> createCurrentTimestampMsg()
                                 .count()) /
         MICROSECONDS_PER_SECOND;
 
-    timestamp_msg->set_epoch_timestamp_seconds(time_in_seconds);
-    return std::move(timestamp_msg);
+    return time_in_seconds;
 }

--- a/src/software/proto/message_translation/tbots_protobuf.cpp
+++ b/src/software/proto/message_translation/tbots_protobuf.cpp
@@ -2,7 +2,6 @@
 
 #include "shared/constants.h"
 #include "shared/proto/geometry.pb.h"
-#include "shared/proto/tbots_software_msgs.pb.h"
 #include "shared/proto/vision.pb.h"
 #include "software/primitive/primitive.h"
 #include "software/proto/message_translation/proto_creator_primitive_visitor.h"

--- a/src/software/proto/message_translation/tbots_protobuf.h
+++ b/src/software/proto/message_translation/tbots_protobuf.h
@@ -44,8 +44,8 @@ std::unique_ptr<AngleMsg> createAngleMsg(const Angle& angle);
 std::unique_ptr<VectorMsg> createVectorMsg(const Vector& vector);
 
 /**
- * Returns a timestamp msg with the time that this function was called
+ * Returns the time that this function was called
  *
- * @return The unique_ptr to a TimestampMsg with the current UTC time
+ * @return current time in seconds
  */
-std::unique_ptr<TimestampMsg> createCurrentTimestampMsg();
+double createCurrentTime();

--- a/src/software/proto/message_translation/tbots_protobuf_test.cpp
+++ b/src/software/proto/message_translation/tbots_protobuf_test.cpp
@@ -53,7 +53,7 @@ class TbotsProtobufTest : public ::testing::Test
             robot_state_msg.global_angular_velocity_radians_per_sec());
     }
 
-    static void assertSaneTimestamp(const TimestampMsg& timestamp)
+    static void assertSaneTimestamp(double timestamp_seconds)
     {
         // time will only move forward
         // we make sure the number that the timestamp is from the past
@@ -63,7 +63,7 @@ class TbotsProtobufTest : public ::testing::Test
                                     clock_time.time_since_epoch())
                                     .count()) /
             MICROSECONDS_PER_SECOND;
-        ASSERT_TRUE(timestamp.epoch_timestamp_seconds() <= time_in_seconds);
+        ASSERT_TRUE(timestamp_seconds <= time_in_seconds);
     }
 };
 
@@ -89,12 +89,6 @@ TEST(TbotsProtobufTest, vector_msg_test)
     auto vector_msg = createVectorMsg(vector);
 
     TbotsProtobufTest::assertVectorMessageEqual(vector, *vector_msg);
-}
-
-TEST(TbotsProtobufTest, timestamp_msg_test)
-{
-    auto timestamp_msg = createCurrentTimestampMsg();
-    TbotsProtobufTest::assertSaneTimestamp(*timestamp_msg);
 }
 
 TEST(TbotsProtobufTest, robot_state_msg_test)
@@ -133,7 +127,7 @@ TEST(TbotsProtobufTest, vision_msg_test)
 
     TbotsProtobufTest::assertBallStateMessageFromBall(world.ball(),
                                                       vision_msg->ball_state());
-    TbotsProtobufTest::assertSaneTimestamp(vision_msg->time_sent());
+    TbotsProtobufTest::assertSaneTimestamp(vision_msg->timestamp_seconds());
 
     auto friendly_robots   = world.friendlyTeam().getAllRobots();
     auto& robot_states_map = *vision_msg->mutable_robot_states();

--- a/src/software/simulated_tests/BUILD
+++ b/src/software/simulated_tests/BUILD
@@ -6,6 +6,7 @@ cc_library(
     srcs = ["simulated_test_fixture.cpp"],
     hdrs = ["simulated_test_fixture.h"],
     deps = [
+        ":simulated_test_simulator",
         "//software/ai",
         "//software/gui/drawing:navigator",
         "//software/gui/full_system:threaded_full_system_gui",
@@ -13,9 +14,19 @@ cc_library(
         "//software/sensor_fusion",
         "//software/simulated_tests/validation:non_terminating_function_validator",
         "//software/simulated_tests/validation:terminating_function_validator",
-        "//software/simulation:simulator",
         "//software/test_util",
         "//software/time:duration",
+        "@gtest",
+    ],
+)
+
+cc_library(
+    name = "simulated_test_simulator",
+    testonly = True,
+    srcs = ["simulated_test_simulator.cpp"],
+    hdrs = ["simulated_test_simulator.h"],
+    deps = [
+        "//software/simulation:simulator",
         "@gtest",
     ],
 )

--- a/src/software/simulated_tests/BUILD
+++ b/src/software/simulated_tests/BUILD
@@ -11,6 +11,7 @@ cc_library(
         "//software/gui/drawing:navigator",
         "//software/gui/full_system:threaded_full_system_gui",
         "//software/logger",
+        "//software/proto/message_translation:tbots_protobuf",
         "//software/sensor_fusion",
         "//software/simulated_tests/validation:non_terminating_function_validator",
         "//software/simulated_tests/validation:terminating_function_validator",

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -7,7 +7,8 @@
 #include "software/time/duration.h"
 
 SimulatedTestFixture::SimulatedTestFixture()
-    : simulator(std::make_unique<Simulator>(Field::createSSLDivisionBField())),
+    : simulated_test_simulator(
+          std::make_unique<SimulatedTestSimulator>(Field::createSSLDivisionBField())),
       sensor_fusion(DynamicParameters->getSensorFusionConfig()),
       ai(DynamicParameters->getAIConfig(), DynamicParameters->getAIControlConfig()),
       run_simulation_in_realtime(false)
@@ -23,10 +24,11 @@ void SimulatedTestFixture::SetUp()
     // until https://github.com/UBC-Thunderbots/Software/issues/1483 is complete
 
     // Re-create all objects for each test so we start from a clean setup
-    // every time. Because the simulator is created initially in the constructor's
-    // initialization list, and before every test in this SetUp function, we can
-    // guarantee the pointer will never be null / empty
-    simulator = std::make_unique<Simulator>(Field::createSSLDivisionBField());
+    // every time. Because the simulated_test_simulator is created initially in the
+    // constructor's initialization list, and before every test in this SetUp function, we
+    // can guarantee the pointer will never be null / empty
+    simulated_test_simulator =
+        std::make_unique<SimulatedTestSimulator>(Field::createSSLDivisionBField());
     ai = AI(DynamicParameters->getAIConfig(), DynamicParameters->getAIControlConfig());
     sensor_fusion = SensorFusion(DynamicParameters->getSensorFusionConfig());
 
@@ -55,22 +57,22 @@ void SimulatedTestFixture::SetUp()
 
 void SimulatedTestFixture::setBallState(const BallState &ball)
 {
-    simulator->setBallState(ball);
+    simulated_test_simulator->setBallState(ball);
 }
 
 void SimulatedTestFixture::addFriendlyRobots(const std::vector<RobotStateWithId> &robots)
 {
-    simulator->addYellowRobots(robots);
+    simulated_test_simulator->addYellowRobots(robots);
 }
 
 void SimulatedTestFixture::addEnemyRobots(const std::vector<RobotStateWithId> &robots)
 {
-    simulator->addBlueRobots(robots);
+    simulated_test_simulator->addBlueRobots(robots);
 }
 
 Field SimulatedTestFixture::field() const
 {
-    return simulator->getField();
+    return simulated_test_simulator->getField();
 }
 
 void SimulatedTestFixture::setFriendlyGoalie(RobotId goalie_id)
@@ -136,7 +138,7 @@ bool SimulatedTestFixture::validateAndCheckCompletion(
 
 void SimulatedTestFixture::updateSensorFusion()
 {
-    auto ssl_wrapper_packet = simulator->getSSLWrapperPacket();
+    auto ssl_wrapper_packet = simulated_test_simulator->getSSLWrapperPacket();
     assert(ssl_wrapper_packet);
 
     auto sensor_msg                        = SensorMsg();
@@ -190,18 +192,18 @@ void SimulatedTestFixture::runTest(
             NonTerminatingFunctionValidator(validation_function, world));
     }
 
-    const Timestamp timeout_time = simulator->getTimestamp() + timeout;
+    const Timestamp timeout_time = simulated_test_simulator->getTimestamp() + timeout;
     const Duration simulation_time_step =
         Duration::fromSeconds(1.0 / SIMULATED_CAMERA_FPS);
     const Duration ai_time_step = Duration::fromSeconds(
         simulation_time_step.getSeconds() * CAMERA_FRAMES_PER_AI_TICK);
     bool validation_functions_done = false;
-    while (simulator->getTimestamp() < timeout_time)
+    while (simulated_test_simulator->getTimestamp() < timeout_time)
     {
         auto wall_start_time = std::chrono::steady_clock::now();
         for (size_t i = 0; i < CAMERA_FRAMES_PER_AI_TICK; i++)
         {
-            simulator->stepSimulation(simulation_time_step);
+            simulated_test_simulator->stepSimulation(simulation_time_step);
             updateSensorFusion();
         }
 
@@ -224,8 +226,8 @@ void SimulatedTestFixture::runTest(
             {
                 PrimitiveMsg primitive_msg = createNanoPbPrimitiveMsg(*primitive_ptr);
 
-                simulator->setYellowRobotPrimitive(primitive_ptr->getRobotId(),
-                                                   primitive_msg);
+                simulated_test_simulator->setYellowRobotPrimitive(
+                    primitive_ptr->getRobotId(), primitive_msg);
             }
 
             if (run_simulation_in_realtime)

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -218,12 +218,7 @@ void SimulatedTestFixture::runTest(
                 break;
             }
 
-            auto primitives = ai.getPrimitives(*world);
-
-            auto yellow_primitives_ptr =
-                std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
-                    std::move(primitives));
-            auto primitive_set_msg = createPrimitiveSetMsg(yellow_primitives_ptr);
+            auto primitive_set_msg = ai.getPrimitiveSetMsg(*world);
             std::vector<uint8_t> serialized_proto(primitive_set_msg->ByteSizeLong());
             primitive_set_msg->SerializeToArray(
                 serialized_proto.data(),

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -2,6 +2,7 @@
 
 #include "software/gui/drawing/navigator.h"
 #include "software/logger/logger.h"
+#include "software/simulation/convert_primitive_to_nanopb.h"
 #include "software/test_util/test_util.h"
 #include "software/time/duration.h"
 
@@ -216,10 +217,16 @@ void SimulatedTestFixture::runTest(
             }
 
             auto primitives = ai.getPrimitives(*world);
-            auto primitives_ptr =
+            auto yellow_primitives_ptr =
                 std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
                     std::move(primitives));
-            simulator->setYellowRobotPrimitives(primitives_ptr);
+            for (const auto &primitive_ptr : *yellow_primitives_ptr)
+            {
+                PrimitiveMsg primitive_msg = createNanoPbPrimitiveMsg(*primitive_ptr);
+
+                simulator->setYellowRobotPrimitive(primitive_ptr->getRobotId(),
+                                                   primitive_msg);
+            }
 
             if (run_simulation_in_realtime)
             {

--- a/src/software/simulated_tests/simulated_test_fixture.h
+++ b/src/software/simulated_tests/simulated_test_fixture.h
@@ -5,9 +5,9 @@
 #include "software/ai/ai.h"
 #include "software/gui/full_system/threaded_full_system_gui.h"
 #include "software/sensor_fusion/sensor_fusion.h"
+#include "software/simulated_tests/simulated_test_simulator.h"
 #include "software/simulated_tests/validation/non_terminating_function_validator.h"
 #include "software/simulated_tests/validation/terminating_function_validator.h"
-#include "software/simulation/simulator.h"
 
 /**
  * This is a test fixture designed to make it easy to write integration tests. It provides
@@ -153,7 +153,7 @@ class SimulatedTestFixture : public ::testing::Test
     // the object in the SetUp function. Because the simulator has no
     // copy assignment operator, we have to make it a dynamically-allocated
     // object so we can assign new instances to this variable
-    std::unique_ptr<Simulator> simulator;
+    std::unique_ptr<SimulatedTestSimulator> simulated_test_simulator;
     // The SensorFusion being tested and used in simulation
     SensorFusion sensor_fusion;
     // The AI being tested and used in simulation

--- a/src/software/simulated_tests/simulated_test_simulator.cpp
+++ b/src/software/simulated_tests/simulated_test_simulator.cpp
@@ -1,0 +1,53 @@
+#include "software/simulated_tests/simulated_test_simulator.h"
+
+#include "software/simulation/simulator.h"
+
+// We use a static variable here to hide simulator.h's NanoPb PrimitiveSetMsg from users
+// of this class
+static std::shared_ptr<Simulator> simulator_static;
+
+SimulatedTestSimulator::SimulatedTestSimulator(const Field& field)
+{
+    simulator_static = std::make_shared<Simulator>(field);
+}
+
+void SimulatedTestSimulator::setBallState(const BallState& ball_state)
+{
+    simulator_static->setBallState(ball_state);
+}
+
+void SimulatedTestSimulator::addYellowRobots(const std::vector<RobotStateWithId>& robots)
+{
+    simulator_static->addYellowRobots(robots);
+}
+
+void SimulatedTestSimulator::addBlueRobots(const std::vector<RobotStateWithId>& robots)
+{
+    simulator_static->addBlueRobots(robots);
+}
+
+Field SimulatedTestSimulator::getField() const
+{
+    return simulator_static->getField();
+}
+
+std::unique_ptr<SSL_WrapperPacket> SimulatedTestSimulator::getSSLWrapperPacket() const
+{
+    return simulator_static->getSSLWrapperPacket();
+}
+
+Timestamp SimulatedTestSimulator::getTimestamp() const
+{
+    return simulator_static->getTimestamp();
+}
+
+void SimulatedTestSimulator::stepSimulation(const Duration& time_step)
+{
+    simulator_static->stepSimulation(time_step);
+}
+
+void SimulatedTestSimulator::setYellowRobotPrimitive(RobotId id,
+                                                     const PrimitiveMsg& primitive_msg)
+{
+    simulator_static->setYellowRobotPrimitive(id, primitive_msg);
+}

--- a/src/software/simulated_tests/simulated_test_simulator.h
+++ b/src/software/simulated_tests/simulated_test_simulator.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "software/proto/messages_robocup_ssl_wrapper.pb.h"
+#include "software/time/timestamp.h"
+#include "software/world/ball_state.h"
+#include "software/world/field.h"
+#include "software/world/robot_state.h"
+
+extern "C"
+{
+#include "shared/proto/primitive.nanopb.h"
+}
+
+/**
+ * This class wraps Simulator for the SimulatedTestFixture
+ */
+class SimulatedTestSimulator
+{
+   public:
+    SimulatedTestSimulator() = delete;
+
+    /**
+     * Creates a new SimulatedTestSimulator. The starting state of the simulation
+     * will have the given field, with no robots or ball.
+     *
+     * @param field The field to initialize the simulation with
+     */
+    explicit SimulatedTestSimulator(const Field& field);
+
+    /**
+     * Sets the state of the ball in the simulation. No more than 1 ball may exist
+     * in the simulation at a time. If a ball does not already exist, a ball
+     * is added with the given state. If a ball already exists, it's state is set to the
+     * given state.
+     *
+     * @param ball_state The new ball state
+     */
+    void setBallState(const BallState& ball_state);
+
+    /**
+     * Adds robots to the specified team with the given initial states.
+     *
+     * @pre The robot IDs must not be duplicated and must not match the ID
+     * of any robot already on the specified team.
+     *
+     * @throws runtime_error if any of the given robot ids are duplicated, or a
+     * robot already exists on the specified team with one of the new IDs
+     *
+     * @param robots the robots to add
+     */
+    void addYellowRobots(const std::vector<RobotStateWithId>& robots);
+    void addBlueRobots(const std::vector<RobotStateWithId>& robots);
+
+
+    /**
+     * Returns the field in the simulation
+     *
+     * @return the field in the simulation
+     */
+    Field getField() const;
+
+    /**
+     * Returns an SSL_WrapperPacket representing the most recent state
+     * of the simulation
+     *
+     * @return an SSL_WrapperPacket representing the most recent state
+     * of the simulation
+     */
+    std::unique_ptr<SSL_WrapperPacket> getSSLWrapperPacket() const;
+
+    /**
+     * Returns the current time in the simulation
+     *
+     * @return the current time in the simulation
+     */
+    Timestamp getTimestamp() const;
+
+    /**
+     * Advances the simulation by the given time step. This will simulate
+     * one "camera frame" of data and increase the camera_frame value by 1.
+     *
+     * @param time_step how much to advance the simulation by
+     */
+    void stepSimulation(const Duration& time_step);
+
+    /**
+     * Sets the primitive being simulated by the robot on the corresponding team
+     * in simulation
+     *
+     * @param id The id of the robot to set the primitive for
+     * @param primitive_msg The primitive to run on the robot
+     */
+    void setYellowRobotPrimitive(RobotId id, const PrimitiveMsg& primitive_msg);
+};

--- a/src/software/simulated_tests/simulated_test_simulator.h
+++ b/src/software/simulated_tests/simulated_test_simulator.h
@@ -9,11 +9,6 @@
 #include "software/world/field.h"
 #include "software/world/robot_state.h"
 
-extern "C"
-{
-#include "shared/proto/primitive.nanopb.h"
-}
-
 /**
  * This class wraps Simulator for the SimulatedTestFixture
  */
@@ -87,11 +82,11 @@ class SimulatedTestSimulator
     void stepSimulation(const Duration& time_step);
 
     /**
-     * Sets the primitive being simulated by the robot on the corresponding team
-     * in simulation
+     * Sets the primitives on the corresponding team in simulation
      *
-     * @param id The id of the robot to set the primitive for
-     * @param primitive_msg The primitive to run on the robot
+     * @param serialized_primitive_set_msg the serialized proto of the PrimitiveSetMsg to
+     * set
      */
-    void setYellowRobotPrimitive(RobotId id, const PrimitiveMsg& primitive_msg);
+    void setYellowRobotSerializedPrimitiveSet(
+        std::vector<uint8_t> serialized_primitive_set_msg);
 };

--- a/src/software/simulation/BUILD
+++ b/src/software/simulation/BUILD
@@ -165,6 +165,7 @@ cc_test(
     name = "simulator_test",
     srcs = ["simulator_test.cpp"],
     deps = [
+        ":convert_primitive_to_nanopb",
         ":simulator",
         "//software/test_util",
         "//software/world",
@@ -186,6 +187,7 @@ cc_test(
     name = "threaded_simulator_test",
     srcs = ["threaded_simulator_test.cpp"],
     deps = [
+        ":convert_primitive_to_nanopb",
         ":threaded_simulator",
         "//software/test_util",
         "//software/world",

--- a/src/software/simulation/BUILD
+++ b/src/software/simulation/BUILD
@@ -189,6 +189,7 @@ cc_test(
     deps = [
         ":convert_primitive_to_nanopb",
         ":threaded_simulator",
+        "//software/proto/message_translation:tbots_protobuf",
         "//software/test_util",
         "//software/world",
         "@gtest//:gtest_main",

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -81,6 +81,22 @@ void Simulator::setBlueRobotPrimitive(RobotId id, const PrimitiveMsg& primitive_
     setRobotPrimitive(id, primitive_msg, blue_simulator_robots, simulator_ball);
 }
 
+void Simulator::setYellowRobotPrimitiveSet(const PrimitiveSetMsg& primitive_set_msg)
+{
+    for (auto& [robot_id, primitive_msg] : primitive_set_msg.robot_primitives)
+    {
+        setYellowRobotPrimitive(robot_id, primitive_msg);
+    }
+}
+
+void Simulator::setBlueRobotPrimitiveSet(const PrimitiveSetMsg& primitive_set_msg)
+{
+    for (auto& [robot_id, primitive_msg] : primitive_set_msg.robot_primitives)
+    {
+        setBlueRobotPrimitive(robot_id, primitive_msg);
+    }
+}
+
 void Simulator::setRobotPrimitive(
     RobotId id, const PrimitiveMsg& primitive_msg,
     std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -83,17 +83,19 @@ void Simulator::setBlueRobotPrimitive(RobotId id, const PrimitiveMsg& primitive_
 
 void Simulator::setYellowRobotPrimitiveSet(const PrimitiveSetMsg& primitive_set_msg)
 {
-    for (auto& [robot_id, primitive_msg] : primitive_set_msg.robot_primitives)
+    for (pb_size_t i = 0; i < primitive_set_msg.robot_primitives_count; i++)
     {
-        setYellowRobotPrimitive(robot_id, primitive_msg);
+        setYellowRobotPrimitive(primitive_set_msg.robot_primitives[i].key,
+                                primitive_set_msg.robot_primitives[i].value);
     }
 }
 
 void Simulator::setBlueRobotPrimitiveSet(const PrimitiveSetMsg& primitive_set_msg)
 {
-    for (auto& [robot_id, primitive_msg] : primitive_set_msg.robot_primitives)
+    for (pb_size_t i = 0; i < primitive_set_msg.robot_primitives_count; i++)
     {
-        setBlueRobotPrimitive(robot_id, primitive_msg);
+        setBlueRobotPrimitive(primitive_set_msg.robot_primitives[i].key,
+                              primitive_set_msg.robot_primitives[i].value);
     }
 }
 

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -71,36 +71,6 @@ void Simulator::updateSimulatorRobots(
     }
 }
 
-void Simulator::setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives)
-{
-    setRobotPrimitives(primitives, yellow_simulator_robots, simulator_ball);
-}
-
-void Simulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives)
-{
-    setRobotPrimitives(primitives, blue_simulator_robots, simulator_ball);
-}
-
-void Simulator::setRobotPrimitives(
-    ConstPrimitiveVectorPtr primitives,
-    std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
-        simulator_robots,
-    const std::shared_ptr<SimulatorBall>& simulator_ball)
-{
-    if (!primitives)
-    {
-        return;
-    }
-
-    for (const auto& primitive_ptr : *primitives)
-    {
-        PrimitiveMsg primitive_msg = createNanoPbPrimitiveMsg(*primitive_ptr);
-
-        setRobotPrimitive(primitive_ptr->getRobotId(), primitive_msg, simulator_robots,
-                          simulator_ball);
-    }
-}
-
 void Simulator::setYellowRobotPrimitive(RobotId id, const PrimitiveMsg& primitive_msg)
 {
     setRobotPrimitive(id, primitive_msg, yellow_simulator_robots, simulator_ball);

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -10,6 +10,7 @@
 extern "C"
 {
 #include "shared/proto/primitive.nanopb.h"
+#include "shared/proto/tbots_software_msgs.nanopb.h"
 }
 
 /**
@@ -131,6 +132,15 @@ class Simulator
      */
     void setYellowRobotPrimitive(RobotId id, const PrimitiveMsg& primitive_msg);
     void setBlueRobotPrimitive(RobotId id, const PrimitiveMsg& primitive_msg);
+
+    /**
+     * Sets the primitive being simulated by the robot on the corresponding team
+     * in simulation
+     *
+     * @param primitive_set_msg The set of primitives to run on the robot
+     */
+    void setYellowRobotPrimitiveSet(const PrimitiveSetMsg& primitive_set_msg);
+    void setBlueRobotPrimitiveSet(const PrimitiveSetMsg& primitive_set_msg);
 
     /**
      * Advances the simulation by the given time step. This will simulate

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -123,14 +123,6 @@ class Simulator
     void addBlueRobots(const std::vector<RobotStateWithId>& robots);
 
     /**
-     * Sets the primitives being simulated by the robots in simulation
-     *
-     * @param primitives The primitives to simulate
-     */
-    void setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives);
-    void setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives);
-
-    /**
      * Sets the primitive being simulated by the robot on the corresponding team
      * in simulation
      *
@@ -201,19 +193,6 @@ class Simulator
         const std::vector<std::weak_ptr<PhysicsRobot>>& physics_robots,
         std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
             simulator_robots);
-
-    /**
-     * Sets the given primitives on the given simulator robots
-     *
-     * @param primitives The primitives to set
-     * @param simulator_robots The robots to set the primitives on
-     * @param simulator_ball The simulator ball to use in the primitives
-     */
-    static void setRobotPrimitives(
-        ConstPrimitiveVectorPtr primitives,
-        std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
-            simulator_robots,
-        const std::shared_ptr<SimulatorBall>& simulator_ball);
 
     /**
      * Sets the primitive being simulated by the robot in simulation

--- a/src/software/simulation/simulator_test.cpp
+++ b/src/software/simulation/simulator_test.cpp
@@ -4,6 +4,7 @@
 
 #include "software/primitive/move_primitive.h"
 #include "software/primitive/primitive.h"
+#include "software/simulation/convert_primitive_to_nanopb.h"
 #include "software/test_util/test_util.h"
 
 TEST(SimulatorTest, get_field)
@@ -307,9 +308,15 @@ TEST(SimulatorTest, simulate_single_yellow_robot_with_primitive)
         AutochickType::NONE);
     std::vector<std::unique_ptr<Primitive>> primitives;
     primitives.emplace_back(std::move(move_primitive));
-    auto primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
-        std::move(primitives));
-    simulator.setYellowRobotPrimitives(primitives_ptr);
+    auto yellow_primitives_ptr =
+        std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
+            std::move(primitives));
+    for (const auto& primitive_ptr : *yellow_primitives_ptr)
+    {
+        PrimitiveMsg primitive_msg = createNanoPbPrimitiveMsg(*primitive_ptr);
+
+        simulator.setYellowRobotPrimitive(primitive_ptr->getRobotId(), primitive_msg);
+    }
 
     for (unsigned int i = 0; i < 120; i++)
     {
@@ -374,9 +381,15 @@ TEST(SimulatorTest, simulate_single_blue_robot_with_primitive)
         AutochickType::NONE);
     std::vector<std::unique_ptr<Primitive>> primitives;
     primitives.emplace_back(std::move(move_primitive));
-    auto primitives_ptr = std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
-        std::move(primitives));
-    simulator.setBlueRobotPrimitives(primitives_ptr);
+    auto blue_primitives_ptr =
+        std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
+            std::move(primitives));
+    for (const auto& primitive_ptr : *blue_primitives_ptr)
+    {
+        PrimitiveMsg primitive_msg = createNanoPbPrimitiveMsg(*primitive_ptr);
+
+        simulator.setBlueRobotPrimitive(primitive_ptr->getRobotId(), primitive_msg);
+    }
 
     for (unsigned int i = 0; i < 120; i++)
     {
@@ -435,7 +448,12 @@ TEST(SimulatorTest, simulate_multiple_blue_and_yellow_robots_with_primitives)
     auto blue_primitives_ptr =
         std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
             std::move(blue_robot_primitives));
-    simulator.setBlueRobotPrimitives(blue_primitives_ptr);
+    for (const auto& primitive_ptr : *blue_primitives_ptr)
+    {
+        PrimitiveMsg primitive_msg = createNanoPbPrimitiveMsg(*primitive_ptr);
+
+        simulator.setBlueRobotPrimitive(primitive_ptr->getRobotId(), primitive_msg);
+    }
 
     std::unique_ptr<Primitive> yellow_move_primitive1 = std::make_unique<MovePrimitive>(
         1, Point(1, 1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
@@ -449,7 +467,12 @@ TEST(SimulatorTest, simulate_multiple_blue_and_yellow_robots_with_primitives)
     auto yellow_primitives_ptr =
         std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
             std::move(yellow_robot_primitives));
-    simulator.setYellowRobotPrimitives(yellow_primitives_ptr);
+    for (const auto& primitive_ptr : *yellow_primitives_ptr)
+    {
+        PrimitiveMsg primitive_msg = createNanoPbPrimitiveMsg(*primitive_ptr);
+
+        simulator.setYellowRobotPrimitive(primitive_ptr->getRobotId(), primitive_msg);
+    }
 
     for (unsigned int i = 0; i < 120; i++)
     {

--- a/src/software/simulation/standalone_simulator.cpp
+++ b/src/software/simulation/standalone_simulator.cpp
@@ -61,11 +61,11 @@ void StandaloneSimulator::initNetworking()
     yellow_team_primitive_listener =
         std::make_unique<ThreadedNanoPbPrimitiveSetMulticastListener>(
             yellow_team_ip, PRIMITIVE_PORT,
-            boost::bind(&StandaloneSimulator::setYellowRobotPrimitives, this, _1));
+            boost::bind(&StandaloneSimulator::setYellowRobotPrimitiveSet, this, _1));
     blue_team_primitive_listener =
         std::make_unique<ThreadedNanoPbPrimitiveSetMulticastListener>(
             blue_team_ip, PRIMITIVE_PORT,
-            boost::bind(&StandaloneSimulator::setBlueRobotPrimitives, this, _1));
+            boost::bind(&StandaloneSimulator::setBlueRobotPrimitiveSet, this, _1));
 }
 
 void StandaloneSimulator::setupInitialSimulationState()
@@ -121,24 +121,14 @@ SSL_WrapperPacket StandaloneSimulator::getSSLWrapperPacket() const
     return most_recent_ssl_wrapper_packet;
 }
 
-void StandaloneSimulator::setYellowRobotPrimitives(PrimitiveSetMsg primitive_set_msg)
+void StandaloneSimulator::setYellowRobotPrimitiveSet(PrimitiveSetMsg primitive_set_msg)
 {
-    for (pb_size_t i = 0; i < primitive_set_msg.robot_primitives_count; i++)
-    {
-        RobotId id                 = primitive_set_msg.robot_primitives[i].key;
-        PrimitiveMsg primitive_msg = primitive_set_msg.robot_primitives[i].value;
-        simulator.setYellowRobotPrimitive(id, primitive_msg);
-    }
+    simulator.setYellowRobotPrimitiveSet(primitive_set_msg);
 }
 
-void StandaloneSimulator::setBlueRobotPrimitives(PrimitiveSetMsg primitive_set_msg)
+void StandaloneSimulator::setBlueRobotPrimitiveSet(PrimitiveSetMsg primitive_set_msg)
 {
-    for (pb_size_t i = 0; i < primitive_set_msg.robot_primitives_count; i++)
-    {
-        RobotId id                 = primitive_set_msg.robot_primitives[i].key;
-        PrimitiveMsg primitive_msg = primitive_set_msg.robot_primitives[i].value;
-        simulator.setBlueRobotPrimitive(id, primitive_msg);
-    }
+    simulator.setBlueRobotPrimitiveSet(primitive_set_msg);
 }
 
 void StandaloneSimulator::startSimulation()

--- a/src/software/simulation/standalone_simulator.h
+++ b/src/software/simulation/standalone_simulator.h
@@ -114,8 +114,8 @@ class StandaloneSimulator
      *
      * @param primitive_set_msg The set of primitives to run on the respective team
      */
-    void setYellowRobotPrimitives(PrimitiveSetMsg primitive_set_msg);
-    void setBlueRobotPrimitives(PrimitiveSetMsg primitive_set_msg);
+    void setYellowRobotPrimitiveSet(PrimitiveSetMsg primitive_set_msg);
+    void setBlueRobotPrimitiveSet(PrimitiveSetMsg primitive_set_msg);
 
     /**
      * A helper function that sets up all networking functionality with

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -110,6 +110,19 @@ void ThreadedSimulator::setBlueRobotPrimitive(RobotId id,
     simulator.setBlueRobotPrimitive(id, primitive_msg);
 }
 
+void ThreadedSimulator::setYellowRobotPrimitiveSet(
+    const PrimitiveSetMsg &primitive_set_msg)
+{
+    std::scoped_lock lock(simulator_mutex);
+    simulator.setYellowRobotPrimitiveSet(primitive_set_msg);
+}
+
+void ThreadedSimulator::setBlueRobotPrimitiveSet(const PrimitiveSetMsg &primitive_set_msg)
+{
+    std::scoped_lock lock(simulator_mutex);
+    simulator.setBlueRobotPrimitiveSet(primitive_set_msg);
+}
+
 void ThreadedSimulator::runSimulationLoop()
 {
     Duration time_step = Duration::fromSeconds(TIME_STEP_SECONDS);

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -96,18 +96,6 @@ void ThreadedSimulator::addBlueRobots(const std::vector<RobotStateWithId> &robot
     updateCallbacks();
 }
 
-void ThreadedSimulator::setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives)
-{
-    std::scoped_lock lock(simulator_mutex);
-    simulator.setYellowRobotPrimitives(primitives);
-}
-
-void ThreadedSimulator::setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives)
-{
-    std::scoped_lock lock(simulator_mutex);
-    simulator.setBlueRobotPrimitives(primitives);
-}
-
 void ThreadedSimulator::setYellowRobotPrimitive(RobotId id,
                                                 const PrimitiveMsg &primitive_msg)
 {

--- a/src/software/simulation/threaded_simulator.h
+++ b/src/software/simulation/threaded_simulator.h
@@ -122,6 +122,15 @@ class ThreadedSimulator
     void setBlueRobotPrimitive(RobotId id, const PrimitiveMsg& primitive_msg);
 
     /**
+     * Sets the primitive being simulated by the robot on the corresponding team
+     * in simulation
+     *
+     * @param primitive_set_msg The set of primitives to run on the robot
+     */
+    void setYellowRobotPrimitiveSet(const PrimitiveSetMsg& primitive_set_msg);
+    void setBlueRobotPrimitiveSet(const PrimitiveSetMsg& primitive_set_msg);
+
+    /**
      * Returns the PhysicsRobot at the given position. This function accounts
      * for robot radius, so a robot will be returned if the given position is
      * within the robot's radius from its position.

--- a/src/software/simulation/threaded_simulator.h
+++ b/src/software/simulation/threaded_simulator.h
@@ -113,16 +113,6 @@ class ThreadedSimulator
     void addBlueRobots(const std::vector<RobotStateWithId>& robots);
 
     /**
-     * Sets the primitives being simulated by the robots in simulation
-     *
-     * Note: These functions are threadsafe.
-     *
-     * @param primitives The primitives to simulate
-     */
-    void setYellowRobotPrimitives(ConstPrimitiveVectorPtr primitives);
-    void setBlueRobotPrimitives(ConstPrimitiveVectorPtr primitives);
-
-    /**
      * Sets the primitive being simulated by the robot in simulation
      *
      * @param id The id of the robot to set the primitive for

--- a/src/software/simulation/threaded_simulator_test.cpp
+++ b/src/software/simulation/threaded_simulator_test.cpp
@@ -4,6 +4,7 @@
 
 #include "software/primitive/move_primitive.h"
 #include "software/primitive/primitive.h"
+#include "software/simulation/convert_primitive_to_nanopb.h"
 #include "software/test_util/test_util.h"
 
 class ThreadedSimulatorTest : public ::testing::Test
@@ -181,7 +182,13 @@ TEST_F(ThreadedSimulatorTest, add_robots_and_primitives_while_simulation_running
     auto blue_primitives_ptr =
         std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
             std::move(blue_robot_primitives));
-    threaded_simulator.setBlueRobotPrimitives(blue_primitives_ptr);
+    for (const auto& primitive_ptr : *blue_primitives_ptr)
+    {
+        PrimitiveMsg primitive_msg = createNanoPbPrimitiveMsg(*primitive_ptr);
+
+        threaded_simulator.setBlueRobotPrimitive(primitive_ptr->getRobotId(),
+                                                 primitive_msg);
+    }
 
     std::unique_ptr<Primitive> yellow_move_primitive1 = std::make_unique<MovePrimitive>(
         1, Point(1, 1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
@@ -195,7 +202,13 @@ TEST_F(ThreadedSimulatorTest, add_robots_and_primitives_while_simulation_running
     auto yellow_primitives_ptr =
         std::make_shared<const std::vector<std::unique_ptr<Primitive>>>(
             std::move(yellow_robot_primitives));
-    threaded_simulator.setYellowRobotPrimitives(yellow_primitives_ptr);
+    for (const auto& primitive_ptr : *yellow_primitives_ptr)
+    {
+        PrimitiveMsg primitive_msg = createNanoPbPrimitiveMsg(*primitive_ptr);
+
+        threaded_simulator.setYellowRobotPrimitive(primitive_ptr->getRobotId(),
+                                                   primitive_msg);
+    }
 
     std::this_thread::yield();
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
* Replaced ConstPrimitiveVectorPtr with PrimitiveSetMsg outside of AI and tests
* Requires an extra layer between SimulatedTestFixture and Simulator
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
existing tests continue to pass
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
