### PR TITLE
Replace Chicker fixture with Dribbler Damper in PhysicsRobot

### DIFF
--- a/src/software/simulation/physics/physics_field.cpp
+++ b/src/software/simulation/physics/physics_field.cpp
@@ -47,7 +47,7 @@ void PhysicsField::setupFieldBoundary(const Field &field)
         createVec2(field.fieldBoundary().negXPosYCorner()),
     };
     field_boundary_shape.CreateLoop(field_boundary_vertices, num_field_boundary_vertices);
-    field_boundary_fixture_def.shape = &field_boundary_shape;
+    field_boundary_fixture_def.shape       = &field_boundary_shape;
     field_boundary_fixture_def.restitution = FIELD_WALL_RESTITUTION;
     field_boundary_fixture_def.friction    = FIELD_WALL_FRICTION;
     field_body->CreateFixture(&field_boundary_fixture_def);
@@ -62,7 +62,7 @@ void PhysicsField::setupEnemyGoal(const Field &field)
         createVec2(field.enemyGoalpostPos() + Vector(field.goalXLength(), 0)),
         createVec2(field.enemyGoalpostPos())};
     enemy_goal_shape.CreateChain(enemy_goal_vertices, num_enemy_goal_vertices);
-    enemy_goal_fixture_def.shape = &enemy_goal_shape;
+    enemy_goal_fixture_def.shape       = &enemy_goal_shape;
     enemy_goal_fixture_def.restitution = FIELD_WALL_RESTITUTION;
     enemy_goal_fixture_def.friction    = FIELD_WALL_FRICTION;
     field_body->CreateFixture(&enemy_goal_fixture_def);
@@ -77,7 +77,7 @@ void PhysicsField::setupFriendlyGoal(const Field &field)
         createVec2(field.friendlyGoalpostPos() - Vector(field.goalXLength(), 0)),
         createVec2(field.friendlyGoalpostPos())};
     friendly_goal_shape.CreateChain(friendly_goal_vertices, num_friendly_goal_vertices);
-    friendly_goal_fixture_def.shape = &friendly_goal_shape;
+    friendly_goal_fixture_def.shape       = &friendly_goal_shape;
     friendly_goal_fixture_def.restitution = FIELD_WALL_RESTITUTION;
     friendly_goal_fixture_def.friction    = FIELD_WALL_FRICTION;
     field_body->CreateFixture(&friendly_goal_fixture_def);

--- a/src/software/simulation/physics/physics_field.cpp
+++ b/src/software/simulation/physics/physics_field.cpp
@@ -48,10 +48,8 @@ void PhysicsField::setupFieldBoundary(const Field &field)
     };
     field_boundary_shape.CreateLoop(field_boundary_vertices, num_field_boundary_vertices);
     field_boundary_fixture_def.shape = &field_boundary_shape;
-    // Collisions with the field boundary are perfectly elastic and have
-    // no friction
-    field_boundary_fixture_def.restitution = 1.0;
-    field_boundary_fixture_def.friction    = 0.0;
+    field_boundary_fixture_def.restitution = FIELD_WALL_RESTITUTION;
+    field_boundary_fixture_def.friction    = FIELD_WALL_FRICTION;
     field_body->CreateFixture(&field_boundary_fixture_def);
 }
 
@@ -65,9 +63,8 @@ void PhysicsField::setupEnemyGoal(const Field &field)
         createVec2(field.enemyGoalpostPos())};
     enemy_goal_shape.CreateChain(enemy_goal_vertices, num_enemy_goal_vertices);
     enemy_goal_fixture_def.shape = &enemy_goal_shape;
-    // Collisions with the enemy goal are perfectly elastic and have no friction
-    enemy_goal_fixture_def.restitution = 1.0;
-    enemy_goal_fixture_def.friction    = 1.0;
+    enemy_goal_fixture_def.restitution = FIELD_WALL_RESTITUTION;
+    enemy_goal_fixture_def.friction    = FIELD_WALL_FRICTION;
     field_body->CreateFixture(&enemy_goal_fixture_def);
 }
 
@@ -81,9 +78,8 @@ void PhysicsField::setupFriendlyGoal(const Field &field)
         createVec2(field.friendlyGoalpostPos())};
     friendly_goal_shape.CreateChain(friendly_goal_vertices, num_friendly_goal_vertices);
     friendly_goal_fixture_def.shape = &friendly_goal_shape;
-    // Collisions with the friendly goal are perfectly elastic and have no friction
-    friendly_goal_fixture_def.restitution = 1.0;
-    friendly_goal_fixture_def.friction    = 1.0;
+    friendly_goal_fixture_def.restitution = FIELD_WALL_RESTITUTION;
+    friendly_goal_fixture_def.friction    = FIELD_WALL_FRICTION;
     field_body->CreateFixture(&friendly_goal_fixture_def);
 }
 

--- a/src/software/simulation/physics/physics_field.h
+++ b/src/software/simulation/physics/physics_field.h
@@ -97,7 +97,7 @@ class PhysicsField
     // We set the field restitution to 0 so that behaviour of bouncing off walls is
     // completely determined by the ball's restitution
     static constexpr float FIELD_WALL_RESTITUTION = 0.0f;
-    static constexpr float FIELD_WALL_FRICTION = 0.0f;
+    static constexpr float FIELD_WALL_FRICTION    = 0.0f;
 
     // Since the field never changes during simulation, we store the initial field
     // used during construction to make it easy to return Field objects when requested

--- a/src/software/simulation/physics/physics_field.h
+++ b/src/software/simulation/physics/physics_field.h
@@ -94,9 +94,10 @@ class PhysicsField
     b2ChainShape friendly_goal_shape;
     b2FixtureDef friendly_goal_fixture_def;
 
-    // We set the field restitution to 0 so that behavioiur of bouncing off walls is
+    // We set the field restitution to 0 so that behaviour of bouncing off walls is
     // completely determined by the ball's restitution
-    const float field_restitution = 0.0f;
+    static constexpr float FIELD_WALL_RESTITUTION = 0.0f;
+    static constexpr float FIELD_WALL_FRICTION = 0.0f;
 
     // Since the field never changes during simulation, we store the initial field
     // used during construction to make it easy to return Field objects when requested

--- a/src/software/simulation/physics/physics_robot.cpp
+++ b/src/software/simulation/physics/physics_robot.cpp
@@ -21,7 +21,7 @@ const double PhysicsRobot::DRIBBLER_DEPTH =
 // without letting the ball tunnel and collide with the robot body
 const double PhysicsRobot::DRIBBLER_DAMPER_THICKNESS = 0.005;
 const double PhysicsRobot::TOTAL_DRIBBLER_DEPTH =
-        PhysicsRobot::DRIBBLER_DEPTH + PhysicsRobot::DRIBBLER_DAMPER_THICKNESS;
+    PhysicsRobot::DRIBBLER_DEPTH + PhysicsRobot::DRIBBLER_DAMPER_THICKNESS;
 
 PhysicsRobot::PhysicsRobot(RobotId id, std::shared_ptr<b2World> world,
                            const RobotState& robot_state, const double mass_kg)
@@ -156,14 +156,14 @@ void PhysicsRobot::setupDribblerDamperFixture(const RobotState& robot_state)
     const unsigned int num_vertices                     = 4;
     b2Vec2 dribbler_damper_shape_vertices[num_vertices] = {
         createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - TOTAL_DRIBBLER_DEPTH +
-                         DRIBBLER_DAMPER_THICKNESS,
+                             DRIBBLER_DAMPER_THICKNESS,
                          DRIBBLER_WIDTH_METERS / 2.0)),
         createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - TOTAL_DRIBBLER_DEPTH,
                          DRIBBLER_WIDTH_METERS / 2.0)),
         createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - TOTAL_DRIBBLER_DEPTH,
                          -DRIBBLER_WIDTH_METERS / 2.0)),
         createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - TOTAL_DRIBBLER_DEPTH +
-                         DRIBBLER_DAMPER_THICKNESS,
+                             DRIBBLER_DAMPER_THICKNESS,
                          -DRIBBLER_WIDTH_METERS / 2.0))};
 
     b2PolygonShape* dribbler_damper_shape = new b2PolygonShape();

--- a/src/software/simulation/physics/physics_robot.cpp
+++ b/src/software/simulation/physics/physics_robot.cpp
@@ -43,7 +43,7 @@ PhysicsRobot::PhysicsRobot(RobotId id, std::shared_ptr<b2World> world,
 
     setupRobotBodyFixtures(robot_state, mass_kg);
     setupDribblerFixture(robot_state);
-    setupChickerFixture(robot_state);
+    setupDribblerDamperFixture(robot_state);
 
     // For some reason adding fixtures with mass slightly changes the linear velocity
     // of the body, so we make sure to reset it to the desired value at the end
@@ -141,7 +141,7 @@ void PhysicsRobot::setupDribblerFixture(const RobotState&)
     delete dribbler_shape;
 }
 
-void PhysicsRobot::setupChickerFixture(const RobotState&)
+void PhysicsRobot::setupDribblerDamperFixture(const RobotState &robot_state)
 {
     b2FixtureDef dribbler_damper_fixture_def;
     dribbler_damper_fixture_def.restitution = static_cast<float>(DRIBBLER_DAMPER_RESTITUTION);
@@ -221,7 +221,7 @@ PhysicsRobot::getDribblerBallEndContactCallbacks() const
 }
 
 std::vector<std::function<void(PhysicsRobot*, PhysicsBall*)>>
