### PR TITLE
Dynamically add robots to Simulator

### DIFF
--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -53,17 +53,14 @@ void StandaloneSimulatorDrawFunctionVisualizer::mouseMoveEvent(QMouseEvent* even
 
 void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEvent *event) {
     Point point_in_scene = createPoint(mapToScene(event->pos()));
-    // get robot under cursor if exists
 
     QMenu menu(this);
     menu.addAction("Add Yellow Robot Here", [&]() {
-//        standalone_simulator->addYellowRobot(point_in_scene);
+        standalone_simulator->addYellowRobot(point_in_scene);
     });
     menu.addAction("Add Blue Robot Here", [&]() {
-//        standalone_simulator->addBlueRobot(point_in_scene);
+        standalone_simulator->addBlueRobot(point_in_scene);
     });
-    menu.addAction("Remove robot");
-//    menu.show();
+
     menu.exec(event->globalPos());
-    std::cout << "CONTEXT MENU EVENT " << std::endl;
 }

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -1,6 +1,7 @@
 #include "software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h"
 
 #include "software/gui/geometry_conversion.h"
+#include <QtWidgets/QMenu>
 
 StandaloneSimulatorDrawFunctionVisualizer::StandaloneSimulatorDrawFunctionVisualizer(
     QWidget* parent)
@@ -48,4 +49,21 @@ void StandaloneSimulatorDrawFunctionVisualizer::mouseMoveEvent(QMouseEvent* even
         physics_robot->setPosition(point_in_scene);
     }
     DrawFunctionVisualizer::mouseMoveEvent(event);
+}
+
+void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEvent *event) {
+    Point point_in_scene = createPoint(mapToScene(event->pos()));
+    // get robot under cursor if exists
+
+    QMenu menu(this);
+    menu.addAction("Add Yellow Robot Here", [&]() {
+//        standalone_simulator->addYellowRobot(point_in_scene);
+    });
+    menu.addAction("Add Blue Robot Here", [&]() {
+//        standalone_simulator->addBlueRobot(point_in_scene);
+    });
+    menu.addAction("Remove robot");
+//    menu.show();
+    menu.exec(event->globalPos());
+    std::cout << "CONTEXT MENU EVENT " << std::endl;
 }

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -1,7 +1,8 @@
 #include "software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h"
 
-#include "software/gui/geometry_conversion.h"
 #include <QtWidgets/QMenu>
+
+#include "software/gui/geometry_conversion.h"
 
 StandaloneSimulatorDrawFunctionVisualizer::StandaloneSimulatorDrawFunctionVisualizer(
     QWidget* parent)
@@ -51,16 +52,15 @@ void StandaloneSimulatorDrawFunctionVisualizer::mouseMoveEvent(QMouseEvent* even
     DrawFunctionVisualizer::mouseMoveEvent(event);
 }
 
-void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEvent *event) {
+void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEvent* event)
+{
     Point point_in_scene = createPoint(mapToScene(event->pos()));
 
     QMenu menu(this);
-    menu.addAction("Add Yellow Robot Here", [&]() {
-        standalone_simulator->addYellowRobot(point_in_scene);
-    });
-    menu.addAction("Add Blue Robot Here", [&]() {
-        standalone_simulator->addBlueRobot(point_in_scene);
-    });
+    menu.addAction("Add Yellow Robot Here",
+                   [&]() { standalone_simulator->addYellowRobot(point_in_scene); });
+    menu.addAction("Add Blue Robot Here",
+                   [&]() { standalone_simulator->addBlueRobot(point_in_scene); });
 
     menu.exec(event->globalPos());
 }

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
@@ -32,6 +32,7 @@ class StandaloneSimulatorDrawFunctionVisualizer : public DrawFunctionVisualizer
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent *event) override;
 
     // The robot currently being placed by the user, if any
     std::weak_ptr<PhysicsRobot> robot;

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
@@ -32,7 +32,7 @@ class StandaloneSimulatorDrawFunctionVisualizer : public DrawFunctionVisualizer
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
-    void contextMenuEvent(QContextMenuEvent *event) override;
+    void contextMenuEvent(QContextMenuEvent* event) override;
 
     // The robot currently being placed by the user, if any
     std::weak_ptr<PhysicsRobot> robot;

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -237,3 +237,17 @@ std::weak_ptr<PhysicsRobot> Simulator::getRobotAtPosition(const Point& position)
 {
     return physics_world.getRobotAtPosition(position);
 }
+
+void Simulator::addYellowRobot(const Point &position) {
+    RobotId id = physics_world.getAvailableYellowRobotId();
+    auto state = RobotState(position, Vector(0, 0), Angle::zero(), AngularVelocity::zero());
+    auto state_with_id = RobotStateWithId{.id = id, .robot_state = state};
+    addYellowRobots({state_with_id});
+}
+
+void Simulator::addBlueRobot(const Point &position) {
+    RobotId id = physics_world.getAvailableBlueRobotId();
+    auto state = RobotState(position, Vector(0, 0), Angle::zero(), AngularVelocity::zero());
+    auto state_with_id = RobotStateWithId{.id = id, .robot_state = state};
+    addBlueRobots({state_with_id});
+}

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -238,16 +238,20 @@ std::weak_ptr<PhysicsRobot> Simulator::getRobotAtPosition(const Point& position)
     return physics_world.getRobotAtPosition(position);
 }
 
