### PR TITLE
UART logger

### DIFF
--- a/src/firmware/boards/legacy_robot_stm32f4/io/uart_logger.c
+++ b/src/firmware/boards/legacy_robot_stm32f4/io/uart_logger.c
@@ -6,7 +6,7 @@
 #include "shared/proto/robot_log_msg.nanopb.h"
 
 
-void io_uart_logger_handle_robot_log(TbotsProto_RobotLog log)
+void io_uart_logger_handleRobotLog(TbotsProto_RobotLog log)
 {
     printf("[%s:%d] %s", log.file_name, log.line_number, log.log_msg);
 }

--- a/src/firmware/boards/legacy_robot_stm32f4/io/uart_logger.h
+++ b/src/firmware/boards/legacy_robot_stm32f4/io/uart_logger.h
@@ -7,4 +7,4 @@
  *
  * @param log The log msg to print over UART
  */
-void io_uart_logger_handle_robot_log(TbotsProto_RobotLog log);
+void io_uart_logger_handleRobotLog(TbotsProto_RobotLog log);

--- a/src/firmware/boards/legacy_robot_stm32f4/main.c
+++ b/src/firmware/boards/legacy_robot_stm32f4/main.c
@@ -485,7 +485,7 @@ static void run_normal(void)
         exception_reboot_without_core = false;
     }
 
-    app_logger_init(switches[0U], &io_uart_logger_handle_robot_log);
+    app_logger_init(switches[0U], &io_uart_logger_handleRobotLog);
 
     // Setup the world that acts as the interface for the higher level firmware
     // (like primitives or the controller) to interface with the outside world

