### PR TITLE
Add ball and robot placement to right-click menu in SimulatorGUI

### DIFF
--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -62,7 +62,8 @@ void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEve
 
     QMenu menu(this);
     menu.addAction("Place Ball Here", [&]() {
-        standalone_simulator->setBallState(BallState{.position_ = point_in_scene, .velocity_ = Vector(0, 0), .height_ = 0});
+        standalone_simulator->setBallState(BallState{
+            .position_ = point_in_scene, .velocity_ = Vector(0, 0), .height_ = 0});
     });
     menu.addAction("Add Yellow Robot Here",
                    [&]() { standalone_simulator->addYellowRobot(point_in_scene); });
@@ -70,13 +71,9 @@ void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEve
                    [&]() { standalone_simulator->addBlueRobot(point_in_scene); });
     if (auto physics_robot = robot_under_cursor.lock())
     {
-        menu.addAction("Move Robot",
-                       [&](){
-                           robot = robot_under_cursor;
-                       });
+        menu.addAction("Move Robot", [&]() { robot = robot_under_cursor; });
         menu.addAction("Remove Robot",
                        [&]() { standalone_simulator->removeRobot(robot_under_cursor); });
-
     }
 
     menu.exec(event->globalPos());

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -58,6 +58,9 @@ void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEve
     auto robot_under_cursor = standalone_simulator->getRobotAtPosition(point_in_scene);
 
     QMenu menu(this);
+    menu.addAction("Place Ball Here", [&]() {
+        standalone_simulator->setBallState(BallState{.position_ = point_in_scene, .velocity_ = Vector(0, 0), .height_ = 0});
+    });
     menu.addAction("Add Yellow Robot Here",
                    [&]() { standalone_simulator->addYellowRobot(point_in_scene); });
     menu.addAction("Add Blue Robot Here",

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -8,6 +8,8 @@ StandaloneSimulatorDrawFunctionVisualizer::StandaloneSimulatorDrawFunctionVisual
     QWidget* parent)
     : DrawFunctionVisualizer(parent)
 {
+    // Let mouseMoveEvents be triggered even if a mouse button is not pressed
+    this->setMouseTracking(true);
 }
 
 void StandaloneSimulatorDrawFunctionVisualizer::setStandaloneSimulator(
@@ -31,6 +33,7 @@ void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* eve
     }
     else
     {
+        robot.reset();
         DrawFunctionVisualizer::mousePressEvent(event);
     }
 }
@@ -65,10 +68,15 @@ void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEve
                    [&]() { standalone_simulator->addYellowRobot(point_in_scene); });
     menu.addAction("Add Blue Robot Here",
                    [&]() { standalone_simulator->addBlueRobot(point_in_scene); });
-    if (!robot_under_cursor.expired())
+    if (auto physics_robot = robot_under_cursor.lock())
     {
+        menu.addAction("Move Robot",
+                       [&](){
+                           robot = robot_under_cursor;
+                       });
         menu.addAction("Remove Robot",
                        [&]() { standalone_simulator->removeRobot(robot_under_cursor); });
+
     }
 
     menu.exec(event->globalPos());


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Users can now place the ball and robots using the right-click menu in the SimulatorGUI. See slack for a video.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
manual tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
none

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
