### PR TITLE
Scoped lock and pass generator lock cleanup

### DIFF
--- a/src/software/ai/passing/pass_generator.cpp
+++ b/src/software/ai/passing/pass_generator.cpp
@@ -38,6 +38,7 @@ PassGenerator::PassGenerator(const World& world, const Point& passer_point,
 
 void PassGenerator::setWorld(World world)
 {
+    std::scoped_lock(pass_generator_mutex);
     // Take ownership of the updated world for the duration of this function
     std::lock_guard<std::mutex> updated_world_lock(updated_world_mutex);
 
@@ -47,6 +48,7 @@ void PassGenerator::setWorld(World world)
 
 void PassGenerator::setPasserPoint(Point passer_point)
 {
+    std::scoped_lock(pass_generator_mutex);
     // Take ownership of the passer_point for the duration of this function
     std::lock_guard<std::mutex> passer_point_lock(passer_point_mutex);
 
@@ -56,6 +58,7 @@ void PassGenerator::setPasserPoint(Point passer_point)
 
 void PassGenerator::setPasserRobotId(unsigned int robot_id)
 {
+    std::scoped_lock(pass_generator_mutex);
     // Take ownershp of the passer robot id for the duration of this function
     std::lock_guard<std::mutex> passer_robot_id_lock(passer_robot_id_mutex);
 
@@ -74,6 +77,7 @@ PassWithRating PassGenerator::getBestPassSoFar()
         }
     }
 
+    std::scoped_lock(pass_generator_mutex);
     // Take ownership of the best_known_pass for the rest of this function
     std::lock_guard<std::mutex> best_known_pass_lock(best_known_pass_mutex);
 
@@ -83,6 +87,7 @@ PassWithRating PassGenerator::getBestPassSoFar()
 
 void PassGenerator::setTargetRegion(std::optional<Rectangle> area)
 {
+    std::scoped_lock(pass_generator_mutex);
     // Take ownership of the target_region for the duration of this function
     std::lock_guard<std::mutex> target_region_lock(target_region_mutex);
 
@@ -132,6 +137,7 @@ void PassGenerator::continuouslyGeneratePasses()
 
 void PassGenerator::updateAndOptimizeAndPrunePasses()
 {
+    std::scoped_lock(pass_generator_mutex);
     // Copy over the updated world and remove the passer robot
     world_mutex.lock();
     updated_world_mutex.lock();
@@ -234,6 +240,7 @@ void PassGenerator::pruneAndReplacePasses()
 
 void PassGenerator::saveBestPass()
 {
+    std::scoped_lock(pass_generator_mutex);
     // Take ownership of the best_known_pass for the duration of this function
     std::lock_guard<std::mutex> best_known_pass_lock(best_known_pass_mutex);
 
@@ -282,6 +289,7 @@ void PassGenerator::updatePasserPointOfAllPasses(const Point& new_passer_point)
 
 double PassGenerator::ratePass(const Pass& pass)
 {
+    std::scoped_lock(pass_generator_mutex);
     // Take ownership of world, target_region, passer_robot_id for the duration of this
     // function
     std::lock_guard<std::mutex> world_lock(world_mutex);
@@ -304,6 +312,7 @@ double PassGenerator::ratePass(const Pass& pass)
 
 std::vector<Pass> PassGenerator::generatePasses(unsigned long num_passes_to_gen)
 {
+    std::scoped_lock(pass_generator_mutex);
     // Take ownership of world for the duration of this function
     std::lock_guard<std::mutex> world_lock(world_mutex);
 
@@ -385,6 +394,7 @@ bool PassGenerator::passesEqual(Pass pass1, Pass pass2)
 std::array<double, PassGenerator::NUM_PARAMS_TO_OPTIMIZE>
 PassGenerator::convertPassToArray(const Pass& pass)
 {
+    std::scoped_lock(pass_generator_mutex);
     // Take ownership of the world for the duration of this function
     std::lock_guard<std::mutex> world_lock(world_mutex);
 
@@ -395,6 +405,7 @@ PassGenerator::convertPassToArray(const Pass& pass)
 Pass PassGenerator::convertArrayToPass(
     const std::array<double, PassGenerator::NUM_PARAMS_TO_OPTIMIZE>& array)
 {
+    std::scoped_lock(pass_generator_mutex);
     // Take ownership of the passer_point and world for the duration of this function
     std::lock_guard<std::mutex> passer_point_lock(passer_point_mutex);
     std::lock_guard<std::mutex> world_lock(world_mutex);

--- a/src/software/ai/passing/pass_generator.h
+++ b/src/software/ai/passing/pass_generator.h
@@ -327,8 +327,12 @@ class PassGenerator
 
     // What type of pass we're trying to generate
     PassType pass_type;
+
     // The mutex for the in_destructor flag
     std::mutex in_destructor_mutex;
+
+    // mutex to protect fields in the pass generator
+    std::mutex pass_generator_mutex;
 
     // This flag is used to indicate that we are in the destructor. We use this to
     // communicate with pass_generation_thread that it is

--- a/src/software/ai/passing/pass_generator.h
+++ b/src/software/ai/passing/pass_generator.h
@@ -19,13 +19,13 @@
  * It is built such that when it is constructed, a thread is immediately started in
  * the background continuously optimizing/pruning/re-generating passes. As such, any
  * modifications to data in this class through a public interface *must* be managed
- * by mutexes. Generally in functions that touch data we use "std::lock_guard" to
- * take ownership of the mutex protecting that data for the duration of the function.
+ * by mutexes. Generally in functions that touch data we use "std::scoped_lock" to
+ * take ownership of the mutex protecting data for the duration of the function.
  *
  * == Making Changes/Additions ==
  * Whenever you change/add a function, you need to ask: "what data is this _directly_
  * touching?". If the function is touching anything internal to the class, you should
- * be getting a lock on the mutex for that data member for the duration of the
+ * be getting a lock on the pass_generator_mutex for the duration of the
  * function (see below for examples). Note the *directly* bit! If you are
  * changing/adding function "A", and you have it call function "B", if B touches
  * data, then B should be responsible for getting a lock on the data. If you acquire
@@ -278,22 +278,13 @@ class PassGenerator
     // background. This thread will run for the entire lifetime of the class
     std::thread pass_generation_thread;
 
-    // The mutex for the updated world
-    std::mutex updated_world_mutex;
-
     // This world is the most recently updated one. We use this variable to "buffer"
     // the most recently updated world so that the world stays the same for the
     // entirety of each optimization loop, which makes things easier to reason about
     World updated_world;
 
-    // The mutex for the world
-    std::mutex world_mutex;
-
     // This world is what is used in the optimization loop
     World world;
-
-    // The mutex for the passer robot ID
-    std::mutex passer_robot_id_mutex;
 
     // The id of the robot that is performing the pass. We want to ignore this robot
     std::optional<unsigned int> passer_robot_id;
@@ -304,20 +295,11 @@ class PassGenerator
     // The optimizer we're using to find passes
     GradientDescentOptimizer<NUM_PARAMS_TO_OPTIMIZE> optimizer;
 
-    // The mutex for the passer_point
-    std::mutex passer_point_mutex;
-
     // The point we are passing from
     Point passer_point;
 
-    // The mutex for the passer_point
-    std::mutex best_known_pass_mutex;
-
     // The best pass we currently know about
     Pass best_known_pass;
-
-    // The mutex for the target region
-    std::mutex target_region_mutex;
 
     // The area that we want to pass to
     std::optional<Rectangle> target_region;

--- a/src/software/backend/radio/mrf/annunciator.cpp
+++ b/src/software/backend/radio/mrf/annunciator.cpp
@@ -110,7 +110,7 @@ void Annunciator::handle_robot_message(int index, const void *data, std::size_t 
     RadioRobotStatus robot_status;
 
     // Guard robot status state for this bot
-    std::lock_guard<std::mutex> lock(
+    std::scoped_lock lock(
         robot_status_states[static_cast<unsigned char>(index)].bot_mutex);
 
     robot_status.link_quality = lqi / 255.0;

--- a/src/software/backend/radio/mrf/dongle.cpp
+++ b/src/software/backend/radio/mrf/dongle.cpp
@@ -375,7 +375,7 @@ void MRFDongle::send_camera_packet(std::vector<std::tuple<uint8_t, Point, Angle>
     // the packet
     camera_packet[0] = mask_vec;
 
-    std::lock_guard<std::mutex> lock(cam_mtx);
+    std::scoped_lock lock(cam_mtx);
 
     if (camera_transfers.size() >= 8)
     {
@@ -484,7 +484,7 @@ void MRFDongle::handle_camera_transfer_done(
     AsyncOperation<void> &op,
     std::list<std::pair<std::unique_ptr<USB::BulkOutTransfer>, uint64_t>>::iterator iter)
 {
-    std::lock_guard<std::mutex> lock(cam_mtx);
+    std::scoped_lock lock(cam_mtx);
     op.result();
     camera_transfers.erase(iter);
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
* Replace lock_guard with [scoped_lock](https://stackoverflow.com/questions/43019598/stdlock-guard-or-stdscoped-lock)
* Replaced fine-grained locks with one big lock in pass_generator
  * Should be easier to work with
  * `std::atomic` does not work because the types, e.g. `World`, `Point`, are not [trivially copyable](https://stackoverflow.com/questions/43019598/stdlock-guard-or-stdscoped-lock)
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
No degradations in the running time of pass_generator_test in fastbuild or optimized
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #1072 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