--- a/src/firmware_new/boards/frankie_v1/BUILD
+++ b/src/firmware_new/boards/frankie_v1/BUILD
@@ -4,7 +4,10 @@ load("//firmware_new:rules.bzl", "stm32h7_hal_library_files_genrule")
 
 cc_binary(
     name = "frankie_v1_main",
-    srcs = ["main.c"],
+    srcs = [
+        "freertos.c",
+        "main.c",
+    ],
     copts = [
         # We don't want to mark warnings as errors for 3rd party code
         "-Wno-error",
@@ -24,36 +27,30 @@ cc_binary(
     deps = [
         ":STM32H743ZITx_FLASH.ld",
         ":frankie_v1_main_lib",
+        ":gpio",
+        ":lwip",
+        "//firmware/app/logger",
         "//firmware_new/boards/frankie_v1/io:drivetrain",
         "//firmware_new/boards/frankie_v1/io:drivetrain_unit",
         "//firmware_new/boards/frankie_v1/io:gpio_pin",
+        "//firmware_new/boards/frankie_v1/io:network_logger",
         "//firmware_new/boards/frankie_v1/io:pwm_pin",
+        "//firmware_new/boards/frankie_v1/io:uart_logger",
     ],
 )
 
 cc_library(
     name = "frankie_v1_main_lib",
     srcs = [
-        "crc.c",
-        "freertos.c",
-        "gpio.c",
         "startup_stm32h743xx.s",
         "stm32h7xx_hal_msp.c",
         "stm32h7xx_it.c",
         "system_stm32h7xx.c",
-        "tim.c",
-        "usart.c",
-        "usb_otg.c",
     ],
     hdrs = [
         "FreeRTOSConfig.h",
-        "crc.h",
-        "gpio.h",
         "stm32h7xx_hal_conf.h",
         "stm32h7xx_it.h",
-        "tim.h",
-        "usart.h",
-        "usb_otg.h",
     ],
     copts = [
         "-DSTM32H743xx",
@@ -62,10 +59,12 @@ cc_library(
     ],
     restricted_to = ["//cc_toolchain:stm32h7"],
     deps = [
+        ":crc",
         ":hal",
         ":lwip",
-        "//firmware/app/logger",
-        "//firmware_new/boards/frankie_v1/io:network_logger",
+        ":tim",
+        ":usart",
+        ":usb_otg",
         "//firmware_new/boards/frankie_v1/io:proto_multicast_communication",
         "//shared:constants",
         "//shared/proto:tbots_nanopb_proto",
@@ -78,26 +77,118 @@ cc_library(
 )
 
 cc_library(
-    name = "frankie_v1_lwip",
+    name = "usb_otg",
     srcs = [
-        "ethernetif.c",
-        "lwip.c",
+        "usb_otg.c",
     ],
     hdrs = [
-        "FreeRTOSConfig.h",
-        "ethernetif.h",
-        "lwip.h",
-        "lwipopts.h",
+        "main.h",
+        "usb_otg.h",
     ],
     copts = [
-        "-DSTM32H743xx",
         # We don't want to mark warnings as errors for 3rd party code
         "-Wno-error",
+        "-DSTM32H743xx",
     ],
     restricted_to = ["//cc_toolchain:stm32h7"],
     deps = [
         ":hal",
-        ":lwip",
+    ],
+    # This is _very_ important. If we don't do this, bazel will not link in the
+    # interrupt handling code, which *will not* cause an error, and *will* cause
+    # interrupts to stop working
+    alwayslink = True,
+)
+
+cc_library(
+    name = "crc",
+    srcs = [
+        "crc.c",
+    ],
+    hdrs = [
+        "crc.h",
+        "main.h",
+    ],
+    copts = [
+        # We don't want to mark warnings as errors for 3rd party code
+        "-Wno-error",
+        "-DSTM32H743xx",
+    ],
+    restricted_to = ["//cc_toolchain:stm32h7"],
+    deps = [
+        ":hal",
+    ],
+    # This is _very_ important. If we don't do this, bazel will not link in the
+    # interrupt handling code, which *will not* cause an error, and *will* cause
+    # interrupts to stop working
+    alwayslink = True,
+)
+
+cc_library(
+    name = "tim",
+    srcs = [
+        "tim.c",
+    ],
+    hdrs = [
+        "main.h",
+        "tim.h",
+    ],
+    copts = [
+        # We don't want to mark warnings as errors for 3rd party code
+        "-Wno-error",
+        "-DSTM32H743xx",
+    ],
+    restricted_to = ["//cc_toolchain:stm32h7"],
+    deps = [
+        ":hal",
+    ],
+    # This is _very_ important. If we don't do this, bazel will not link in the
+    # interrupt handling code, which *will not* cause an error, and *will* cause
+    # interrupts to stop working
+    alwayslink = True,
+)
+
+cc_library(
+    name = "gpio",
+    srcs = [
+        "gpio.c",
+    ],
+    hdrs = [
+        "gpio.h",
+        "main.h",
+    ],
+    copts = [
+        # We don't want to mark warnings as errors for 3rd party code
+        "-Wno-error",
+        "-DSTM32H743xx",
+    ],
+    restricted_to = ["//cc_toolchain:stm32h7"],
+    deps = [
+        ":hal",
+    ],
+    # This is _very_ important. If we don't do this, bazel will not link in the
+    # interrupt handling code, which *will not* cause an error, and *will* cause
+    # interrupts to stop working
+    alwayslink = True,
+)
+
+cc_library(
+    name = "usart",
+    srcs = [
+        "usart.c",
+    ],
+    hdrs = [
+        "main.h",
+        "usart.h",
+    ],
+    copts = [
+        # We don't want to mark warnings as errors for 3rd party code
+        "-Wno-error",
+        "-DSTM32H743xx",
+    ],
+    restricted_to = ["//cc_toolchain:stm32h7"],
+    deps = [
+        ":hal",
     ],
     # This is _very_ important. If we don't do this, bazel will not link in the
     # interrupt handling code, which *will not* cause an error, and *will* cause
@@ -243,6 +334,7 @@ cc_library(
     ],
     hdrs = [
         "FreeRTOSConfig.h",
+        "Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/cmsis_os.h",
         "Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/cmsis_os2.h",
         "Middlewares/Third_Party/FreeRTOS/Source/include/FreeRTOS.h",
         "Middlewares/Third_Party/FreeRTOS/Source/include/deprecated_definitions.h",
@@ -385,12 +477,12 @@ cc_library(
         "Middlewares/Third_Party/LwIP/src/netif/ppp/utils.c",
         "Middlewares/Third_Party/LwIP/src/netif/ppp/vj.c",
         "Middlewares/Third_Party/LwIP/system/OS/sys_arch.c",
+        "ethernetif.c",
+        "lwip.c",
     ],
     hdrs = [
         "Drivers/BSP/Components/lan8742/lan8742.h",
         "FreeRTOSConfig.h",
-        "Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/cmsis_os.h",
-        "Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/cmsis_os2.h",
         "Middlewares/Third_Party/LwIP/src/apps/httpd/fsdata.c",
         "Middlewares/Third_Party/LwIP/src/apps/httpd/fsdata.h",
         "Middlewares/Third_Party/LwIP/src/apps/httpd/httpd_structs.h",

--- a/src/firmware_new/boards/frankie_v1/freertos.c
+++ b/src/firmware_new/boards/frankie_v1/freertos.c
@@ -235,8 +235,6 @@ void test_msg_update(void *argument)
     ProtoMulticastCommunicationProfile_t *comm_profile =
         (ProtoMulticastCommunicationProfile_t *)argument;
 
-    app_logger_init(0, &io_network_logger_handle_robot_log);
-
     /* Infinite loop */
     for (;;)
     {
@@ -248,12 +246,9 @@ void test_msg_update(void *argument)
         io_proto_multicast_communication_profile_notifyEvents(comm_profile,
                                                               PROTO_UPDATED);
         TLOG_DEBUG("logging debug level message %d", sys_now());
-        TLOG_INFO("logging info level message %x", sys_now());
-        TLOG_WARNING("logging warning level message %x", sys_now());
-        TLOG_FATAL("logging error level message %d", sys_now());
 
         // run loop at 100hz
-        osDelay(1 / 100 * MILLISECONDS_PER_SECOND);
+        osDelay(1 / 10 * MILLISECONDS_PER_SECOND);
     }
     /* USER CODE END test_msg_update */
 }

--- a/src/firmware_new/boards/frankie_v1/io/BUILD
+++ b/src/firmware_new/boards/frankie_v1/io/BUILD
@@ -74,7 +74,6 @@ cc_library(
     ],
     restricted_to = ["//cc_toolchain:stm32h7"],
     deps = [
-        "//firmware_new/boards/frankie_v1:frankie_v1_lwip",
         "//firmware_new/boards/frankie_v1:hal",
         "//firmware_new/boards/frankie_v1:lwip",
         "//shared/proto:tbots_nanopb_proto",
@@ -92,6 +91,21 @@ cc_library(
         "//firmware_new/boards/frankie_v1:lwip",
         "//firmware_new/boards/frankie_v1:rtos",
         "//firmware_new/boards/frankie_v1/io:proto_multicast_communication",
+        "//shared/proto:tbots_nanopb_proto",
+        "@nanopb",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "uart_logger",
+    srcs = ["uart_logger.c"],
+    hdrs = ["uart_logger.h"],
+    restricted_to = ["//cc_toolchain:stm32h7"],
+    deps = [
+        "//firmware_new/boards/frankie_v1:hal",
+        "//firmware_new/boards/frankie_v1:rtos",
+        "//firmware_new/boards/frankie_v1:usart",
         "//shared/proto:tbots_nanopb_proto",
         "@nanopb",
     ],

--- a/src/firmware_new/boards/frankie_v1/io/network_logger.c
+++ b/src/firmware_new/boards/frankie_v1/io/network_logger.c
@@ -44,7 +44,7 @@ void io_network_logger_init(osMessageQueueId_t message_queue_id)
     log_message_queue_id_ = message_queue_id;
 }
 
-void io_network_logger_handle_robot_log(TbotsProto_RobotLog robot_log)
+void io_network_logger_handleRobotLog(TbotsProto_RobotLog robot_log)
 {
     // NOTE: we pass in a ptr to the robot_log on the stack, normally this can be
     // catastrophic, but osMessageQueuePut guarantees that the msg is copied, and

--- a/src/firmware_new/boards/frankie_v1/io/network_logger.h
+++ b/src/firmware_new/boards/frankie_v1/io/network_logger.h
@@ -24,4 +24,4 @@ void io_network_logger_init(osMessageQueueId_t log_message_queue_id);
  *
  * @param robot_log The log msg to send
  */
-void io_network_logger_handle_robot_log(TbotsProto_RobotLog robot_log);
+void io_network_logger_handleRobotLog(TbotsProto_RobotLog robot_log);

--- a/src/firmware_new/boards/frankie_v1/io/uart_logger.c
+++ b/src/firmware_new/boards/frankie_v1/io/uart_logger.c
@@ -13,34 +13,40 @@ void io_uart_logger_init(UART_HandleTypeDef* uart_handle)
     g_uart_handle = uart_handle;
 }
 
-void io_uart_logger_handle_robot_log(TbotsProto_RobotLog robot_log)
+void io_uart_logger_handleRobotLog(TbotsProto_RobotLog robot_log)
 {
-    const char* log_level;
-
-    if (robot_log.log_level == TbotsProto_LogLevel_DEBUG)
-    {
-        log_level = "DEBUG";
-    }
-    else if (robot_log.log_level == TbotsProto_LogLevel_INFO)
-    {
-        log_level = "INFO";
-    }
-    else if (robot_log.log_level == TbotsProto_LogLevel_WARNING)
-    {
-        log_level = "WARNING";
-    }
-    else if (robot_log.log_level == TbotsProto_LogLevel_FATAL)
-    {
-        log_level = "FATAL";
-    }
-    else
-    {
-        log_level = "UNKOWN";
-    }
-
-    int size = sprintf(g_robot_log_buffer, "[%s][%s:%ld]: %s\r\n", log_level,
+    int size = sprintf(g_robot_log_buffer, "[%s][%s:%ld]: %s\r\n",
+                       io_uart_logger_convertLogLevelEnumToString(log_level),
                        robot_log.file_name, robot_log.line_number, robot_log.log_msg);
 
     HAL_UART_Transmit(g_uart_handle, (uint8_t*)g_robot_log_buffer, (uint16_t)size,
                       HAL_MAX_DELAY);
 }
+
+const char* io_uart_logger_convertLogLevelEnumToString(TbotsProto_LogLevel log_level)
+{
+    switch(log_level)
+    {
+        case TbotsProto_LogLevel_DEBUG:
+        {
+            return "DEBUG";
+        }
+        case TbotsProto_LogLevel_INFO:
+        {
+            return "INFO";
+        }
+        case TbotsProto_LogLevel_WARNING:
+        {
+            return "WARNING";
+        }
+        case TbotsProto_LogLevel_FATAL:
+        {
+            return "FATAL";
+        }
+        default:
+        {
+            return "UNKOWN";
+        }
+    }
+}
+

--- a/src/firmware_new/boards/frankie_v1/io/uart_logger.c
+++ b/src/firmware_new/boards/frankie_v1/io/uart_logger.c
@@ -45,7 +45,7 @@ const char* io_uart_logger_convertLogLevelEnumToString(TbotsProto_LogLevel log_l
         }
         default:
         {
-            return "UNKOWN";
+            return "UNKNOWN";
         }
     }
 }

--- a/src/firmware_new/boards/frankie_v1/io/uart_logger.c
+++ b/src/firmware_new/boards/frankie_v1/io/uart_logger.c
@@ -16,7 +16,7 @@ void io_uart_logger_init(UART_HandleTypeDef* uart_handle)
 void io_uart_logger_handleRobotLog(TbotsProto_RobotLog robot_log)
 {
     int size = sprintf(g_robot_log_buffer, "[%s][%s:%ld]: %s\r\n",
-                       io_uart_logger_convertLogLevelEnumToString(log_level),
+                       io_uart_logger_convertLogLevelEnumToString(robot_log.log_level),
                        robot_log.file_name, robot_log.line_number, robot_log.log_msg);
 
     HAL_UART_Transmit(g_uart_handle, (uint8_t*)g_robot_log_buffer, (uint16_t)size,
@@ -25,7 +25,7 @@ void io_uart_logger_handleRobotLog(TbotsProto_RobotLog robot_log)
 
 const char* io_uart_logger_convertLogLevelEnumToString(TbotsProto_LogLevel log_level)
 {
-    switch(log_level)
+    switch (log_level)
     {
         case TbotsProto_LogLevel_DEBUG:
         {
@@ -49,4 +49,3 @@ const char* io_uart_logger_convertLogLevelEnumToString(TbotsProto_LogLevel log_l
         }
     }
 }
-

--- a/src/firmware_new/boards/frankie_v1/io/uart_logger.c
+++ b/src/firmware_new/boards/frankie_v1/io/uart_logger.c
@@ -1,0 +1,46 @@
+#include "firmware_new/boards/frankie_v1/io/uart_logger.h"
+
+#include <stdio.h>
+
+#include "firmware_new/boards/frankie_v1/usart.h"
+#include "shared/proto/robot_log_msg.nanopb.h"
+
+static char g_robot_log_buffer[TbotsProto_RobotLog_size];
+static UART_HandleTypeDef* g_uart_handle;
+
+void io_uart_logger_init(UART_HandleTypeDef* uart_handle)
+{
+    g_uart_handle = uart_handle;
+}
+
+void io_uart_logger_handle_robot_log(TbotsProto_RobotLog robot_log)
+{
+    const char* log_level;
+
+    if (robot_log.log_level == TbotsProto_LogLevel_DEBUG)
+    {
+        log_level = "DEBUG";
+    }
+    else if (robot_log.log_level == TbotsProto_LogLevel_INFO)
+    {
+        log_level = "INFO";
+    }
+    else if (robot_log.log_level == TbotsProto_LogLevel_WARNING)
+    {
+        log_level = "WARNING";
+    }
+    else if (robot_log.log_level == TbotsProto_LogLevel_FATAL)
+    {
+        log_level = "FATAL";
+    }
+    else
+    {
+        log_level = "UNKOWN";
+    }
+
+    int size = sprintf(g_robot_log_buffer, "[%s][%s:%ld]: %s\r\n", log_level,
+                       robot_log.file_name, robot_log.line_number, robot_log.log_msg);
+
+    HAL_UART_Transmit(g_uart_handle, (uint8_t*)g_robot_log_buffer, (uint16_t)size,
+                      HAL_MAX_DELAY);
+}

--- a/src/firmware_new/boards/frankie_v1/io/uart_logger.h
+++ b/src/firmware_new/boards/frankie_v1/io/uart_logger.h
@@ -12,8 +12,7 @@
 void io_uart_logger_init(UART_HandleTypeDef* uart_handle);
 
 /**
- * Transfers the robot_log over UART. This is routed through the STLink
- * and shows up on /dev/ttyACM*. You can view the logs with screen /dev/ttyACM0 115200
+ * Transfers the robot_log over UART.
  *
  * @param robot_log The log msg to send
  */

--- a/src/firmware_new/boards/frankie_v1/io/uart_logger.h
+++ b/src/firmware_new/boards/frankie_v1/io/uart_logger.h
@@ -16,4 +16,12 @@ void io_uart_logger_init(UART_HandleTypeDef* uart_handle);
  *
  * @param robot_log The log msg to send
  */
-void io_uart_logger_handle_robot_log(TbotsProto_RobotLog robot_log);
+void io_uart_logger_handleRobotLog(TbotsProto_RobotLog robot_log);
+
+/**
+ * Converts the TbotsProto_LogLevel enum to a string
+ *
+ * @param log_level The log level to convert to a string
+ * @returns converted string
+ */
+const char* io_uart_logger_convertLogLevelEnumToString(TbotsProto_LogLevel log_level);

--- a/src/firmware_new/boards/frankie_v1/io/uart_logger.h
+++ b/src/firmware_new/boards/frankie_v1/io/uart_logger.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "FreeRTOS.h"
+#include "cmsis_os.h"
+#include "firmware_new/boards/frankie_v1/usart.h"
+#include "shared/proto/robot_log_msg.nanopb.h"
+
+/**
+ * Initialize the UART logger
+ *
+ * @param uart_handle The UART handle to send the logs over
+ */
+void io_uart_logger_init(UART_HandleTypeDef* uart_handle);
+
+/**
+ * Transfers the robot_log over UART. This is routed through the STLink
+ * and shows up on /dev/ttyACM*. You can view the logs with screen /dev/ttyACM0 115200
+ *
+ * @param robot_log The log msg to send
+ */
+void io_uart_logger_handle_robot_log(TbotsProto_RobotLog robot_log);

--- a/src/firmware_new/boards/frankie_v1/main.c
+++ b/src/firmware_new/boards/frankie_v1/main.c
@@ -178,7 +178,7 @@ int main(void)
     //
     // Logs can been seen through `screen /dev/ttyACM0 115200`
     io_uart_logger_init(&huart3);
-    app_logger_init(0, &io_uart_logger_handle_robot_log);
+    app_logger_init(0, &io_uart_logger_handleRobotLog);
 
     TLOG_INFO("Initializing IO Layer");
     initIoLayer();

--- a/src/firmware_new/boards/frankie_v1/main.c
+++ b/src/firmware_new/boards/frankie_v1/main.c
@@ -176,8 +176,7 @@ int main(void)
     // At this point the UART peripheral should be configured correctly,
     // so we initialize the logger with a UART robot log handler.
     //
-    // Logs can been seen through `screen /dev/ttyACM0 115200` until the
-    // robot connects to a network.
+    // Logs can been seen through `screen /dev/ttyACM0 115200`
     io_uart_logger_init(&huart3);
     app_logger_init(0, &io_uart_logger_handle_robot_log);
 

--- a/src/firmware_new/boards/frankie_v1/main.c
+++ b/src/firmware_new/boards/frankie_v1/main.c
@@ -30,7 +30,10 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include "firmware/app/logger/logger.h"
 #include "firmware_new/boards/frankie_v1/io/drivetrain.h"
+#include "firmware_new/boards/frankie_v1/io/uart_logger.h"
+
 
 /* USER CODE END Includes */
 
@@ -168,6 +171,17 @@ int main(void)
     MX_TIM4_Init();
     /* USER CODE BEGIN 2 */
 
+    //               ---- Initialize App/IO Layer ----
+    //
+    // At this point the UART peripheral should be configured correctly,
+    // so we initialize the logger with a UART robot log handler.
+    //
+    // Logs can been seen through `screen /dev/ttyACM0 115200` until the
+    // robot connects to a network.
+    io_uart_logger_init(&huart3);
+    app_logger_init(0, &io_uart_logger_handle_robot_log);
+
+    TLOG_INFO("Initializing IO Layer");
     initIoLayer();
 
     /* USER CODE END 2 */


### PR DESCRIPTION

<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
- add uart logger
- reduce rate of test task to 10hz
- reduce clutter in build file
- Part 1 of 3 PRs
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Tested manually, logs print on screen
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
N/A Part of Wifi abstractions, we need the UART logger to look at logs during initialization before we connect to Wifi.
### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
