### PR TITLE
Remove Priority from Intents

### DIFF
--- a/src/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/software/ai/hl/stp/action/chip_action.cpp
@@ -121,14 +121,13 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         if (!robot_behind_ball)
         {
             yield(std::make_unique<MoveIntent>(
-                robot->id(), point_behind_ball, chip_direction, 0.0, 0,
-                DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
-                BallCollisionType::ALLOW));
+                robot->id(), point_behind_ball, chip_direction, 0.0, DribblerEnable::OFF,
+                MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW));
         }
         else
         {
             yield(std::make_unique<ChipIntent>(robot->id(), chip_origin, chip_direction,
-                                               chip_distance_meters, 0));
+                                               chip_distance_meters));
         }
     } while (!ball.hasBallBeenKicked(chip_direction));
 }

--- a/src/software/ai/hl/stp/action/intercept_ball_action.cpp
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.cpp
@@ -43,7 +43,7 @@ void InterceptBallAction::interceptSlowBall(IntentCoroutine::push_type& yield)
     {
         auto face_ball_orientation = (ball.position() - robot->position()).orientation();
         yield(std::make_unique<MoveIntent>(
-            robot->id(), ball.position(), face_ball_orientation, 0, 0, DribblerEnable::ON,
+            robot->id(), ball.position(), face_ball_orientation, 0, DribblerEnable::ON,
             MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW));
 
         // Restart the action if the ball's speed has sped up substantially.
@@ -83,9 +83,8 @@ void InterceptBallAction::interceptSlowBall(IntentCoroutine::push_type& yield)
         auto face_ball_orientation = (ball.position() - robot->position()).orientation();
 
         yield(std::make_unique<MoveIntent>(
-            robot->id(), robot->position(), face_ball_orientation, 0, 0,
-            DribblerEnable::ON, MoveType::NORMAL, AutochickType::NONE,
-            BallCollisionType::ALLOW));
+            robot->id(), robot->position(), face_ball_orientation, 0, DribblerEnable::ON,
+            MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW));
     } while (robot->velocity().length() > ROBOT_STOPPED_SPEED_M_PER_S);
 }
 
@@ -114,7 +113,7 @@ void InterceptBallAction::interceptFastBall(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<MoveIntent>(
-            robot->id(), intercept_position, (-ball.velocity()).orientation(), 0, 0,
+            robot->id(), intercept_position, (-ball.velocity()).orientation(), 0,
             DribblerEnable::ON, MoveType::NORMAL, AutochickType::NONE,
             BallCollisionType::AVOID));
 
@@ -141,7 +140,7 @@ void InterceptBallAction::interceptFastBall(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<MoveIntent>(
-            robot->id(), intercept_position, (-ball.velocity()).orientation(), 0, 0,
+            robot->id(), intercept_position, (-ball.velocity()).orientation(), 0,
             DribblerEnable::ON, MoveType::NORMAL, AutochickType::NONE,
             BallCollisionType::ALLOW));
 

--- a/src/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/software/ai/hl/stp/action/kick_action.cpp
@@ -117,14 +117,13 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
         if (!robot_behind_ball)
         {
             yield(std::make_unique<MoveIntent>(
-                robot->id(), point_behind_ball, kick_direction, 0.0, 0,
-                DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
-                BallCollisionType::AVOID));
+                robot->id(), point_behind_ball, kick_direction, 0.0, DribblerEnable::OFF,
+                MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID));
         }
         else
         {
             yield(std::make_unique<KickIntent>(robot->id(), kick_origin, kick_direction,
-                                               kick_speed_meters_per_second, 0));
+                                               kick_speed_meters_per_second));
         }
     } while (!ball.hasBallBeenKicked(kick_direction));
 }