-PhysicsRobot::getChickerBallStartContactCallbacks() const
+PhysicsRobot::getDribblerDamperBallStartContactCallbacks() const
 {
     return dribbler_damper_ball_contact_callbacks;
 }

--- a/src/software/simulation/physics/physics_robot.cpp
+++ b/src/software/simulation/physics/physics_robot.cpp
@@ -196,12 +196,6 @@ void PhysicsRobot::registerDribblerBallEndContactCallback(
     dribbler_ball_end_contact_callbacks.emplace_back(callback);
 }
 
-void PhysicsRobot::registerDribblerDamperBallStartContactCallback(
-    std::function<void(PhysicsRobot*, PhysicsBall*)> callback)
-{
-    dribbler_damper_ball_contact_callbacks.emplace_back(callback);
-}
-
 std::vector<std::function<void(PhysicsRobot*, PhysicsBall*)>>
 PhysicsRobot::getDribblerBallContactCallbacks() const
 {
@@ -218,12 +212,6 @@ std::vector<std::function<void(PhysicsRobot*, PhysicsBall*)>>
 PhysicsRobot::getDribblerBallEndContactCallbacks() const
 {
     return dribbler_ball_end_contact_callbacks;
-}
-
-std::vector<std::function<void(PhysicsRobot*, PhysicsBall*)>>
-PhysicsRobot::getDribblerDamperBallStartContactCallbacks() const
-{
-    return dribbler_damper_ball_contact_callbacks;
 }
 
 RobotState PhysicsRobot::getRobotState() const

--- a/src/software/simulation/physics/physics_robot.cpp
+++ b/src/software/simulation/physics/physics_robot.cpp
@@ -116,10 +116,9 @@ void PhysicsRobot::setupDribblerFixture(const RobotState&)
     // We explicitly choose to make the dribbler NOT a sensor, because sensor fixtures do
     // not trigger PreSolve contact callbacks, which we rely on to apply dribbling force
     // at every physics step
-    robot_dribbler_fixture_def.isSensor = false;
-    robot_dribbler_fixture_def.restitution =
-        static_cast<float>(DRIBBLER_RESTITUTION);
-    robot_dribbler_fixture_def.friction = static_cast<float>(DRIBBLER_FRICTION);
+    robot_dribbler_fixture_def.isSensor    = false;
+    robot_dribbler_fixture_def.restitution = static_cast<float>(DRIBBLER_RESTITUTION);
+    robot_dribbler_fixture_def.friction    = static_cast<float>(DRIBBLER_FRICTION);
     robot_dribbler_fixture_def.userData =
         new PhysicsObjectUserData({PhysicsObjectType::ROBOT_DRIBBLER, this});
 
@@ -141,30 +140,31 @@ void PhysicsRobot::setupDribblerFixture(const RobotState&)
     delete dribbler_shape;
 }
 
-void PhysicsRobot::setupDribblerDamperFixture(const RobotState &robot_state)
+void PhysicsRobot::setupDribblerDamperFixture(const RobotState& robot_state)
 {
     b2FixtureDef dribbler_damper_fixture_def;
-    dribbler_damper_fixture_def.restitution = static_cast<float>(DRIBBLER_DAMPER_RESTITUTION);
-    dribbler_damper_fixture_def.friction    = static_cast<float>(DRIBBLER_DAMPER_FRICTION);
-    dribbler_damper_fixture_def.density     = static_cast<float>(DRIBBLER_DAMPER_DENSITY);
+    dribbler_damper_fixture_def.restitution =
+        static_cast<float>(DRIBBLER_DAMPER_RESTITUTION);
+    dribbler_damper_fixture_def.friction = static_cast<float>(DRIBBLER_DAMPER_FRICTION);
+    dribbler_damper_fixture_def.density  = static_cast<float>(DRIBBLER_DAMPER_DENSITY);
     dribbler_damper_fixture_def.userData =
         new PhysicsObjectUserData({PhysicsObjectType::ROBOT_CHICKER, this});
 
     // Box2D requires that polygon vertices are specified in counter-clockwise order.
     // The fixture shape is added relative to the body in its local coordinate frame,
     // so we do not need to rotate the points to match the orientation of the robot.
-    const unsigned int num_vertices             = 4;
+    const unsigned int num_vertices                     = 4;
     b2Vec2 dribbler_damper_shape_vertices[num_vertices] = {
-        createVec2(
-            Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth + dribbler_damper_thickness,
-                  DRIBBLER_WIDTH_METERS / 2.0)),
+        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth +
+                             dribbler_damper_thickness,
+                         DRIBBLER_WIDTH_METERS / 2.0)),
         createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth,
                          DRIBBLER_WIDTH_METERS / 2.0)),
         createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth,
                          -DRIBBLER_WIDTH_METERS / 2.0)),
-        createVec2(
-            Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth + dribbler_damper_thickness,
-                  -DRIBBLER_WIDTH_METERS / 2.0))};
+        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth +
+                             dribbler_damper_thickness,
+                         -DRIBBLER_WIDTH_METERS / 2.0))};
 
     b2PolygonShape* dribbler_damper_shape = new b2PolygonShape();
     dribbler_damper_shape->Set(dribbler_damper_shape_vertices, num_vertices);

--- a/src/software/simulation/physics/physics_robot.cpp
+++ b/src/software/simulation/physics/physics_robot.cpp
@@ -14,14 +14,14 @@ extern "C"
 // We are only allowed to cover a fraction of the ball according to the rules, so we use
 // this to calculate the depth. We assume the ball can be dribbled as long as it is
 // anywhere within this small area.
-const double PhysicsRobot::dribbler_depth =
+const double PhysicsRobot::DRIBBLER_DEPTH =
     BALL_MAX_RADIUS_METERS * 2 * MAX_FRACTION_OF_BALL_COVERED_BY_ROBOT;
 // We can use a very small value for the dribbler damper thickness since the
 // damper just needs to be large enough to collide with the ball and detect collisions
 // without letting the ball tunnel and collide with the robot body
-const double PhysicsRobot::dribbler_damper_thickness = 0.005;
-const double PhysicsRobot::total_dribbler_depth =
-    PhysicsRobot::dribbler_depth + PhysicsRobot::dribbler_damper_thickness;
+const double PhysicsRobot::DRIBBLER_DAMPER_THICKNESS = 0.005;
+const double PhysicsRobot::TOTAL_DRIBBLER_DEPTH =
+        PhysicsRobot::DRIBBLER_DEPTH + PhysicsRobot::DRIBBLER_DAMPER_THICKNESS;
 
 PhysicsRobot::PhysicsRobot(RobotId id, std::shared_ptr<b2World> world,
                            const RobotState& robot_state, const double mass_kg)
@@ -74,11 +74,11 @@ PhysicsRobot::~PhysicsRobot()
 void PhysicsRobot::setupRobotBodyFixtures(const RobotState&, const double mass_kg)
 {
     b2PolygonShape* main_body_shape =
-        PhysicsRobotModel::getMainRobotBodyShape(total_dribbler_depth);
+        PhysicsRobotModel::getMainRobotBodyShape(TOTAL_DRIBBLER_DEPTH);
     b2PolygonShape* front_left_body_shape =
-        PhysicsRobotModel::getRobotBodyShapeFrontLeft(total_dribbler_depth);
+        PhysicsRobotModel::getRobotBodyShapeFrontLeft(TOTAL_DRIBBLER_DEPTH);
     b2PolygonShape* front_right_body_shape =
-        PhysicsRobotModel::getRobotBodyShapeFrontRight(total_dribbler_depth);
+        PhysicsRobotModel::getRobotBodyShapeFrontRight(TOTAL_DRIBBLER_DEPTH);
 
     auto body_shapes = {main_body_shape, front_left_body_shape, front_right_body_shape};
     double total_shape_area = 0.0;
@@ -128,9 +128,9 @@ void PhysicsRobot::setupDribblerFixture(const RobotState&)
     const unsigned int num_vertices              = 4;
     b2Vec2 dribbler_shape_vertices[num_vertices] = {
         createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS, DRIBBLER_WIDTH_METERS / 2.0)),
-        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth,
+        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - DRIBBLER_DEPTH,
                          DRIBBLER_WIDTH_METERS / 2.0)),
-        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth,
+        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - DRIBBLER_DEPTH,
                          -DRIBBLER_WIDTH_METERS / 2.0)),
         createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS, -DRIBBLER_WIDTH_METERS / 2.0))};
     b2PolygonShape* dribbler_shape = new b2PolygonShape();
@@ -155,15 +155,15 @@ void PhysicsRobot::setupDribblerDamperFixture(const RobotState& robot_state)
     // so we do not need to rotate the points to match the orientation of the robot.
     const unsigned int num_vertices                     = 4;
     b2Vec2 dribbler_damper_shape_vertices[num_vertices] = {
-        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth +
-                             dribbler_damper_thickness,
+        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - TOTAL_DRIBBLER_DEPTH +
+                         DRIBBLER_DAMPER_THICKNESS,
                          DRIBBLER_WIDTH_METERS / 2.0)),
-        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth,
+        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - TOTAL_DRIBBLER_DEPTH,
                          DRIBBLER_WIDTH_METERS / 2.0)),