-void Simulator::addYellowRobot(const Point &position) {
+void Simulator::addYellowRobot(const Point& position)
+{
     RobotId id = physics_world.getAvailableYellowRobotId();
-    auto state = RobotState(position, Vector(0, 0), Angle::zero(), AngularVelocity::zero());
+    auto state =
+        RobotState(position, Vector(0, 0), Angle::zero(), AngularVelocity::zero());
     auto state_with_id = RobotStateWithId{.id = id, .robot_state = state};
     addYellowRobots({state_with_id});
 }
 
-void Simulator::addBlueRobot(const Point &position) {
+void Simulator::addBlueRobot(const Point& position)
+{
     RobotId id = physics_world.getAvailableBlueRobotId();
-    auto state = RobotState(position, Vector(0, 0), Angle::zero(), AngularVelocity::zero());
+    auto state =
+        RobotState(position, Vector(0, 0), Angle::zero(), AngularVelocity::zero());
     auto state_with_id = RobotStateWithId{.id = id, .robot_state = state};
     addBlueRobots({state_with_id});
 }

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -123,6 +123,15 @@ class Simulator
     void addBlueRobots(const std::vector<RobotStateWithId>& robots);
 
     /**
+     * Adds a robots to the specified team at the given position. The robot will
+     * automatically be given a valid ID.
+     *
+     * @param position the position at which to add the robot
+     */
+    void addYellowRobot(const Point& position);
+    void addBlueRobot(const Point& position);
+
+    /**
      * Sets the primitives being simulated by the robots in simulation
      *
      * @param primitives The primitives to simulate

--- a/src/software/simulation/simulator_test.cpp
+++ b/src/software/simulation/simulator_test.cpp
@@ -239,6 +239,42 @@ TEST(SimulatorTest, add_blue_robots_with_ids_that_already_exist_in_the_simulatio
     EXPECT_THROW(simulator.addBlueRobots(states2), std::runtime_error);
 }
 
+TEST(SimulatorTest, add_yellow_robot)
+{
+    Simulator simulator(Field::createSSLDivisionBField());
+
+    auto wrapper_packet = simulator.getSSLWrapperPacket();
+    ASSERT_TRUE(wrapper_packet->has_detection());
+    EXPECT_EQ(0, wrapper_packet->detection().robots_yellow_size());
+
+    simulator.addYellowRobot(Point(0, 1));
+
+    wrapper_packet = simulator.getSSLWrapperPacket();
+    ASSERT_TRUE(wrapper_packet->has_detection());
+    EXPECT_EQ(1, wrapper_packet->detection().robots_yellow_size());
+
+    auto robot = simulator.getRobotAtPosition(Point(0, 1));
+    EXPECT_TRUE(robot.lock());
+}
+
+TEST(SimulatorTest, add_blue_robot)
+{
+    Simulator simulator(Field::createSSLDivisionBField());
+
+    auto wrapper_packet = simulator.getSSLWrapperPacket();
+    ASSERT_TRUE(wrapper_packet->has_detection());
+    EXPECT_EQ(0, wrapper_packet->detection().robots_blue_size());
+
+    simulator.addBlueRobot(Point(-0.5, -2));
+
+    wrapper_packet = simulator.getSSLWrapperPacket();
+    ASSERT_TRUE(wrapper_packet->has_detection());
+    EXPECT_EQ(1, wrapper_packet->detection().robots_blue_size());
+
+    auto robot = simulator.getRobotAtPosition(Point(-0.5, -2));
+    EXPECT_TRUE(robot.lock());
+}
+
 TEST(SimulatorTest, simulation_step_updates_the_ball)
 {
     // A sanity test to make sure stepping the simulation actually updates

--- a/src/software/simulation/standalone_simulator.cpp
+++ b/src/software/simulation/standalone_simulator.cpp
@@ -171,10 +171,12 @@ std::weak_ptr<PhysicsRobot> StandaloneSimulator::getRobotAtPosition(const Point&
     return simulator.getRobotAtPosition(position);
 }
 
-void StandaloneSimulator::addYellowRobot(const Point &position) {
+void StandaloneSimulator::addYellowRobot(const Point& position)
+{
     simulator.addYellowRobot(position);
 }
 
-void StandaloneSimulator::addBlueRobot(const Point &position) {
+void StandaloneSimulator::addBlueRobot(const Point& position)
+{
     simulator.addBlueRobot(position);
 }

--- a/src/software/simulation/standalone_simulator.cpp
+++ b/src/software/simulation/standalone_simulator.cpp
@@ -170,3 +170,11 @@ std::weak_ptr<PhysicsRobot> StandaloneSimulator::getRobotAtPosition(const Point&
 {
     return simulator.getRobotAtPosition(position);
 }
+
+void StandaloneSimulator::addYellowRobot(const Point &position) {
+    simulator.addYellowRobot(position);
+}
+
+void StandaloneSimulator::addBlueRobot(const Point &position) {
+    simulator.addBlueRobot(position);
+}

--- a/src/software/simulation/standalone_simulator.h
+++ b/src/software/simulation/standalone_simulator.h
@@ -104,6 +104,15 @@ class StandaloneSimulator
      */
     std::weak_ptr<PhysicsRobot> getRobotAtPosition(const Point& position);
 
+    /**
+     * Adds a robots to the specified team at the given position. The robot will
+     * automatically be given a valid ID.
+     *
+     * @param position the position at which to add the robot
+     */
+    void addYellowRobot(const Point& position);
+    void addBlueRobot(const Point& position);
+
     // This is a somewhat arbitrary value that results in slow motion
     // simulation looking appropriately / usefully slow
     static constexpr double DEFAULT_SLOW_MOTION_MULTIPLIER = 8.0;

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -169,10 +169,12 @@ std::weak_ptr<PhysicsRobot> ThreadedSimulator::getRobotAtPosition(const Point &p
     return simulator.getRobotAtPosition(position);
 }
 
-void ThreadedSimulator::addYellowRobot(const Point &position) {
+void ThreadedSimulator::addYellowRobot(const Point &position)
+{
     simulator.addYellowRobot(position);
 }
 
-void ThreadedSimulator::addBlueRobot(const Point &position) {
+void ThreadedSimulator::addBlueRobot(const Point &position)
+{
     simulator.addBlueRobot(position);
 }

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -171,10 +171,12 @@ std::weak_ptr<PhysicsRobot> ThreadedSimulator::getRobotAtPosition(const Point &p
 
 void ThreadedSimulator::addYellowRobot(const Point &position)
 {
+    std::scoped_lock lock(simulator_mutex);
     simulator.addYellowRobot(position);
 }
 
 void ThreadedSimulator::addBlueRobot(const Point &position)
 {
+    std::scoped_lock lock(simulator_mutex);
     simulator.addBlueRobot(position);
 }

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -168,3 +168,11 @@ std::weak_ptr<PhysicsRobot> ThreadedSimulator::getRobotAtPosition(const Point &p
     std::scoped_lock lock(simulator_mutex);
     return simulator.getRobotAtPosition(position);
 }
+
+void ThreadedSimulator::addYellowRobot(const Point &position) {
+    simulator.addYellowRobot(position);
+}
+
+void ThreadedSimulator::addBlueRobot(const Point &position) {
+    simulator.addBlueRobot(position);
+}

--- a/src/software/simulation/threaded_simulator.h
+++ b/src/software/simulation/threaded_simulator.h
@@ -113,6 +113,15 @@ class ThreadedSimulator
     void addBlueRobots(const std::vector<RobotStateWithId>& robots);
 
     /**
+     * Adds a robots to the specified team at the given position. The robot will
+     * automatically be given a valid ID.
+     *
+     * @param position the position at which to add the robot
+     */
+    void addYellowRobot(const Point& position);
+    void addBlueRobot(const Point& position);
+
+    /**
      * Sets the primitives being simulated by the robots in simulation
      *
      * Note: These functions are threadsafe.

--- a/src/software/simulation/threaded_simulator_test.cpp
+++ b/src/software/simulation/threaded_simulator_test.cpp
@@ -258,3 +258,25 @@ TEST_F(ThreadedSimulatorTest, add_robots_and_primitives_while_simulation_running
         Angle::half(), Angle::fromRadians(blue_robot_2->orientation()),
         Angle::fromDegrees(10)));
 }
+
+TEST_F(ThreadedSimulatorTest, add_individual_robots_at_position_while_simulation_running)
+{
+    threaded_simulator.startSimulation();
+    // yield and sleep to give the simulation thread the best chance of running
+    std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    threaded_simulator.addYellowRobot(Point(0, 0));
+    threaded_simulator.addBlueRobot(Point(2.1, 1));
+
+    std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    threaded_simulator.stopSimulation();
+
+    auto ssl_wrapper_packet = most_recent_wrapper_packet;
+    ASSERT_TRUE(ssl_wrapper_packet);
+    ASSERT_TRUE(ssl_wrapper_packet->has_detection());
+    auto detection_frame = ssl_wrapper_packet->detection();
+    ASSERT_EQ(1, detection_frame.robots_yellow_size());
+    ASSERT_EQ(1, detection_frame.robots_blue_size());
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Users can now right-click in the simulator to bring up a small dialog with options to `Add Yellow Robot Here` and `Add Blue Robot Here`. This will allow robots to be added dynamically to the simulator like grsim.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
unit tests and manual testing

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
#1536 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