--- a/src/software/ai/hl/stp/action/move_action.cpp
+++ b/src/software/ai/hl/stp/action/move_action.cpp
@@ -71,7 +71,7 @@ void MoveAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<MoveIntent>(robot->id(), destination, final_orientation,
-                                           final_speed, 0, enable_dribbler, move_type,
+                                           final_speed, enable_dribbler, move_type,
                                            autokick_type, ball_collision_type));
     } while ((robot->position() - destination).length() > close_to_dest_threshold ||
              (robot->orientation().minDiff(final_orientation) >

--- a/src/software/ai/hl/stp/action/spinning_move_action.cpp
+++ b/src/software/ai/hl/stp/action/spinning_move_action.cpp
@@ -36,7 +36,7 @@ void SpinningMoveAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     // different location
     do
     {
-        yield(std::make_unique<SpinningMoveIntent>(
-            robot->id(), destination, angular_velocity, final_linear_speed, 0));
+        yield(std::make_unique<SpinningMoveIntent>(robot->id(), destination,
+                                                   angular_velocity, final_linear_speed));
     } while ((robot->position() - destination).length() > close_to_dest_threshold);
 }

--- a/src/software/ai/hl/stp/action/stop_action.cpp
+++ b/src/software/ai/hl/stp/action/stop_action.cpp
@@ -23,6 +23,6 @@ void StopAction::calculateNextIntent(IntentCoroutine::push_type& yield)
 {
     do
     {
-        yield(std::make_unique<StopIntent>(robot->id(), coast, 0));
+        yield(std::make_unique<StopIntent>(robot->id(), coast));
     } while (robot->velocity().length() > stopped_speed_threshold);
 }

--- a/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
+++ b/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
@@ -24,7 +24,7 @@ void MoveTestAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<MoveIntent>(
-            robot->id(), destination, Angle::zero(), 0.0, 0, DribblerEnable::OFF,
+            robot->id(), destination, Angle::zero(), 0.0, DribblerEnable::OFF,
             MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID));
     } while ((robot->position() - destination).length() > close_to_dest_threshold);
 }

--- a/src/software/ai/hl/stp/stp.cpp
+++ b/src/software/ai/hl/stp/stp.cpp
@@ -118,7 +118,7 @@ std::vector<std::unique_ptr<Intent>> STP::getIntentsFromCurrentPlay(const World&
             // If we couldn't get an intent, we send the robot a StopIntent so
             // it doesn't do anything crazy until it starts running a new Tactic
             intents.emplace_back(
-                std::make_unique<StopIntent>(tactic->getAssignedRobot()->id(), false, 0));
+                std::make_unique<StopIntent>(tactic->getAssignedRobot()->id(), false));
         }
         else
         {

--- a/src/software/ai/intent/chip_intent.cpp
+++ b/src/software/ai/intent/chip_intent.cpp
@@ -1,10 +1,8 @@
 #include "software/ai/intent/chip_intent.h"
 
 ChipIntent::ChipIntent(unsigned int robot_id, const Point &chip_origin,
-                       const Angle &chip_direction, double chip_distance_meters,
-                       unsigned int priority)
-    : DirectPrimitiveIntent(
-          robot_id, priority,
-          *createChipPrimitive(chip_origin, chip_direction, chip_distance_meters))
+                       const Angle &chip_direction, double chip_distance_meters)
+    : DirectPrimitiveIntent(robot_id, *createChipPrimitive(chip_origin, chip_direction,
+                                                           chip_distance_meters))
 {
 }

--- a/src/software/ai/intent/chip_intent.h
+++ b/src/software/ai/intent/chip_intent.h
@@ -15,12 +15,9 @@ class ChipIntent : public DirectPrimitiveIntent
      * @param chip_direction The orientation the Robot will chip at
      * @param chip_distance_meters The distance between the starting location
      * of the chip and the location of the first bounce
-     * @param priority The priority of this Intent. A larger number indicates a higher
-     * priority
      */
     explicit ChipIntent(unsigned int robot_id, const Point& chip_origin,
-                        const Angle& chip_direction, double chip_distance_meters,
-                        unsigned int priority);
+                        const Angle& chip_direction, double chip_distance_meters);
 
     ChipIntent() = delete;
 };

