### PR TITLE
Remove robots using the StandaloneSimulatorGUI

### DIFF
--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -55,12 +55,17 @@ void StandaloneSimulatorDrawFunctionVisualizer::mouseMoveEvent(QMouseEvent* even
 void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEvent* event)
 {
     Point point_in_scene = createPoint(mapToScene(event->pos()));
+    auto robot_under_cursor = standalone_simulator->getRobotAtPosition(point_in_scene);
 
     QMenu menu(this);
     menu.addAction("Add Yellow Robot Here",
                    [&]() { standalone_simulator->addYellowRobot(point_in_scene); });
     menu.addAction("Add Blue Robot Here",
                    [&]() { standalone_simulator->addBlueRobot(point_in_scene); });
+    if(!robot_under_cursor.expired()) {
+        menu.addAction("Remove Robot",
+                       [&]() { standalone_simulator->removeRobot(robot_under_cursor); });
+    }
 
     menu.exec(event->globalPos());
 }

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -54,7 +54,7 @@ void StandaloneSimulatorDrawFunctionVisualizer::mouseMoveEvent(QMouseEvent* even
 
 void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEvent* event)
 {
-    Point point_in_scene = createPoint(mapToScene(event->pos()));
+    Point point_in_scene    = createPoint(mapToScene(event->pos()));
     auto robot_under_cursor = standalone_simulator->getRobotAtPosition(point_in_scene);
 
     QMenu menu(this);
@@ -62,7 +62,8 @@ void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEve
                    [&]() { standalone_simulator->addYellowRobot(point_in_scene); });
     menu.addAction("Add Blue Robot Here",
                    [&]() { standalone_simulator->addBlueRobot(point_in_scene); });
