### PR TITLE
Fix Intermittent nanopb converter test failure

### DIFF
--- a/src/software/proto/message_translation/primitive_google_to_nanopb_converter_test.cpp
+++ b/src/software/proto/message_translation/primitive_google_to_nanopb_converter_test.cpp
@@ -50,25 +50,38 @@ TEST(PrimitiveGoogleToNanoPbConverterTest, convert_primitive_set)
 
     TbotsProto_PrimitiveSet nanopb_primitive_set =
         createNanoPbPrimitiveSet(*google_primitive_set);
-    auto nanopb_primitive_1 = nanopb_primitive_set.robot_primitives[0].value;
-    EXPECT_EQ(nanopb_primitive_set.robot_primitives[0].key, 0);
-    ASSERT_EQ(nanopb_primitive_1.which_primitive, TbotsProto_Primitive_move_tag);
-    EXPECT_EQ(nanopb_primitive_1.primitive.move.parameter1, 1000.0f);
-    EXPECT_EQ(nanopb_primitive_1.primitive.move.parameter2, 2000.0f);
-    EXPECT_EQ(nanopb_primitive_1.primitive.move.parameter3,
-              static_cast<float>(M_PI * 100));
-    EXPECT_EQ(nanopb_primitive_1.primitive.move.parameter4, 100000.0f);
-    EXPECT_EQ(nanopb_primitive_1.primitive.move.extra_bits, 0x04 | 0x02);
-    EXPECT_EQ(nanopb_primitive_1.primitive.move.slow, true);
 
-    EXPECT_EQ(nanopb_primitive_set.robot_primitives[1].key, 2);
-    auto nanopb_primitive_2 = nanopb_primitive_set.robot_primitives[1].value;
-    ASSERT_EQ(nanopb_primitive_2.which_primitive, TbotsProto_Primitive_move_tag);
-    EXPECT_EQ(nanopb_primitive_2.primitive.move.parameter1, 2000.0f);
-    EXPECT_EQ(nanopb_primitive_2.primitive.move.parameter2, 4000.0f);
-    EXPECT_EQ(nanopb_primitive_2.primitive.move.parameter3,
-              static_cast<float>(M_PI * 100));
-    EXPECT_EQ(nanopb_primitive_2.primitive.move.parameter4, 50000.0f);
-    EXPECT_EQ(nanopb_primitive_2.primitive.move.extra_bits, 0x04 | 0x02);
-    EXPECT_EQ(nanopb_primitive_2.primitive.move.slow, false);
+    // Test below assumes that map is of size 2
+    ASSERT_EQ(2, nanopb_primitive_set.robot_primitives_count);
+
+    for (pb_size_t i = 0; i < nanopb_primitive_set.robot_primitives_count; i++)
+    {
+        auto nanopb_primitive = nanopb_primitive_set.robot_primitives[i].value;
+        if (nanopb_primitive_set.robot_primitives[i].key == 0)
+        {
+            EXPECT_EQ(nanopb_primitive_set.robot_primitives[i].key, 0);
+            ASSERT_EQ(nanopb_primitive.which_primitive, TbotsProto_Primitive_move_tag);
+            EXPECT_EQ(nanopb_primitive.primitive.move.parameter1, 1000.0f);
+            EXPECT_EQ(nanopb_primitive.primitive.move.parameter2, 2000.0f);
+            EXPECT_EQ(nanopb_primitive.primitive.move.parameter3,
+                      static_cast<float>(M_PI * 100));
+            EXPECT_EQ(nanopb_primitive.primitive.move.parameter4, 100000.0f);
+            EXPECT_EQ(nanopb_primitive.primitive.move.extra_bits, 0x04 | 0x02);
+            EXPECT_EQ(nanopb_primitive.primitive.move.slow, true);
+        }
+        else
+        {
+            // Only other possible key is 2
+            ASSERT_EQ(nanopb_primitive_set.robot_primitives[i].key, 2);
+            auto nanopb_primitive = nanopb_primitive_set.robot_primitives[1].value;
+            ASSERT_EQ(nanopb_primitive.which_primitive, TbotsProto_Primitive_move_tag);
+            EXPECT_EQ(nanopb_primitive.primitive.move.parameter1, 2000.0f);
+            EXPECT_EQ(nanopb_primitive.primitive.move.parameter2, 4000.0f);
+            EXPECT_EQ(nanopb_primitive.primitive.move.parameter3,
+                      static_cast<float>(M_PI * 100));
+            EXPECT_EQ(nanopb_primitive.primitive.move.parameter4, 50000.0f);
+            EXPECT_EQ(nanopb_primitive.primitive.move.extra_bits, 0x04 | 0x02);
+            EXPECT_EQ(nanopb_primitive.primitive.move.slow, false);
+        }
+    }
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Noticed CI failures https://travis-ci.org/github/UBC-Thunderbots/Software/jobs/718129927 and it's because the test made some assumptions about the order of the deserialized nanopb map, i.e. index 0 is  for robot_id 0 and index 1 is for robot_id 2. It turns out it will _sometimes_ be the case, but sadly, not always.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Hard to repro, will just have to confident that the root cause is correct
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