--- a/src/software/ai/intent/chip_intent_test.cpp
+++ b/src/software/ai/intent/chip_intent_test.cpp
@@ -7,16 +7,8 @@
 // since Intents inherit from Primitives
 TEST(ChipIntentTest, test_equality_operator_intents_equal)
 {
-    ChipIntent chip_intent       = ChipIntent(0, Point(), Angle::zero(), 0, 0);
-    ChipIntent chip_intent_other = ChipIntent(0, Point(), Angle::zero(), 0, 0);
+    ChipIntent chip_intent       = ChipIntent(0, Point(), Angle::zero(), 0);
+    ChipIntent chip_intent_other = ChipIntent(0, Point(), Angle::zero(), 0);
 
     EXPECT_EQ(chip_intent, chip_intent_other);
-}
-
-TEST(ChipIntentTest, test_inequality_operator_with_mismatched_priorities)
-{
-    ChipIntent chip_intent       = ChipIntent(0, Point(), Angle::zero(), 0, 1);
-    ChipIntent chip_intent_other = ChipIntent(0, Point(), Angle::zero(), 0, 3);
-
-    EXPECT_NE(chip_intent, chip_intent_other);
 }

--- a/src/software/ai/intent/direct_primitive_intent.cpp
+++ b/src/software/ai/intent/direct_primitive_intent.cpp
@@ -2,9 +2,9 @@
 
 #include <google/protobuf/util/message_differencer.h>
 