-        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth,
+        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - TOTAL_DRIBBLER_DEPTH,
                          -DRIBBLER_WIDTH_METERS / 2.0)),
-        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth +
-                             dribbler_damper_thickness,
+        createVec2(Point(DIST_TO_FRONT_OF_ROBOT_METERS - TOTAL_DRIBBLER_DEPTH +
+                         DRIBBLER_DAMPER_THICKNESS,
                          -DRIBBLER_WIDTH_METERS / 2.0))};
 
     b2PolygonShape* dribbler_damper_shape = new b2PolygonShape();

--- a/src/software/simulation/physics/physics_robot.h
+++ b/src/software/simulation/physics/physics_robot.h
@@ -98,15 +98,6 @@ class PhysicsRobot
         std::function<void(PhysicsRobot *, PhysicsBall *)> callback);
 
     /**
-     * Adds the given function to this PhysicsRobot's list of dribbler damper-ball contact
-     * callbacks. These callbacks will be called once at the start of the contact.
-     *
-     * @param callback The function to register
-     */
-    void registerDribblerDamperBallStartContactCallback(
-        std::function<void(PhysicsRobot *, PhysicsBall *)> callback);
-
-    /**
      * Returns a list of contact callbacks for this class
      *
      * @return a list of contact callbacks for this class
@@ -117,8 +108,6 @@ class PhysicsRobot
     getDribblerBallStartContactCallbacks() const;
     std::vector<std::function<void(PhysicsRobot *, PhysicsBall *)>>
     getDribblerBallEndContactCallbacks() const;
-    std::vector<std::function<void(PhysicsRobot *, PhysicsBall *)>>
-    getDribblerDamperBallStartContactCallbacks() const;
 
     /**
      * Returns the current robot state

--- a/src/software/simulation/physics/physics_robot.h
+++ b/src/software/simulation/physics/physics_robot.h
@@ -212,8 +212,8 @@ class PhysicsRobot
     void setupRobotBodyFixture(const b2PolygonShape *shape, const float density);
 
     /**
-     * Creates a fixture to represent the dribbler damper of the robot. It is partially inset into
-     * the front of the robot.
+     * Creates a fixture to represent the dribbler damper of the robot. It is partially
+     * inset into the front of the robot.
      *
      * @param robot_state The robot to create the fixture for
      */
@@ -305,7 +305,7 @@ class PhysicsRobot
     static constexpr double DRIBBLER_DAMPER_RESTITUTION = 0.0;
     // We want lots of friction for when the ball is being dribbled so it stays controlled
     static constexpr double DRIBBLER_DAMPER_FRICTION = 1.0;
-    // The dribbler damper has no mass in simulation. Mass is already accounted for by the robot
-    // body
+    // The dribbler damper has no mass in simulation. Mass is already accounted for by the
+    // robot body
     static constexpr double DRIBBLER_DAMPER_DENSITY = 0.0;
 };

--- a/src/software/simulation/physics/physics_robot.h
+++ b/src/software/simulation/physics/physics_robot.h
@@ -28,10 +28,10 @@ class PhysicsRobot
     // The depth of the dribbling area at the front of the robot.
     // We assume the ball can be dribbled as long as it is anywhere within this small
     // area.
-    static double const dribbler_depth;
+    static double const DRIBBLER_DEPTH;
     // The thickness of the dribbler damper fixture shape.
-    static double const dribbler_damper_thickness;
-    static double const total_dribbler_depth;
+    static double const DRIBBLER_DAMPER_THICKNESS;
+    static double const TOTAL_DRIBBLER_DEPTH;
 
     friend class PhysicsWorld;
 

--- a/src/software/simulation/physics/physics_robot.h
+++ b/src/software/simulation/physics/physics_robot.h
@@ -29,9 +29,9 @@ class PhysicsRobot
     // We assume the ball can be dribbled as long as it is anywhere within this small
     // area.
     static double const dribbler_depth;
-    // The thickness of the chicker fixture shape.
-    static double const chicker_thickness;
-    static double const total_chicker_depth;
+    // The thickness of the dribbler damper fixture shape.
+    static double const dribbler_damper_thickness;
+    static double const total_dribbler_depth;
 
     friend class PhysicsWorld;
 
@@ -98,12 +98,12 @@ class PhysicsRobot
         std::function<void(PhysicsRobot *, PhysicsBall *)> callback);
 
     /**
-     * Adds the given function to this PhysicsRobot's list of chicker-ball contact
+     * Adds the given function to this PhysicsRobot's list of dribbler damper-ball contact
      * callbacks. These callbacks will be called once at the start of the contact.
      *
      * @param callback The function to register
      */