-    if(!robot_under_cursor.expired()) {
+    if (!robot_under_cursor.expired())
+    {
         menu.addAction("Remove Robot",
                        [&]() { standalone_simulator->removeRobot(robot_under_cursor); });
     }

--- a/src/software/simulation/physics/physics_world.cpp
+++ b/src/software/simulation/physics/physics_world.cpp
@@ -264,9 +264,15 @@ std::weak_ptr<PhysicsRobot> PhysicsWorld::getRobotAtPosition(const Point& positi
     return result;
 }
 
-void PhysicsWorld::removeRobot(std::weak_ptr<PhysicsRobot> robot) {
-    if(auto r = robot.lock()) {
-        yellow_physics_robots.erase(std::remove(yellow_physics_robots.begin(), yellow_physics_robots.end(), r), yellow_physics_robots.end());
-        blue_physics_robots.erase(std::remove(blue_physics_robots.begin(), blue_physics_robots.end(), r), blue_physics_robots.end());
+void PhysicsWorld::removeRobot(std::weak_ptr<PhysicsRobot> robot)
+{
+    if (auto r = robot.lock())
+    {
+        yellow_physics_robots.erase(
+            std::remove(yellow_physics_robots.begin(), yellow_physics_robots.end(), r),
+            yellow_physics_robots.end());
+        blue_physics_robots.erase(
+            std::remove(blue_physics_robots.begin(), blue_physics_robots.end(), r),
+            blue_physics_robots.end());
     }
 }

--- a/src/software/simulation/physics/physics_world.cpp
+++ b/src/software/simulation/physics/physics_world.cpp
@@ -263,3 +263,10 @@ std::weak_ptr<PhysicsRobot> PhysicsWorld::getRobotAtPosition(const Point& positi
 
     return result;
 }
+
+void PhysicsWorld::removeRobot(std::weak_ptr<PhysicsRobot> robot) {
+    if(auto r = robot.lock()) {
+        yellow_physics_robots.erase(std::remove(yellow_physics_robots.begin(), yellow_physics_robots.end(), r), yellow_physics_robots.end());
+        blue_physics_robots.erase(std::remove(blue_physics_robots.begin(), blue_physics_robots.end(), r), blue_physics_robots.end());
+    }
+}

--- a/src/software/simulation/physics/physics_world.h
+++ b/src/software/simulation/physics/physics_world.h
@@ -172,6 +172,11 @@ class PhysicsWorld
      */
     std::weak_ptr<PhysicsRobot> getRobotAtPosition(const Point& position);
 
+    /**
+     * Removes the given PhysicsRobot from the PhysicsWorld, if it exists.
+     *
+     * @param robot The robot to be removed
+     */
     void removeRobot(std::weak_ptr<PhysicsRobot> robot);
 
    private:

--- a/src/software/simulation/physics/physics_world.h
+++ b/src/software/simulation/physics/physics_world.h
@@ -172,6 +172,8 @@ class PhysicsWorld
      */
     std::weak_ptr<PhysicsRobot> getRobotAtPosition(const Point& position);
 
+    void removeRobot(std::weak_ptr<PhysicsRobot> robot);
+
    private:
     /**
      * Returns the states and IDs of all robots of the specified colour.

--- a/src/software/simulation/physics/physics_world_test.cpp
+++ b/src/software/simulation/physics/physics_world_test.cpp
@@ -241,6 +241,95 @@ TEST(PhysicsWorldTest, test_add_blue_robots_to_physics_world_with_existing_ids)
     EXPECT_THROW(physics_world.addBlueRobots(states2), std::runtime_error);
 }
 
+TEST(PhysicsWorldTest, test_remove_robot_with_invalid_ptr)
+{
+    PhysicsWorld physics_world(Field::createSSLDivisionBField());
+
+    EXPECT_TRUE(physics_world.getBluePhysicsRobots().empty());
+    EXPECT_TRUE(physics_world.getYellowPhysicsRobots().empty());
+
+    physics_world.removeRobot(std::weak_ptr<PhysicsRobot>());
+
+    EXPECT_TRUE(physics_world.getBluePhysicsRobots().empty());
+    EXPECT_TRUE(physics_world.getYellowPhysicsRobots().empty());
+}
+
+TEST(PhysicsWorldTest, remove_existing_yellow_team_robot)
+{
+    PhysicsWorld physics_world(Field::createSSLDivisionBField());
+
+    EXPECT_TRUE(physics_world.getBluePhysicsRobots().empty());
+    EXPECT_TRUE(physics_world.getYellowPhysicsRobots().empty());
+
+    RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
+                            AngularVelocity::half());
+    std::vector<RobotStateWithId> states1 = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+
+    physics_world.addYellowRobots(states1);
+
+    auto yellow_robots = physics_world.getYellowPhysicsRobots();
+    ASSERT_FALSE(yellow_robots.empty());
+    auto robot_to_remove = yellow_robots.at(0);
+
+    physics_world.removeRobot(robot_to_remove);
+
+    EXPECT_TRUE(physics_world.getBluePhysicsRobots().empty());
+    EXPECT_TRUE(physics_world.getYellowPhysicsRobots().empty());
+}
+
+TEST(PhysicsWorldTest, remove_existing_blue_team_robot)
+{
+    PhysicsWorld physics_world(Field::createSSLDivisionBField());
+
+    EXPECT_TRUE(physics_world.getBluePhysicsRobots().empty());
+    EXPECT_TRUE(physics_world.getYellowPhysicsRobots().empty());
+
+    RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
+                            AngularVelocity::half());
+    std::vector<RobotStateWithId> states1 = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+
+    physics_world.addBlueRobots(states1);
+
+    auto blue_robots = physics_world.getBluePhysicsRobots();
+    ASSERT_FALSE(blue_robots.empty());
+    auto robot_to_remove = blue_robots.at(0);
+
+    physics_world.removeRobot(robot_to_remove);
+
+    EXPECT_TRUE(physics_world.getBluePhysicsRobots().empty());
+    EXPECT_TRUE(physics_world.getYellowPhysicsRobots().empty());
+}
+
+TEST(PhysicsWorldTest, remove_existing_robot_twice)
+{
+    PhysicsWorld physics_world(Field::createSSLDivisionBField());
+
+    EXPECT_TRUE(physics_world.getBluePhysicsRobots().empty());
+    EXPECT_TRUE(physics_world.getYellowPhysicsRobots().empty());
+
+    RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
+                            AngularVelocity::half());
+    std::vector<RobotStateWithId> states1 = {
+            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+    };
+
+    physics_world.addBlueRobots(states1);
+
+    auto blue_robots = physics_world.getBluePhysicsRobots();
+    ASSERT_FALSE(blue_robots.empty());
+    auto robot_to_remove = blue_robots.at(0);
+
+    physics_world.removeRobot(robot_to_remove);
+    physics_world.removeRobot(robot_to_remove);
+
+    EXPECT_TRUE(physics_world.getBluePhysicsRobots().empty());
+    EXPECT_TRUE(physics_world.getYellowPhysicsRobots().empty());
+}
+
 TEST(PhysicsWorldTest, get_available_yellow_robot_ids_with_no_existing_robots)
 {
     PhysicsWorld physics_world(Field::createSSLDivisionBField());

--- a/src/software/simulation/physics/physics_world_test.cpp
+++ b/src/software/simulation/physics/physics_world_test.cpp
@@ -264,7 +264,7 @@ TEST(PhysicsWorldTest, remove_existing_yellow_team_robot)
     RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
                             AngularVelocity::half());
     std::vector<RobotStateWithId> states1 = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
 
     physics_world.addYellowRobots(states1);
@@ -289,7 +289,7 @@ TEST(PhysicsWorldTest, remove_existing_blue_team_robot)
     RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
                             AngularVelocity::half());
     std::vector<RobotStateWithId> states1 = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
 
     physics_world.addBlueRobots(states1);
@@ -314,7 +314,7 @@ TEST(PhysicsWorldTest, remove_existing_robot_twice)
     RobotState robot_state1(Point(1, 0), Vector(0, 0), Angle::quarter(),
                             AngularVelocity::half());
     std::vector<RobotStateWithId> states1 = {
-            RobotStateWithId{.id = 1, .robot_state = robot_state1},
+        RobotStateWithId{.id = 1, .robot_state = robot_state1},
     };
 
     physics_world.addBlueRobots(states1);

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -260,6 +260,7 @@ void Simulator::addBlueRobot(const Point& position)
     addBlueRobots({state_with_id});
 }
 
-void Simulator::removeRobot(std::weak_ptr<PhysicsRobot> robot) {
+void Simulator::removeRobot(std::weak_ptr<PhysicsRobot> robot)
+{
     physics_world.removeRobot(robot);
 }

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -259,3 +259,7 @@ void Simulator::addBlueRobot(const Point& position)
     auto state_with_id = RobotStateWithId{.id = id, .robot_state = state};
     addBlueRobots({state_with_id});
 }
+
+void Simulator::removeRobot(std::weak_ptr<PhysicsRobot> robot) {
+    physics_world.removeRobot(robot);
+}

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -199,6 +199,11 @@ class Simulator
      */
     std::weak_ptr<PhysicsRobot> getRobotAtPosition(const Point& position);
 
+    /**
+     * Removes the given PhysicsRobot from the PhysicsWorld, if it exists.
+     *
+     * @param robot The robot to be removed
+     */
     void removeRobot(std::weak_ptr<PhysicsRobot> robot);
 
    private:

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -199,6 +199,8 @@ class Simulator
      */
     std::weak_ptr<PhysicsRobot> getRobotAtPosition(const Point& position);
 
+    void removeRobot(std::weak_ptr<PhysicsRobot> robot);
+
    private:
     /**
      * Updates the given simulator_robots to contain and control the given physics_robots

--- a/src/software/simulation/standalone_simulator.cpp
+++ b/src/software/simulation/standalone_simulator.cpp
@@ -182,3 +182,7 @@ void StandaloneSimulator::addBlueRobot(const Point& position)
 {
     simulator.addBlueRobot(position);
 }
+
+void StandaloneSimulator::removeRobot(std::weak_ptr<PhysicsRobot> robot) {
+    simulator.removeRobot(robot);
+}

--- a/src/software/simulation/standalone_simulator.cpp
+++ b/src/software/simulation/standalone_simulator.cpp
@@ -183,6 +183,7 @@ void StandaloneSimulator::addBlueRobot(const Point& position)
     simulator.addBlueRobot(position);
 }
 
-void StandaloneSimulator::removeRobot(std::weak_ptr<PhysicsRobot> robot) {
+void StandaloneSimulator::removeRobot(std::weak_ptr<PhysicsRobot> robot)
+{
     simulator.removeRobot(robot);
 }

--- a/src/software/simulation/standalone_simulator.h
+++ b/src/software/simulation/standalone_simulator.h
@@ -113,6 +113,13 @@ class StandaloneSimulator
     void addYellowRobot(const Point& position);
     void addBlueRobot(const Point& position);
 
+    /**
+     * Removes the given PhysicsRobot from the PhysicsWorld, if it exists.
+     *
+     * @param robot The robot to be removed
+     */
+    void removeRobot(std::weak_ptr<PhysicsRobot> robot);
+
     // This is a somewhat arbitrary value that results in slow motion
     // simulation looking appropriately / usefully slow
     static constexpr double DEFAULT_SLOW_MOTION_MULTIPLIER = 8.0;

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -181,7 +181,8 @@ void ThreadedSimulator::addBlueRobot(const Point &position)
     simulator.addBlueRobot(position);
 }
 
-void ThreadedSimulator::removeRobot(std::weak_ptr<PhysicsRobot> robot) {
+void ThreadedSimulator::removeRobot(std::weak_ptr<PhysicsRobot> robot)
+{
     std::scoped_lock lock(simulator_mutex);
     simulator.removeRobot(robot);
 }

--- a/src/software/simulation/threaded_simulator.cpp
+++ b/src/software/simulation/threaded_simulator.cpp
@@ -180,3 +180,8 @@ void ThreadedSimulator::addBlueRobot(const Point &position)
     std::scoped_lock lock(simulator_mutex);
     simulator.addBlueRobot(position);
 }
+
+void ThreadedSimulator::removeRobot(std::weak_ptr<PhysicsRobot> robot) {
+    std::scoped_lock lock(simulator_mutex);
+    simulator.removeRobot(robot);
+}

--- a/src/software/simulation/threaded_simulator.h
+++ b/src/software/simulation/threaded_simulator.h
@@ -152,6 +152,13 @@ class ThreadedSimulator
      */
     std::weak_ptr<PhysicsRobot> getRobotAtPosition(const Point& position);
 
+    /**
+     * Removes the given PhysicsRobot from the PhysicsWorld, if it exists.
+     *
+     * @param robot The robot to be removed
+     */
+    void removeRobot(std::weak_ptr<PhysicsRobot> robot);
+
    private:
     /**
      * The function that runs inside the simulation thread, handling


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Robots can now be right-clicked and removed from the StandaloneSimulator via the StandaloneSimulatorGUI. This option will only show up if you right-click a robot.

(See slack for a video)

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests and manual testing.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #1537 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
