### PR TITLE
WIP: Remove expired robots when `new_robot_data` is empty

### DIFF
--- a/src/software/sensor_fusion/filter/robot_filter.cpp
+++ b/src/software/sensor_fusion/filter/robot_filter.cpp
@@ -57,8 +57,9 @@ std::optional<Robot> RobotFilter::getFilteredData(
         // if there is no data the duration of expiry_buffer_duration after previously
         // recorded robot state, return null. Otherwise remain the same state
         if (latest_timestamp.getMilliseconds() >
-            this->expiry_buffer_duration.getMilliseconds() +
-                current_robot_state.lastUpdateTimestamp().getMilliseconds())
+                this->expiry_buffer_duration.getMilliseconds() +
+                    current_robot_state.lastUpdateTimestamp().getMilliseconds() ||
+            new_robot_data.empty())
         {
             return std::nullopt;
         }

--- a/src/software/sensor_fusion/filter/robot_filter_test.cpp
+++ b/src/software/sensor_fusion/filter/robot_filter_test.cpp
@@ -53,3 +53,12 @@ TEST(RobotFilterTest, two_match_robot_data_robot_state_not_expired_test)
                            Timestamp::fromSeconds(9)));
     EXPECT_EQ(op_robot.value(), robot_filter.getFilteredData(new_robot_data).value());
 }
+
+TEST(RobotFilterTest, empty_new_robot_data_test)
+{
+    Robot robot(1, Point(0, 0), Vector(0, 0), Angle::fromRadians(0),
+                AngularVelocity::fromRadians(0), Timestamp::fromSeconds(0));
+    RobotFilter robot_filter(robot, Duration::fromSeconds(10));
+    std::vector<RobotDetection> new_robot_data;
+    EXPECT_EQ(std::nullopt, robot_filter.getFilteredData(new_robot_data));
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

`getFilteredData` in `robot_filter.cpp` doesn't do properly return expired robots when `new_robot_data` is empty.
This is because `latest_timestamp` is not set after initialization.

Will discuss more in tonight's SSH meeting.

### Testing Done

Added test in `robot_filter_test.cpp`

### Resolved Issues

Resolves #1717 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