-    void registerChickerBallStartContactCallback(
+    void registerDribblerDamperBallStartContactCallback(
         std::function<void(PhysicsRobot *, PhysicsBall *)> callback);
 
     /**
@@ -209,12 +209,9 @@ class PhysicsRobot
      * robot and add them to this class' b2Body
      *
      * @param robot_state The robot to create fixtures for
-     * @param total_chicker_depth The distance from the front face of the robot to the
-     * back of the chicker, ie. how far inset into the front of the robot the chicker is
      * @param mass_kg The mass of the robot in kg
      */
-    void setupRobotBodyFixtures(const RobotState &robot_state, double total_chicker_depth,
-                                double mass_kg);
+    void setupRobotBodyFixtures(const RobotState &robot_state, double mass_kg);
 
     /**
      * Creates a robot body fixture with the given shape and density and adds it to this
@@ -226,16 +223,12 @@ class PhysicsRobot
     void setupRobotBodyFixture(const b2PolygonShape *shape, const float density);
 
     /**
-     * Creates a fixture to represent the chicker of the robot. It is partially inset into
+     * Creates a fixture to represent the dribbler damper of the robot. It is partially inset into
      * the front of the robot.
      *
      * @param robot_state The robot to create the fixture for
-     * @param total_chicker_depth The distance from the front face of the robot to the
-     * back of the chicker, ie. how far inset into the front of the robot the chicker is
-     * @param chicker_thickness How thick the chicker fixture shape is
      */
-    void setupChickerFixture(const RobotState &robot_state, double total_chicker_depth,
-                             double chicker_thickness);
+    void setupChickerFixture(const RobotState &robot_state);
 
     /**
      * Creates a fixture to represent the dribbler of the robot. It does not interact
@@ -244,9 +237,9 @@ class PhysicsRobot
      * robot.
      *
      * @param robot_state The robot to create the fixture for
-     * @param dribbler_depth How far inset into the front of the robot the chicker is
+     * @param dribbler_depth How far inset into the front of the robot the dribbler is
      */
-    void setupDribblerFixture(const RobotState &robot_state, double dribbler_depth);
+    void setupDribblerFixture(const RobotState &robot_state);
 
     /**
      * A helper function that applies force to the robot body as if there was a wheel
@@ -288,7 +281,7 @@ class PhysicsRobot
     std::vector<std::function<void(PhysicsRobot *, PhysicsBall *)>>
         dribbler_ball_end_contact_callbacks;
     std::vector<std::function<void(PhysicsRobot *, PhysicsBall *)>>
-        chicker_ball_contact_callbacks;
+        dribbler_damper_ball_contact_callbacks;
 
     std::queue<std::function<void()>> post_physics_step_functions;
 
@@ -301,29 +294,29 @@ class PhysicsRobot
     // simulated in the robot firmware to behave reasonably. These values should be
     // changed back to something around 0.2
     // https://github.com/UBC-Thunderbots/Software/issues/1187
-    const double robot_linear_damping  = 2.0;
-    const double robot_angular_damping = 2.0;
+    static constexpr double ROBOT_LINEAR_DAMPING  = 2.0;
+    static constexpr double ROBOT_ANGULAR_DAMPING = 2.0;
 
     // This is a somewhat arbitrary value. Collisions with robots are not perfectly
     // elastic. However because this is an "ideal" simulation and we generally don't care
     // about the exact behaviour of collisions, getting this value to perfectly match
     // reality isn't too important.
-    const double robot_body_restitution = 0.5;
-    const double robot_body_friction    = 0.0;
+    static constexpr double ROBOT_BODY_RESTITUTION = 0.5;
+    static constexpr double ROBOT_BODY_FRICTION    = 0.0;
 
     // The dribbler has no mass in simulation. Mass is already accounted for by the robot
     // body
-    const double robot_dribbler_density = 0.0;
+    static constexpr double DRIBBLER_DENSITY = 0.0;
     // We assume the ContactListener for the world will disable collisions with the
     // dribbler so the restitution and friction don't matter
-    const double robot_dribbler_restitution = 0.0;
-    const double robot_dribbler_friction    = 0.0;
+    static constexpr double DRIBBLER_RESTITUTION = 0.0;
+    static constexpr double DRIBBLER_FRICTION    = 0.0;
 
     // We want perfect damping to help us keep the ball when dribbling
-    const double robot_chicker_restitution = 0.0;
+    static constexpr double DRIBBLER_DAMPER_RESTITUTION = 0.0;
     // We want lots of friction for when the ball is being dribbled so it stays controlled
-    const double robot_chicker_friction = 1.0;
-    // The chicker has no mass in simulation. Mass is already accounted for by the robot
+    static constexpr double DRIBBLER_DAMPER_FRICTION = 1.0;
+    // The dribbler damper has no mass in simulation. Mass is already accounted for by the robot
     // body
-    const double robot_chicker_density = 0.0;
+    static constexpr double DRIBBLER_DAMPER_DENSITY = 0.0;
 };

--- a/src/software/simulation/physics/physics_robot.h
+++ b/src/software/simulation/physics/physics_robot.h
@@ -118,7 +118,7 @@ class PhysicsRobot
     std::vector<std::function<void(PhysicsRobot *, PhysicsBall *)>>
     getDribblerBallEndContactCallbacks() const;
     std::vector<std::function<void(PhysicsRobot *, PhysicsBall *)>>
-    getChickerBallStartContactCallbacks() const;
+    getDribblerDamperBallStartContactCallbacks() const;
 
     /**
      * Returns the current robot state
@@ -228,7 +228,7 @@ class PhysicsRobot
      *
      * @param robot_state The robot to create the fixture for
      */
-    void setupChickerFixture(const RobotState &robot_state);
+    void setupDribblerDamperFixture(const RobotState &robot_state);
 
     /**
      * Creates a fixture to represent the dribbler of the robot. It does not interact

--- a/src/software/simulation/physics/physics_robot_model.cpp
+++ b/src/software/simulation/physics/physics_robot_model.cpp
@@ -62,7 +62,8 @@ b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontLeft(double total_dribb
     return shape;
 }
 
-b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontRight(double total_dribbler_depth)
+b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontRight(
+    double total_dribbler_depth)
 {
     auto shape_points = getRobotFrontLeftShapePoints(total_dribbler_depth);
 
@@ -90,18 +91,21 @@ b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontRight(double total_drib
     return shape;
 }
 
-std::vector<Point> PhysicsRobotModel::getRobotFrontLeftShapePoints(double total_dribbler_depth)
+std::vector<Point> PhysicsRobotModel::getRobotFrontLeftShapePoints(
+    double total_dribbler_depth)
 {
     // Assuming the robot is at (0, 0) and facing the +x axis (aka has an orientation of
     // 0) First find the y-coordinate of the front-left edge of the body by solving x^2 +
     // y^2 = ROBOT_RADIUS^2
-    double y = std::sqrt(std::pow(ROBOT_MAX_RADIUS_METERS, 2) -
-                         std::pow(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth, 2));
+    double y =
+        std::sqrt(std::pow(ROBOT_MAX_RADIUS_METERS, 2) -
+                  std::pow(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth, 2));
 
     // Box2D requires polygon vertices are provided in counter-clockwise order
     std::vector<Point> vertices{
         Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth, y),
-        Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth, DRIBBLER_WIDTH_METERS / 2.0),
+        Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth,
+              DRIBBLER_WIDTH_METERS / 2.0),
         Point(DIST_TO_FRONT_OF_ROBOT_METERS, DRIBBLER_WIDTH_METERS / 2.0),
         Point(DIST_TO_FRONT_OF_ROBOT_METERS, FRONT_OF_ROBOT_WIDTH_METERS / 2.0)};
 

--- a/src/software/simulation/physics/physics_robot_model.cpp
+++ b/src/software/simulation/physics/physics_robot_model.cpp
@@ -6,7 +6,7 @@
 #include "shared/constants.h"
 #include "software/simulation/physics/box2d_util.h"
 
-b2PolygonShape* PhysicsRobotModel::getMainRobotBodyShape(double dribbler_depth)
+b2PolygonShape* PhysicsRobotModel::getMainRobotBodyShape(double total_dribbler_depth)
 {
     const unsigned int num_shape_vertices = b2_maxPolygonVertices;
     b2Vec2 robot_body_vertices[num_shape_vertices];
@@ -16,9 +16,9 @@ b2PolygonShape* PhysicsRobotModel::getMainRobotBodyShape(double dribbler_depth)
     // y^2 = ROBOT_RADIUS^2
     double y =
         std::sqrt(std::pow(ROBOT_MAX_RADIUS_METERS, 2) -
-                  std::pow(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth, 2));
+                  std::pow(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth, 2));
 
-    Vector starting_vector(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth, y);
+    Vector starting_vector(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth, y);
     Angle starting_angle        = starting_vector.orientation();
     Angle angle_to_sweep_across = Angle::full() - (2 * starting_angle);
     // The angle increment is positive, so we rotate counter-clockwise and add points
@@ -40,12 +40,12 @@ b2PolygonShape* PhysicsRobotModel::getMainRobotBodyShape(double dribbler_depth)
     return body_shape;
 }
 
-b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontLeft(double dribbler_depth)
+b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontLeft(double total_dribbler_depth)
 {
     // These points are already give in counter-clockwise order, so we can directly create
     // a polygon (Box2D requires that polygon vertices are given in counter-clockwise
     // order)
-    auto shape_points = getRobotFrontLeftShapePoints(dribbler_depth);
+    auto shape_points = getRobotFrontLeftShapePoints(total_dribbler_depth);
 
     // The shape is added relative to the body, so we do not need to rotate these points
     // to match the robot's orientation
@@ -62,9 +62,9 @@ b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontLeft(double dribbler_de
     return shape;
 }
 
-b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontRight(double dribbler_depth)
+b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontRight(double total_dribbler_depth)
 {
-    auto shape_points = getRobotFrontLeftShapePoints(dribbler_depth);
+    auto shape_points = getRobotFrontLeftShapePoints(total_dribbler_depth);
 
     // Mirror the points over the x-axis to get the points for the front-right shape
     std::transform(shape_points.begin(), shape_points.end(), shape_points.begin(),
@@ -90,18 +90,18 @@ b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontRight(double dribbler_d
     return shape;
 }
 
-std::vector<Point> PhysicsRobotModel::getRobotFrontLeftShapePoints(double dribbler_depth)
+std::vector<Point> PhysicsRobotModel::getRobotFrontLeftShapePoints(double total_dribbler_depth)
 {
     // Assuming the robot is at (0, 0) and facing the +x axis (aka has an orientation of
     // 0) First find the y-coordinate of the front-left edge of the body by solving x^2 +
     // y^2 = ROBOT_RADIUS^2
     double y = std::sqrt(std::pow(ROBOT_MAX_RADIUS_METERS, 2) -
-                         std::pow(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth, 2));
+                         std::pow(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth, 2));
 
     // Box2D requires polygon vertices are provided in counter-clockwise order
     std::vector<Point> vertices{
-        Point(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth, y),
-        Point(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth, DRIBBLER_WIDTH_METERS / 2.0),
+        Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth, y),
+        Point(DIST_TO_FRONT_OF_ROBOT_METERS - total_dribbler_depth, DRIBBLER_WIDTH_METERS / 2.0),
         Point(DIST_TO_FRONT_OF_ROBOT_METERS, DRIBBLER_WIDTH_METERS / 2.0),
         Point(DIST_TO_FRONT_OF_ROBOT_METERS, FRONT_OF_ROBOT_WIDTH_METERS / 2.0)};
 

--- a/src/software/simulation/physics/physics_robot_model.cpp
+++ b/src/software/simulation/physics/physics_robot_model.cpp
@@ -6,7 +6,7 @@
 #include "shared/constants.h"
 #include "software/simulation/physics/box2d_util.h"
 
-b2PolygonShape* PhysicsRobotModel::getMainRobotBodyShape(double total_chicker_depth)
+b2PolygonShape* PhysicsRobotModel::getMainRobotBodyShape(double dribbler_depth)
 {
     const unsigned int num_shape_vertices = b2_maxPolygonVertices;
     b2Vec2 robot_body_vertices[num_shape_vertices];
@@ -16,9 +16,9 @@ b2PolygonShape* PhysicsRobotModel::getMainRobotBodyShape(double total_chicker_de
     // y^2 = ROBOT_RADIUS^2
     double y =
         std::sqrt(std::pow(ROBOT_MAX_RADIUS_METERS, 2) -
-                  std::pow(DIST_TO_FRONT_OF_ROBOT_METERS - total_chicker_depth, 2));
+                  std::pow(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth, 2));
 
-    Vector starting_vector(DIST_TO_FRONT_OF_ROBOT_METERS - total_chicker_depth, y);
+    Vector starting_vector(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth, y);
     Angle starting_angle        = starting_vector.orientation();
     Angle angle_to_sweep_across = Angle::full() - (2 * starting_angle);
     // The angle increment is positive, so we rotate counter-clockwise and add points
@@ -40,12 +40,12 @@ b2PolygonShape* PhysicsRobotModel::getMainRobotBodyShape(double total_chicker_de
     return body_shape;
 }
 
-b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontLeft(double total_chicker_depth)
+b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontLeft(double dribbler_depth)
 {
     // These points are already give in counter-clockwise order, so we can directly create
     // a polygon (Box2D requires that polygon vertices are given in counter-clockwise
     // order)
-    auto shape_points = getRobotFrontLeftShapePoints(total_chicker_depth);
+    auto shape_points = getRobotFrontLeftShapePoints(dribbler_depth);
 
     // The shape is added relative to the body, so we do not need to rotate these points
     // to match the robot's orientation
@@ -62,9 +62,9 @@ b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontLeft(double total_chick
     return shape;
 }
 
-b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontRight(double total_chicker_depth)
+b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontRight(double dribbler_depth)
 {
-    auto shape_points = getRobotFrontLeftShapePoints(total_chicker_depth);
+    auto shape_points = getRobotFrontLeftShapePoints(dribbler_depth);
 
     // Mirror the points over the x-axis to get the points for the front-right shape
     std::transform(shape_points.begin(), shape_points.end(), shape_points.begin(),
@@ -90,18 +90,18 @@ b2PolygonShape* PhysicsRobotModel::getRobotBodyShapeFrontRight(double total_chic
     return shape;
 }
 
-std::vector<Point> PhysicsRobotModel::getRobotFrontLeftShapePoints(double chicker_depth)
+std::vector<Point> PhysicsRobotModel::getRobotFrontLeftShapePoints(double dribbler_depth)
 {
     // Assuming the robot is at (0, 0) and facing the +x axis (aka has an orientation of
     // 0) First find the y-coordinate of the front-left edge of the body by solving x^2 +
     // y^2 = ROBOT_RADIUS^2
     double y = std::sqrt(std::pow(ROBOT_MAX_RADIUS_METERS, 2) -
-                         std::pow(DIST_TO_FRONT_OF_ROBOT_METERS - chicker_depth, 2));
+                         std::pow(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth, 2));
 
     // Box2D requires polygon vertices are provided in counter-clockwise order
     std::vector<Point> vertices{
-        Point(DIST_TO_FRONT_OF_ROBOT_METERS - chicker_depth, y),
-        Point(DIST_TO_FRONT_OF_ROBOT_METERS - chicker_depth, DRIBBLER_WIDTH_METERS / 2.0),
+        Point(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth, y),
+        Point(DIST_TO_FRONT_OF_ROBOT_METERS - dribbler_depth, DRIBBLER_WIDTH_METERS / 2.0),
         Point(DIST_TO_FRONT_OF_ROBOT_METERS, DRIBBLER_WIDTH_METERS / 2.0),
         Point(DIST_TO_FRONT_OF_ROBOT_METERS, FRONT_OF_ROBOT_WIDTH_METERS / 2.0)};
 

--- a/src/software/simulation/physics/physics_robot_model.h
+++ b/src/software/simulation/physics/physics_robot_model.h
@@ -45,11 +45,11 @@ class PhysicsRobotModel
      *       x                                                x+   +  <--- Front left part
      *       x                                                x+   +       (indicated by '+')
      *       x                                                x+++++
-     *       x                                                x| |d|
-     *       x                                                x|d|r|
-     *       x                                                x|a|i|
-     *       x                                                x|m|b|
-     *       x                                                x|p|b|
+     *       x                                                x|c|d|
+     *       x                                                x|h|r|
+     *       x                                                x|i|i|
+     *       x                                                x|c|b|
+     *       x                                                x|k|b|
      *       x                                                x|e|l|
      *       x                                                x|r|e|
      *       x                                                x+++++
@@ -65,14 +65,14 @@ class PhysicsRobotModel
      */
     /* clang-format on */
     /**
-     * @param dribbler_depth The distance from the front face of the robot to the
+     * @param total_dribbler_depth The distance from the front face of the robot to the
      * back of the dribbler
      *
      * @return A b2PolygonShape for the corresponding part of the robot body
      */
-    static b2PolygonShape *getMainRobotBodyShape(double dribbler_depth);
-    static b2PolygonShape *getRobotBodyShapeFrontLeft(double dribbler_depth);
-    static b2PolygonShape *getRobotBodyShapeFrontRight(double dribbler_depth);
+    static b2PolygonShape *getMainRobotBodyShape(double total_dribbler_depth);
+    static b2PolygonShape *getRobotBodyShapeFrontLeft(double total_dribbler_depth);
+    static b2PolygonShape *getRobotBodyShapeFrontRight(double total_dribbler_depth);
 
    private:
     /**
@@ -82,9 +82,10 @@ class PhysicsRobotModel
      * in counter-clockwise order.
      *
      * @param robot_state The robot to create
-     * @param dribbler_depth The depth of the dribbler
+     * @param total_dribbler_depth The distance from the front face of the robot to the
+     * back of the dribbler
      *
      * @return The points that make up the front-left shape for the robot body
      */
-    static std::vector<Point> getRobotFrontLeftShapePoints(double dribbler_depth);
+    static std::vector<Point> getRobotFrontLeftShapePoints(double total_dribbler_depth);
 };

