### PR TITLE
Renamed tick functions to app_[primitive_name]_primitive_tick

### DIFF
--- a/src/firmware/app/primitives/autochip_move_primitive.c
+++ b/src/firmware/app/primitives/autochip_move_primitive.c
@@ -20,7 +20,7 @@ void app_autochip_move_primitive_start(TbotsProto_AutochipMovePrimitive prim_msg
     app_chicker_enableAutochip(chicker, prim_msg.chip_distance_meters);
 }
 
-static void autochip_move_tick(void* void_state_ptr, FirmwareWorld_t* world)
+static void app_autochip_move_primitive_tick(void* void_state_ptr, FirmwareWorld_t* world)
 {
     app_move_helper_tick(void_state_ptr, world);
 }
@@ -28,7 +28,7 @@ static void autochip_move_tick(void* void_state_ptr, FirmwareWorld_t* world)
 /**
  * \brief The autochip move primitive.
  */
-const primitive_t AUTOCHIP_MOVE_PRIMITIVE = {.direct        = false,
-                                             .tick          = &autochip_move_tick,
+const primitive_t AUTOCHIP_MOVE_PRIMITIVE = {.direct = false,
+                                             .tick   = &app_autochip_move_primitive_tick,
                                              .create_state  = &createMoveHelperState_t,
                                              .destroy_state = &destroyMoveHelperState_t};

--- a/src/firmware/app/primitives/autokick_move_primitive.c
+++ b/src/firmware/app/primitives/autokick_move_primitive.c
@@ -20,7 +20,7 @@ void app_autokick_move_primitive_start(TbotsProto_AutokickMovePrimitive prim_msg
     app_chicker_enableAutokick(chicker, prim_msg.kick_speed_meters_per_second);
 }
 
-static void autokick_move_tick(void* void_state_ptr, FirmwareWorld_t* world)
+static void app_autokick_move_primitive_tick(void* void_state_ptr, FirmwareWorld_t* world)
 {
     app_move_helper_tick(void_state_ptr, world);
 }
@@ -28,7 +28,7 @@ static void autokick_move_tick(void* void_state_ptr, FirmwareWorld_t* world)
 /**
  * \brief The autokick move primitive.
  */
-const primitive_t AUTOKICK_MOVE_PRIMITIVE = {.direct        = false,
-                                             .tick          = &autokick_move_tick,
+const primitive_t AUTOKICK_MOVE_PRIMITIVE = {.direct = false,
+                                             .tick   = &app_autokick_move_primitive_tick,
                                              .create_state  = &createMoveHelperState_t,
                                              .destroy_state = &destroyMoveHelperState_t};

--- a/src/firmware/app/primitives/chip_primitive.c
+++ b/src/firmware/app/primitives/chip_primitive.c
@@ -14,7 +14,7 @@ void app_chip_primitive_start(TbotsProto_ChipPrimitive prim_msg, void *void_stat
     app_chicker_enableAutochip(chicker, prim_msg.chip_distance_meters);
 }
 
-static void chip_tick(void *void_state_ptr, FirmwareWorld_t *world)
+static void app_chip_primitive_tick(void *void_state_ptr, FirmwareWorld_t *world)
 {
     app_chick_motion_tick(void_state_ptr, world);
 }
@@ -23,6 +23,6 @@ static void chip_tick(void *void_state_ptr, FirmwareWorld_t *world)
  * \brief The chip primitive.
  */
 const primitive_t CHIP_PRIMITIVE = {.direct        = false,
-                                    .tick          = &chip_tick,
+                                    .tick          = &app_chip_primitive_tick,
                                     .create_state  = createChickMotionState_t,
                                     .destroy_state = destroyChickMotionState_t};

--- a/src/firmware/app/primitives/direct_control_primitive.c
+++ b/src/firmware/app/primitives/direct_control_primitive.c
@@ -116,7 +116,8 @@ void app_direct_control_primitive_start(TbotsProto_DirectControlPrimitive prim_m
     app_dribbler_setSpeed(dribbler, (uint32_t)prim_msg.dribbler_speed_rpm);
 }
 
-static void direct_control_tick(void* void_state_ptr, FirmwareWorld_t* world)
+static void app_direct_control_primitive_tick(void* void_state_ptr,
+                                              FirmwareWorld_t* world)
 {
     DirectControlPrimitiveState_t* state = (DirectControlPrimitiveState_t*)void_state_ptr;
     if (state->direct_velocity)
@@ -133,6 +134,6 @@ static void direct_control_tick(void* void_state_ptr, FirmwareWorld_t* world)
  */
 const primitive_t DIRECT_CONTROL_PRIMITIVE = {
     .direct        = true,
-    .tick          = &direct_control_tick,
+    .tick          = &app_direct_control_primitive_tick,
     .create_state  = &createDirectControlPrimitiveState_t,
     .destroy_state = &destroyDirectControlPrimitiveState_t};

--- a/src/firmware/app/primitives/kick_primitive.c
+++ b/src/firmware/app/primitives/kick_primitive.c
@@ -14,7 +14,7 @@ void app_kick_primitive_start(TbotsProto_KickPrimitive prim_msg, void *void_stat
     app_chicker_enableAutokick(chicker, prim_msg.kick_speed_meters_per_second);
 }
 
-static void kick_tick(void *void_state_ptr, FirmwareWorld_t *world)
+static void app_kick_primitive_tick(void *void_state_ptr, FirmwareWorld_t *world)
 {
     app_chick_motion_tick(void_state_ptr, world);
 }
@@ -23,6 +23,6 @@ static void kick_tick(void *void_state_ptr, FirmwareWorld_t *world)
  * \brief The kick primitive.
  */
 const primitive_t KICK_PRIMITIVE = {.direct        = false,
-                                    .tick          = &kick_tick,
+                                    .tick          = &app_kick_primitive_tick,
                                     .create_state  = createChickMotionState_t,
                                     .destroy_state = destroyChickMotionState_t};

--- a/src/firmware/app/primitives/move_primitive.c
+++ b/src/firmware/app/primitives/move_primitive.c
@@ -17,7 +17,7 @@ void app_move_primitive_start(TbotsProto_MovePrimitive prim_msg, void *void_stat
     app_dribbler_setSpeed(dribbler, (uint32_t)prim_msg.dribbler_speed_rpm);
 }
 
-static void move_tick(void *void_state_ptr, FirmwareWorld_t *world)
+static void app_move_primitive_tick(void *void_state_ptr, FirmwareWorld_t *world)
 {
     app_move_helper_tick(void_state_ptr, world);
 }
@@ -26,6 +26,6 @@ static void move_tick(void *void_state_ptr, FirmwareWorld_t *world)
  * \brief The move primitive.
  */
 const primitive_t MOVE_PRIMITIVE = {.direct        = false,
-                                    .tick          = &move_tick,
+                                    .tick          = &app_move_primitive_tick,
                                     .create_state  = &createMoveHelperState_t,
                                     .destroy_state = &destroyMoveHelperState_t};

--- a/src/firmware/app/primitives/spinning_move_primitive.c
+++ b/src/firmware/app/primitives/spinning_move_primitive.c
@@ -64,7 +64,7 @@ void app_spinning_move_primitive_start(TbotsProto_SpinningMovePrimitive prim_msg
     app_dribbler_setSpeed(dribbler, (uint32_t)prim_msg.dribbler_speed_rpm);
 }
 
-static void spinning_move_tick(void *void_state_ptr, FirmwareWorld_t *world)
+static void app_spinning_move_primitive_tick(void *void_state_ptr, FirmwareWorld_t *world)
 {
     const FirmwareRobot_t *robot = app_firmware_world_getRobot(world);
     const SpinningMovePrimitiveState_t *state =
@@ -143,6 +143,6 @@ static void spinning_move_tick(void *void_state_ptr, FirmwareWorld_t *world)
  */
 const primitive_t SPINNING_MOVE_PRIMITIVE = {
     .direct        = false,
-    .tick          = &spinning_move_tick,
+    .tick          = &app_spinning_move_primitive_tick,
     .create_state  = &createSpinningMovePrimitiveState_t,
     .destroy_state = &destroySpinningMovePrimitiveState_t};

--- a/src/firmware/app/primitives/stop_primitive.c
+++ b/src/firmware/app/primitives/stop_primitive.c
@@ -32,12 +32,12 @@ void app_stop_primitive_start(TbotsProto_StopPrimitive prim_msg, void* void_stat
     wheel_op(app_firmware_robot_getBackRightWheel(robot));
 }
 
-static void stop_tick(void* void_state_ptr, FirmwareWorld_t* world) {}
+static void app_stop_primitive_tick(void* void_state_ptr, FirmwareWorld_t* world) {}
 
 /**
  * \brief The stop movement primitive.
  */
 const primitive_t STOP_PRIMITIVE = {.direct        = false,
-                                    .tick          = &stop_tick,
+                                    .tick          = &app_stop_primitive_tick,
                                     .create_state  = &createStopPrimitiveState_t,
                                     .destroy_state = &destroyStopPrimitiveState_t};


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Renamed all the tick functions located in the firmware/app/primitive folder to follow app_[primitive_name]_primitive_tick
### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

Resolves #1631 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
