### PR TITLE
Use ConvexPolygon to calculate polygon area in box2d_util

### DIFF
--- a/src/software/simulation/physics/BUILD
+++ b/src/software/simulation/physics/BUILD
@@ -5,7 +5,9 @@ cc_library(
     srcs = ["box2d_util.cpp"],
     hdrs = ["box2d_util.h"],
     deps = [
+        "//software/geom:convex_polygon",
         "//software/geom:point",
+        "//software/geom:vector",
         "@box2d",
     ],
 )

--- a/src/software/simulation/physics/box2d_util.cpp
+++ b/src/software/simulation/physics/box2d_util.cpp
@@ -1,4 +1,6 @@
 #include "software/simulation/physics/box2d_util.h"
+#include <vector>
+#include "software/geom/convex_polygon.h"
 
 bool bodyExistsInWorld(b2Body* body, b2World* world)
 {
@@ -47,20 +49,12 @@ float polygonArea(const b2PolygonShape& polygon)
 {
     // Box2D already asserts that Polygons are not degenerate (have < 3 vertices) when
     // they are created, so we do not need to check for that here.
-
-    // Using the shoelace formula / algorithm from
-    // https://www.geeksforgeeks.org/area-of-a-polygon-with-given-n-ordered-vertices/
-    // This requires that the vertices are given in order, either clockwise or
-    // counter-clockwise.
-    double area    = 0.0;
-    unsigned int j = polygon.m_count - 1;
+    std::vector<Point> vertices;
     for (int i = 0; i < polygon.m_count; i++)
     {
-        double x_sum        = polygon.m_vertices[j].x + polygon.m_vertices[i].x;
-        double y_difference = polygon.m_vertices[j].y - polygon.m_vertices[i].y;
-        area += x_sum * y_difference;
-        j = i;
+        vertices.emplace_back(Point(polygon.m_vertices[i].x, polygon.m_vertices[i].y));
     }
+    ConvexPolygon convex_polygon(vertices);
 
-    return static_cast<float>(std::fabs(area / 2.0));
+    return static_cast<float>(convex_polygon.area());
 }

--- a/src/software/simulation/physics/box2d_util.cpp
+++ b/src/software/simulation/physics/box2d_util.cpp
@@ -1,5 +1,7 @@
 #include "software/simulation/physics/box2d_util.h"
+
 #include <vector>
+
 #include "software/geom/convex_polygon.h"
 
 bool bodyExistsInWorld(b2Body* body, b2World* world)


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Replaced the polygon area algorithm in box2d_util with our existing ConvexPolygon algorithm.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
unit tests still pass

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #1131 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