--- a/src/software/simulation/physics/physics_robot_model.h
+++ b/src/software/simulation/physics/physics_robot_model.h
@@ -17,10 +17,10 @@ class PhysicsRobotModel
      * Together these functions return 3 polygons that together make up the shape of the
      * robot. It is broken up this way because Box2D can only have convex polygons. We
      * split the body into 3 parts:
-     * - The main body, which is everything behind the chicker
-     * - The front-left part, which is the bit that is to the front-left of the chicker,
+     * - The main body, which is everything behind the dribbler
+     * - The front-left part, which is the bit that is to the front-left of the dribbler,
      * partially enclosing it
-     * - The front-right part, which is the bit that is to the front-right of the chicker,
+     * - The front-right part, which is the bit that is to the front-right of the dribbler,
      * partially enclosing it
      *
      * These polygons are all created assuming the robot is at (0, 0) and facing along the
@@ -45,11 +45,11 @@ class PhysicsRobotModel
      *       x                                                x+   +  <--- Front left part
      *       x                                                x+   +       (indicated by '+')
      *       x                                                x+++++
-     *       x                                                x|c|d|
-     *       x                                                x|h|r|
-     *       x                                                x|i|i|
-     *       x                                                x|c|b|
-     *       x                                                x|k|b|
+     *       x                                                x| |d|
+     *       x                                                x|d|r|
+     *       x                                                x|a|i|
+     *       x                                                x|m|b|
+     *       x                                                x|p|b|
      *       x                                                x|e|l|
      *       x                                                x|r|e|
      *       x                                                x+++++
@@ -65,14 +65,14 @@ class PhysicsRobotModel
      */
     /* clang-format on */
     /**
-     * @param total_chicker_depth The distance from the front face of the robot to the
-     * back of the chicker, ie. how far inset into the front of the robot the chicker is
+     * @param dribbler_depth The distance from the front face of the robot to the
+     * back of the dribbler
      *
      * @return A b2PolygonShape for the corresponding part of the robot body
      */
-    static b2PolygonShape *getMainRobotBodyShape(double total_chicker_depth);
-    static b2PolygonShape *getRobotBodyShapeFrontLeft(double total_chicker_depth);
-    static b2PolygonShape *getRobotBodyShapeFrontRight(double total_chicker_depth);
+    static b2PolygonShape *getMainRobotBodyShape(double dribbler_depth);
+    static b2PolygonShape *getRobotBodyShapeFrontLeft(double dribbler_depth);
+    static b2PolygonShape *getRobotBodyShapeFrontRight(double dribbler_depth);
 
    private:
     /**
@@ -82,9 +82,9 @@ class PhysicsRobotModel
      * in counter-clockwise order.
      *
      * @param robot_state The robot to create
-     * @param chicker_depth How far inset into the front of the robot the chicker is
+     * @param dribbler_depth The depth of the dribbler
      *
      * @return The points that make up the front-left shape for the robot body
      */
-    static std::vector<Point> getRobotFrontLeftShapePoints(double chicker_depth);
+    static std::vector<Point> getRobotFrontLeftShapePoints(double dribbler_depth);
 };

--- a/src/software/simulation/physics/physics_robot_model.h
+++ b/src/software/simulation/physics/physics_robot_model.h
@@ -20,8 +20,8 @@ class PhysicsRobotModel
      * - The main body, which is everything behind the dribbler
      * - The front-left part, which is the bit that is to the front-left of the dribbler,
      * partially enclosing it
-     * - The front-right part, which is the bit that is to the front-right of the dribbler,
-     * partially enclosing it
+     * - The front-right part, which is the bit that is to the front-right of the
+     * dribbler, partially enclosing it
      *
      * These polygons are all created assuming the robot is at (0, 0) and facing along the
      * positive x-axis (ie. has an orientation of 0). This is fine because when these

--- a/src/software/simulation/physics/physics_robot_model.h
+++ b/src/software/simulation/physics/physics_robot_model.h
@@ -18,9 +18,9 @@ class PhysicsRobotModel
      * robot. It is broken up this way because Box2D can only have convex polygons. We
      * split the body into 3 parts:
      * - The main body, which is everything behind the dribbler
-     * - The front-left part, which is the bit that is to the front-left of the dribbler,
+     * - The front-left part, which is the bit to the front-left of the dribbler,
      * partially enclosing it
-     * - The front-right part, which is the bit that is to the front-right of the
+     * - The front-right part, which is the bit to the front-right of the
      * dribbler, partially enclosing it
      *
      * These polygons are all created assuming the robot is at (0, 0) and facing along the

--- a/src/software/simulation/physics/physics_robot_test.cpp
+++ b/src/software/simulation/physics/physics_robot_test.cpp
@@ -421,7 +421,7 @@ TEST_F(PhysicsRobotTest, test_chicker_ball_start_contact_callbacks)
         callback_called = true;
     };
 
-    physics_robot.registerChickerBallStartContactCallback(callback);
+    physics_robot.registerDribblerDamperBallStartContactCallback(callback);
 
     ASSERT_EQ(physics_robot.getChickerBallStartContactCallbacks().size(), 1);
     physics_robot.getChickerBallStartContactCallbacks().at(0)(nullptr, nullptr);