-DirectPrimitiveIntent::DirectPrimitiveIntent(unsigned int robot_id, unsigned int priority,
+DirectPrimitiveIntent::DirectPrimitiveIntent(unsigned int robot_id,
                                              TbotsProto::Primitive primitive_msg)
-    : Intent(robot_id, priority), primitive_msg(primitive_msg)
+    : Intent(robot_id), primitive_msg(primitive_msg)
 {
 }
 

--- a/src/software/ai/intent/direct_primitive_intent.h
+++ b/src/software/ai/intent/direct_primitive_intent.h
@@ -13,11 +13,9 @@ class DirectPrimitiveIntent : public Intent
      * Creates a new DirectPrimitiveIntent
      *
      * @param robot_id The id of the Robot to run this Primitive
-     * @param priority The priority of this Intent. A larger number indicates a higher
-     * priority
      * @param the TbotsProto::Primitive directly underlying this Intent
      */
-    explicit DirectPrimitiveIntent(unsigned int robot_id, unsigned int priority,
+    explicit DirectPrimitiveIntent(unsigned int robot_id,
                                    TbotsProto::Primitive primitive_msg);
 
     DirectPrimitiveIntent() = delete;

--- a/src/software/ai/intent/intent.cpp
+++ b/src/software/ai/intent/intent.cpp
@@ -4,36 +4,16 @@
 
 #include "software/logger/logger.h"
 
-Intent::Intent(unsigned int robot_id, unsigned int priority)
-    : robot_id(robot_id), motion_constraints()
-{
-    setPriority(priority);
-}
-
-unsigned int Intent::getPriority(void) const
-{
-    return priority;
-}
+Intent::Intent(unsigned int robot_id) : robot_id(robot_id), motion_constraints() {}
 
 unsigned int Intent::getRobotId() const
 {
     return robot_id;
 }
 
-void Intent::setPriority(unsigned int new_priority)
-{
-    if (new_priority > 100)
-    {
-        LOG(WARNING) << "Intent set with out of range priority value: " << new_priority
-                     << ". Clamping to range [0, 100]" << std::endl;
-        new_priority = std::clamp<unsigned int>(new_priority, 0, 100);
-    }
-    priority = new_priority;
-}
-
 bool Intent::operator==(const Intent &other) const
 {
-    return this->priority == other.priority && this->robot_id == other.robot_id &&
+    return this->robot_id == other.robot_id &&
            motion_constraints == other.motion_constraints;
 }
 

--- a/src/software/ai/intent/intent.h
+++ b/src/software/ai/intent/intent.h
@@ -30,23 +30,13 @@ class Intent
 {
    public:
     /**
-     * Creates a new Intent with the given priority. A larger number indicates a higher
-     * priority. The priority value must be in the range [0, 100]
+     * Creates a new Intent
      *
      * @param robot_id The id of the Robot to run this Primitive
-     * @param priority The priority of this Intent
      */
-    explicit Intent(unsigned int robot_id, unsigned int priority);
+    explicit Intent(unsigned int robot_id);
 
     Intent() = delete;
-
-    /**
-     * Returns the priority of this Intent. The priority value is an integer in the range
-     * [0, 100] that indicates the priority of this Intent.
-     *
-     * @return the priority of this Intent
-     */
-    unsigned int getPriority(void) const;
 
     /**
      * Returns the ID of the robot that this Intent corresponds to
@@ -54,12 +44,6 @@ class Intent
      * @return The robot id
      */
     unsigned int getRobotId() const;
-
-    /**
-     * Sets the priority of this Intent. The priority value must be an integer in the
-     * range [0, 100]
-     */
-    void setPriority(unsigned int new_priority);
 
     /**
      * Compares Intents for equality. Intents are considered equal if all
@@ -108,12 +92,6 @@ class Intent
      * The id of the robot that this intent is meant to be run on
      */
     unsigned int robot_id;
-
-    /**
-     * The priority of this intent. Must be in the range [0, 100]
-     * higher value => higher priority
-     */
-    unsigned int priority;
 
     /**
      * The constraints on this intent's motion. These are enforced by the navigator

--- a/src/software/ai/intent/intent_test.cpp
+++ b/src/software/ai/intent/intent_test.cpp
@@ -10,37 +10,16 @@
  * the `Intent` class)
  */
 
-TEST(IntentTest, test_get_priority)
-{
-    StopIntent stop_intent = StopIntent(1, false, 2);
-    EXPECT_EQ(2, stop_intent.getPriority());
-}
-
-TEST(IntentTest, test_set_priority)
-{
-    StopIntent stop_intent = StopIntent(1, false, 2);
-    stop_intent.setPriority(7);
-    EXPECT_EQ(7, stop_intent.getPriority());
-}
-
 TEST(IntentTest, test_get_robot_id)
 {
-    StopIntent stop_intent = StopIntent(1, false, 2);
+    StopIntent stop_intent = StopIntent(1, false);
     EXPECT_EQ(stop_intent.getRobotId(), 1);
 }
 
 TEST(IntentTest, test_robot_id_inequality)
 {
-    StopIntent stop_intent_1 = StopIntent(0, false, 1);
-    StopIntent stop_intent_2 = StopIntent(1, false, 1);
-
-    EXPECT_NE(stop_intent_1, stop_intent_2);
-}
-
-TEST(IntentTest, test_priority_inequality)
-{
-    StopIntent stop_intent_1 = StopIntent(1, false, 2);
-    StopIntent stop_intent_2 = StopIntent(1, false, 1);
+    StopIntent stop_intent_1 = StopIntent(0, false);
+    StopIntent stop_intent_2 = StopIntent(1, false);
 
     EXPECT_NE(stop_intent_1, stop_intent_2);
 }

--- a/src/software/ai/intent/kick_intent.cpp
+++ b/src/software/ai/intent/kick_intent.cpp
@@ -1,10 +1,8 @@
 #include "software/ai/intent/kick_intent.h"
 
 KickIntent::KickIntent(unsigned int robot_id, const Point &kick_origin,
-                       const Angle &kick_direction, double kick_speed_meters_per_second,
-                       unsigned int priority)
-    : DirectPrimitiveIntent(
-          robot_id, priority,
-          *createKickPrimitive(kick_origin, kick_direction, kick_speed_meters_per_second))
+                       const Angle &kick_direction, double kick_speed_meters_per_second)
+    : DirectPrimitiveIntent(robot_id, *createKickPrimitive(kick_origin, kick_direction,
+                                                           kick_speed_meters_per_second))
 {
 }

--- a/src/software/ai/intent/kick_intent.h
+++ b/src/software/ai/intent/kick_intent.h
@@ -15,12 +15,9 @@ class KickIntent : public DirectPrimitiveIntent
      * @param final_angle The final angle the robot should have at the end of the movement
      * @param final_speed The final speed the robot should have when it arrives at its
      * destination
-     * @param priority The priority of this Intent. A larger number indicates a higher
-     * priority
      */
     explicit KickIntent(unsigned int robot_id, const Point& dest,
-                        const Angle& final_angle, double final_speed,
-                        unsigned int priority);
+                        const Angle& final_angle, double final_speed);
 
     KickIntent() = delete;
 };

