### PR TITLE
Reset Dynamic Parameters in SimulatedTestFixture::SetUp()

### DIFF
--- a/src/software/parameter/constants.py
+++ b/src/software/parameter/constants.py
@@ -78,10 +78,15 @@ IMMUTABLE_PARAMETER_LIST_CONFIG_ENTRY = (
     "std::const_pointer_cast<const {config_name}>({config_variable_name})"
 )
 
+# NOTE the init() function allow us to reset dynamic parameters, but it should be removed once we have dependency injection, which we can do after https://github.com/UBC-Thunderbots/Software/issues/1299
 CONFIG_CLASS = """class {config_name} : public Config
 {{
    public:
     {config_name}()
+    {{
+        init();
+    }}
+    void init()
     {{
         {constructor_entries}
         mutable_internal_param_list = {{{mutable_parameter_list_entries}}};

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -19,15 +19,15 @@ void SimulatedTestFixture::SetUp()
 {
     LoggerSingleton::initializeLogger();
 
-    // TODO: Ideally we should reset all DynamicParameters for each test. However
-    // because DynamicParameters are still partially global, this can't be done
-    // until https://github.com/UBC-Thunderbots/Software/issues/1483 is complete
-
-    // Re-create all objects for each test so we start from a clean setup
-    // every time. Because the simulator is created initially in the
-    // constructor's initialization list, and before every test in this SetUp function, we
-    // can guarantee the pointer will never be null / empty
-    simulator = std::make_unique<Simulator>(Field::createSSLDivisionBField());
+    // init() resets all DynamicParameters for each test. Since DynamicParameters are
+    // still partially global, we need to reinitialize simulator, sensor_fusion, and ai,
+    // so that they can grab the new dynamic parameter pointers. Note that this is a bit
+    // of hack because we're changing a global variable, but it can't be easily fixed
+    // through dependency injection until
+    // https://github.com/UBC-Thunderbots/Software/issues/1299
+    MutableDynamicParameters->init();
+    simulator     = std::make_unique<Simulator>(Field::createSSLDivisionBField());
+    sensor_fusion = SensorFusion(DynamicParameters->getSensorFusionConfig());
     ai = AI(DynamicParameters->getAIConfig(), DynamicParameters->getAIControlConfig());
 
     MutableDynamicParameters->getMutableAIControlConfig()->mutableRunAI()->setValue(true);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
This fixes the segfault on consecutive simulated tests that run with visualizer enabled. The problem was that the first test's fullsystemgui would register callbacks with the global dynamic parameters. When the first test's fullsystemgui is destroyed, then when the second test changes dynamic parameters, it calls callbacks to functions that are part of destroyed objects
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
works locally
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves  #1483
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