--- a/src/software/simulation/physics/physics_robot_test.cpp
+++ b/src/software/simulation/physics/physics_robot_test.cpp
@@ -405,7 +405,7 @@ TEST_F(PhysicsRobotTest, test_dribbler_ball_end_contact_callbacks)
     EXPECT_TRUE(callback_called);
 }
 
-TEST_F(PhysicsRobotTest, test_chicker_ball_start_contact_callbacks)
+TEST_F(PhysicsRobotTest, test_dribbler_damper_ball_start_contact_callbacks)
 {
     b2Vec2 gravity(0, 0);
     auto world = std::make_shared<b2World>(gravity);
@@ -414,7 +414,7 @@ TEST_F(PhysicsRobotTest, test_chicker_ball_start_contact_callbacks)
                                    AngularVelocity::zero());
     PhysicsRobot physics_robot(0, world, initial_robot_state, 1.0);
 
-    EXPECT_TRUE(physics_robot.getChickerBallStartContactCallbacks().empty());
+    EXPECT_TRUE(physics_robot.getDribblerDamperBallStartContactCallbacks().empty());
 
     bool callback_called = false;
     auto callback        = [&callback_called](PhysicsRobot* robot, PhysicsBall* ball) {
@@ -423,8 +423,8 @@ TEST_F(PhysicsRobotTest, test_chicker_ball_start_contact_callbacks)
 
     physics_robot.registerDribblerDamperBallStartContactCallback(callback);
 
-    ASSERT_EQ(physics_robot.getChickerBallStartContactCallbacks().size(), 1);
-    physics_robot.getChickerBallStartContactCallbacks().at(0)(nullptr, nullptr);
+    ASSERT_EQ(physics_robot.getDribblerDamperBallStartContactCallbacks().size(), 1);
+    physics_robot.getDribblerDamperBallStartContactCallbacks().at(0)(nullptr, nullptr);
     EXPECT_TRUE(callback_called);
 }
 

--- a/src/software/simulation/physics/physics_robot_test.cpp
+++ b/src/software/simulation/physics/physics_robot_test.cpp
@@ -405,29 +405,6 @@ TEST_F(PhysicsRobotTest, test_dribbler_ball_end_contact_callbacks)
     EXPECT_TRUE(callback_called);
 }
 
-TEST_F(PhysicsRobotTest, test_dribbler_damper_ball_start_contact_callbacks)
-{
-    b2Vec2 gravity(0, 0);
-    auto world = std::make_shared<b2World>(gravity);
-
-    RobotState initial_robot_state(Point(0, 0), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    PhysicsRobot physics_robot(0, world, initial_robot_state, 1.0);
-
-    EXPECT_TRUE(physics_robot.getDribblerDamperBallStartContactCallbacks().empty());
-
-    bool callback_called = false;
-    auto callback        = [&callback_called](PhysicsRobot* robot, PhysicsBall* ball) {
-        callback_called = true;
-    };
-
-    physics_robot.registerDribblerDamperBallStartContactCallback(callback);
-
-    ASSERT_EQ(physics_robot.getDribblerDamperBallStartContactCallbacks().size(), 1);
-    physics_robot.getDribblerDamperBallStartContactCallbacks().at(0)(nullptr, nullptr);
-    EXPECT_TRUE(callback_called);
-}
-
 enum class RobotWheel
 {
     FRONT_LEFT,

--- a/src/software/simulation/physics/simulation_contact_listener.cpp
+++ b/src/software/simulation/physics/simulation_contact_listener.cpp
@@ -24,16 +24,7 @@ void SimulationContactListener::BeginContact(b2Contact *contact)
             }
         }
 
-        if (auto ball_chicker_pair = isBallChickerContact(user_data_a, user_data_b))
-        {
-            PhysicsBall *ball   = ball_chicker_pair->first;
-            PhysicsRobot *robot = ball_chicker_pair->second;
-            for (auto contact_callback : robot->getDribblerDamperBallStartContactCallbacks())
-            {
-                contact_callback(robot, ball);
-            }
-        }
-        if (auto ball_dribbler_pair = isBallDribblerContact(user_data_a, user_data_b))
+        if (auto ball_dribbler_pair = isDribblerBallContact(user_data_a, user_data_b))
         {
             PhysicsBall *ball   = ball_dribbler_pair->first;
             PhysicsRobot *robot = ball_dribbler_pair->second;
@@ -70,12 +61,12 @@ void SimulationContactListener::PreSolve(b2Contact *contact,
             }
         }
 
-        if (auto ball_dribbler_pair = isBallDribblerContact(user_data_a, user_data_b))
+        if (auto ball_dribbler_pair = isDribblerBallContact(user_data_a, user_data_b))
         {
             // We always disable contacts between the ball and the dribbler so that the
             // ball can pass through the dribbler area. This is needed so that the ball
             // can exist inside the dribbling "zone", as well as pass through the dribbler
-            // to make contact with the robot chicker
+            // to make contact with the dribbler damper
             contact->SetEnabled(false);
             PhysicsBall *ball   = ball_dribbler_pair->first;
             PhysicsRobot *robot = ball_dribbler_pair->second;
@@ -84,9 +75,9 @@ void SimulationContactListener::PreSolve(b2Contact *contact,
                 contact_callback(robot, ball);
             }
         }
-        if (auto ball_chicker_pair = isBallChickerContact(user_data_a, user_data_b))
+        if (auto ball_dribbler_damper_pair = isDribblerDamperBallContact(user_data_a, user_data_b))
         {
-            // Ensure that the ball is perfectly damped if it collides with the chicker.
+            // Ensure that the ball is perfectly damped if it collides with the dribbler damper.
             // This helps the robot keep the ball while dribbling.
             contact->SetRestitution(0.0);
         }
@@ -115,7 +106,7 @@ void SimulationContactListener::EndContact(b2Contact *contact)
         }
     }
 
-    if (auto ball_dribbler_pair = isBallDribblerContact(user_data_a, user_data_b))
+    if (auto ball_dribbler_pair = isDribblerBallContact(user_data_a, user_data_b))
     {
         PhysicsBall *ball   = ball_dribbler_pair->first;
         PhysicsRobot *robot = ball_dribbler_pair->second;
@@ -127,8 +118,8 @@ void SimulationContactListener::EndContact(b2Contact *contact)
 }
 
 std::optional<std::pair<PhysicsBall *, PhysicsRobot *>>