--- a/src/software/ai/intent/kick_intent_test.cpp
+++ b/src/software/ai/intent/kick_intent_test.cpp
@@ -7,16 +7,8 @@
 // since Intents inherit from Primitives
 TEST(KickIntentTest, test_equality_operator_intents_equal)
 {
-    KickIntent kick_intent       = KickIntent(0, Point(), Angle::zero(), 0, 0);
-    KickIntent kick_intent_other = KickIntent(0, Point(), Angle::zero(), 0, 0);
+    KickIntent kick_intent       = KickIntent(0, Point(), Angle::zero(), 0);
+    KickIntent kick_intent_other = KickIntent(0, Point(), Angle::zero(), 0);
 
     EXPECT_EQ(kick_intent, kick_intent_other);
-}
-
-TEST(KickIntentTest, test_inequality_operator_with_mismatched_priorities)
-{
-    KickIntent kick_intent       = KickIntent(0, Point(), Angle::zero(), 0, 9);
-    KickIntent kick_intent_other = KickIntent(0, Point(), Angle::zero(), 0, 7);
-
-    EXPECT_NE(kick_intent, kick_intent_other);
 }

--- a/src/software/ai/intent/move_intent.cpp
+++ b/src/software/ai/intent/move_intent.cpp
@@ -2,10 +2,9 @@
 
 MoveIntent::MoveIntent(unsigned int robot_id, const Point &destination,
                        const Angle &final_angle, double final_speed,
-                       unsigned int priority, DribblerEnable enable_dribbler,
-                       MoveType move_type, AutochickType autokick,
-                       BallCollisionType ball_collision_type)
-    : NavigatingIntent(robot_id, priority, destination, final_speed, ball_collision_type),
+                       DribblerEnable enable_dribbler, MoveType move_type,
+                       AutochickType autokick, BallCollisionType ball_collision_type)
+    : NavigatingIntent(robot_id, destination, final_speed, ball_collision_type),
       final_angle(final_angle),
       enable_dribbler(enable_dribbler),
       move_type(move_type),

--- a/src/software/ai/intent/move_intent.h
+++ b/src/software/ai/intent/move_intent.h
@@ -13,8 +13,6 @@ class MoveIntent : public NavigatingIntent
      * @param final_angle The final angle the robot should have at the end of the movement
      * @param final_speed The final speed the robot should have when it arrives at its
      * destination
-     * @param priority The priority of this Intent. A larger number indicates a higher
-     * priority
      * @param enable_dribbler Whether or not to enable the dribbler
      * @param slow Whether or not to move slower (1 m/s)
      * @param autokick This will enable the "break-beam" on the robot, that will
@@ -24,9 +22,8 @@ class MoveIntent : public NavigatingIntent
      */
     explicit MoveIntent(unsigned int robot_id, const Point& destination,
                         const Angle& final_angle, double final_speed,
-                        unsigned int priority, DribblerEnable enable_dribbler,
-                        MoveType move_type, AutochickType autokick,
-                        BallCollisionType ball_collision_type);
+                        DribblerEnable enable_dribbler, MoveType move_type,
+                        AutochickType autokick, BallCollisionType ball_collision_type);
 
     MoveIntent() = delete;
 

