### PR TITLE
Update GUI variables to match new conventions

### DIFF
--- a/src/software/gui/full_system/ui/main_widget.ui
+++ b/src/software/gui/full_system/ui/main_widget.ui
@@ -52,7 +52,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>1</number>
        </property>
        <property name="usesScrollButtons">
         <bool>false</bool>
@@ -137,7 +137,7 @@
             <widget class="QComboBox" name="team_colour_combo_box"/>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="label">
+            <widget class="QLabel" name="channel_label">
              <property name="text">
               <string>Channel</string>
              </property>
@@ -147,7 +147,7 @@
             <widget class="QSpinBox" name="channel_spin_box"/>
            </item>
            <item row="5" column="0">
-            <widget class="QLabel" name="label_2">
+            <widget class="QLabel" name="friendly_goalie_id_label">
              <property name="text">
               <string>Friendly Goalie ID</string>
              </property>
@@ -157,7 +157,7 @@
             <widget class="QSpinBox" name="friendly_goalie_id_spin_box"/>
            </item>
            <item row="6" column="0">
-            <widget class="QLabel" name="label_3">
+            <widget class="QLabel" name="enemy_goalie_id_label">
              <property name="text">
               <string>Enemy Goalie ID</string>
              </property>
@@ -224,7 +224,7 @@ p, li { white-space: pre-wrap; }
           <enum>QLayout::SetNoConstraint</enum>
          </property>
          <item>
-          <widget class="DynamicParameterWidget" name="widget" native="true"/>
+          <widget class="DynamicParameterWidget" name="dynamic_parameter_widget" native="true"/>
          </item>
         </layout>
        </widget>

--- a/src/software/gui/full_system/ui/main_widget.ui
+++ b/src/software/gui/full_system/ui/main_widget.ui
@@ -52,7 +52,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <property name="usesScrollButtons">
         <bool>false</bool>

--- a/src/software/gui/standalone_simulator/ui/main_widget.ui
+++ b/src/software/gui/standalone_simulator/ui/main_widget.ui
@@ -54,7 +54,7 @@
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer">
+       <spacer name="simulation_controls_horizontal_spacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Updated variable names in the StandaloneSimulatorGUI and FullSystemGUI to match new variable naming conventions for the GUI (see #1718 )

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