-SimulationContactListener::isBallChickerContact(PhysicsObjectUserData *user_data_a,
-                                                PhysicsObjectUserData *user_data_b)
+SimulationContactListener::isDribblerDamperBallContact(PhysicsObjectUserData *user_data_a,
+                                                       PhysicsObjectUserData *user_data_b)
 {
     if (!user_data_a || !user_data_b)
     {
@@ -168,7 +159,7 @@ SimulationContactListener::isBallChickerContact(PhysicsObjectUserData *user_data
 }
 
 std::optional<std::pair<PhysicsBall *, PhysicsRobot *>>
-SimulationContactListener::isBallDribblerContact(PhysicsObjectUserData *user_data_a,
+SimulationContactListener::isDribblerBallContact(PhysicsObjectUserData *user_data_a,
                                                  PhysicsObjectUserData *user_data_b)
 {
     if (!user_data_a || !user_data_b)

--- a/src/software/simulation/physics/simulation_contact_listener.cpp
+++ b/src/software/simulation/physics/simulation_contact_listener.cpp
@@ -75,10 +75,11 @@ void SimulationContactListener::PreSolve(b2Contact *contact,
                 contact_callback(robot, ball);
             }
         }
-        if (auto ball_dribbler_damper_pair = isDribblerDamperBallContact(user_data_a, user_data_b))
+        if (auto ball_dribbler_damper_pair =
+                isDribblerDamperBallContact(user_data_a, user_data_b))
         {
-            // Ensure that the ball is perfectly damped if it collides with the dribbler damper.
-            // This helps the robot keep the ball while dribbling.
+            // Ensure that the ball is perfectly damped if it collides with the dribbler
+            // damper. This helps the robot keep the ball while dribbling.
             contact->SetRestitution(0.0);
         }
     }

--- a/src/software/simulation/physics/simulation_contact_listener.cpp
+++ b/src/software/simulation/physics/simulation_contact_listener.cpp
@@ -28,7 +28,7 @@ void SimulationContactListener::BeginContact(b2Contact *contact)
         {
             PhysicsBall *ball   = ball_chicker_pair->first;
             PhysicsRobot *robot = ball_chicker_pair->second;
-            for (auto contact_callback : robot->getChickerBallStartContactCallbacks())
+            for (auto contact_callback : robot->getDribblerDamperBallStartContactCallbacks())
             {
                 contact_callback(robot, ball);
             }

--- a/src/software/simulation/physics/simulation_contact_listener.h
+++ b/src/software/simulation/physics/simulation_contact_listener.h
@@ -34,8 +34,9 @@ class SimulationContactListener : public b2ContactListener
      * was a contact between a ball and dribbler damper, and returns std::nullopt
      * otherwise
      */
-    static std::optional<std::pair<PhysicsBall*, PhysicsRobot*>> isDribblerDamperBallContact(
-        PhysicsObjectUserData* user_data_a, PhysicsObjectUserData* user_data_b);
+    static std::optional<std::pair<PhysicsBall*, PhysicsRobot*>>
+    isDribblerDamperBallContact(PhysicsObjectUserData* user_data_a,
+                                PhysicsObjectUserData* user_data_b);
 
     /**
      * Given the user data of 2 objects involved in a contact, returns a pair of
@@ -64,5 +65,5 @@ class SimulationContactListener : public b2ContactListener
      * a contact between a ball and any other object, and returns std::nullopt otherwise
      */
     static PhysicsBall* isBallContact(PhysicsObjectUserData* user_data_a,
-                               PhysicsObjectUserData* user_data_b);
+                                      PhysicsObjectUserData* user_data_b);
 };

--- a/src/software/simulation/physics/simulation_contact_listener.h
+++ b/src/software/simulation/physics/simulation_contact_listener.h
@@ -25,13 +25,13 @@ class SimulationContactListener : public b2ContactListener
     /**
      * Given the user data of 2 objects involved in a contact, returns a pair of
      * pointers to the physics objects involved in the contact if there was a contact
-     * between a ball and dribbler damper. Otherwise returns std::nullopt
+     * point between a ball and dribbler damper. Otherwise returns std::nullopt
      *
      * @param user_data_a The user data for the first object in the contact
      * @param user_data_b The user data for the second object in the contact
      *
      * @return A pair of pointers to the physics objects involved in the constact if there
-     * was a contact between a ball and dribbler damper, and returns std::nullopt
+     * was a contact point between a ball and dribbler damper, and returns std::nullopt
      * otherwise
      */
     static std::optional<std::pair<PhysicsBall*, PhysicsRobot*>>
@@ -41,13 +41,13 @@ class SimulationContactListener : public b2ContactListener
     /**
      * Given the user data of 2 objects involved in a contact, returns a pair of
      * pointers to the physics objects involved in the contact if there was a contact
-     * between a ball and robot dribbler. Otherwise returns std::nullopt
+     * point between a ball and robot dribbler. Otherwise returns std::nullopt
      *
      * @param user_data_a The user data for the first object in the contact
      * @param user_data_b The user data for the second object in the contact
      *
      * @return A pair of pointers to the physics objects involved in the contact if there
-     * was a contact between a ball and robot dribbler, and returns std::nullopt
+     * was a contact point between a ball and robot dribbler, and returns std::nullopt
      * otherwise
      */
     static std::optional<std::pair<PhysicsBall*, PhysicsRobot*>> isDribblerBallContact(
@@ -55,14 +55,14 @@ class SimulationContactListener : public b2ContactListener
 
     /**
      * Given the user data of 2 objects involved in a contact, returns a pointer
-     * to the PhysicsBall involved in the contact if there was a contact between
+     * to the PhysicsBall involved in the contact if there was a contact point between
      * a ball and any other object. Otherwise returns std::nullopt
      *
      * @param user_data_a The user data for the first object in the contact
      * @param user_data_b The user data for the second object in the contact
      *
      * @return A pointers to the PhysicsBall involved in the contact if there was
-     * a contact between a ball and any other object, and returns std::nullopt otherwise
+     * a contact point between a ball and any other object, and returns std::nullopt otherwise
      */
     static PhysicsBall* isBallContact(PhysicsObjectUserData* user_data_a,
                                       PhysicsObjectUserData* user_data_b);

--- a/src/software/simulation/physics/simulation_contact_listener.h
+++ b/src/software/simulation/physics/simulation_contact_listener.h
@@ -25,16 +25,16 @@ class SimulationContactListener : public b2ContactListener
     /**
      * Given the user data of 2 objects involved in a contact, returns a pair of
      * pointers to the physics objects involved in the contact if there was a contact
-     * between a ball and robot chicker. Otherwise returns std::nullopt
+     * between a ball and dribbler damper. Otherwise returns std::nullopt
      *
      * @param user_data_a The user data for the first object in the contact
      * @param user_data_b The user data for the second object in the contact
      *
      * @return A pair of pointers to the physics objects involved in the constact if there
-     * was a contact between a ball and robot chicker, and returns std::nullopt
+     * was a contact between a ball and dribbler damper, and returns std::nullopt
      * otherwise
      */
-    std::optional<std::pair<PhysicsBall*, PhysicsRobot*>> isBallChickerContact(
+    static std::optional<std::pair<PhysicsBall*, PhysicsRobot*>> isDribblerDamperBallContact(
         PhysicsObjectUserData* user_data_a, PhysicsObjectUserData* user_data_b);
 
     /**
@@ -49,7 +49,7 @@ class SimulationContactListener : public b2ContactListener
      * was a contact between a ball and robot dribbler, and returns std::nullopt
      * otherwise
      */
-    std::optional<std::pair<PhysicsBall*, PhysicsRobot*>> isBallDribblerContact(
+    static std::optional<std::pair<PhysicsBall*, PhysicsRobot*>> isDribblerBallContact(
         PhysicsObjectUserData* user_data_a, PhysicsObjectUserData* user_data_b);
 
     /**
@@ -63,6 +63,6 @@ class SimulationContactListener : public b2ContactListener
      * @return A pointers to the PhysicsBall involved in the contact if there was
      * a contact between a ball and any other object, and returns std::nullopt otherwise
      */
-    PhysicsBall* isBallContact(PhysicsObjectUserData* user_data_a,
+    static PhysicsBall* isBallContact(PhysicsObjectUserData* user_data_a,
                                PhysicsObjectUserData* user_data_b);
 };

--- a/src/software/simulation/physics/simulation_contact_listener.h
+++ b/src/software/simulation/physics/simulation_contact_listener.h
@@ -62,7 +62,8 @@ class SimulationContactListener : public b2ContactListener
      * @param user_data_b The user data for the second object in the contact
      *
      * @return A pointers to the PhysicsBall involved in the contact if there was
-     * a contact point between a ball and any other object, and returns std::nullopt otherwise
+     * a contact point between a ball and any other object, and returns std::nullopt
+     * otherwise
      */
     static PhysicsBall* isBallContact(PhysicsObjectUserData* user_data_a,
                                       PhysicsObjectUserData* user_data_b);

--- a/src/software/simulation/physics/simulation_contact_listener_test.cpp
+++ b/src/software/simulation/physics/simulation_contact_listener_test.cpp
@@ -96,7 +96,7 @@ TEST_F(SimulationContactListenerTest, test_is_ball_chicker_contact)
                                             physics_robot.get()};
 
     SimulationContactListener listener;
-    auto result = listener.isBallChickerContact(&user_data_chicker, &user_data_ball);
+    auto result = listener.isDribblerDamperBallContact(&user_data_chicker, &user_data_ball);
 
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->first);
@@ -119,7 +119,7 @@ TEST_F(SimulationContactListenerTest, test_is_ball_chicker_contact_with_reversed
                                             physics_robot.get()};
 
     SimulationContactListener listener;
-    auto result = listener.isBallChickerContact(&user_data_ball, &user_data_chicker);
+    auto result = listener.isDribblerDamperBallContact(&user_data_ball, &user_data_chicker);
 
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->first);
@@ -142,7 +142,7 @@ TEST_F(SimulationContactListenerTest, test_is_ball_dribbler_contact)
                                              physics_robot.get()};
 
     SimulationContactListener listener;
-    auto result = listener.isBallDribblerContact(&user_data_ball, &user_data_dribbler);
+    auto result = listener.isDribblerBallContact(&user_data_ball, &user_data_dribbler);
 
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->first);
@@ -165,7 +165,7 @@ TEST_F(SimulationContactListenerTest, test_is_ball_dribbler_contact_with_reverse
                                              physics_robot.get()};
 
     SimulationContactListener listener;
-    auto result = listener.isBallDribblerContact(&user_data_dribbler, &user_data_ball);
+    auto result = listener.isDribblerBallContact(&user_data_dribbler, &user_data_ball);
 
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->first);

--- a/src/software/simulation/physics/simulation_contact_listener_test.cpp
+++ b/src/software/simulation/physics/simulation_contact_listener_test.cpp
@@ -96,7 +96,8 @@ TEST_F(SimulationContactListenerTest, test_is_ball_chicker_contact)
                                             physics_robot.get()};
 
     SimulationContactListener listener;
-    auto result = listener.isDribblerDamperBallContact(&user_data_chicker, &user_data_ball);
+    auto result =
+        listener.isDribblerDamperBallContact(&user_data_chicker, &user_data_ball);
 
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->first);
@@ -119,7 +120,8 @@ TEST_F(SimulationContactListenerTest, test_is_ball_chicker_contact_with_reversed
                                             physics_robot.get()};
 
     SimulationContactListener listener;