--- a/src/software/ai/intent/move_intent_test.cpp
+++ b/src/software/ai/intent/move_intent_test.cpp
@@ -8,31 +8,19 @@
 TEST(MoveIntentTest, test_equality_operator_intents_equal)
 {
     MoveIntent move_intent =
-        MoveIntent(0, Point(), Angle::zero(), 0, 0, DribblerEnable::OFF, MoveType::NORMAL,
+        MoveIntent(0, Point(), Angle::zero(), 0, DribblerEnable::OFF, MoveType::NORMAL,
                    AutochickType::NONE, BallCollisionType::AVOID);
     MoveIntent move_intent_other =
-        MoveIntent(0, Point(), Angle::zero(), 0, 0, DribblerEnable::OFF, MoveType::NORMAL,
+        MoveIntent(0, Point(), Angle::zero(), 0, DribblerEnable::OFF, MoveType::NORMAL,
                    AutochickType::NONE, BallCollisionType::AVOID);
 
     EXPECT_EQ(move_intent, move_intent_other);
 }
 
-TEST(MoveIntentTest, test_inequality_operator_with_mismatched_priorities)
-{
-    MoveIntent move_intent =
-        MoveIntent(0, Point(), Angle::zero(), 0, 1, DribblerEnable::OFF, MoveType::NORMAL,
-                   AutochickType::NONE, BallCollisionType::AVOID);
-    MoveIntent move_intent_other =
-        MoveIntent(0, Point(), Angle::zero(), 0, 3, DribblerEnable::OFF, MoveType::NORMAL,
-                   AutochickType::NONE, BallCollisionType::AVOID);
-
-    EXPECT_NE(move_intent, move_intent_other);
-}
-
 TEST(MoveIntentTest, test_get_destination_ball_collision)
 {
     MoveIntent move_intent =
-        MoveIntent(0, Point(1, 2), Angle::quarter(), 2.3, 1, DribblerEnable::OFF,
+        MoveIntent(0, Point(1, 2), Angle::quarter(), 2.3, DribblerEnable::OFF,
                    MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID);
     EXPECT_EQ(move_intent.getDestination(), Point(1, 2));
     EXPECT_EQ(move_intent.getBallCollisionType(), BallCollisionType::AVOID);

--- a/src/software/ai/intent/navigating_intent.cpp
+++ b/src/software/ai/intent/navigating_intent.cpp
@@ -1,9 +1,9 @@
 #include "software/ai/intent/navigating_intent.h"
 
-NavigatingIntent::NavigatingIntent(unsigned int robot_id, unsigned int priority,
-                                   Point destination, double final_speed,
+NavigatingIntent::NavigatingIntent(unsigned int robot_id, Point destination,
+                                   double final_speed,
                                    BallCollisionType ball_collision_type)
-    : Intent(robot_id, priority),
+    : Intent(robot_id),
       destination(destination),
       final_speed(final_speed),
       ball_collision_type(ball_collision_type)

--- a/src/software/ai/intent/navigating_intent.h
+++ b/src/software/ai/intent/navigating_intent.h
@@ -10,19 +10,16 @@ class NavigatingIntent : public Intent
 {
    public:
     /**
-     * Creates a new Intent with the given priority. A larger number indicates a higher
-     * priority. The priority value must be in the range [0, 100]
+     * Creates a new Navigating Intent
      *
      * @param robot_id The id of the Robot to run this Primitive
-     * @param priority The priority of this Intent
      * @param destination The destination of the Movement
      * @param final_speed The final speed the robot should have when it arrives at its
      * destination
      * @param ball_collision_type how to navigate around the ball
      */
-    explicit NavigatingIntent(unsigned int robot_id, unsigned int priority,
-                              Point destination, double final_speed,
-                              BallCollisionType ball_collision_type);
+    explicit NavigatingIntent(unsigned int robot_id, Point destination,
+                              double final_speed, BallCollisionType ball_collision_type);
 
     NavigatingIntent() = delete;
 

--- a/src/software/ai/intent/spinning_move_intent.cpp
+++ b/src/software/ai/intent/spinning_move_intent.cpp
@@ -2,9 +2,8 @@
 
 SpinningMoveIntent::SpinningMoveIntent(unsigned int robot_id, const Point &dest,
                                        const AngularVelocity &angular_vel,
-                                       double final_speed, unsigned int priority)
-    : DirectPrimitiveIntent(
-          robot_id, priority,
-          *createSpinningMovePrimitive(dest, final_speed, false, angular_vel, 0))
+                                       double final_speed)
+    : DirectPrimitiveIntent(robot_id, *createSpinningMovePrimitive(dest, final_speed,
+                                                                   false, angular_vel, 0))
 {
 }

--- a/src/software/ai/intent/spinning_move_intent.h
+++ b/src/software/ai/intent/spinning_move_intent.h
@@ -13,12 +13,9 @@ class SpinningMoveIntent : public DirectPrimitiveIntent
      * @param angular_vel The angular velocity of the robot
      * of the movement
      * @param final_speed The speed at final destination
-     * @param priority The priority of this Intent. A larger number indicates a higher
-     * priority
      */
     explicit SpinningMoveIntent(unsigned int robot_id, const Point& dest,
-                                const AngularVelocity& angular_vel, double final_speed,
-                                unsigned int priority);
+                                const AngularVelocity& angular_vel, double final_speed);
 
     SpinningMoveIntent() = delete;
 };

--- a/src/software/ai/intent/spinning_move_intent_test.cpp
+++ b/src/software/ai/intent/spinning_move_intent_test.cpp
@@ -8,19 +8,9 @@
 TEST(SpinningMoveIntentTest, test_equality_operator_intents_equal)
 {
     SpinningMoveIntent spinning_move_intent =
-        SpinningMoveIntent(0, Point(), Angle::zero(), 1.0, 0);
+        SpinningMoveIntent(0, Point(), Angle::zero(), 1.0);
     SpinningMoveIntent spinning_move_intent_other =
-        SpinningMoveIntent(0, Point(), Angle::zero(), 1.0, 0);
+        SpinningMoveIntent(0, Point(), Angle::zero(), 1.0);
 
     EXPECT_EQ(spinning_move_intent, spinning_move_intent_other);
-}
-
-TEST(SpinningMoveIntentTest, test_inequality_operator_with_mismatched_priorities)
-{
-    SpinningMoveIntent spinning_move_intent =
-        SpinningMoveIntent(0, Point(), Angle::zero(), 1.0, 1);
-    SpinningMoveIntent spinning_move_intent_other =
-        SpinningMoveIntent(0, Point(), Angle::zero(), 1.0, 3);
-
-    EXPECT_NE(spinning_move_intent, spinning_move_intent_other);
 }

--- a/src/software/ai/intent/stop_intent.cpp
+++ b/src/software/ai/intent/stop_intent.cpp
@@ -1,6 +1,6 @@
 #include "software/ai/intent/stop_intent.h"
 
-StopIntent::StopIntent(unsigned int robot_id, bool coast, unsigned int priority)
-    : DirectPrimitiveIntent(robot_id, priority, *createStopPrimitive(coast))
+StopIntent::StopIntent(unsigned int robot_id, bool coast)
+    : DirectPrimitiveIntent(robot_id, *createStopPrimitive(coast))
 {
 }

--- a/src/software/ai/intent/stop_intent.h
+++ b/src/software/ai/intent/stop_intent.h
@@ -12,10 +12,8 @@ class StopIntent : public DirectPrimitiveIntent
      *
      * @param robot_id The id of the Robot to run this Primitive
      * @param coast to coast to a stop or not
-     * @param priority The priority of this Intent. A larger number indicates a higher
-     * priority
      */
-    explicit StopIntent(unsigned int robot_id, bool coast, unsigned int priority);
+    explicit StopIntent(unsigned int robot_id, bool coast);
 
     StopIntent() = delete;
 };

--- a/src/software/ai/intent/stop_intent_test.cpp
+++ b/src/software/ai/intent/stop_intent_test.cpp
@@ -7,16 +7,8 @@
 // since Intents inherit from Primitives
 TEST(StopIntentTest, test_equality_operator_intents_equal)
 {
-    StopIntent stop_intent       = StopIntent(0, false, 0);
-    StopIntent stop_intent_other = StopIntent(0, false, 0);
+    StopIntent stop_intent       = StopIntent(0, false);
+    StopIntent stop_intent_other = StopIntent(0, false);
 
     EXPECT_EQ(stop_intent, stop_intent_other);
-}
-
-TEST(StopIntentTest, test_inequality_operator_with_mismatched_priorities)
-{
-    StopIntent stop_intent       = StopIntent(0, false, 1);
-    StopIntent stop_intent_other = StopIntent(0, false, 3);
-
-    EXPECT_NE(stop_intent, stop_intent_other);
 }

--- a/src/software/ai/navigator/navigator_test.cpp
+++ b/src/software/ai/navigator/navigator_test.cpp
@@ -67,8 +67,7 @@ TEST_F(ThetaStarNavigatorTest, convert_chip_intent_to_chip_primitive)
     World world = ::TestUtil::createBlankTestingWorld();
 
     std::vector<std::unique_ptr<Intent>> intents;
-    intents.emplace_back(
-        std::make_unique<ChipIntent>(0, Point(), Angle::quarter(), 0, 1));
+    intents.emplace_back(std::make_unique<ChipIntent>(0, Point(), Angle::quarter(), 0));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);
 
@@ -85,8 +84,7 @@ TEST_F(ThetaStarNavigatorTest, convert_kick_intent_to_kick_primitive)
     World world = ::TestUtil::createBlankTestingWorld();
 
     std::vector<std::unique_ptr<Intent>> intents;
-    intents.emplace_back(
-        std::make_unique<KickIntent>(0, Point(), Angle::quarter(), 0, 1));
+    intents.emplace_back(std::make_unique<KickIntent>(0, Point(), Angle::quarter(), 0));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);
 
