### PR TITLE
Limit number of balls in the dribbler to one

### DIFF
--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -33,6 +33,16 @@ void Simulator::setBallState(const BallState& ball_state)
 {
     physics_world.setBallState(ball_state);
     simulator_ball = std::make_shared<SimulatorBall>(physics_world.getPhysicsBall());
+
+    for (auto& robot_pair : yellow_simulator_robots)
+    {
+        robot_pair.first->clearBallInDribblerArea();
+    }
+
+    for (auto& robot_pair : blue_simulator_robots)
+    {
+        robot_pair.first->clearBallInDribblerArea();
+    }
 }
 
 void Simulator::removeBall()

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -113,14 +113,9 @@ float SimulatorRobot::getBatteryVoltage()
 void SimulatorRobot::kick(float speed_m_per_s)
 {
     checkValidAndExecuteVoid([this, speed_m_per_s](auto robot) {
-        for (auto &dribbler_ball : this->balls_in_dribbler_area)
+        if (ball_in_dribbler_area && ball_in_dribbler_area->can_be_controlled)
         {
-            if (!dribbler_ball.can_be_controlled)
-            {
-                continue;
-            }
-
-            auto ball = dribbler_ball.ball;
+            auto ball = ball_in_dribbler_area->ball;
             Vector robot_orientation_vector =
                 Vector::createFromAngle(robot->getRobotState().orientation());
 
@@ -162,7 +157,7 @@ void SimulatorRobot::kick(float speed_m_per_s)
                 robot_orientation_vector.normalize(ball_head_on_momentum.length()));
             ball->applyImpulse(kick_impulse);
 
-            dribbler_ball.can_be_controlled = false;
+            ball_in_dribbler_area->can_be_controlled = false;
         }
     });
 }
@@ -170,14 +165,9 @@ void SimulatorRobot::kick(float speed_m_per_s)
 void SimulatorRobot::chip(float distance_m)
 {
     checkValidAndExecuteVoid([this, distance_m](auto robot) {
-        for (auto &dribbler_ball : this->balls_in_dribbler_area)
+        if (ball_in_dribbler_area && ball_in_dribbler_area->can_be_controlled)
         {
-            if (!dribbler_ball.can_be_controlled)
-            {
-                continue;
-            }
-
-            auto ball = dribbler_ball.ball;
+            auto ball = ball_in_dribbler_area->ball;
             // Assume the ball is chipped at a 45 degree angle
             // TODO: Use a robot-specific constant
             // https://github.com/UBC-Thunderbots/Software/issues/1179
@@ -201,7 +191,7 @@ void SimulatorRobot::chip(float distance_m)
                 initial_velocity * static_cast<float>(chip_angle.cos());
             kick(ground_velocity);
 
-            dribbler_ball.can_be_controlled = false;
+            ball_in_dribbler_area->can_be_controlled = false;
         }
     });
 }
@@ -354,20 +344,14 @@ void SimulatorRobot::brakeMotorFrontRight()
 void SimulatorRobot::onDribblerBallContact(PhysicsRobot *physics_robot,
                                            PhysicsBall *physics_ball)
 {
-    if (dribbler_rpm > 0)
+    if (dribbler_rpm > 0 && ball_in_dribbler_area)
     {
-        auto iter =
-            std::find_if(balls_in_dribbler_area.begin(), balls_in_dribbler_area.end(),
-                         [physics_ball](DribblerBall dribbler_ball) {
-                             return dribbler_ball.ball == physics_ball;
-                         });
-
-        if (iter == balls_in_dribbler_area.end())
+        if (ball_in_dribbler_area->ball != physics_ball)
         {
             throw std::runtime_error("Trying to dribble ball not in the dribbler area");
         }
 
-        if (iter->can_be_controlled)
+        if (ball_in_dribbler_area->can_be_controlled)
         {
             applyDribblerForce(physics_robot, physics_ball);
         }
@@ -393,7 +377,7 @@ void SimulatorRobot::onDribblerBallStartContact(PhysicsRobot *physics_robot,
     auto ball = DribblerBall{.ball = physics_ball, .can_be_controlled = true};
 
     // Keep track of all balls in the dribbler
-    balls_in_dribbler_area.emplace_back(ball);
+    ball_in_dribbler_area = ball;
 
     // Even if the dribbler is on, we are guaranteed to apply kicking force
     // and disable ball control before the dribbler checks to apply dribbling force.
@@ -418,15 +402,7 @@ void SimulatorRobot::onDribblerBallStartContact(PhysicsRobot *physics_robot,
 void SimulatorRobot::onDribblerBallEndContact(PhysicsRobot *physics_robot,
                                               PhysicsBall *physics_ball)
 {
-    auto iter = std::find_if(balls_in_dribbler_area.begin(), balls_in_dribbler_area.end(),
-                             [physics_ball](DribblerBall dribbler_ball) {
-                                 return dribbler_ball.ball == physics_ball;
-                             });
-
-    if (iter != balls_in_dribbler_area.end())
-    {
-        balls_in_dribbler_area.erase(iter);
-    }
+    ball_in_dribbler_area = std::nullopt;
 }
 
 void SimulatorRobot::startNewPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world,

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -402,7 +402,7 @@ void SimulatorRobot::onDribblerBallStartContact(PhysicsRobot *physics_robot,
 void SimulatorRobot::onDribblerBallEndContact(PhysicsRobot *physics_robot,
                                               PhysicsBall *physics_ball)
 {
-    ball_in_dribbler_area = std::nullopt;
+    clearBallInDribblerArea();
 }
 
 void SimulatorRobot::startNewPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world,
@@ -416,6 +416,11 @@ void SimulatorRobot::runCurrentPrimitive(std::shared_ptr<FirmwareWorld_t> firmwa
 {
     app_primitive_manager_runCurrentPrimitive(primitive_manager.get(),
                                               firmware_world.get());
+}
+
+void SimulatorRobot::clearBallInDribblerArea()
+{
+    ball_in_dribbler_area = std::nullopt;
 }
 
 void SimulatorRobot::applyDribblerForce(PhysicsRobot *physics_robot,

--- a/src/software/simulation/simulator_robot.h
+++ b/src/software/simulation/simulator_robot.h
@@ -287,7 +287,7 @@ class SimulatorRobot
         bool can_be_controlled;
     } DribblerBall;
 
-    std::vector<DribblerBall> balls_in_dribbler_area;
+    std::optional<DribblerBall> ball_in_dribbler_area;
 
     std::unique_ptr<PrimitiveManager, FirmwarePrimitiveManagerDeleter> primitive_manager;
 

--- a/src/software/simulation/simulator_robot.h
+++ b/src/software/simulation/simulator_robot.h
@@ -40,6 +40,11 @@ class SimulatorRobot
      */
     unsigned int getRobotId();
 
+    /**
+     * Clears balls tracked as being in dribbler area
+     */
+    void clearBallInDribblerArea();
+
    protected:
     /**
      * Returns the x-position of the robot, in global field coordinates, in meters


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Since `PhysicsWorld` only tracks one `PhysicsBall`, the `setBallState` function will destroy the old `PhysicsBall`. `onDribblerBallStartContact` previously tracked a `balls_in_dribbler_area` list of raw pointers to `PhysicsBall`, some of which are destroyed before they can leave the dribbler. This caused segfaults when we try to kick these destroyed `PhysicsBall`s.

This PR fixes this issue by only allowing one ball to be tracked by `SimulatorRobot` as being in the dribbler area.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
manual testing revealed the root cause, which was fixed
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