-    auto result = listener.isDribblerDamperBallContact(&user_data_ball, &user_data_chicker);
+    auto result =
+        listener.isDribblerDamperBallContact(&user_data_ball, &user_data_chicker);
 
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->first);

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -438,7 +438,7 @@ void SimulatorRobot::applyDribblerForce(PhysicsRobot *physics_robot,
         robot.position() +
         Vector::createFromAngle(robot.orientation())
             .normalize(DIST_TO_FRONT_OF_ROBOT_METERS + BALL_MAX_RADIUS_METERS -
-                       PhysicsRobot::dribbler_depth);
+                       PhysicsRobot::DRIBBLER_DEPTH);
     Vector dribble_force_vector = dribble_point - ball.position();
     // convert to cm so we operate on a small scale
     double dist_from_dribble_point_cm =

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -12,10 +12,10 @@ SimulatorRobot::SimulatorRobot(std::weak_ptr<PhysicsRobot> physics_robot)
 {
     if (auto robot = this->physics_robot.lock())
     {
-        robot->registerChickerBallStartContactCallback(
-            [this](PhysicsRobot *robot, PhysicsBall *ball) {
-                this->onChickerBallContact(robot, ball);
-            });
+        robot->registerDribblerDamperBallStartContactCallback(
+                [this](PhysicsRobot *robot, PhysicsBall *ball) {
+                    this->onChickerBallContact(robot, ball);
+                });
         robot->registerDribblerBallContactCallback(
             [this](PhysicsRobot *robot, PhysicsBall *ball) {
                 this->onDribblerBallContact(robot, ball);

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -376,43 +376,7 @@ void SimulatorRobot::onDribblerBallContact(PhysicsRobot *physics_robot,
 {
     if (dribbler_rpm > 0)
     {
-        auto robot = physics_robot->getRobotState();
-        auto ball  = physics_ball->getBallState();
-
-        // To dribble, we apply a force towards the center and back of the dribbling area,
-        // closest to the chicker. We vary the magnitude of the force by how far the ball
-        // is from this "dribbling point". This more-or-less acts like a tiny gravity well
-        // that sucks the ball into place, except with more force the further away the
-        // ball is. Once the ball is no longer in the dribbler area this force is not
-        // applied (it is only applied as long as the ball is in the dribbler area).
-
-        Point dribble_point =
-            robot.position() +
-            Vector::createFromAngle(robot.orientation())
-                .normalize(DIST_TO_FRONT_OF_ROBOT_METERS + BALL_MAX_RADIUS_METERS -
-                           PhysicsRobot::dribbler_depth);
-        Vector dribble_force_vector = dribble_point - ball.position();
-        // convert to cm so we operate on a small scale
-        double dist_from_dribble_point_cm =
-            dribble_force_vector.length() * CENTIMETERS_PER_METER;
-        // Combine a polynomial with a slightly offset linear function. This shifts the
-        // intercept with the x-axis to a small positive x-value, so that there is a small
-        // region when the ball is extremely close to the back of the dribbler area (and
-        // close to the chicker) where a tiny amount of force will be applied away from
-        // the robot. This helps prevent us from applying a force into the robot while the
-        // ball is touching it and creating a net force that moves the robot.
-        //
-        // The constants in this equation have been tuned manually so that the dribbling
-        // scenarios in the unit tests pass, which represent reasonable dribbling
-        // behaviour.
-        double polynomial_component = 0.1 * std::pow(dist_from_dribble_point_cm, 4);
-        double linear_component     = ((1.0 / 10.0) * (dist_from_dribble_point_cm - 0.5));
-        double dribble_force_magnitude = polynomial_component + linear_component;
-        dribble_force_magnitude =
-            std::clamp<double>(dribble_force_magnitude, 0, dribble_force_magnitude);
-        dribble_force_vector = dribble_force_vector.normalize(dribble_force_magnitude);
-
-        physics_ball->applyForce(dribble_force_vector);
+        applyDribblerForce(physics_robot, physics_ball);
     }
 }
 
@@ -463,4 +427,44 @@ void SimulatorRobot::runCurrentPrimitive(std::shared_ptr<FirmwareWorld_t> firmwa
 {
     app_primitive_manager_runCurrentPrimitive(primitive_manager.get(),
                                               firmware_world.get());
+}
+
+void SimulatorRobot::applyDribblerForce(PhysicsRobot *physics_robot, PhysicsBall *physics_ball) {
+    auto robot = physics_robot->getRobotState();
+    auto ball  = physics_ball->getBallState();
+
+    // To dribble, we apply a force towards the center and back of the dribbling area,
+    // closest to the chicker. We vary the magnitude of the force by how far the ball
+    // is from this "dribbling point". This more-or-less acts like a tiny gravity well
+    // that sucks the ball into place, except with more force the further away the
+    // ball is. Once the ball is no longer in the dribbler area this force is not
+    // applied (it is only applied as long as the ball is in the dribbler area).
+
+    Point dribble_point =
+            robot.position() +
+            Vector::createFromAngle(robot.orientation())
+                    .normalize(DIST_TO_FRONT_OF_ROBOT_METERS + BALL_MAX_RADIUS_METERS -
+                               PhysicsRobot::dribbler_depth);
+    Vector dribble_force_vector = dribble_point - ball.position();
+    // convert to cm so we operate on a small scale
+    double dist_from_dribble_point_cm =
+            dribble_force_vector.length() * CENTIMETERS_PER_METER;
+    // Combine a polynomial with a slightly offset linear function. This shifts the
+    // intercept with the x-axis to a small positive x-value, so that there is a small
+    // region when the ball is extremely close to the back of the dribbler area (and
+    // close to the chicker) where a tiny amount of force will be applied away from
+    // the robot. This helps prevent us from applying a force into the robot while the
+    // ball is touching it and creating a net force that moves the robot.
+    //
+    // The constants in this equation have been tuned manually so that the dribbling
+    // scenarios in the unit tests pass, which represent reasonable dribbling
+    // behaviour.
+    double polynomial_component = 0.1 * std::pow(dist_from_dribble_point_cm, 4);
+    double linear_component     = ((1.0 / 10.0) * (dist_from_dribble_point_cm - 0.5));
+    double dribble_force_magnitude = polynomial_component + linear_component;
+    dribble_force_magnitude =
+            std::clamp<double>(dribble_force_magnitude, 0, dribble_force_magnitude);
+    dribble_force_vector = dribble_force_vector.normalize(dribble_force_magnitude);
+
+    physics_ball->applyForce(dribble_force_vector);
 }

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -443,6 +443,7 @@ void SimulatorRobot::applyDribblerForce(PhysicsRobot *physics_robot,
     // convert to cm so we operate on a small scale
     double dist_from_dribble_point_cm =
         dribble_force_vector.length() * CENTIMETERS_PER_METER;
+
     // Combine a polynomial with a slightly offset linear function. This shifts the
     // intercept with the x-axis to a small positive x-value, so that there is a small
     // region when the ball is extremely close to the back of the dribbler area (and

--- a/src/software/simulation/simulator_robot.h
+++ b/src/software/simulation/simulator_robot.h
@@ -221,15 +221,6 @@ class SimulatorRobot
    private:
     /**
      * A function that is called during every physics step for as long as the ball
-     * is touching this robot's chicker
-     *
-     * @param physics_robot The robot involved in the contact
-     * @param physics_ball The ball invovled in the contact
-     */
-    void onChickerBallContact(PhysicsRobot* physics_robot, PhysicsBall* physics_ball);
-
-    /**
-     * A function that is called during every physics step for as long as the ball
      * is touching this robot's dribbler
      *
      * @param physics_robot The robot involved in the contact

--- a/src/software/simulation/simulator_robot.h
+++ b/src/software/simulation/simulator_robot.h
@@ -270,6 +270,15 @@ class SimulatorRobot
     unsigned int checkValidAndReturnUint(
         std::function<unsigned int(std::shared_ptr<PhysicsRobot>)> func);
 
+    /**
+     * Applies force to the physics ball to simulate it being dribbled by the
+     * physics robot.
+     *
+     * @param physics_robot The robot that shoudl dribble the ball
+     * @param physics_ball The ball to be dribbled
+     */
+    void applyDribblerForce(PhysicsRobot* physics_robot, PhysicsBall* physics_ball);
+
     std::weak_ptr<PhysicsRobot> physics_robot;
     std::optional<float> autokick_speed_m_per_s;
     std::optional<float> autochip_distance_m;

--- a/src/software/simulation/simulator_robot.h
+++ b/src/software/simulation/simulator_robot.h
@@ -265,7 +265,7 @@ class SimulatorRobot
      * Applies force to the physics ball to simulate it being dribbled by the
      * physics robot.
      *
-     * @param physics_robot The robot that shoudl dribble the ball
+     * @param physics_robot The robot that should dribble the ball
      * @param physics_ball The ball to be dribbled
      */
     void applyDribblerForce(PhysicsRobot* physics_robot, PhysicsBall* physics_ball);

--- a/src/software/simulation/simulator_robot_singleton_test.cpp
+++ b/src/software/simulation/simulator_robot_singleton_test.cpp
@@ -98,7 +98,7 @@ class SimulatorRobotSingletonTest : public testing::Test
 
     Point getDribblingPoint(const Point& robot_position, const Angle& robot_orientation)
     {
-        double dribbler_depth = PhysicsRobot::dribbler_depth;
+        double dribbler_depth = PhysicsRobot::DRIBBLER_DEPTH;
         Point dribbling_point =
             robot_position + Vector::createFromAngle(robot_orientation)
                                  .normalize(DIST_TO_FRONT_OF_ROBOT_METERS +


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Removed the chicker from the physics robot and moved its functionality to the dribbler. Effectively renamed the old chicker fixture to be the new "dribbler damper" that damps incoming balls so they can be caught and dribbled by the robot.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit tests pass. Functionality is equivalent

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #1695 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
