### PR TITLE
Rename Blacklist and Whitelist to More Precise Names

### DIFF
--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -359,7 +359,7 @@ void STP::assignNonGoalieRobotsToTactics(
             std::set<RobotCapability> required_capabilities =
                 tactic->robotCapabilityRequirements();
             std::set<RobotCapability> robot_capabilities =
-                robot.getCapabilitiesWhitelist();
+                robot.getAvailableCapabilities();
             std::set<RobotCapability> missing_capabilities;
             std::set_difference(
                 required_capabilities.begin(), required_capabilities.end(),

--- a/src/software/ai/motion_constraint/motion_constraint_manager.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_manager.cpp
@@ -5,12 +5,12 @@
 std::set<MotionConstraint> MotionConstraintManager::getMotionConstraints(
     const GameState &game_state, Tactic &tactic)
 {
-    current_whitelisted_constraints.clear();
+    current_allowed_constraints.clear();
     std::set<MotionConstraint> current_motion_constraints =
         getMotionConstraintsFromGameState(game_state);
     try
     {
-        // updates current_whitelisted_constraints
+        // updates current_allowed_constraints
         tactic.accept(*this);
     }
     catch (std::invalid_argument)
@@ -18,7 +18,7 @@ std::set<MotionConstraint> MotionConstraintManager::getMotionConstraints(
         // Tactic didn't implement accept so don't add any more motion constraints
     }
 
-    for (const auto &constraint : current_whitelisted_constraints)
+    for (const auto &constraint : current_allowed_constraints)
     {
         current_motion_constraints.erase(constraint);
     }
@@ -35,7 +35,7 @@ void MotionConstraintManager::visit(ShadowFreekickerTactic &tactic) {}
 
 void MotionConstraintManager::visit(GoalieTactic &tactic)
 {
-    current_whitelisted_constraints = std::set<MotionConstraint>({
+    current_allowed_constraints = std::set<MotionConstraint>({
        MotionConstraint::FRIENDLY_DEFENSE_AREA,
        MotionConstraint::FRIENDLY_DEFENSE_AREA,
        MotionConstraint::HALF_METER_AROUND_BALL,
@@ -53,7 +53,7 @@ void MotionConstraintManager::visit(ChipTactic &tactic) {}
 
 void MotionConstraintManager::visit(KickoffChipTactic &tactic)
 {
-    current_whitelisted_constraints = std::set<MotionConstraint>({
+    current_allowed_constraints = std::set<MotionConstraint>({
        MotionConstraint::CENTER_CIRCLE,
        MotionConstraint::HALF_METER_AROUND_BALL
        });
@@ -65,7 +65,7 @@ void MotionConstraintManager::visit(PatrolTactic &tactic) {}
 
 void MotionConstraintManager::visit(PenaltyKickTactic &tactic)
 {
-    current_whitelisted_constraints = std::set<MotionConstraint>({
+    current_allowed_constraints = std::set<MotionConstraint>({
         MotionConstraint::HALF_METER_AROUND_BALL,
         MotionConstraint::ENEMY_DEFENSE_AREA,
         MotionConstraint::ENEMY_HALF
@@ -74,7 +74,7 @@ void MotionConstraintManager::visit(PenaltyKickTactic &tactic)
 
 void MotionConstraintManager::visit(PenaltySetupTactic &tactic)
 {
-    current_whitelisted_constraints = std::set<MotionConstraint>({
+    current_allowed_constraints = std::set<MotionConstraint>({
         MotionConstraint::ENEMY_HALF,
         MotionConstraint::ENEMY_DEFENSE_AREA,
         MotionConstraint::FRIENDLY_HALF,
@@ -86,7 +86,7 @@ void MotionConstraintManager::visit(ReceiverTactic &tactic) {}
 
 void MotionConstraintManager::visit(ShootGoalTactic &tactic)
 {
-    current_whitelisted_constraints = std::set<MotionConstraint>({
+    current_allowed_constraints = std::set<MotionConstraint>({
         MotionConstraint::HALF_METER_AROUND_BALL
         });
 }

--- a/src/software/ai/motion_constraint/motion_constraint_manager.h
+++ b/src/software/ai/motion_constraint/motion_constraint_manager.h
@@ -28,7 +28,7 @@ class MotionConstraintManager : public MutableTacticVisitor
      *
      * @param The tactic to register
      *
-     * @modifies current_whitelisted_constraints
+     * @modifies current_allowed_constraints
      */
     void visit(CherryPickTactic &tactic) override;
     void visit(ShadowFreekickerTactic &tactic) override;
@@ -51,7 +51,7 @@ class MotionConstraintManager : public MutableTacticVisitor
     void visit(GoalieTestTactic &tactic) override;
 
    private:
-    std::set<MotionConstraint> current_whitelisted_constraints;
+    std::set<MotionConstraint> current_allowed_constraints;
 
     /**
      * Adds move constraints determined from gamestate to current_motion_constraints

--- a/src/software/ai/motion_constraint/motion_constraint_manager_test.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_manager_test.cpp
@@ -15,7 +15,7 @@ namespace
     Pass pass({1, 1}, {0.5, 0}, 2.29, Timestamp::fromSeconds(5));
 
 
-    // vector of pairs of Tactic and whitelists
+    // vector of pairs of Tactic and allowed MotionConstraints
     std::vector<std::pair<std::shared_ptr<Tactic>, std::set<MotionConstraint>>>
         test_vector = {
             std::pair<std::shared_ptr<Tactic>, std::set<MotionConstraint>>(

--- a/src/software/world/robot.cpp
+++ b/src/software/world/robot.cpp
@@ -96,20 +96,20 @@ bool Robot::operator!=(const Robot &other) const
     return !(*this == other);
 }
 
-const std::set<RobotCapability> &Robot::getCapabilitiesBlacklist() const
+const std::set<RobotCapability> &Robot::getUnavailableCapabilities() const
 {
     return unavailable_capabilities_;
 }
 
-std::set<RobotCapability> Robot::getCapabilitiesWhitelist() const
+std::set<RobotCapability> Robot::getAvailableCapabilities() const
 {
     // robot capabilities = all possible capabilities - unavailable capabilities
 
     std::set<RobotCapability> all_capabilities = allRobotCapabilities();
     std::set<RobotCapability> robot_capabilities;
     std::set_difference(all_capabilities.begin(), all_capabilities.end(),
-                        getCapabilitiesBlacklist().begin(),
-                        getCapabilitiesBlacklist().end(),
+                        getUnavailableCapabilities().begin(),
+                        getUnavailableCapabilities().end(),
                         std::inserter(robot_capabilities, robot_capabilities.begin()));
 
     return robot_capabilities;

--- a/src/software/world/robot.h
+++ b/src/software/world/robot.h
@@ -119,9 +119,9 @@ class Robot
     const std::set<RobotCapability> &getUnavailableCapabilities() const;
 
     /**
-     * Returns all capabilities this robot has
+     * Returns all available capabilities this robot has
      *
-     * @return Returns all capabilities this robot has
+     * @return Returns all available capabilities this robot has
      */
     std::set<RobotCapability> getAvailableCapabilities() const;
 

--- a/src/software/world/robot.h
+++ b/src/software/world/robot.h
@@ -116,14 +116,14 @@ class Robot
      *
      * @return the missing capabilities of the robot
      */
-    const std::set<RobotCapability> &getCapabilitiesBlacklist() const;
+    const std::set<RobotCapability> &getUnavailableCapabilities() const;
 
     /**
      * Returns all capabilities this robot has
      *
      * @return Returns all capabilities this robot has
      */
-    std::set<RobotCapability> getCapabilitiesWhitelist() const;
+    std::set<RobotCapability> getAvailableCapabilities() const;
 
     /**
      * Returns the mutable hardware capabilities of the robot

--- a/src/software/world/robot_test.cpp
+++ b/src/software/world/robot_test.cpp
@@ -311,30 +311,30 @@ TEST_F(RobotTest, get_unavailable_capabilities)
         RobotCapability::Chip,
     };
 
-    Robot robot =
-        Robot(0, Point(3, 1.2), Vector(-3, 1), Angle::fromDegrees(0),
-              AngularVelocity::fromDegrees(25), current_time, 3, unavailable_capabilities);
+    Robot robot = Robot(0, Point(3, 1.2), Vector(-3, 1), Angle::fromDegrees(0),
+                        AngularVelocity::fromDegrees(25), current_time, 3,
+                        unavailable_capabilities);
 
     EXPECT_EQ(unavailable_capabilities, robot.getUnavailableCapabilities());
 }
 
 TEST_F(RobotTest, get_available_capabilities)
 {
-    std::set<RobotCapability> unavailableCapabilities = {
+    std::set<RobotCapability> unavailable_capabilities = {
         RobotCapability::Dribble,
         RobotCapability::Chip,
     };
 
-    Robot robot =
-        Robot(0, Point(3, 1.2), Vector(-3, 1), Angle::fromDegrees(0),
-              AngularVelocity::fromDegrees(25), current_time, 3, unavailableCapabilities);
+    Robot robot = Robot(0, Point(3, 1.2), Vector(-3, 1), Angle::fromDegrees(0),
+                        AngularVelocity::fromDegrees(25), current_time, 3,
+                        unavailable_capabilities);
 
-    // available capabilities = all capabilities - unavailableCapabilities
+    // available capabilities = all capabilities - unavailable capabilities
     std::set<RobotCapability> all_capabilities = allRobotCapabilities();
     std::set<RobotCapability> expected_capabilities;
     std::set_difference(
-        all_capabilities.begin(), all_capabilities.end(), unavailableCapabilities.begin(),
-        unavailableCapabilities.end(),
+        all_capabilities.begin(), all_capabilities.end(),
+        unavailable_capabilities.begin(), unavailable_capabilities.end(),
         std::inserter(expected_capabilities, expected_capabilities.begin()));
 
     EXPECT_EQ(expected_capabilities, robot.getAvailableCapabilities());

--- a/src/software/world/robot_test.cpp
+++ b/src/software/world/robot_test.cpp
@@ -329,7 +329,7 @@ TEST_F(RobotTest, get_available_capabilities)
         Robot(0, Point(3, 1.2), Vector(-3, 1), Angle::fromDegrees(0),
               AngularVelocity::fromDegrees(25), current_time, 3, unavailableCapabilities);
 
-    // possible capabilities = all capabilities - unavailableCapabilities
+    // available capabilities = all capabilities - unavailableCapabilities
     std::set<RobotCapability> all_capabilities = allRobotCapabilities();
     std::set<RobotCapability> expected_capabilities;
     std::set_difference(

--- a/src/software/world/robot_test.cpp
+++ b/src/software/world/robot_test.cpp
@@ -304,35 +304,38 @@ TEST_F(RobotTest, get_timestamp_history)
     EXPECT_EQ(prevTimestamps, previous_timestamps);
 }
 
-TEST_F(RobotTest, get_capabilities_blacklist)
+TEST_F(RobotTest, get_unavailable_capabilities)
 {
-    std::set<RobotCapability> blacklist = {
+    std::set<RobotCapability> unavailableCapabilities = {
         RobotCapability::Dribble,
         RobotCapability::Chip,
     };
 
-    Robot robot = Robot(0, Point(3, 1.2), Vector(-3, 1), Angle::fromDegrees(0),
-                        AngularVelocity::fromDegrees(25), current_time, 3, blacklist);
+    Robot robot =
+        Robot(0, Point(3, 1.2), Vector(-3, 1), Angle::fromDegrees(0),
+              AngularVelocity::fromDegrees(25), current_time, 3, unavailableCapabilities);
 
-    EXPECT_EQ(blacklist, robot.getCapabilitiesBlacklist());
+    EXPECT_EQ(unavailableCapabilities, robot.getUnavailableCapabilities());
 }
 
-TEST_F(RobotTest, get_capabilities_whitelist)
+TEST_F(RobotTest, get_available_capabilities)
 {
-    std::set<RobotCapability> blacklist = {
+    std::set<RobotCapability> unavailableCapabilities = {
         RobotCapability::Dribble,
         RobotCapability::Chip,
     };
 
-    Robot robot = Robot(0, Point(3, 1.2), Vector(-3, 1), Angle::fromDegrees(0),
-                        AngularVelocity::fromDegrees(25), current_time, 3, blacklist);
+    Robot robot =
+        Robot(0, Point(3, 1.2), Vector(-3, 1), Angle::fromDegrees(0),
+              AngularVelocity::fromDegrees(25), current_time, 3, unavailableCapabilities);
 
-    // whitelist = all capabilities - blacklist
+    // possible capabilities = all capabilities - unavailableCapabilities
     std::set<RobotCapability> all_capabilities = allRobotCapabilities();
-    std::set<RobotCapability> expected_whitelist;
-    std::set_difference(all_capabilities.begin(), all_capabilities.end(),
-                        blacklist.begin(), blacklist.end(),
-                        std::inserter(expected_whitelist, expected_whitelist.begin()));
+    std::set<RobotCapability> expected_capabilities;
+    std::set_difference(
+        all_capabilities.begin(), all_capabilities.end(), unavailableCapabilities.begin(),
+        unavailableCapabilities.end(),
+        std::inserter(expected_capabilities, expected_capabilities.begin()));
 
-    EXPECT_EQ(expected_whitelist, robot.getCapabilitiesWhitelist());
+    EXPECT_EQ(expected_capabilities, robot.getAvailableCapabilities());
 }

--- a/src/software/world/robot_test.cpp
+++ b/src/software/world/robot_test.cpp
@@ -306,16 +306,16 @@ TEST_F(RobotTest, get_timestamp_history)
 
 TEST_F(RobotTest, get_unavailable_capabilities)
 {
-    std::set<RobotCapability> unavailableCapabilities = {
+    std::set<RobotCapability> unavailable_capabilities = {
         RobotCapability::Dribble,
         RobotCapability::Chip,
     };
 
     Robot robot =
         Robot(0, Point(3, 1.2), Vector(-3, 1), Angle::fromDegrees(0),
-              AngularVelocity::fromDegrees(25), current_time, 3, unavailableCapabilities);
+              AngularVelocity::fromDegrees(25), current_time, 3, unavailable_capabilities);
 
-    EXPECT_EQ(unavailableCapabilities, robot.getUnavailableCapabilities());
+    EXPECT_EQ(unavailable_capabilities, robot.getUnavailableCapabilities());
 }
 
 TEST_F(RobotTest, get_available_capabilities)


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

Made changes in code base to rename any whitelist and blacklist to more descriptive names. Whitelists and Blacklists were found in two places, the motion_constraint_manager.cpp and robot.cpp. The changes are as follows:

in motion_constraint_manager.cpp
- changed current_whitelists_constraints list to current_allowed_constraints to better reflect the allowed constraints to be placed on where the robot can go

In robot.cpp
- changed getCapabilitiesWhitelist to getAvailableCapabilites
- changed getCapabilitiesBlacklist to getUnavailableCapabilities

The respective tests for the motion constraint manager and the robots were also modified to reflect these new names, and I changed the comments in the code so everything makes sense at first glance.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Ran the clang formatter, as well as the bazel build tests for files that were modified. All tests passed.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #1655
### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