@@ -104,7 +102,7 @@ TEST_F(ThetaStarNavigatorTest, convert_spinning_move_intent_to_spinning_move_pri
 
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(
-        std::make_unique<SpinningMoveIntent>(0, Point(), AngularVelocity::full(), 1, 0));
+        std::make_unique<SpinningMoveIntent>(0, Point(), AngularVelocity::full(), 1));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);
 
@@ -122,7 +120,7 @@ TEST_F(ThetaStarNavigatorTest, convert_stop_intent_to_stop_primitive)
     World world = ::TestUtil::createBlankTestingWorld();
 
     std::vector<std::unique_ptr<Intent>> intents;
-    intents.emplace_back(std::make_unique<StopIntent>(0, false, 1));
+    intents.emplace_back(std::make_unique<StopIntent>(0, false));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);
 
@@ -139,8 +137,8 @@ TEST_F(ThetaStarNavigatorTest, convert_multiple_intents_to_primitives)
     World world = ::TestUtil::createBlankTestingWorld();
 
     std::vector<std::unique_ptr<Intent>> intents;
-    intents.emplace_back(std::make_unique<StopIntent>(0, false, 1));
-    intents.emplace_back(std::make_unique<StopIntent>(1, false, 1));
+    intents.emplace_back(std::make_unique<StopIntent>(0, false));
+    intents.emplace_back(std::make_unique<StopIntent>(1, false));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);
 
@@ -201,7 +199,7 @@ TEST(NavigatorTest, move_intent_with_one_point_path_test_path_planner)
 
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(std::make_unique<MoveIntent>(
-        0, poi, Angle::zero(), 0, 0, DribblerEnable::OFF, MoveType::NORMAL,
+        0, poi, Angle::zero(), 0, DribblerEnable::OFF, MoveType::NORMAL,
         AutochickType::NONE, BallCollisionType::AVOID));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);
@@ -241,7 +239,7 @@ TEST_F(NoPathNavigatorTest, move_intent_with_no_path_test_path_planner)
 
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(std::make_unique<MoveIntent>(
-        0, Point(), Angle::zero(), 0, 0, DribblerEnable::OFF, MoveType::NORMAL,
+        0, Point(), Angle::zero(), 0, DribblerEnable::OFF, MoveType::NORMAL,
         AutochickType::NONE, BallCollisionType::AVOID));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Priority isn't used by the Navigator. Instead, the order of the intents determines priority, which come from tactics. 
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
regression tests
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
