### PR TITLE
Removed unnecessary if/else statements

### DIFF
--- a/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
@@ -63,19 +63,8 @@ std::set<MotionConstraint> buildMotionConstraintSetFromGameState(
     }
     else
     {
-        if (game_state.stayAwayFromBall() || game_state.isOurKickoff())
-        {
-            motion_constraints.insert(MotionConstraint::HALF_METER_AROUND_BALL);
-        }
-
-        if (game_state.isOurPenalty())
-        {
-            motion_constraints.insert(MotionConstraint::ENEMY_DEFENSE_AREA);
-        }
-        else
-        {
-            motion_constraints.insert(MotionConstraint::INFLATED_ENEMY_DEFENSE_AREA);
-        }
+        motion_constraints.insert(MotionConstraint::INFLATED_ENEMY_DEFENSE_AREA);
+        
     }
 
     return motion_constraints;

--- a/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
@@ -64,7 +64,6 @@ std::set<MotionConstraint> buildMotionConstraintSetFromGameState(
     else
     {
         motion_constraints.insert(MotionConstraint::INFLATED_ENEMY_DEFENSE_AREA);
-        
     }
 
     return motion_constraints;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Removed unnecessary if and else statements in the workflow for building motion_constraints

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Existing tests still pass

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
Resolves #1821 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
