### PR TITLE
Made Robot Max Voltage Constant

### DIFF
--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -119,5 +119,7 @@ const unsigned NETWORK_TIMEOUT_MS = 1000;
 // this is an int to avoid Wconversion with lwip
 const int MAXIMUM_TRANSFER_UNIT_BYTES = 1500;
 
-// makes the battery max voltage a constant now that we are simulating firmware
+// We currently have 4s batteries on the robot that charge up to a little over
+// 16V, so we use 16 here to approximate a fully-charged battery
+// Makes the battery max voltage a constant now that we are simulating firmware
 const float ROBOT_MAX_BATTERY_VOLTAGE = 16.0;

--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -118,3 +118,6 @@ const unsigned NETWORK_TIMEOUT_MS = 1000;
 // maximum transfer unit of the network interface
 // this is an int to avoid Wconversion with lwip
 const int MAXIMUM_TRANSFER_UNIT_BYTES = 1500;
+
+// makes the battery max voltage a constant now that we are simulating firmware
+const float ROBOT_MAX_BATTERY_VOLTAGE = 16.0;

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -107,8 +107,6 @@ float SimulatorRobot::getVelocityAngular()
 
 float SimulatorRobot::getBatteryVoltage()
 {
-    // We currently have 4s batteries on the robot that charge up to a little over
-    // 16V, so we use 16 here to approximate a fully-charged battery
     return ROBOT_MAX_BATTERY_VOLTAGE;
 }
 

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -107,10 +107,6 @@ float SimulatorRobot::getVelocityAngular()
 
 float SimulatorRobot::getBatteryVoltage()
 {
-    // We currently have 4s batteries on the robot that charge up to a little over
-    // 16V, so we use 16 here to approximate a fully-charged battery
-    // TODO: Should max battery voltage be a constant / injected robot param?
-    // See https://github.com/UBC-Thunderbots/Software/issues/1173
     return ROBOT_MAX_BATTERY_VOLTAGE;
 }
 

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -107,6 +107,8 @@ float SimulatorRobot::getVelocityAngular()
 
 float SimulatorRobot::getBatteryVoltage()
 {
+    // We currently have 4s batteries on the robot that charge up to a little over
+    // 16V, so we use 16 here to approximate a fully-charged battery
     return ROBOT_MAX_BATTERY_VOLTAGE;
 }
 

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -111,7 +111,7 @@ float SimulatorRobot::getBatteryVoltage()
     // 16V, so we use 16 here to approximate a fully-charged battery
     // TODO: Should max battery voltage be a constant / injected robot param?
     // See https://github.com/UBC-Thunderbots/Software/issues/1173
-    return 16.0;
+    return ROBOT_MAX_BATTERY_VOLTAGE;
 }
 
 void SimulatorRobot::kick(float speed_m_per_s)


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Added a constant in `src/shared/constants.h` called `ROBOT_MAX_BATTERY_VOLTAGE`, and it is now used in the function call. 
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
None
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #1173
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
