### PR TITLE
Added dribbler modes and removed slow from move primitives

### DIFF
--- a/src/firmware/app/primitives/move_helper.c
+++ b/src/firmware/app/primitives/move_helper.c
@@ -33,7 +33,6 @@ typedef struct MoveHelperState
     // We store a wheel index here so we only have to calculate the axis
     // we want to use when move start is called
     unsigned optimal_wheel_axes_index;
-    bool slow;
 } MoveHelperState_t;
 DEFINE_PRIMITIVE_STATE_CREATE_AND_DESTROY_FUNCTIONS(MoveHelperState_t)
 
@@ -161,7 +160,6 @@ void app_move_helper_start(void* void_state_ptr, FirmwareWorld_t* world,
     state->destination[1] = move_position_params.destination.y_meters;
     state->destination[2] = final_angle;
     state->end_speed      = move_position_params.final_speed_meters_per_second;
-    state->slow           = move_position_params.slow;
 
     const FirmwareRobot_t* robot = app_firmware_world_getRobot(world);
 
@@ -199,7 +197,7 @@ void app_move_helper_tick(void* void_state_ptr, FirmwareWorld_t* world)
 
     // plan major axis movement
     float max_major_a     = 3.5;
-    float max_major_v     = state->slow ? 1.25 : 3.0;
+    float max_major_v     = 3.0;
     float major_params[3] = {state->end_speed, max_major_a, max_major_v};
     app_physbot_planMove(&pb.maj, major_params);
 

--- a/src/firmware/app/primitives/spinning_move_primitive.c
+++ b/src/firmware/app/primitives/spinning_move_primitive.c
@@ -15,7 +15,6 @@ typedef struct SpinningMovePrimitiveState
     float y_final;
     float avel_final;
     float end_speed;
-    bool slow;
 
     float major_vec[2];
     float minor_vec[2];
@@ -38,7 +37,6 @@ void app_spinning_move_primitive_start(TbotsProto_SpinningMovePrimitive prim_msg
     state->y_final    = prim_msg.position_params.destination.y_meters;
     state->avel_final = prim_msg.angular_velocity.radians_per_second;
     state->end_speed  = prim_msg.position_params.final_speed_meters_per_second;
-    state->slow       = prim_msg.position_params.slow;
 
     const FirmwareRobot_t *robot = app_firmware_world_getRobot(world);
 

--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -66,8 +66,9 @@ const double SECONDS_PER_MICROSECOND      = 1.0 / 1000000.0;
 const double SECONDS_PER_MILLISECOND      = 1.0 / 1000.0;
 const double MILLISECONDS_PER_MICROSECOND = 1.0 / 1000.0;
 
-// Converts dribbler RPM to a smaller number firmware uses
-const double DRIBBLER_RPM_TO_RADIO_CONVERSION_FACTOR = 1.0 / 300.0;
+// Dribbler speed in indefinite and max force modes
+const double INDEFINITE_DRIBBLER_SPEED = 1000.0;
+const double MAX_FORCE_DRIBBLER_SPEED  = 16000.0;
 
 const double POSSESSION_TIMESTAMP_TOLERANCE_IN_MILLISECONDS = 10;
 

--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -66,9 +66,11 @@ const double SECONDS_PER_MICROSECOND      = 1.0 / 1000000.0;
 const double SECONDS_PER_MILLISECOND      = 1.0 / 1000.0;
 const double MILLISECONDS_PER_MICROSECOND = 1.0 / 1000.0;
 
-// Dribbler speed in indefinite and max force modes
+// Indefinite dribbler mode sets a speed that can be maintained indefinitely
 const double INDEFINITE_DRIBBLER_SPEED = 1000.0;
-const double MAX_FORCE_DRIBBLER_SPEED  = 16000.0;
+// Max force dribbler mode sets the speed that applies the maximum amount of force on the
+// ball
+const double MAX_FORCE_DRIBBLER_SPEED = 16000.0;
 
 const double POSSESSION_TIMESTAMP_TOLERANCE_IN_MILLISECONDS = 10;
 

--- a/src/shared/proto/primitive.proto
+++ b/src/shared/proto/primitive.proto
@@ -119,5 +119,4 @@ message MovePositionParams
 {
     Point destination                   = 1;
     float final_speed_meters_per_second = 2;
-    bool slow                           = 3;
 }

--- a/src/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/software/ai/hl/stp/action/chip_action.cpp
@@ -121,7 +121,7 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         if (!robot_behind_ball)
         {
             yield(std::make_unique<MoveIntent>(
-                robot->id(), point_behind_ball, chip_direction, 0.0, DribblerEnable::OFF,
+                robot->id(), point_behind_ball, chip_direction, 0.0, DribblerMode::OFF,
                 MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW));
         }
         else

--- a/src/software/ai/hl/stp/action/chip_action.cpp
+++ b/src/software/ai/hl/stp/action/chip_action.cpp
@@ -122,7 +122,7 @@ void ChipAction::calculateNextIntent(IntentCoroutine::push_type& yield)
         {
             yield(std::make_unique<MoveIntent>(
                 robot->id(), point_behind_ball, chip_direction, 0.0, DribblerMode::OFF,
-                MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW));
+                AutochickType::NONE, BallCollisionType::ALLOW));
         }
         else
         {

--- a/src/software/ai/hl/stp/action/intercept_ball_action.cpp
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.cpp
@@ -44,7 +44,7 @@ void InterceptBallAction::interceptSlowBall(IntentCoroutine::push_type& yield)
         auto face_ball_orientation = (ball.position() - robot->position()).orientation();
         yield(std::make_unique<MoveIntent>(
             robot->id(), ball.position(), face_ball_orientation, 0,
-            DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::ALLOW));
+            DribblerMode::MAX_FORCE, AutochickType::NONE, BallCollisionType::ALLOW));
 
         // Restart the action if the ball's speed has sped up substantially.
         // The extra factor of 2 is to prevent being overly sensitive to restarts
@@ -84,7 +84,7 @@ void InterceptBallAction::interceptSlowBall(IntentCoroutine::push_type& yield)
 
         yield(std::make_unique<MoveIntent>(
             robot->id(), robot->position(), face_ball_orientation, 0,
-            DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::ALLOW));
+            DribblerMode::MAX_FORCE, AutochickType::NONE, BallCollisionType::ALLOW));
     } while (robot->velocity().length() > ROBOT_STOPPED_SPEED_M_PER_S);
 }
 
@@ -114,7 +114,7 @@ void InterceptBallAction::interceptFastBall(IntentCoroutine::push_type& yield)
     {
         yield(std::make_unique<MoveIntent>(
             robot->id(), intercept_position, (-ball.velocity()).orientation(), 0,
-            DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::AVOID));
+            DribblerMode::MAX_FORCE, AutochickType::NONE, BallCollisionType::AVOID));
 
         // Restart the action if the ball's speed has slowed down substantially.
         // The extra factor of 2 is to prevent being overly sensitive to restarts
@@ -140,7 +140,7 @@ void InterceptBallAction::interceptFastBall(IntentCoroutine::push_type& yield)
     {
         yield(std::make_unique<MoveIntent>(
             robot->id(), intercept_position, (-ball.velocity()).orientation(), 0,
-            DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::ALLOW));
+            DribblerMode::MAX_FORCE, AutochickType::NONE, BallCollisionType::ALLOW));
 
         if (!intercept_done &&
             ball.velocity().length() < BALL_MOVING_SLOW_SPEED_THRESHOLD / 2.0)

--- a/src/software/ai/hl/stp/action/intercept_ball_action.cpp
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.cpp
@@ -43,8 +43,8 @@ void InterceptBallAction::interceptSlowBall(IntentCoroutine::push_type& yield)
     {
         auto face_ball_orientation = (ball.position() - robot->position()).orientation();
         yield(std::make_unique<MoveIntent>(
-            robot->id(), ball.position(), face_ball_orientation, 0, DribblerMode::INDEFINITE,
-            MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW));
+            robot->id(), ball.position(), face_ball_orientation, 0,
+            DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::ALLOW));
 
         // Restart the action if the ball's speed has sped up substantially.
         // The extra factor of 2 is to prevent being overly sensitive to restarts
@@ -83,8 +83,8 @@ void InterceptBallAction::interceptSlowBall(IntentCoroutine::push_type& yield)
         auto face_ball_orientation = (ball.position() - robot->position()).orientation();
 
         yield(std::make_unique<MoveIntent>(
-            robot->id(), robot->position(), face_ball_orientation, 0, DribblerMode::INDEFINITE,
-            MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW));
+            robot->id(), robot->position(), face_ball_orientation, 0,
+            DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::ALLOW));
     } while (robot->velocity().length() > ROBOT_STOPPED_SPEED_M_PER_S);
 }
 
@@ -114,8 +114,7 @@ void InterceptBallAction::interceptFastBall(IntentCoroutine::push_type& yield)
     {
         yield(std::make_unique<MoveIntent>(
             robot->id(), intercept_position, (-ball.velocity()).orientation(), 0,
-            DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::NONE,
-            BallCollisionType::AVOID));
+            DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::AVOID));
 
         // Restart the action if the ball's speed has slowed down substantially.
         // The extra factor of 2 is to prevent being overly sensitive to restarts
@@ -141,8 +140,7 @@ void InterceptBallAction::interceptFastBall(IntentCoroutine::push_type& yield)
     {
         yield(std::make_unique<MoveIntent>(
             robot->id(), intercept_position, (-ball.velocity()).orientation(), 0,
-            DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::NONE,
-            BallCollisionType::ALLOW));
+            DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::ALLOW));
 
         if (!intercept_done &&
             ball.velocity().length() < BALL_MOVING_SLOW_SPEED_THRESHOLD / 2.0)

--- a/src/software/ai/hl/stp/action/intercept_ball_action.cpp
+++ b/src/software/ai/hl/stp/action/intercept_ball_action.cpp
@@ -43,7 +43,7 @@ void InterceptBallAction::interceptSlowBall(IntentCoroutine::push_type& yield)
     {
         auto face_ball_orientation = (ball.position() - robot->position()).orientation();
         yield(std::make_unique<MoveIntent>(
-            robot->id(), ball.position(), face_ball_orientation, 0, DribblerEnable::ON,
+            robot->id(), ball.position(), face_ball_orientation, 0, DribblerMode::INDEFINITE,
             MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW));
 
         // Restart the action if the ball's speed has sped up substantially.
@@ -83,7 +83,7 @@ void InterceptBallAction::interceptSlowBall(IntentCoroutine::push_type& yield)
         auto face_ball_orientation = (ball.position() - robot->position()).orientation();
 
         yield(std::make_unique<MoveIntent>(
-            robot->id(), robot->position(), face_ball_orientation, 0, DribblerEnable::ON,
+            robot->id(), robot->position(), face_ball_orientation, 0, DribblerMode::INDEFINITE,
             MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW));
     } while (robot->velocity().length() > ROBOT_STOPPED_SPEED_M_PER_S);
 }
@@ -114,7 +114,7 @@ void InterceptBallAction::interceptFastBall(IntentCoroutine::push_type& yield)
     {
         yield(std::make_unique<MoveIntent>(
             robot->id(), intercept_position, (-ball.velocity()).orientation(), 0,
-            DribblerEnable::ON, MoveType::NORMAL, AutochickType::NONE,
+            DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::NONE,
             BallCollisionType::AVOID));
 
         // Restart the action if the ball's speed has slowed down substantially.
@@ -141,7 +141,7 @@ void InterceptBallAction::interceptFastBall(IntentCoroutine::push_type& yield)
     {
         yield(std::make_unique<MoveIntent>(
             robot->id(), intercept_position, (-ball.velocity()).orientation(), 0,
-            DribblerEnable::ON, MoveType::NORMAL, AutochickType::NONE,
+            DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::NONE,
             BallCollisionType::ALLOW));
 
         if (!intercept_done &&

--- a/src/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/software/ai/hl/stp/action/kick_action.cpp
@@ -117,7 +117,7 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
         if (!robot_behind_ball)
         {
             yield(std::make_unique<MoveIntent>(
-                robot->id(), point_behind_ball, kick_direction, 0.0, DribblerEnable::OFF,
+                robot->id(), point_behind_ball, kick_direction, 0.0, DribblerMode::OFF,
                 MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID));
         }
         else

--- a/src/software/ai/hl/stp/action/kick_action.cpp
+++ b/src/software/ai/hl/stp/action/kick_action.cpp
@@ -118,7 +118,7 @@ void KickAction::calculateNextIntent(IntentCoroutine::push_type &yield)
         {
             yield(std::make_unique<MoveIntent>(
                 robot->id(), point_behind_ball, kick_direction, 0.0, DribblerMode::OFF,
-                MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID));
+                AutochickType::NONE, BallCollisionType::AVOID));
         }
         else
         {

--- a/src/software/ai/hl/stp/action/move_action.cpp
+++ b/src/software/ai/hl/stp/action/move_action.cpp
@@ -48,7 +48,7 @@ AutochickType MoveAction::getAutochickType()
     return autokick_type;
 }
 
-DribblerMode MoveAction::getDribblerModed()
+DribblerMode MoveAction::getDribblerMode()
 {
     return dribbler_mode;
 }

--- a/src/software/ai/hl/stp/action/move_action.cpp
+++ b/src/software/ai/hl/stp/action/move_action.cpp
@@ -7,7 +7,6 @@ MoveAction::MoveAction(bool loop_forever, double close_to_dest_threshold,
       final_orientation(Angle::zero()),
       final_speed(0.0),
       dribbler_mode(DribblerMode::OFF),
-      move_type(MoveType::NORMAL),
       autokick_type(AutochickType::NONE),
       ball_collision_type(BallCollisionType::AVOID),
       close_to_dest_threshold(close_to_dest_threshold),
@@ -17,16 +16,14 @@ MoveAction::MoveAction(bool loop_forever, double close_to_dest_threshold,
 
 void MoveAction::updateControlParams(const Robot& robot, Point destination,
                                      Angle final_orientation, double final_speed,
-                                     DribblerMode dribbler_mode, MoveType move_type,
-                                     AutochickType autokick,
+                                     DribblerMode dribbler_mode, AutochickType autokick,
                                      BallCollisionType ball_collision_type)
 {
     this->robot               = robot;
     this->destination         = destination;
     this->final_orientation   = final_orientation;
     this->final_speed         = final_speed;
-    this->dribbler_mode     = dribbler_mode;
-    this->move_type           = move_type;
+    this->dribbler_mode       = dribbler_mode;
     this->autokick_type       = autokick;
     this->ball_collision_type = ball_collision_type;
 }
@@ -71,8 +68,8 @@ void MoveAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<MoveIntent>(robot->id(), destination, final_orientation,
-                                           final_speed, dribbler_mode, move_type,
-                                           autokick_type, ball_collision_type));
+                                           final_speed, dribbler_mode, autokick_type,
+                                           ball_collision_type));
     } while ((robot->position() - destination).length() > close_to_dest_threshold ||
              (robot->orientation().minDiff(final_orientation) >
               close_to_orientation_threshold));

--- a/src/software/ai/hl/stp/action/move_action.cpp
+++ b/src/software/ai/hl/stp/action/move_action.cpp
@@ -6,7 +6,7 @@ MoveAction::MoveAction(bool loop_forever, double close_to_dest_threshold,
       destination(0, 0),
       final_orientation(Angle::zero()),
       final_speed(0.0),
-      enable_dribbler(DribblerEnable::OFF),
+      dribbler_mode(DribblerMode::OFF),
       move_type(MoveType::NORMAL),
       autokick_type(AutochickType::NONE),
       ball_collision_type(BallCollisionType::AVOID),
@@ -17,7 +17,7 @@ MoveAction::MoveAction(bool loop_forever, double close_to_dest_threshold,
 
 void MoveAction::updateControlParams(const Robot& robot, Point destination,
                                      Angle final_orientation, double final_speed,
-                                     DribblerEnable enable_dribbler, MoveType move_type,
+                                     DribblerMode dribbler_mode, MoveType move_type,
                                      AutochickType autokick,
                                      BallCollisionType ball_collision_type)
 {
@@ -25,7 +25,7 @@ void MoveAction::updateControlParams(const Robot& robot, Point destination,
     this->destination         = destination;
     this->final_orientation   = final_orientation;
     this->final_speed         = final_speed;
-    this->enable_dribbler     = enable_dribbler;
+    this->dribbler_mode     = dribbler_mode;
     this->move_type           = move_type;
     this->autokick_type       = autokick;
     this->ball_collision_type = ball_collision_type;
@@ -51,9 +51,9 @@ AutochickType MoveAction::getAutochickType()
     return autokick_type;
 }
 
-DribblerEnable MoveAction::getDribblerEnabled()
+DribblerMode MoveAction::getDribblerModed()
 {
-    return enable_dribbler;
+    return dribbler_mode;
 }
 
 void MoveAction::accept(MutableActionVisitor& visitor)
@@ -71,7 +71,7 @@ void MoveAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<MoveIntent>(robot->id(), destination, final_orientation,
-                                           final_speed, enable_dribbler, move_type,
+                                           final_speed, dribbler_mode, move_type,
                                            autokick_type, ball_collision_type));
     } while ((robot->position() - destination).length() > close_to_dest_threshold ||
              (robot->orientation().minDiff(final_orientation) >

--- a/src/software/ai/hl/stp/action/move_action.h
+++ b/src/software/ai/hl/stp/action/move_action.h
@@ -36,7 +36,6 @@ class MoveAction : public Action
      * the destination
      * @param final_speed The final speed the robot should have at the destination
      * @param dribbler_mode The dribbler mode
-     * @param slow Whether or not to move slow
      * @param autokick This will enable the "break-beam" on the robot, that will
      * trigger the kicker or chippper to fire as soon as the ball is in front of it
      * @param ball_collision_type how to navigate around the ball

--- a/src/software/ai/hl/stp/action/move_action.h
+++ b/src/software/ai/hl/stp/action/move_action.h
@@ -35,7 +35,7 @@ class MoveAction : public Action
      * @param final_orientation The final orientation the robot should have at
      * the destination
      * @param final_speed The final speed the robot should have at the destination
-     * @param enable_dribbler Whether or not to enable the dribbler
+     * @param dribbler_mode Whether or not to enable the dribbler
      * @param slow Whether or not to move slow
      * @param autokick This will enable the "break-beam" on the robot, that will
      * trigger the kicker or chippper to fire as soon as the ball is in front of it
@@ -43,7 +43,7 @@ class MoveAction : public Action
      */
     void updateControlParams(const Robot& robot, Point destination,
                              Angle final_orientation, double final_speed,
-                             DribblerEnable enable_dribbler, MoveType move_type,
+                             DribblerMode dribbler_mode, MoveType move_type,
                              AutochickType autokick,
                              BallCollisionType ball_collision_type);
 
@@ -82,7 +82,7 @@ class MoveAction : public Action
      *
      * @return the dribbler mode this move action should operate with
      */
-    DribblerEnable getDribblerEnabled();
+    DribblerMode getDribblerModed();
 
     void accept(MutableActionVisitor& visitor) override;
 
@@ -93,7 +93,7 @@ class MoveAction : public Action
     Point destination;
     Angle final_orientation;
     double final_speed;
-    DribblerEnable enable_dribbler;
+    DribblerMode dribbler_mode;
     MoveType move_type;
     AutochickType autokick_type;
     BallCollisionType ball_collision_type;

--- a/src/software/ai/hl/stp/action/move_action.h
+++ b/src/software/ai/hl/stp/action/move_action.h
@@ -80,7 +80,7 @@ class MoveAction : public Action
      *
      * @return the dribbler mode this move action should operate with
      */
-    DribblerMode getDribblerModed();
+    DribblerMode getDribblerMode();
 
     void accept(MutableActionVisitor& visitor) override;
 

--- a/src/software/ai/hl/stp/action/move_action.h
+++ b/src/software/ai/hl/stp/action/move_action.h
@@ -35,7 +35,7 @@ class MoveAction : public Action
      * @param final_orientation The final orientation the robot should have at
      * the destination
      * @param final_speed The final speed the robot should have at the destination
-     * @param dribbler_mode Whether or not to enable the dribbler
+     * @param dribbler_mode The dribbler mode
      * @param slow Whether or not to move slow
      * @param autokick This will enable the "break-beam" on the robot, that will
      * trigger the kicker or chippper to fire as soon as the ball is in front of it
@@ -43,8 +43,7 @@ class MoveAction : public Action
      */
     void updateControlParams(const Robot& robot, Point destination,
                              Angle final_orientation, double final_speed,
-                             DribblerMode dribbler_mode, MoveType move_type,
-                             AutochickType autokick,
+                             DribblerMode dribbler_mode, AutochickType autokick,
                              BallCollisionType ball_collision_type);
 
     /**
@@ -94,7 +93,6 @@ class MoveAction : public Action
     Angle final_orientation;
     double final_speed;
     DribblerMode dribbler_mode;
-    MoveType move_type;
     AutochickType autokick_type;
     BallCollisionType ball_collision_type;
 

--- a/src/software/ai/hl/stp/action/move_action_test.cpp
+++ b/src/software/ai/hl/stp/action/move_action_test.cpp
@@ -11,7 +11,7 @@ TEST(MoveActionTest, getDestination)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(11, 12), Angle::quarter(), 1.0,
-                               DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
     EXPECT_EQ(Point(11, 12), action.getDestination());
@@ -24,7 +24,7 @@ TEST(MoveActionTest, getFinalOrientation)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
     EXPECT_EQ(Angle::quarter(), action.getFinalOrientation());
@@ -37,7 +37,7 @@ TEST(MoveActionTest, getFinalSpeed)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
     EXPECT_EQ(99, action.getFinalSpeed());
@@ -50,35 +50,35 @@ TEST(MoveActionTest, getAutochickType)
     MoveAction action = MoveAction(false);
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
     EXPECT_EQ(AutochickType::NONE, action.getAutochickType());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerEnable::OFF, MoveType::NORMAL,
+                               DribblerMode::OFF, MoveType::NORMAL,
                                AutochickType::AUTOCHIP, BallCollisionType::AVOID);
 
     EXPECT_EQ(AutochickType::AUTOCHIP, action.getAutochickType());
 }
 
-TEST(MoveActionTest, getDribblerEnabled)
+TEST(MoveActionTest, getDribblerModed)
 {
     Robot robot       = Robot(13, Point(1, 2), Vector(3, 4), Angle::fromDegrees(5),
                         AngularVelocity::fromDegrees(6), Timestamp::fromSeconds(7));
     MoveAction action = MoveAction(false);
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
-    EXPECT_EQ(DribblerEnable::OFF, action.getDribblerEnabled());
+    EXPECT_EQ(DribblerMode::OFF, action.getDribblerModed());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerEnable::ON, MoveType::NORMAL,
+                               DribblerMode::INDEFINITE, MoveType::NORMAL,
                                AutochickType::AUTOCHIP, BallCollisionType::AVOID);
 
-    EXPECT_EQ(DribblerEnable::ON, action.getDribblerEnabled());
+    EXPECT_EQ(DribblerMode::INDEFINITE, action.getDribblerModed());
 }
 
 TEST(MoveActionTest, robot_far_from_destination)
@@ -88,7 +88,7 @@ TEST(MoveActionTest, robot_far_from_destination)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
     auto intent_ptr = action.getNextIntent();
 
@@ -101,7 +101,7 @@ TEST(MoveActionTest, robot_far_from_destination)
     EXPECT_EQ(Point(1, 0), move_intent.getDestination());
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
-    EXPECT_FALSE(move_intent.getDribblerEnable() == DribblerEnable::ON);
+    EXPECT_FALSE(move_intent.getDribblerMode() == DribblerMode::INDEFINITE);
     EXPECT_EQ(move_intent.getAutochickType(), AutochickType::NONE);
 }
 
@@ -115,7 +115,7 @@ TEST(MoveActionTest, robot_at_destination)
     // ensure the Robot is doing the right thing. In all future calls, the action will be
     // done and so will return a null pointer
     action.updateControlParams(robot, Point(0, 0), Angle::zero(), 0.0,
-                               DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
     action.getNextIntent();
     action.getNextIntent();
@@ -131,7 +131,7 @@ TEST(MoveActionTest, test_action_does_not_prematurely_report_done)
 
     // Run the Action several times
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
     for (int i = 0; i < 10; i++)
     {
@@ -152,7 +152,7 @@ TEST(MoveActionTest, test_action_does_not_prematurely_report_done_angle_threshol
 
     // Run the Action several times
     action.updateControlParams(robot, Point(0, 0), Angle::quarter(), 1.0,
-                               DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
     for (int i = 0; i < 10; i++)
     {
@@ -172,7 +172,7 @@ TEST(MoveActionTest, test_action_finishes_within_orientation_threshold)
 
     // Run the Action several times
     action.updateControlParams(robot, Point(0, 0), Angle::quarter(), 1.0,
-                               DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
     for (int i = 0; i < 10; i++)
     {
@@ -192,7 +192,7 @@ TEST(MoveActionTest, robot_far_from_destination_autokick_turned_on)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerEnable::OFF, MoveType::NORMAL,
+                               DribblerMode::OFF, MoveType::NORMAL,
                                AutochickType::AUTOKICK, BallCollisionType::AVOID);
     auto intent_ptr = action.getNextIntent();
 
@@ -205,7 +205,7 @@ TEST(MoveActionTest, robot_far_from_destination_autokick_turned_on)
     EXPECT_EQ(Point(1, 0), move_intent.getDestination());
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
-    EXPECT_EQ(move_intent.getDribblerEnable(), DribblerEnable::OFF);
+    EXPECT_EQ(move_intent.getDribblerMode(), DribblerMode::OFF);
     EXPECT_EQ(move_intent.getAutochickType(), AutochickType::AUTOKICK);
 }
 
@@ -216,7 +216,7 @@ TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerEnable::ON, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::NONE,
                                BallCollisionType::AVOID);
     auto intent_ptr = action.getNextIntent();
 
@@ -229,6 +229,6 @@ TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
     EXPECT_EQ(Point(1, 0), move_intent.getDestination());
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
-    EXPECT_TRUE(move_intent.getDribblerEnable() == DribblerEnable::ON);
+    EXPECT_TRUE(move_intent.getDribblerMode() == DribblerMode::INDEFINITE);
     EXPECT_EQ(move_intent.getAutochickType(), AutochickType::NONE);
 }

--- a/src/software/ai/hl/stp/action/move_action_test.cpp
+++ b/src/software/ai/hl/stp/action/move_action_test.cpp
@@ -11,7 +11,7 @@ TEST(MoveActionTest, getDestination)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(11, 12), Angle::quarter(), 1.0,
-                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
     EXPECT_EQ(Point(11, 12), action.getDestination());
@@ -24,7 +24,7 @@ TEST(MoveActionTest, getFinalOrientation)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
     EXPECT_EQ(Angle::quarter(), action.getFinalOrientation());
@@ -37,7 +37,7 @@ TEST(MoveActionTest, getFinalSpeed)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
     EXPECT_EQ(99, action.getFinalSpeed());
@@ -50,14 +50,14 @@ TEST(MoveActionTest, getAutochickType)
     MoveAction action = MoveAction(false);
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
     EXPECT_EQ(AutochickType::NONE, action.getAutochickType());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerMode::OFF, MoveType::NORMAL,
-                               AutochickType::AUTOCHIP, BallCollisionType::AVOID);
+                               DribblerMode::OFF, AutochickType::AUTOCHIP,
+                               BallCollisionType::AVOID);
 
     EXPECT_EQ(AutochickType::AUTOCHIP, action.getAutochickType());
 }
@@ -69,14 +69,14 @@ TEST(MoveActionTest, getDribblerModed)
     MoveAction action = MoveAction(false);
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
     EXPECT_EQ(DribblerMode::OFF, action.getDribblerModed());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerMode::INDEFINITE, MoveType::NORMAL,
-                               AutochickType::AUTOCHIP, BallCollisionType::AVOID);
+                               DribblerMode::INDEFINITE, AutochickType::AUTOCHIP,
+                               BallCollisionType::AVOID);
 
     EXPECT_EQ(DribblerMode::INDEFINITE, action.getDribblerModed());
 }
@@ -88,7 +88,7 @@ TEST(MoveActionTest, robot_far_from_destination)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, AutochickType::NONE,
                                BallCollisionType::AVOID);
     auto intent_ptr = action.getNextIntent();
 
@@ -114,9 +114,8 @@ TEST(MoveActionTest, robot_at_destination)
     // We call the action twice. The first time the Intent will always be returned to
     // ensure the Robot is doing the right thing. In all future calls, the action will be
     // done and so will return a null pointer
-    action.updateControlParams(robot, Point(0, 0), Angle::zero(), 0.0,
-                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
-                               BallCollisionType::AVOID);
+    action.updateControlParams(robot, Point(0, 0), Angle::zero(), 0.0, DribblerMode::OFF,
+                               AutochickType::NONE, BallCollisionType::AVOID);
     action.getNextIntent();
     action.getNextIntent();
 
@@ -131,7 +130,7 @@ TEST(MoveActionTest, test_action_does_not_prematurely_report_done)
 
     // Run the Action several times
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, AutochickType::NONE,
                                BallCollisionType::AVOID);
     for (int i = 0; i < 10; i++)
     {
@@ -152,7 +151,7 @@ TEST(MoveActionTest, test_action_does_not_prematurely_report_done_angle_threshol
 
     // Run the Action several times
     action.updateControlParams(robot, Point(0, 0), Angle::quarter(), 1.0,
-                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, AutochickType::NONE,
                                BallCollisionType::AVOID);
     for (int i = 0; i < 10; i++)
     {
@@ -172,7 +171,7 @@ TEST(MoveActionTest, test_action_finishes_within_orientation_threshold)
 
     // Run the Action several times
     action.updateControlParams(robot, Point(0, 0), Angle::quarter(), 1.0,
-                               DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::OFF, AutochickType::NONE,
                                BallCollisionType::AVOID);
     for (int i = 0; i < 10; i++)
     {
@@ -192,8 +191,8 @@ TEST(MoveActionTest, robot_far_from_destination_autokick_turned_on)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerMode::OFF, MoveType::NORMAL,
-                               AutochickType::AUTOKICK, BallCollisionType::AVOID);
+                               DribblerMode::OFF, AutochickType::AUTOKICK,
+                               BallCollisionType::AVOID);
     auto intent_ptr = action.getNextIntent();
 
     // Check an intent was returned (the pointer is not null)
@@ -216,7 +215,7 @@ TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::NONE,
+                               DribblerMode::INDEFINITE, AutochickType::NONE,
                                BallCollisionType::AVOID);
     auto intent_ptr = action.getNextIntent();
 

--- a/src/software/ai/hl/stp/action/move_action_test.cpp
+++ b/src/software/ai/hl/stp/action/move_action_test.cpp
@@ -75,10 +75,10 @@ TEST(MoveActionTest, getDribblerModed)
     EXPECT_EQ(DribblerMode::OFF, action.getDribblerModed());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
-                               DribblerMode::INDEFINITE, AutochickType::AUTOCHIP,
+                               DribblerMode::MAX_FORCE, AutochickType::AUTOCHIP,
                                BallCollisionType::AVOID);
 
-    EXPECT_EQ(DribblerMode::INDEFINITE, action.getDribblerModed());
+    EXPECT_EQ(DribblerMode::MAX_FORCE, action.getDribblerModed());
 }
 
 TEST(MoveActionTest, robot_far_from_destination)
@@ -101,7 +101,7 @@ TEST(MoveActionTest, robot_far_from_destination)
     EXPECT_EQ(Point(1, 0), move_intent.getDestination());
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
-    EXPECT_FALSE(move_intent.getDribblerMode() == DribblerMode::INDEFINITE);
+    EXPECT_FALSE(move_intent.getDribblerMode() == DribblerMode::MAX_FORCE);
     EXPECT_EQ(move_intent.getAutochickType(), AutochickType::NONE);
 }
 
@@ -215,7 +215,7 @@ TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
     MoveAction action = MoveAction(false, 0.05, Angle());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 1.0,
-                               DribblerMode::INDEFINITE, AutochickType::NONE,
+                               DribblerMode::MAX_FORCE, AutochickType::NONE,
                                BallCollisionType::AVOID);
     auto intent_ptr = action.getNextIntent();
 
@@ -228,6 +228,6 @@ TEST(MoveActionTest, robot_far_from_destination_dribble_turned_on)
     EXPECT_EQ(Point(1, 0), move_intent.getDestination());
     EXPECT_EQ(Angle::quarter(), move_intent.getFinalAngle());
     EXPECT_EQ(1.0, move_intent.getFinalSpeed());
-    EXPECT_TRUE(move_intent.getDribblerMode() == DribblerMode::INDEFINITE);
+    EXPECT_TRUE(move_intent.getDribblerMode() == DribblerMode::MAX_FORCE);
     EXPECT_EQ(move_intent.getAutochickType(), AutochickType::NONE);
 }

--- a/src/software/ai/hl/stp/action/move_action_test.cpp
+++ b/src/software/ai/hl/stp/action/move_action_test.cpp
@@ -62,7 +62,7 @@ TEST(MoveActionTest, getAutochickType)
     EXPECT_EQ(AutochickType::AUTOCHIP, action.getAutochickType());
 }
 
-TEST(MoveActionTest, getDribblerModed)
+TEST(MoveActionTest, getDribblerMode)
 {
     Robot robot       = Robot(13, Point(1, 2), Vector(3, 4), Angle::fromDegrees(5),
                         AngularVelocity::fromDegrees(6), Timestamp::fromSeconds(7));
@@ -72,13 +72,13 @@ TEST(MoveActionTest, getDribblerModed)
                                DribblerMode::OFF, AutochickType::NONE,
                                BallCollisionType::AVOID);
 
-    EXPECT_EQ(DribblerMode::OFF, action.getDribblerModed());
+    EXPECT_EQ(DribblerMode::OFF, action.getDribblerMode());
 
     action.updateControlParams(robot, Point(1, 0), Angle::quarter(), 99.0,
                                DribblerMode::MAX_FORCE, AutochickType::AUTOCHIP,
                                BallCollisionType::AVOID);
 
-    EXPECT_EQ(DribblerMode::MAX_FORCE, action.getDribblerModed());
+    EXPECT_EQ(DribblerMode::MAX_FORCE, action.getDribblerMode());
 }
 
 TEST(MoveActionTest, robot_far_from_destination)

--- a/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
+++ b/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
@@ -23,9 +23,9 @@ void MoveTestAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     // different location
     do
     {
-        yield(std::make_unique<MoveIntent>(
-            robot->id(), destination, Angle::zero(), 0.0, DribblerMode::OFF,
-            MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID));
+        yield(std::make_unique<MoveIntent>(robot->id(), destination, Angle::zero(), 0.0,
+                                           DribblerMode::OFF, AutochickType::NONE,
+                                           BallCollisionType::AVOID));
     } while ((robot->position() - destination).length() > close_to_dest_threshold);
 }
 

--- a/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
+++ b/src/software/ai/hl/stp/action/test_actions/move_test_action.cpp
@@ -24,7 +24,7 @@ void MoveTestAction::calculateNextIntent(IntentCoroutine::push_type& yield)
     do
     {
         yield(std::make_unique<MoveIntent>(
-            robot->id(), destination, Angle::zero(), 0.0, DribblerEnable::OFF,
+            robot->id(), destination, Angle::zero(), 0.0, DribblerMode::OFF,
             MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID));
     } while ((robot->position() - destination).length() > close_to_dest_threshold);
 }

--- a/src/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -35,8 +35,7 @@ void CherryPickTactic::calculateNextAction(ActionCoroutine::push_type& yield)
         // find (within the target region)
         Pass pass = pass_generator.getBestPassSoFar().pass;
         move_action->updateControlParams(*robot, pass.receiverPoint(),
-                                         pass.receiverOrientation(), 0,
-                                         DribblerMode::OFF, MoveType::NORMAL,
+                                         pass.receiverOrientation(), 0, DribblerMode::OFF,
                                          AutochickType::NONE, BallCollisionType::AVOID);
         yield(move_action);
     } while (true);

--- a/src/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/cherry_pick_tactic.cpp
@@ -36,7 +36,7 @@ void CherryPickTactic::calculateNextAction(ActionCoroutine::push_type& yield)
         Pass pass = pass_generator.getBestPassSoFar().pass;
         move_action->updateControlParams(*robot, pass.receiverPoint(),
                                          pass.receiverOrientation(), 0,
-                                         DribblerEnable::OFF, MoveType::NORMAL,
+                                         DribblerMode::OFF, MoveType::NORMAL,
                                          AutochickType::NONE, BallCollisionType::AVOID);
         yield(move_action);
     } while (true);

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
@@ -168,7 +168,7 @@ void CreaseDefenderTactic::calculateNextAction(ActionCoroutine::push_type &yield
         {
             auto [defender_position, defender_orientation] = *desired_robot_state_opt;
             move_action->updateControlParams(
-                *robot, defender_position, defender_orientation, 0.0, DribblerEnable::OFF,
+                *robot, defender_position, defender_orientation, 0.0, DribblerMode::OFF,
                 MoveType::NORMAL, AutochickType::AUTOCHIP, BallCollisionType::ALLOW);
             yield(move_action);
         }

--- a/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender_tactic.cpp
@@ -169,7 +169,7 @@ void CreaseDefenderTactic::calculateNextAction(ActionCoroutine::push_type &yield
             auto [defender_position, defender_orientation] = *desired_robot_state_opt;
             move_action->updateControlParams(
                 *robot, defender_position, defender_orientation, 0.0, DribblerMode::OFF,
-                MoveType::NORMAL, AutochickType::AUTOCHIP, BallCollisionType::ALLOW);
+                AutochickType::AUTOCHIP, BallCollisionType::ALLOW);
             yield(move_action);
         }
         else

--- a/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
@@ -95,7 +95,7 @@ void DefenseShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &y
         {
             move_action->updateControlParams(
                 *robot, ball.position(), enemy_shot_vector.orientation() + Angle::half(),
-                0, DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::AUTOCHIP,
+                0, DribblerMode::INDEFINITE, AutochickType::AUTOCHIP,
                 BallCollisionType::AVOID);
             yield(move_action);
         }
@@ -103,10 +103,9 @@ void DefenseShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &y
         {
             Angle facing_enemy_robot =
                 (enemy_robot.position() - robot->position()).orientation();
-            move_action->updateControlParams(*robot, position_to_block_shot,
-                                             facing_enemy_robot, 0, DribblerMode::OFF,
-                                             MoveType::NORMAL, AutochickType::AUTOCHIP,
-                                             BallCollisionType::AVOID);
+            move_action->updateControlParams(
+                *robot, position_to_block_shot, facing_enemy_robot, 0, DribblerMode::OFF,
+                AutochickType::AUTOCHIP, BallCollisionType::AVOID);
             yield(move_action);
         }
 

--- a/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
@@ -95,7 +95,7 @@ void DefenseShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &y
         {
             move_action->updateControlParams(
                 *robot, ball.position(), enemy_shot_vector.orientation() + Angle::half(),
-                0, DribblerEnable::ON, MoveType::NORMAL, AutochickType::AUTOCHIP,
+                0, DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::AUTOCHIP,
                 BallCollisionType::AVOID);
             yield(move_action);
         }
@@ -104,7 +104,7 @@ void DefenseShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &y
             Angle facing_enemy_robot =
                 (enemy_robot.position() - robot->position()).orientation();
             move_action->updateControlParams(*robot, position_to_block_shot,
-                                             facing_enemy_robot, 0, DribblerEnable::OFF,
+                                             facing_enemy_robot, 0, DribblerMode::OFF,
                                              MoveType::NORMAL, AutochickType::AUTOCHIP,
                                              BallCollisionType::AVOID);
             yield(move_action);

--- a/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/defense_shadow_enemy_tactic.cpp
@@ -95,7 +95,7 @@ void DefenseShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &y
         {
             move_action->updateControlParams(
                 *robot, ball.position(), enemy_shot_vector.orientation() + Angle::half(),
-                0, DribblerMode::INDEFINITE, AutochickType::AUTOCHIP,
+                0, DribblerMode::MAX_FORCE, AutochickType::AUTOCHIP,
                 BallCollisionType::AVOID);
             yield(move_action);
         }

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -209,9 +209,9 @@ std::shared_ptr<Action> GoalieTactic::panicAndStopBall(
         closestPoint((*robot).position(), Segment(ball.position(), stop_ball_point));
     Angle goalie_orientation = (ball.position() - goalie_pos).orientation();
 
-            move_action->updateControlParams(*robot, goalie_pos, goalie_orientation, 0.0,
-                                             DribblerMode::OFF, AutochickType::AUTOCHIP,
-                                             BallCollisionType::ALLOW);
+    move_action->updateControlParams(*robot, goalie_pos, goalie_orientation, 0.0,
+                                     DribblerMode::OFF, AutochickType::AUTOCHIP,
+                                     BallCollisionType::ALLOW);
     return move_action;
 }
 
@@ -302,10 +302,9 @@ std::shared_ptr<Action> GoalieTactic::positionToBlockShot(
     // what should the final goalie speed be, so that the goalie accelerates
     // faster
     auto goalie_final_speed = goalie_tactic_config->GoalieFinalSpeed()->value();
-            move_action->updateControlParams(*robot, goalie_pos, goalie_orientation,
-                                             goalie_final_speed, DribblerMode::OFF,
-                                              AutochickType::AUTOCHIP,
-                                             BallCollisionType::ALLOW);
+    move_action->updateControlParams(*robot, goalie_pos, goalie_orientation,
+                                     goalie_final_speed, DribblerMode::OFF,
+                                     AutochickType::AUTOCHIP, BallCollisionType::ALLOW);
     return move_action;
 }
 

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -209,9 +209,9 @@ std::shared_ptr<Action> GoalieTactic::panicAndStopBall(
         closestPoint((*robot).position(), Segment(ball.position(), stop_ball_point));
     Angle goalie_orientation = (ball.position() - goalie_pos).orientation();
 
-            move_action->updateControlParams(
-                *robot, goalie_pos, goalie_orientation, 0.0, DribblerMode::OFF,
-                MoveType::NORMAL, AutochickType::AUTOCHIP, BallCollisionType::ALLOW);
+            move_action->updateControlParams(*robot, goalie_pos, goalie_orientation, 0.0,
+                                             DribblerMode::OFF, AutochickType::AUTOCHIP,
+                                             BallCollisionType::ALLOW);
     return move_action;
 }
 
@@ -304,7 +304,7 @@ std::shared_ptr<Action> GoalieTactic::positionToBlockShot(
     auto goalie_final_speed = goalie_tactic_config->GoalieFinalSpeed()->value();
             move_action->updateControlParams(*robot, goalie_pos, goalie_orientation,
                                              goalie_final_speed, DribblerMode::OFF,
-                                             MoveType::NORMAL, AutochickType::AUTOCHIP,
+                                              AutochickType::AUTOCHIP,
                                              BallCollisionType::ALLOW);
     return move_action;
 }

--- a/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie_tactic.cpp
@@ -209,9 +209,9 @@ std::shared_ptr<Action> GoalieTactic::panicAndStopBall(
         closestPoint((*robot).position(), Segment(ball.position(), stop_ball_point));
     Angle goalie_orientation = (ball.position() - goalie_pos).orientation();
 
-    move_action->updateControlParams(*robot, goalie_pos, goalie_orientation, 0.0,
-                                     DribblerEnable::OFF, MoveType::NORMAL,
-                                     AutochickType::AUTOCHIP, BallCollisionType::ALLOW);
+            move_action->updateControlParams(
+                *robot, goalie_pos, goalie_orientation, 0.0, DribblerMode::OFF,
+                MoveType::NORMAL, AutochickType::AUTOCHIP, BallCollisionType::ALLOW);
     return move_action;
 }
 
@@ -302,9 +302,10 @@ std::shared_ptr<Action> GoalieTactic::positionToBlockShot(
     // what should the final goalie speed be, so that the goalie accelerates
     // faster
     auto goalie_final_speed = goalie_tactic_config->GoalieFinalSpeed()->value();
-    move_action->updateControlParams(
-        *robot, goalie_pos, goalie_orientation, goalie_final_speed, DribblerEnable::OFF,
-        MoveType::NORMAL, AutochickType::AUTOCHIP, BallCollisionType::ALLOW);
+            move_action->updateControlParams(*robot, goalie_pos, goalie_orientation,
+                                             goalie_final_speed, DribblerMode::OFF,
+                                             MoveType::NORMAL, AutochickType::AUTOCHIP,
+                                             BallCollisionType::ALLOW);
     return move_action;
 }
 

--- a/src/software/ai/hl/stp/tactic/move_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/move_tactic.cpp
@@ -36,7 +36,7 @@ void MoveTactic::calculateNextAction(ActionCoroutine::push_type &yield)
     do
     {
         move_action->updateControlParams(
-            *robot, destination, final_orientation, final_speed, DribblerEnable::OFF,
+            *robot, destination, final_orientation, final_speed, DribblerMode::OFF,
             MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID);
         yield(move_action);
     } while (!move_action->done());

--- a/src/software/ai/hl/stp/tactic/move_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/move_tactic.cpp
@@ -35,9 +35,9 @@ void MoveTactic::calculateNextAction(ActionCoroutine::push_type &yield)
                                      MoveAction::ROBOT_CLOSE_TO_ORIENTATION_THRESHOLD);
     do
     {
-        move_action->updateControlParams(
-            *robot, destination, final_orientation, final_speed, DribblerMode::OFF,
-            MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID);
+        move_action->updateControlParams(*robot, destination, final_orientation,
+                                         final_speed, DribblerMode::OFF,
+                                         AutochickType::NONE, BallCollisionType::AVOID);
         yield(move_action);
     } while (!move_action->done());
 }

--- a/src/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -66,7 +66,7 @@ void PasserTactic::calculateNextAction(ActionCoroutine::push_type& yield)
         Point wait_position = pass.passerPoint() - ball_offset;
 
         move_action->updateControlParams(*robot, wait_position, pass.passerOrientation(),
-                                         0, DribblerEnable::OFF, MoveType::NORMAL,
+                                         0, DribblerMode::OFF, MoveType::NORMAL,
                                          AutochickType::NONE, BallCollisionType::ALLOW);
         yield(move_action);
     }

--- a/src/software/ai/hl/stp/tactic/passer_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/passer_tactic.cpp
@@ -66,8 +66,8 @@ void PasserTactic::calculateNextAction(ActionCoroutine::push_type& yield)
         Point wait_position = pass.passerPoint() - ball_offset;
 
         move_action->updateControlParams(*robot, wait_position, pass.passerOrientation(),
-                                         0, DribblerMode::OFF, MoveType::NORMAL,
-                                         AutochickType::NONE, BallCollisionType::ALLOW);
+                                         0, DribblerMode::OFF, AutochickType::NONE,
+                                         BallCollisionType::ALLOW);
         yield(move_action);
     }
 

--- a/src/software/ai/hl/stp/tactic/patrol_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/patrol_tactic.cpp
@@ -66,10 +66,10 @@ void PatrolTactic::calculateNextAction(ActionCoroutine::push_type &yield)
         std::make_shared<MoveAction>(false, this->at_patrol_point_tolerance, Angle());
     do
     {
-        move_action->updateControlParams(
-            *robot, patrol_points.at(patrol_point_index), orientation_at_patrol_points,
-            linear_speed_at_patrol_points, DribblerMode::OFF, MoveType::NORMAL,
-            AutochickType::NONE, BallCollisionType::AVOID);
+        move_action->updateControlParams(*robot, patrol_points.at(patrol_point_index),
+                                         orientation_at_patrol_points,
+                                         linear_speed_at_patrol_points, DribblerMode::OFF,
+                                         AutochickType::NONE, BallCollisionType::AVOID);
         if (move_action->done())
         {
             move_action->restart();
@@ -78,8 +78,7 @@ void PatrolTactic::calculateNextAction(ActionCoroutine::push_type &yield)
             move_action->updateControlParams(
                 *robot, patrol_points.at(patrol_point_index),
                 orientation_at_patrol_points, linear_speed_at_patrol_points,
-                DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
-                BallCollisionType::AVOID);
+                DribblerMode::OFF, AutochickType::NONE, BallCollisionType::AVOID);
         }
         yield(move_action);
     } while (true);

--- a/src/software/ai/hl/stp/tactic/patrol_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/patrol_tactic.cpp
@@ -68,7 +68,7 @@ void PatrolTactic::calculateNextAction(ActionCoroutine::push_type &yield)
     {
         move_action->updateControlParams(
             *robot, patrol_points.at(patrol_point_index), orientation_at_patrol_points,
-            linear_speed_at_patrol_points, DribblerEnable::OFF, MoveType::NORMAL,
+            linear_speed_at_patrol_points, DribblerMode::OFF, MoveType::NORMAL,
             AutochickType::NONE, BallCollisionType::AVOID);
         if (move_action->done())
         {
@@ -78,7 +78,7 @@ void PatrolTactic::calculateNextAction(ActionCoroutine::push_type &yield)
             move_action->updateControlParams(
                 *robot, patrol_points.at(patrol_point_index),
                 orientation_at_patrol_points, linear_speed_at_patrol_points,
-                DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                 BallCollisionType::AVOID);
         }
         yield(move_action);

--- a/src/software/ai/hl/stp/tactic/patrol_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/patrol_tactic_test.cpp
@@ -69,8 +69,8 @@ class PatrolTacticTest : public testing::Test
         EXPECT_EQ(expected_move_action->getFinalSpeed(), move_action->getFinalSpeed());
         EXPECT_EQ(expected_move_action->getAutochickType(),
                   move_action->getAutochickType());
-        EXPECT_EQ(expected_move_action->getDribblerModed(),
-                  move_action->getDribblerModed());
+        EXPECT_EQ(expected_move_action->getDribblerMode(),
+                  move_action->getDribblerMode());
     }
 
     /**

--- a/src/software/ai/hl/stp/tactic/patrol_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/patrol_tactic_test.cpp
@@ -29,7 +29,7 @@ class PatrolTacticTest : public testing::Test
             auto expected_action = std::make_shared<MoveAction>(false);
             expected_action->updateControlParams(
                 robot, patrol_points[i], angle, speed_at_patrol_points,
-                DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                 BallCollisionType::AVOID);
             expected_actions.push_back(expected_action);
         }
@@ -70,8 +70,8 @@ class PatrolTacticTest : public testing::Test
         EXPECT_EQ(expected_move_action->getFinalSpeed(), move_action->getFinalSpeed());
         EXPECT_EQ(expected_move_action->getAutochickType(),
                   move_action->getAutochickType());
-        EXPECT_EQ(expected_move_action->getDribblerEnabled(),
-                  move_action->getDribblerEnabled());
+        EXPECT_EQ(expected_move_action->getDribblerModed(),
+                  move_action->getDribblerModed());
     }
 
     /**

--- a/src/software/ai/hl/stp/tactic/patrol_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/patrol_tactic_test.cpp
@@ -28,9 +28,8 @@ class PatrolTacticTest : public testing::Test
         {
             auto expected_action = std::make_shared<MoveAction>(false);
             expected_action->updateControlParams(
-                robot, patrol_points[i], angle, speed_at_patrol_points,
-                DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
-                BallCollisionType::AVOID);
+                robot, patrol_points[i], angle, speed_at_patrol_points, DribblerMode::OFF,
+                AutochickType::NONE, BallCollisionType::AVOID);
             expected_actions.push_back(expected_action);
         }
     }

--- a/src/software/ai/hl/stp/tactic/penalty_kick_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/penalty_kick_tactic.cpp
@@ -166,8 +166,7 @@ void PenaltyKickTactic::calculateNextAction(ActionCoroutine::push_type& yield)
         {
             approach_ball_move_act->updateControlParams(
                 *robot, behind_ball, (-behind_ball_vector).orientation(), 0,
-                DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::NONE,
-                BallCollisionType::ALLOW);
+                DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::ALLOW);
             yield(approach_ball_move_act);
         }
         else
@@ -176,7 +175,7 @@ void PenaltyKickTactic::calculateNextAction(ActionCoroutine::push_type& yield)
             const Angle next_angle = (next_shot_position - ball.position()).orientation();
             rotate_with_ball_move_act->updateControlParams(
                 *robot, robot.value().position(), next_angle, 0, DribblerMode::INDEFINITE,
-                MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW);
+                AutochickType::NONE, BallCollisionType::ALLOW);
             yield(rotate_with_ball_move_act);
         }
 

--- a/src/software/ai/hl/stp/tactic/penalty_kick_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/penalty_kick_tactic.cpp
@@ -166,7 +166,7 @@ void PenaltyKickTactic::calculateNextAction(ActionCoroutine::push_type& yield)
         {
             approach_ball_move_act->updateControlParams(
                 *robot, behind_ball, (-behind_ball_vector).orientation(), 0,
-                DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::ALLOW);
+                DribblerMode::MAX_FORCE, AutochickType::NONE, BallCollisionType::ALLOW);
             yield(approach_ball_move_act);
         }
         else
@@ -174,7 +174,7 @@ void PenaltyKickTactic::calculateNextAction(ActionCoroutine::push_type& yield)
             const Point next_shot_position = evaluate_next_position();
             const Angle next_angle = (next_shot_position - ball.position()).orientation();
             rotate_with_ball_move_act->updateControlParams(
-                *robot, robot.value().position(), next_angle, 0, DribblerMode::INDEFINITE,
+                *robot, robot.value().position(), next_angle, 0, DribblerMode::MAX_FORCE,
                 AutochickType::NONE, BallCollisionType::ALLOW);
             yield(rotate_with_ball_move_act);
         }

--- a/src/software/ai/hl/stp/tactic/penalty_kick_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/penalty_kick_tactic.cpp
@@ -166,7 +166,7 @@ void PenaltyKickTactic::calculateNextAction(ActionCoroutine::push_type& yield)
         {
             approach_ball_move_act->updateControlParams(
                 *robot, behind_ball, (-behind_ball_vector).orientation(), 0,
-                DribblerEnable::ON, MoveType::NORMAL, AutochickType::NONE,
+                DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::NONE,
                 BallCollisionType::ALLOW);
             yield(approach_ball_move_act);
         }
@@ -175,7 +175,7 @@ void PenaltyKickTactic::calculateNextAction(ActionCoroutine::push_type& yield)
             const Point next_shot_position = evaluate_next_position();
             const Angle next_angle = (next_shot_position - ball.position()).orientation();
             rotate_with_ball_move_act->updateControlParams(
-                *robot, robot.value().position(), next_angle, 0, DribblerEnable::ON,
+                *robot, robot.value().position(), next_angle, 0, DribblerMode::INDEFINITE,
                 MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW);
             yield(rotate_with_ball_move_act);
         }

--- a/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -132,7 +132,7 @@ void ReceiverTactic::calculateNextAction(ActionCoroutine::push_type& yield)
             // Move into position with the dribbler on
             move_action->updateControlParams(
                 *robot, ball_receive_pos, ball_receive_orientation, 0,
-                DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::ALLOW);
+                DribblerMode::MAX_FORCE, AutochickType::NONE, BallCollisionType::ALLOW);
             yield(move_action);
         }
     }

--- a/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -71,8 +71,8 @@ void ReceiverTactic::calculateNextAction(ActionCoroutine::push_type& yield)
         // We want the robot to move to the receiving position for the shot and also
         // rotate to the correct orientation
         move_action->updateControlParams(*robot, pass.receiverPoint(), desired_angle, 0,
-                                         DribblerMode::OFF, MoveType::NORMAL,
-                                         AutochickType::NONE, BallCollisionType::ALLOW);
+                                         DribblerMode::OFF, AutochickType::NONE,
+                                         BallCollisionType::ALLOW);
         yield(move_action);
     }
 
@@ -100,9 +100,9 @@ void ReceiverTactic::calculateNextAction(ActionCoroutine::push_type& yield)
             Point ideal_position    = shot.getPointToShootAt();
             Angle ideal_orientation = shot.getOpenAngle();
 
-            move_action->updateControlParams(
-                *robot, ideal_position, ideal_orientation, 0, DribblerMode::OFF,
-                MoveType::NORMAL, AutochickType::AUTOKICK, BallCollisionType::ALLOW);
+            move_action->updateControlParams(*robot, ideal_position, ideal_orientation, 0,
+                                             DribblerMode::OFF, AutochickType::AUTOKICK,
+                                             BallCollisionType::ALLOW);
             yield(move_action);
 
             // Calculations to check for termination conditions
@@ -131,8 +131,8 @@ void ReceiverTactic::calculateNextAction(ActionCoroutine::push_type& yield)
 
             // Move into position with the dribbler on
             move_action->updateControlParams(
-                *robot, ball_receive_pos, ball_receive_orientation, 0, DribblerMode::INDEFINITE,
-                MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW);
+                *robot, ball_receive_pos, ball_receive_orientation, 0,
+                DribblerMode::INDEFINITE, AutochickType::NONE, BallCollisionType::ALLOW);
             yield(move_action);
         }
     }

--- a/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic.cpp
@@ -71,7 +71,7 @@ void ReceiverTactic::calculateNextAction(ActionCoroutine::push_type& yield)
         // We want the robot to move to the receiving position for the shot and also
         // rotate to the correct orientation
         move_action->updateControlParams(*robot, pass.receiverPoint(), desired_angle, 0,
-                                         DribblerEnable::OFF, MoveType::NORMAL,
+                                         DribblerMode::OFF, MoveType::NORMAL,
                                          AutochickType::NONE, BallCollisionType::ALLOW);
         yield(move_action);
     }
@@ -101,7 +101,7 @@ void ReceiverTactic::calculateNextAction(ActionCoroutine::push_type& yield)
             Angle ideal_orientation = shot.getOpenAngle();
 
             move_action->updateControlParams(
-                *robot, ideal_position, ideal_orientation, 0, DribblerEnable::OFF,
+                *robot, ideal_position, ideal_orientation, 0, DribblerMode::OFF,
                 MoveType::NORMAL, AutochickType::AUTOKICK, BallCollisionType::ALLOW);
             yield(move_action);
 
@@ -131,7 +131,7 @@ void ReceiverTactic::calculateNextAction(ActionCoroutine::push_type& yield)
 
             // Move into position with the dribbler on
             move_action->updateControlParams(
-                *robot, ball_receive_pos, ball_receive_orientation, 0, DribblerEnable::ON,
+                *robot, ball_receive_pos, ball_receive_orientation, 0, DribblerMode::INDEFINITE,
                 MoveType::NORMAL, AutochickType::NONE, BallCollisionType::ALLOW);
             yield(move_action);
         }

--- a/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
@@ -163,7 +163,7 @@ TEST(ReceiverTacticTest,
     EXPECT_NEAR(0.0, move_action->getDestination().y(), 0.0001);
     EXPECT_EQ(pass.receiverOrientation(), move_action->getFinalOrientation());
 
-    EXPECT_EQ(DribblerMode::INDEFINITE, move_action->getDribblerModed());
+    EXPECT_EQ(DribblerMode::MAX_FORCE, move_action->getDribblerModed());
     EXPECT_EQ(move_action->getAutochickType(), AutochickType::NONE);
 }
 
@@ -208,7 +208,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_blocked)
     EXPECT_NEAR(0.0, move_action->getDestination().y(), 0.0001);
     EXPECT_EQ(pass.receiverOrientation(), move_action->getFinalOrientation());
 
-    EXPECT_EQ(DribblerMode::INDEFINITE, move_action->getDribblerModed());
+    EXPECT_EQ(DribblerMode::MAX_FORCE, move_action->getDribblerModed());
     EXPECT_EQ(move_action->getAutochickType(), AutochickType::NONE);
 }
 

--- a/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
@@ -37,7 +37,7 @@ TEST(ReceiverTacticTest, robot_not_at_receive_position_pass_not_started)
     EXPECT_DOUBLE_EQ(0.0, move_action->getDestination().y());
     EXPECT_EQ((pass.receiverOrientation() + shot_dir) / 2,
               move_action->getFinalOrientation());
-    EXPECT_EQ(DribblerMode::OFF, move_action->getDribblerModed());
+    EXPECT_EQ(DribblerMode::OFF, move_action->getDribblerMode());
     EXPECT_EQ(move_action->getAutochickType(), AutochickType::NONE);
 }
 
@@ -81,7 +81,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_not_started)
         EXPECT_DOUBLE_EQ(0.0, move_action->getDestination().y());
         EXPECT_EQ((pass.receiverOrientation() + shot_dir) / 2,
                   move_action->getFinalOrientation());
-        EXPECT_EQ(DribblerMode::OFF, move_action->getDribblerModed());
+        EXPECT_EQ(DribblerMode::OFF, move_action->getDribblerMode());
         EXPECT_EQ(move_action->getAutochickType(), AutochickType::NONE);
     }
 }
@@ -125,7 +125,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_open_angle_
     EXPECT_LT(move_action->getFinalOrientation().toDegrees(), -1);
     EXPECT_GT(move_action->getFinalOrientation().toDegrees(), -90);
 
-    EXPECT_EQ(DribblerMode::OFF, move_action->getDribblerModed());
+    EXPECT_EQ(DribblerMode::OFF, move_action->getDribblerMode());
     EXPECT_EQ(move_action->getAutochickType(), AutochickType::AUTOKICK);
 }
 
@@ -163,7 +163,7 @@ TEST(ReceiverTacticTest,
     EXPECT_NEAR(0.0, move_action->getDestination().y(), 0.0001);
     EXPECT_EQ(pass.receiverOrientation(), move_action->getFinalOrientation());
 
-    EXPECT_EQ(DribblerMode::MAX_FORCE, move_action->getDribblerModed());
+    EXPECT_EQ(DribblerMode::MAX_FORCE, move_action->getDribblerMode());
     EXPECT_EQ(move_action->getAutochickType(), AutochickType::NONE);
 }
 
@@ -208,7 +208,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_blocked)
     EXPECT_NEAR(0.0, move_action->getDestination().y(), 0.0001);
     EXPECT_EQ(pass.receiverOrientation(), move_action->getFinalOrientation());
 
-    EXPECT_EQ(DribblerMode::MAX_FORCE, move_action->getDribblerModed());
+    EXPECT_EQ(DribblerMode::MAX_FORCE, move_action->getDribblerMode());
     EXPECT_EQ(move_action->getAutochickType(), AutochickType::NONE);
 }
 

--- a/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/receiver_tactic_test.cpp
@@ -37,7 +37,7 @@ TEST(ReceiverTacticTest, robot_not_at_receive_position_pass_not_started)
     EXPECT_DOUBLE_EQ(0.0, move_action->getDestination().y());
     EXPECT_EQ((pass.receiverOrientation() + shot_dir) / 2,
               move_action->getFinalOrientation());
-    EXPECT_EQ(DribblerEnable::OFF, move_action->getDribblerEnabled());
+    EXPECT_EQ(DribblerMode::OFF, move_action->getDribblerModed());
     EXPECT_EQ(move_action->getAutochickType(), AutochickType::NONE);
 }
 
@@ -81,7 +81,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_not_started)
         EXPECT_DOUBLE_EQ(0.0, move_action->getDestination().y());
         EXPECT_EQ((pass.receiverOrientation() + shot_dir) / 2,
                   move_action->getFinalOrientation());
-        EXPECT_EQ(DribblerEnable::OFF, move_action->getDribblerEnabled());
+        EXPECT_EQ(DribblerMode::OFF, move_action->getDribblerModed());
         EXPECT_EQ(move_action->getAutochickType(), AutochickType::NONE);
     }
 }
@@ -125,7 +125,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_open_angle_
     EXPECT_LT(move_action->getFinalOrientation().toDegrees(), -1);
     EXPECT_GT(move_action->getFinalOrientation().toDegrees(), -90);
 
-    EXPECT_EQ(DribblerEnable::OFF, move_action->getDribblerEnabled());
+    EXPECT_EQ(DribblerMode::OFF, move_action->getDribblerModed());
     EXPECT_EQ(move_action->getAutochickType(), AutochickType::AUTOKICK);
 }
 
@@ -163,7 +163,7 @@ TEST(ReceiverTacticTest,
     EXPECT_NEAR(0.0, move_action->getDestination().y(), 0.0001);
     EXPECT_EQ(pass.receiverOrientation(), move_action->getFinalOrientation());
 
-    EXPECT_EQ(DribblerEnable::ON, move_action->getDribblerEnabled());
+    EXPECT_EQ(DribblerMode::INDEFINITE, move_action->getDribblerModed());
     EXPECT_EQ(move_action->getAutochickType(), AutochickType::NONE);
 }
 
@@ -208,7 +208,7 @@ TEST(ReceiverTacticTest, robot_at_receive_position_pass_started_goal_blocked)
     EXPECT_NEAR(0.0, move_action->getDestination().y(), 0.0001);
     EXPECT_EQ(pass.receiverOrientation(), move_action->getFinalOrientation());
 
-    EXPECT_EQ(DribblerEnable::ON, move_action->getDribblerEnabled());
+    EXPECT_EQ(DribblerMode::INDEFINITE, move_action->getDribblerModed());
     EXPECT_EQ(move_action->getAutochickType(), AutochickType::NONE);
 }
 

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -111,7 +111,7 @@ void ShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
                 move_action->updateControlParams(
                     *robot, ball.position(),
                     (ball.position() - robot->position()).orientation(), 0,
-                    DribblerMode::INDEFINITE, AutochickType::AUTOCHIP,
+                    DribblerMode::MAX_FORCE, AutochickType::AUTOCHIP,
                     BallCollisionType::AVOID);
                 yield(move_action);
             }

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -75,8 +75,7 @@ void ShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
                 enemy_to_passer_vector.normalize(this->shadow_distance);
             move_action->updateControlParams(
                 *robot, position_to_block_pass, enemy_to_passer_vector.orientation(), 0,
-                DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
-                BallCollisionType::AVOID);
+                DribblerMode::OFF, AutochickType::NONE, BallCollisionType::AVOID);
             yield(move_action);
         }
         else
@@ -112,7 +111,7 @@ void ShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
                 move_action->updateControlParams(
                     *robot, ball.position(),
                     (ball.position() - robot->position()).orientation(), 0,
-                    DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::AUTOCHIP,
+                    DribblerMode::INDEFINITE, AutochickType::AUTOCHIP,
                     BallCollisionType::AVOID);
                 yield(move_action);
             }
@@ -120,9 +119,8 @@ void ShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
             {
                 move_action->updateControlParams(
                     *robot, position_to_block_shot,
-                    enemy_shot_vector.orientation() + Angle::half(), 0,
-                    DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
-                    BallCollisionType::AVOID);
+                    enemy_shot_vector.orientation() + Angle::half(), 0, DribblerMode::OFF,
+                    AutochickType::NONE, BallCollisionType::AVOID);
                 yield(move_action);
             }
         }

--- a/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy_tactic.cpp
@@ -75,7 +75,7 @@ void ShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
                 enemy_to_passer_vector.normalize(this->shadow_distance);
             move_action->updateControlParams(
                 *robot, position_to_block_pass, enemy_to_passer_vector.orientation(), 0,
-                DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                 BallCollisionType::AVOID);
             yield(move_action);
         }
@@ -112,7 +112,7 @@ void ShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
                 move_action->updateControlParams(
                     *robot, ball.position(),
                     (ball.position() - robot->position()).orientation(), 0,
-                    DribblerEnable::ON, MoveType::NORMAL, AutochickType::AUTOCHIP,
+                    DribblerMode::INDEFINITE, MoveType::NORMAL, AutochickType::AUTOCHIP,
                     BallCollisionType::AVOID);
                 yield(move_action);
             }
@@ -121,7 +121,7 @@ void ShadowEnemyTactic::calculateNextAction(ActionCoroutine::push_type &yield)
                 move_action->updateControlParams(
                     *robot, position_to_block_shot,
                     enemy_shot_vector.orientation() + Angle::half(), 0,
-                    DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+                    DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
                     BallCollisionType::AVOID);
                 yield(move_action);
             }

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
@@ -76,7 +76,7 @@ void ShadowFreekickerTactic::calculateNextAction(ActionCoroutine::push_type &yie
 
         move_action->updateControlParams(
             *robot, defend_position, (ball.position() - robot->position()).orientation(),
-            0, DribblerEnable::OFF, MoveType::NORMAL, AutochickType::NONE,
+            0, DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
             BallCollisionType::AVOID);
         yield(move_action);
     } while (true);

--- a/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_freekicker_tactic.cpp
@@ -76,8 +76,7 @@ void ShadowFreekickerTactic::calculateNextAction(ActionCoroutine::push_type &yie
 
         move_action->updateControlParams(
             *robot, defend_position, (ball.position() - robot->position()).orientation(),
-            0, DribblerMode::OFF, MoveType::NORMAL, AutochickType::NONE,
-            BallCollisionType::AVOID);
+            0, DribblerMode::OFF, AutochickType::NONE, BallCollisionType::AVOID);
         yield(move_action);
     } while (true);
 }

--- a/src/software/ai/intent/move_intent.cpp
+++ b/src/software/ai/intent/move_intent.cpp
@@ -2,12 +2,11 @@
 
 MoveIntent::MoveIntent(unsigned int robot_id, const Point &destination,
                        const Angle &final_angle, double final_speed,
-                       DribblerMode dribbler_mode, MoveType move_type,
-                       AutochickType autokick, BallCollisionType ball_collision_type)
+                       DribblerMode dribbler_mode, AutochickType autokick,
+                       BallCollisionType ball_collision_type)
     : NavigatingIntent(robot_id, destination, final_speed, ball_collision_type),
       final_angle(final_angle),
       dribbler_mode(dribbler_mode),
-      move_type(move_type),
       autokick(autokick)
 {
 }
@@ -37,17 +36,11 @@ const DribblerMode &MoveIntent::getDribblerMode() const
     return dribbler_mode;
 }
 
-const MoveType &MoveIntent::getMoveType() const
-{
-    return move_type;
-}
-
 bool MoveIntent::operator==(const MoveIntent &other) const
 {
     return NavigatingIntent::operator==(other) &&
            this->final_angle == other.final_angle &&
-           this->dribbler_mode == other.dribbler_mode &&
-           this->move_type == other.move_type && this->autokick == other.autokick;
+           this->dribbler_mode == other.dribbler_mode && this->autokick == other.autokick;
 }
 
 bool MoveIntent::operator!=(const MoveIntent &other) const

--- a/src/software/ai/intent/move_intent.cpp
+++ b/src/software/ai/intent/move_intent.cpp
@@ -2,11 +2,11 @@
 
 MoveIntent::MoveIntent(unsigned int robot_id, const Point &destination,
                        const Angle &final_angle, double final_speed,
-                       DribblerEnable enable_dribbler, MoveType move_type,
+                       DribblerMode dribbler_mode, MoveType move_type,
                        AutochickType autokick, BallCollisionType ball_collision_type)
     : NavigatingIntent(robot_id, destination, final_speed, ball_collision_type),
       final_angle(final_angle),
-      enable_dribbler(enable_dribbler),
+      dribbler_mode(dribbler_mode),
       move_type(move_type),
       autokick(autokick)
 {
@@ -32,9 +32,9 @@ const AutochickType &MoveIntent::getAutochickType() const
     return autokick;
 }
 
-const DribblerEnable &MoveIntent::getDribblerEnable() const
+const DribblerMode &MoveIntent::getDribblerMode() const
 {
-    return enable_dribbler;
+    return dribbler_mode;
 }
 
 const MoveType &MoveIntent::getMoveType() const
@@ -46,7 +46,7 @@ bool MoveIntent::operator==(const MoveIntent &other) const
 {
     return NavigatingIntent::operator==(other) &&
            this->final_angle == other.final_angle &&
-           this->enable_dribbler == other.enable_dribbler &&
+           this->dribbler_mode == other.dribbler_mode &&
            this->move_type == other.move_type && this->autokick == other.autokick;
 }
 

--- a/src/software/ai/intent/move_intent.h
+++ b/src/software/ai/intent/move_intent.h
@@ -13,7 +13,7 @@ class MoveIntent : public NavigatingIntent
      * @param final_angle The final angle the robot should have at the end of the movement
      * @param final_speed The final speed the robot should have when it arrives at its
      * destination
-     * @param enable_dribbler Whether or not to enable the dribbler
+     * @param dribbler_mode Dribbler mode
      * @param slow Whether or not to move slower (1 m/s)
      * @param autokick This will enable the "break-beam" on the robot, that will
      *                        trigger the kicker to fire as soon as the ball is in front
@@ -22,7 +22,7 @@ class MoveIntent : public NavigatingIntent
      */
     explicit MoveIntent(unsigned int robot_id, const Point& destination,
                         const Angle& final_angle, double final_speed,
-                        DribblerEnable enable_dribbler, MoveType move_type,
+                        DribblerMode dribbler_mode, MoveType move_type,
                         AutochickType autokick, BallCollisionType ball_collision_type);
 
     MoveIntent() = delete;
@@ -49,7 +49,7 @@ class MoveIntent : public NavigatingIntent
      *
      * @return whether or not the dribbler should be enabled while moving
      */
-    const DribblerEnable& getDribblerEnable() const;
+    const DribblerMode& getDribblerMode() const;
 
     /**
      * Gets whether or not the robot should be moving slow
@@ -79,7 +79,7 @@ class MoveIntent : public NavigatingIntent
 
    private:
     Angle final_angle;
-    DribblerEnable enable_dribbler;
+    DribblerMode dribbler_mode;
     MoveType move_type;
     AutochickType autokick;
 };

--- a/src/software/ai/intent/move_intent.h
+++ b/src/software/ai/intent/move_intent.h
@@ -45,9 +45,9 @@ class MoveIntent : public NavigatingIntent
     const AutochickType& getAutochickType() const;
 
     /**
-     * Gets whether or not the dribbler should be enabled while moving
+     * Gets DribblerMode for this move intent
      *
-     * @return whether or not the dribbler should be enabled while moving
+     * @return dribbler mode
      */
     const DribblerMode& getDribblerMode() const;
 

--- a/src/software/ai/intent/move_intent.h
+++ b/src/software/ai/intent/move_intent.h
@@ -22,8 +22,8 @@ class MoveIntent : public NavigatingIntent
      */
     explicit MoveIntent(unsigned int robot_id, const Point& destination,
                         const Angle& final_angle, double final_speed,
-                        DribblerMode dribbler_mode, MoveType move_type,
-                        AutochickType autokick, BallCollisionType ball_collision_type);
+                        DribblerMode dribbler_mode, AutochickType autokick,
+                        BallCollisionType ball_collision_type);
 
     MoveIntent() = delete;
 
@@ -52,13 +52,6 @@ class MoveIntent : public NavigatingIntent
     const DribblerMode& getDribblerMode() const;
 
     /**
-     * Gets whether or not the robot should be moving slow
-     *
-     * @return whether or not the robot should be moving slow
-     */
-    const MoveType& getMoveType() const;
-
-    /**
      * Compares MoveIntents for equality. MoveIntents are considered equal if all
      * their member variables are equal.
      *
@@ -80,6 +73,5 @@ class MoveIntent : public NavigatingIntent
    private:
     Angle final_angle;
     DribblerMode dribbler_mode;
-    MoveType move_type;
     AutochickType autokick;
 };

--- a/src/software/ai/intent/move_intent.h
+++ b/src/software/ai/intent/move_intent.h
@@ -14,7 +14,6 @@ class MoveIntent : public NavigatingIntent
      * @param final_speed The final speed the robot should have when it arrives at its
      * destination
      * @param dribbler_mode Dribbler mode
-     * @param slow Whether or not to move slower (1 m/s)
      * @param autokick This will enable the "break-beam" on the robot, that will
      *                        trigger the kicker to fire as soon as the ball is in front
      *                        of it

--- a/src/software/ai/intent/move_intent_test.cpp
+++ b/src/software/ai/intent/move_intent_test.cpp
@@ -8,10 +8,10 @@
 TEST(MoveIntentTest, test_equality_operator_intents_equal)
 {
     MoveIntent move_intent =
-        MoveIntent(0, Point(), Angle::zero(), 0, DribblerEnable::OFF, MoveType::NORMAL,
+        MoveIntent(0, Point(), Angle::zero(), 0, DribblerMode::OFF, MoveType::NORMAL,
                    AutochickType::NONE, BallCollisionType::AVOID);
     MoveIntent move_intent_other =
-        MoveIntent(0, Point(), Angle::zero(), 0, DribblerEnable::OFF, MoveType::NORMAL,
+        MoveIntent(0, Point(), Angle::zero(), 0, DribblerMode::OFF, MoveType::NORMAL,
                    AutochickType::NONE, BallCollisionType::AVOID);
 
     EXPECT_EQ(move_intent, move_intent_other);
@@ -20,7 +20,7 @@ TEST(MoveIntentTest, test_equality_operator_intents_equal)
 TEST(MoveIntentTest, test_get_destination_ball_collision)
 {
     MoveIntent move_intent =
-        MoveIntent(0, Point(1, 2), Angle::quarter(), 2.3, DribblerEnable::OFF,
+        MoveIntent(0, Point(1, 2), Angle::quarter(), 2.3, DribblerMode::OFF,
                    MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID);
     EXPECT_EQ(move_intent.getDestination(), Point(1, 2));
     EXPECT_EQ(move_intent.getBallCollisionType(), BallCollisionType::AVOID);

--- a/src/software/ai/intent/move_intent_test.cpp
+++ b/src/software/ai/intent/move_intent_test.cpp
@@ -7,12 +7,11 @@
 // since Intents inherit from Primitives
 TEST(MoveIntentTest, test_equality_operator_intents_equal)
 {
-    MoveIntent move_intent =
-        MoveIntent(0, Point(), Angle::zero(), 0, DribblerMode::OFF, MoveType::NORMAL,
-                   AutochickType::NONE, BallCollisionType::AVOID);
+    MoveIntent move_intent = MoveIntent(0, Point(), Angle::zero(), 0, DribblerMode::OFF,
+                                        AutochickType::NONE, BallCollisionType::AVOID);
     MoveIntent move_intent_other =
-        MoveIntent(0, Point(), Angle::zero(), 0, DribblerMode::OFF, MoveType::NORMAL,
-                   AutochickType::NONE, BallCollisionType::AVOID);
+        MoveIntent(0, Point(), Angle::zero(), 0, DribblerMode::OFF, AutochickType::NONE,
+                   BallCollisionType::AVOID);
 
     EXPECT_EQ(move_intent, move_intent_other);
 }
@@ -21,7 +20,7 @@ TEST(MoveIntentTest, test_get_destination_ball_collision)
 {
     MoveIntent move_intent =
         MoveIntent(0, Point(1, 2), Angle::quarter(), 2.3, DribblerMode::OFF,
-                   MoveType::NORMAL, AutochickType::NONE, BallCollisionType::AVOID);
+                   AutochickType::NONE, BallCollisionType::AVOID);
     EXPECT_EQ(move_intent.getDestination(), Point(1, 2));
     EXPECT_EQ(move_intent.getBallCollisionType(), BallCollisionType::AVOID);
 }

--- a/src/software/ai/intent/spinning_move_intent.cpp
+++ b/src/software/ai/intent/spinning_move_intent.cpp
@@ -4,6 +4,7 @@ SpinningMoveIntent::SpinningMoveIntent(unsigned int robot_id, const Point &dest,
                                        const AngularVelocity &angular_vel,
                                        double final_speed)
     : DirectPrimitiveIntent(
-          robot_id, *createSpinningMovePrimitive(dest, final_speed, angular_vel, 0))
+          robot_id,
+          *createSpinningMovePrimitive(dest, final_speed, angular_vel, DribblerMode::OFF))
 {
 }

--- a/src/software/ai/intent/spinning_move_intent.cpp
+++ b/src/software/ai/intent/spinning_move_intent.cpp
@@ -3,7 +3,7 @@
 SpinningMoveIntent::SpinningMoveIntent(unsigned int robot_id, const Point &dest,
                                        const AngularVelocity &angular_vel,
                                        double final_speed)
-    : DirectPrimitiveIntent(robot_id, *createSpinningMovePrimitive(dest, final_speed,
-                                                                   false, angular_vel, 0))
+    : DirectPrimitiveIntent(
+          robot_id, *createSpinningMovePrimitive(dest, final_speed, angular_vel, 0))
 {
 }

--- a/src/software/ai/navigator/navigating_primitive_creator.cpp
+++ b/src/software/ai/navigator/navigating_primitive_creator.cpp
@@ -27,7 +27,7 @@ void NavigatingPrimitiveCreator::visit(const MoveIntent &intent)
 {
     current_primitive = *createLegacyMovePrimitive(
         new_destination, intent.getFinalAngle(), new_final_speed,
-        intent.getDribblerMode(), intent.getMoveType(), intent.getAutochickType());
+        intent.getDribblerMode(), intent.getAutochickType());
 }
 
 std::pair<Point, double> NavigatingPrimitiveCreator::calculateDestinationAndFinalSpeed(

--- a/src/software/ai/navigator/navigating_primitive_creator.cpp
+++ b/src/software/ai/navigator/navigating_primitive_creator.cpp
@@ -27,7 +27,7 @@ void NavigatingPrimitiveCreator::visit(const MoveIntent &intent)
 {
     current_primitive = *createLegacyMovePrimitive(
         new_destination, intent.getFinalAngle(), new_final_speed,
-        intent.getDribblerEnable(), intent.getMoveType(), intent.getAutochickType());
+        intent.getDribblerMode(), intent.getMoveType(), intent.getAutochickType());
 }
 
 std::pair<Point, double> NavigatingPrimitiveCreator::calculateDestinationAndFinalSpeed(

--- a/src/software/ai/navigator/navigator_test.cpp
+++ b/src/software/ai/navigator/navigator_test.cpp
@@ -109,8 +109,8 @@ TEST_F(ThetaStarNavigatorTest, convert_spinning_move_intent_to_spinning_move_pri
     // Make sure we got exactly 1 primitive back
     EXPECT_EQ(primitive_set_msg->robot_primitives().size(), 1);
 
-    auto expected_primitive =
-        *createSpinningMovePrimitive(Point(), 1, AngularVelocity::full(), 0);
+    auto expected_primitive = *createSpinningMovePrimitive(
+        Point(), 1, AngularVelocity::full(), DribblerMode::OFF);
     EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
         expected_primitive, primitive_set_msg->robot_primitives().at(0)));
 }

--- a/src/software/ai/navigator/navigator_test.cpp
+++ b/src/software/ai/navigator/navigator_test.cpp
@@ -199,7 +199,7 @@ TEST(NavigatorTest, move_intent_with_one_point_path_test_path_planner)
 
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(std::make_unique<MoveIntent>(
-        0, poi, Angle::zero(), 0, DribblerEnable::OFF, MoveType::NORMAL,
+        0, poi, Angle::zero(), 0, DribblerMode::OFF, MoveType::NORMAL,
         AutochickType::NONE, BallCollisionType::AVOID));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);
@@ -208,7 +208,7 @@ TEST(NavigatorTest, move_intent_with_one_point_path_test_path_planner)
     EXPECT_EQ(primitive_set_msg->robot_primitives().size(), 1);
 
     auto expected_primitive =
-        *createLegacyMovePrimitive(poi, Angle::zero(), 0, DribblerEnable::OFF,
+        *createLegacyMovePrimitive(poi, Angle::zero(), 0, DribblerMode::OFF,
                                    MoveType::NORMAL, AutochickType::NONE);
     EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
         expected_primitive, primitive_set_msg->robot_primitives().at(0)));
@@ -239,7 +239,7 @@ TEST_F(NoPathNavigatorTest, move_intent_with_no_path_test_path_planner)
 
     std::vector<std::unique_ptr<Intent>> intents;
     intents.emplace_back(std::make_unique<MoveIntent>(
-        0, Point(), Angle::zero(), 0, DribblerEnable::OFF, MoveType::NORMAL,
+        0, Point(), Angle::zero(), 0, DribblerMode::OFF, MoveType::NORMAL,
         AutochickType::NONE, BallCollisionType::AVOID));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);

--- a/src/software/ai/navigator/navigator_test.cpp
+++ b/src/software/ai/navigator/navigator_test.cpp
@@ -110,7 +110,7 @@ TEST_F(ThetaStarNavigatorTest, convert_spinning_move_intent_to_spinning_move_pri
     EXPECT_EQ(primitive_set_msg->robot_primitives().size(), 1);
 
     auto expected_primitive =
-        *createSpinningMovePrimitive(Point(), 1, false, AngularVelocity::full(), 0);
+        *createSpinningMovePrimitive(Point(), 1, AngularVelocity::full(), 0);
     EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
         expected_primitive, primitive_set_msg->robot_primitives().at(0)));
 }
@@ -198,18 +198,17 @@ TEST(NavigatorTest, move_intent_with_one_point_path_test_path_planner)
         std::make_shared<NavigatorConfig>());
 
     std::vector<std::unique_ptr<Intent>> intents;
-    intents.emplace_back(std::make_unique<MoveIntent>(
-        0, poi, Angle::zero(), 0, DribblerMode::OFF, MoveType::NORMAL,
-        AutochickType::NONE, BallCollisionType::AVOID));
+    intents.emplace_back(
+        std::make_unique<MoveIntent>(0, poi, Angle::zero(), 0, DribblerMode::OFF,
+                                     AutochickType::NONE, BallCollisionType::AVOID));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);
 
     // Make sure we got exactly 1 primitive back
     EXPECT_EQ(primitive_set_msg->robot_primitives().size(), 1);
 
-    auto expected_primitive =
-        *createLegacyMovePrimitive(poi, Angle::zero(), 0, DribblerMode::OFF,
-                                   MoveType::NORMAL, AutochickType::NONE);
+    auto expected_primitive = *createLegacyMovePrimitive(
+        poi, Angle::zero(), 0, DribblerMode::OFF, AutochickType::NONE);
     EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
         expected_primitive, primitive_set_msg->robot_primitives().at(0)));
 }
@@ -238,9 +237,9 @@ TEST_F(NoPathNavigatorTest, move_intent_with_no_path_test_path_planner)
     World world = World(field, ball, friendly_team, enemy_team);
 
     std::vector<std::unique_ptr<Intent>> intents;
-    intents.emplace_back(std::make_unique<MoveIntent>(
-        0, Point(), Angle::zero(), 0, DribblerMode::OFF, MoveType::NORMAL,
-        AutochickType::NONE, BallCollisionType::AVOID));
+    intents.emplace_back(
+        std::make_unique<MoveIntent>(0, Point(), Angle::zero(), 0, DribblerMode::OFF,
+                                     AutochickType::NONE, BallCollisionType::AVOID));
 
     auto primitive_set_msg = navigator.getAssignedPrimitives(world, intents);
 

--- a/src/software/proto/message_translation/primitive_google_to_nanopb_converter_test.cpp
+++ b/src/software/proto/message_translation/primitive_google_to_nanopb_converter_test.cpp
@@ -16,7 +16,7 @@
 TEST(PrimitiveGoogleToNanoPbConverterTest, convert_move_primitive)
 {
     TbotsProto::Primitive google_primitive = *createLegacyMovePrimitive(
-        Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE, AutochickType::NONE);
+        Point(1, 2), Angle::half(), 100, DribblerMode::MAX_FORCE, AutochickType::NONE);
 
     TbotsProto_Primitive nanopb_primitive = createNanoPbPrimitive(google_primitive);
 
@@ -33,14 +33,14 @@ TEST(PrimitiveGoogleToNanoPbConverterTest, convert_move_primitive)
 
 TEST(PrimitiveGoogleToNanoPbConverterTest, convert_primitive_set)
 {
-    *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE,
+    *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerMode::MAX_FORCE,
                                AutochickType::NONE);
-    *createLegacyMovePrimitive(Point(2, 4), Angle::half(), 50, DribblerMode::INDEFINITE,
+    *createLegacyMovePrimitive(Point(2, 4), Angle::half(), 50, DribblerMode::MAX_FORCE,
                                AutochickType::NONE);
     TbotsProto::Primitive google_primitive_1 = *createLegacyMovePrimitive(
-        Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE, AutochickType::NONE);
+        Point(1, 2), Angle::half(), 100, DribblerMode::MAX_FORCE, AutochickType::NONE);
     TbotsProto::Primitive google_primitive_2 = *createLegacyMovePrimitive(
-        Point(2, 4), Angle::half(), 50, DribblerMode::INDEFINITE, AutochickType::NONE);
+        Point(2, 4), Angle::half(), 50, DribblerMode::MAX_FORCE, AutochickType::NONE);
 
     auto google_primitive_set  = std::make_unique<TbotsProto::PrimitiveSet>();
     auto& robot_primitives_map = *google_primitive_set->mutable_robot_primitives();

--- a/src/software/proto/message_translation/primitive_google_to_nanopb_converter_test.cpp
+++ b/src/software/proto/message_translation/primitive_google_to_nanopb_converter_test.cpp
@@ -16,7 +16,7 @@
 TEST(PrimitiveGoogleToNanoPbConverterTest, convert_move_primitive)
 {
     TbotsProto::Primitive google_primitive =
-        *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerEnable::ON,
+        *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE,
                                    MoveType::SLOW, AutochickType::NONE);
 
     TbotsProto_Primitive nanopb_primitive = createNanoPbPrimitive(google_primitive);
@@ -35,15 +35,15 @@ TEST(PrimitiveGoogleToNanoPbConverterTest, convert_move_primitive)
 
 TEST(PrimitiveGoogleToNanoPbConverterTest, convert_primitive_set)
 {
-    *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerEnable::ON,
+    *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE,
                                MoveType::SLOW, AutochickType::NONE);
-    *createLegacyMovePrimitive(Point(2, 4), Angle::half(), 50, DribblerEnable::ON,
+    *createLegacyMovePrimitive(Point(2, 4), Angle::half(), 50, DribblerMode::INDEFINITE,
                                MoveType::NORMAL, AutochickType::NONE);
     TbotsProto::Primitive google_primitive_1 =
-        *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerEnable::ON,
+        *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE,
                                    MoveType::SLOW, AutochickType::NONE);
     TbotsProto::Primitive google_primitive_2 =
-        *createLegacyMovePrimitive(Point(2, 4), Angle::half(), 50, DribblerEnable::ON,
+        *createLegacyMovePrimitive(Point(2, 4), Angle::half(), 50, DribblerMode::INDEFINITE,
                                    MoveType::NORMAL, AutochickType::NONE);
 
     auto google_primitive_set  = std::make_unique<TbotsProto::PrimitiveSet>();

--- a/src/software/proto/message_translation/primitive_google_to_nanopb_converter_test.cpp
+++ b/src/software/proto/message_translation/primitive_google_to_nanopb_converter_test.cpp
@@ -15,9 +15,8 @@
 
 TEST(PrimitiveGoogleToNanoPbConverterTest, convert_move_primitive)
 {
-    TbotsProto::Primitive google_primitive =
-        *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE,
-                                   MoveType::SLOW, AutochickType::NONE);
+    TbotsProto::Primitive google_primitive = *createLegacyMovePrimitive(
+        Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE, AutochickType::NONE);
 
     TbotsProto_Primitive nanopb_primitive = createNanoPbPrimitive(google_primitive);
 
@@ -27,7 +26,6 @@ TEST(PrimitiveGoogleToNanoPbConverterTest, convert_move_primitive)
     EXPECT_EQ(
         nanopb_primitive.primitive.move.position_params.final_speed_meters_per_second,
         100.0f);
-    EXPECT_EQ(nanopb_primitive.primitive.move.position_params.slow, true);
     EXPECT_EQ(nanopb_primitive.primitive.move.final_angle.radians,
               static_cast<float>(M_PI));
     EXPECT_EQ(nanopb_primitive.primitive.move.dribbler_speed_rpm, 16000);
@@ -36,15 +34,13 @@ TEST(PrimitiveGoogleToNanoPbConverterTest, convert_move_primitive)
 TEST(PrimitiveGoogleToNanoPbConverterTest, convert_primitive_set)
 {
     *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE,
-                               MoveType::SLOW, AutochickType::NONE);
+                               AutochickType::NONE);
     *createLegacyMovePrimitive(Point(2, 4), Angle::half(), 50, DribblerMode::INDEFINITE,
-                               MoveType::NORMAL, AutochickType::NONE);
-    TbotsProto::Primitive google_primitive_1 =
-        *createLegacyMovePrimitive(Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE,
-                                   MoveType::SLOW, AutochickType::NONE);
-    TbotsProto::Primitive google_primitive_2 =
-        *createLegacyMovePrimitive(Point(2, 4), Angle::half(), 50, DribblerMode::INDEFINITE,
-                                   MoveType::NORMAL, AutochickType::NONE);
+                               AutochickType::NONE);
+    TbotsProto::Primitive google_primitive_1 = *createLegacyMovePrimitive(
+        Point(1, 2), Angle::half(), 100, DribblerMode::INDEFINITE, AutochickType::NONE);
+    TbotsProto::Primitive google_primitive_2 = *createLegacyMovePrimitive(
+        Point(2, 4), Angle::half(), 50, DribblerMode::INDEFINITE, AutochickType::NONE);
 
     auto google_primitive_set  = std::make_unique<TbotsProto::PrimitiveSet>();
     auto& robot_primitives_map = *google_primitive_set->mutable_robot_primitives();
@@ -73,7 +69,6 @@ TEST(PrimitiveGoogleToNanoPbConverterTest, convert_primitive_set)
             EXPECT_EQ(nanopb_primitive.primitive.move.position_params
                           .final_speed_meters_per_second,
                       100.0f);
-            EXPECT_EQ(nanopb_primitive.primitive.move.position_params.slow, true);
             EXPECT_EQ(nanopb_primitive.primitive.move.final_angle.radians,
                       static_cast<float>(M_PI));
             EXPECT_EQ(nanopb_primitive.primitive.move.dribbler_speed_rpm, 16000);
@@ -92,7 +87,6 @@ TEST(PrimitiveGoogleToNanoPbConverterTest, convert_primitive_set)
             EXPECT_EQ(nanopb_primitive.primitive.move.position_params
                           .final_speed_meters_per_second,
                       50.0f);
-            EXPECT_EQ(nanopb_primitive.primitive.move.position_params.slow, false);
             EXPECT_EQ(nanopb_primitive.primitive.move.final_angle.radians,
                       static_cast<float>(M_PI));
             EXPECT_EQ(nanopb_primitive.primitive.move.dribbler_speed_rpm, 16000);

--- a/src/software/proto/primitive/primitive_msg_factory.cpp
+++ b/src/software/proto/primitive/primitive_msg_factory.cpp
@@ -39,8 +39,8 @@ std::unique_ptr<TbotsProto::Primitive> createKickPrimitive(
 }
 
 std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
-    const Point &dest, double final_speed_meters_per_second, bool slow,
-    const Angle &final_angle, double dribbler_speed_rpm)
+    const Point &dest, double final_speed_meters_per_second, const Angle &final_angle,
+    double dribbler_speed_rpm)
 {
     auto move_primitive_msg = std::make_unique<TbotsProto::Primitive>();
 
@@ -49,7 +49,6 @@ std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
     *(position_params_msg->mutable_destination()) = *dest_msg;
     position_params_msg->set_final_speed_meters_per_second(
         static_cast<float>(final_speed_meters_per_second));
-    position_params_msg->set_slow(slow);
     *(move_primitive_msg->mutable_move()->mutable_position_params()) =
         *position_params_msg;
 
@@ -64,7 +63,7 @@ std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
 
 std::unique_ptr<TbotsProto::Primitive> createLegacyMovePrimitive(
     const Point &dest, const Angle &final_angle, double final_speed,
-    DribblerMode dribbler_mode, MoveType move_type, AutochickType autochick)
+    DribblerMode dribbler_mode, AutochickType autochick)
 {
     // TODO (#1638): Remove this and use createMovePrimitive, createAutochipMovePrimitive,
     // or createAutokickMovePrimitive instead. This should be done after trajectory
@@ -77,7 +76,7 @@ std::unique_ptr<TbotsProto::Primitive> createLegacyMovePrimitive(
         // The old move primitive hardcoded BALL_MAX_SPEED_METERS_PER_SECOND - 1 as the
         // kick speed
         return createAutokickMovePrimitive(
-            dest, final_speed, move_type == MoveType::SLOW, final_angle,
+            dest, final_speed, final_angle,
             dribbler_mode == DribblerMode::INDEFINITE ? 16000 : 0,
             BALL_MAX_SPEED_METERS_PER_SECOND - 1);
     }
@@ -85,19 +84,18 @@ std::unique_ptr<TbotsProto::Primitive> createLegacyMovePrimitive(
     {
         // The old move primitive hardcoded 2 as the chip distance
         return createAutochipMovePrimitive(
-            dest, final_speed, move_type == MoveType::SLOW, final_angle,
+            dest, final_speed, final_angle,
             dribbler_mode == DribblerMode::INDEFINITE ? 16000 : 0, 2);
     }
     else
     {
-        return createMovePrimitive(dest, final_speed, move_type == MoveType::SLOW,
-                                   final_angle,
+        return createMovePrimitive(dest, final_speed, final_angle,
                                    dribbler_mode == DribblerMode::INDEFINITE ? 16000 : 0);
     }
 }
 
 std::unique_ptr<TbotsProto::Primitive> createSpinningMovePrimitive(
-    const Point &dest, double final_speed_meters_per_second, bool slow,
+    const Point &dest, double final_speed_meters_per_second,
     const AngularVelocity &angular_velocity, double dribbler_speed_rpm)
 {
     auto spinning_move_primitive_msg = std::make_unique<TbotsProto::Primitive>();
@@ -107,7 +105,6 @@ std::unique_ptr<TbotsProto::Primitive> createSpinningMovePrimitive(
     *(position_params_msg->mutable_destination()) = *dest_msg;
     position_params_msg->set_final_speed_meters_per_second(
         static_cast<float>(final_speed_meters_per_second));
-    position_params_msg->set_slow(slow);
     *(spinning_move_primitive_msg->mutable_spinning_move()->mutable_position_params()) =
         *position_params_msg;
 
@@ -122,8 +119,8 @@ std::unique_ptr<TbotsProto::Primitive> createSpinningMovePrimitive(
 }
 
 std::unique_ptr<TbotsProto::Primitive> createAutochipMovePrimitive(
-    const Point &dest, double final_speed_meters_per_second, bool slow,
-    const Angle &final_angle, double dribbler_speed_rpm, double chip_distance_meters)
+    const Point &dest, double final_speed_meters_per_second, const Angle &final_angle,
+    double dribbler_speed_rpm, double chip_distance_meters)
 {
     auto autochip_move_primitive_msg = std::make_unique<TbotsProto::Primitive>();
 
@@ -132,7 +129,6 @@ std::unique_ptr<TbotsProto::Primitive> createAutochipMovePrimitive(
     *(position_params_msg->mutable_destination()) = *dest_msg;
     position_params_msg->set_final_speed_meters_per_second(
         static_cast<float>(final_speed_meters_per_second));
-    position_params_msg->set_slow(slow);
     *(autochip_move_primitive_msg->mutable_autochip_move()->mutable_position_params()) =
         *position_params_msg;
 
@@ -150,9 +146,8 @@ std::unique_ptr<TbotsProto::Primitive> createAutochipMovePrimitive(
 }
 
 std::unique_ptr<TbotsProto::Primitive> createAutokickMovePrimitive(
-    const Point &dest, double final_speed_meters_per_second, bool slow,
-    const Angle &final_angle, double dribbler_speed_rpm,
-    double kick_speed_meters_per_second)
+    const Point &dest, double final_speed_meters_per_second, const Angle &final_angle,
+    double dribbler_speed_rpm, double kick_speed_meters_per_second)
 {
     auto autokick_move_primitive_msg = std::make_unique<TbotsProto::Primitive>();
 
@@ -161,7 +156,6 @@ std::unique_ptr<TbotsProto::Primitive> createAutokickMovePrimitive(
     *(position_params_msg->mutable_destination()) = *dest_msg;
     position_params_msg->set_final_speed_meters_per_second(
         static_cast<float>(final_speed_meters_per_second));
-    position_params_msg->set_slow(slow);
     *(autokick_move_primitive_msg->mutable_autokick_move()->mutable_position_params()) =
         *position_params_msg;
 

--- a/src/software/proto/primitive/primitive_msg_factory.cpp
+++ b/src/software/proto/primitive/primitive_msg_factory.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
 
 std::unique_ptr<TbotsProto::Primitive> createLegacyMovePrimitive(
     const Point &dest, const Angle &final_angle, double final_speed,
-    DribblerEnable enable_dribbler, MoveType move_type, AutochickType autochick)
+    DribblerMode dribbler_mode, MoveType move_type, AutochickType autochick)
 {
     // TODO (#1638): Remove this and use createMovePrimitive, createAutochipMovePrimitive,
     // or createAutokickMovePrimitive instead. This should be done after trajectory
@@ -78,7 +78,7 @@ std::unique_ptr<TbotsProto::Primitive> createLegacyMovePrimitive(
         // kick speed
         return createAutokickMovePrimitive(
             dest, final_speed, move_type == MoveType::SLOW, final_angle,
-            enable_dribbler == DribblerEnable::ON ? 16000 : 0,
+            dribbler_mode == DribblerMode::INDEFINITE ? 16000 : 0,
             BALL_MAX_SPEED_METERS_PER_SECOND - 1);
     }
     else if (autochick == AutochickType::AUTOCHIP)
@@ -86,13 +86,13 @@ std::unique_ptr<TbotsProto::Primitive> createLegacyMovePrimitive(
         // The old move primitive hardcoded 2 as the chip distance
         return createAutochipMovePrimitive(
             dest, final_speed, move_type == MoveType::SLOW, final_angle,
-            enable_dribbler == DribblerEnable::ON ? 16000 : 0, 2);
+            dribbler_mode == DribblerMode::INDEFINITE ? 16000 : 0, 2);
     }
     else
     {
         return createMovePrimitive(dest, final_speed, move_type == MoveType::SLOW,
                                    final_angle,
-                                   enable_dribbler == DribblerEnable::ON ? 16000 : 0);
+                                   dribbler_mode == DribblerMode::INDEFINITE ? 16000 : 0);
     }
 }
 

--- a/src/software/proto/primitive/primitive_msg_factory.h
+++ b/src/software/proto/primitive/primitive_msg_factory.h
@@ -8,8 +8,6 @@
 
 MAKE_ENUM(AutochickType, NONE, AUTOKICK, AUTOCHIP);
 
-MAKE_ENUM(MoveType, NORMAL, SLOW);
-
 MAKE_ENUM(DribblerMode, OFF, INDEFINITE, MAX_FORCE);
 
 /**
@@ -45,7 +43,6 @@ std::unique_ptr<TbotsProto::Primitive> createKickPrimitive(
  *
  * @param dest The final destination of the movement
  * @param final_speed_meters_per_second The speed at final destination
- * @param slow Whether or not to move at a slower speed (1m/s)
  * @param final_angle The final orientation the robot should have at the end
  * of the movement
  * @param dribbler_speed_rpm The speed of how fast the dribbler runs
@@ -53,8 +50,8 @@ std::unique_ptr<TbotsProto::Primitive> createKickPrimitive(
  * @return Pointer to Move Primitive Message
  */
 std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
-    const Point &dest, double final_speed_meters_per_second, bool slow,
-    const Angle &final_angle, double dribbler_speed_rpm);
+    const Point &dest, double final_speed_meters_per_second, const Angle &final_angle,
+    double dribbler_speed_rpm);
 
 /**
  * Create a Move Primitive Message using the arguments of the old MovePrimitive
@@ -66,7 +63,6 @@ std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
  * @param final_speed The final speed the Robot should have when it reaches
  * its destination at the end of the movement
  * @param dribbler_mode Whether or not to enable the dribbler
- * @param slow Whether or not to move at a slower speed (1m/s)
  * @param autochick A flag indicating if autokick should be enabled while the robot is
  * moving. This will enable the "break-beam" on the robot that will trigger the kicker
  * or chipper to fire as soon as the ball is in front of it
@@ -75,14 +71,13 @@ std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
  */
 std::unique_ptr<TbotsProto::Primitive> createLegacyMovePrimitive(
     const Point &dest, const Angle &final_angle, double final_speed,
-    DribblerMode dribbler_mode, MoveType move_type, AutochickType autochick);
+    DribblerMode dribbler_mode, AutochickType autochick);
 
 /**
  * Create a Spinning Move Primitive Message
  *
  * @param dest The final destination of the movement
  * @param final_speed_meters_per_second The speed at final destination
- * @param slow Whether or not to move at a slower speed (1m/s)
  * @param angular_velocity The angular velocity of the robot
  * of the movement
  * @param dribbler_speed_rpm The speed of how fast the dribbler runs
@@ -90,7 +85,7 @@ std::unique_ptr<TbotsProto::Primitive> createLegacyMovePrimitive(
  * @return Pointer to Spinning Move Primitive Message
  */
 std::unique_ptr<TbotsProto::Primitive> createSpinningMovePrimitive(
-    const Point &dest, double final_speed_meters_per_second, bool slow,
+    const Point &dest, double final_speed_meters_per_second,
     const AngularVelocity &angular_velocity, double dribbler_speed_rpm);
 
 /**
@@ -98,7 +93,6 @@ std::unique_ptr<TbotsProto::Primitive> createSpinningMovePrimitive(
  *
  * @param dest The final destination of the movement
  * @param final_speed_meters_per_second The speed at final destination
- * @param slow Whether or not to move at a slower speed (1m/s)
  * @param final_angle The final orientation the robot should have at the end
  * of the movement
  * @param dribbler_speed_rpm The speed of how fast the dribbler runs
@@ -108,15 +102,14 @@ std::unique_ptr<TbotsProto::Primitive> createSpinningMovePrimitive(
  * @return Pointer to Autochip Move Primitive Message
  */
 std::unique_ptr<TbotsProto::Primitive> createAutochipMovePrimitive(
-    const Point &dest, double final_speed_meters_per_second, bool slow,
-    const Angle &final_angle, double dribbler_speed_rpm, double chip_distance_meters);
+    const Point &dest, double final_speed_meters_per_second, const Angle &final_angle,
+    double dribbler_speed_rpm, double chip_distance_meters);
 
 /**
  * Create an Autokick Move Primitive Message
  *
  * @param dest The final destination of the movement
  * @param final_speed_meters_per_second The speed at final destination
- * @param slow Whether or not to move at a slower speed (1m/s)
  * @param final_angle The final orientation the robot should have at the end
  * of the movement
  * @param dribbler_speed_rpm The speed of how fast the dribbler runs
@@ -126,9 +119,8 @@ std::unique_ptr<TbotsProto::Primitive> createAutochipMovePrimitive(
  * @return Pointer to Autokick Move Primitive Message
  */
 std::unique_ptr<TbotsProto::Primitive> createAutokickMovePrimitive(
-    const Point &dest, double final_speed_meters_per_second, bool slow,
-    const Angle &final_angle, double dribbler_speed_rpm,
-    double kick_speed_meters_per_second);
+    const Point &dest, double final_speed_meters_per_second, const Angle &final_angle,
+    double dribbler_speed_rpm, double kick_speed_meters_per_second);
 
 /**
  * Create a Stop Move Primitive Message

--- a/src/software/proto/primitive/primitive_msg_factory.h
+++ b/src/software/proto/primitive/primitive_msg_factory.h
@@ -10,7 +10,7 @@ MAKE_ENUM(AutochickType, NONE, AUTOKICK, AUTOCHIP);
 
 MAKE_ENUM(MoveType, NORMAL, SLOW);
 
-MAKE_ENUM(DribblerEnable, OFF, ON);
+MAKE_ENUM(DribblerMode, OFF, INDEFINITE, MAX_FORCE);
 
 /**
  * Create a Chip Primitive Message
@@ -65,7 +65,7 @@ std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
  * of the movement
  * @param final_speed The final speed the Robot should have when it reaches
  * its destination at the end of the movement
- * @param enable_dribbler Whether or not to enable the dribbler
+ * @param dribbler_mode Whether or not to enable the dribbler
  * @param slow Whether or not to move at a slower speed (1m/s)
  * @param autochick A flag indicating if autokick should be enabled while the robot is
  * moving. This will enable the "break-beam" on the robot that will trigger the kicker
@@ -75,7 +75,7 @@ std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
  */
 std::unique_ptr<TbotsProto::Primitive> createLegacyMovePrimitive(
     const Point &dest, const Angle &final_angle, double final_speed,
-    DribblerEnable enable_dribbler, MoveType move_type, AutochickType autochick);
+    DribblerMode dribbler_mode, MoveType move_type, AutochickType autochick);
 
 /**
  * Create a Spinning Move Primitive Message

--- a/src/software/proto/primitive/primitive_msg_factory.h
+++ b/src/software/proto/primitive/primitive_msg_factory.h
@@ -136,6 +136,6 @@ std::unique_ptr<TbotsProto::Primitive> createStopPrimitive(bool coast);
  *
  * @param dribbler_mode The DribblerMode
  *
- * @return the dribbler speed
+ * @return the dribbler speed in RPM
  */
 double convertDribblerModeToDribblerSpeed(DribblerMode dribbler_mode);

--- a/src/software/proto/primitive/primitive_msg_factory.h
+++ b/src/software/proto/primitive/primitive_msg_factory.h
@@ -45,13 +45,13 @@ std::unique_ptr<TbotsProto::Primitive> createKickPrimitive(
  * @param final_speed_meters_per_second The speed at final destination
  * @param final_angle The final orientation the robot should have at the end
  * of the movement
- * @param dribbler_speed_rpm The speed of how fast the dribbler runs
+ * @param dribbler_mode The dribbler mode
  *
  * @return Pointer to Move Primitive Message
  */
 std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
     const Point &dest, double final_speed_meters_per_second, const Angle &final_angle,
-    double dribbler_speed_rpm);
+    DribblerMode dribbler_mode);
 
 /**
  * Create a Move Primitive Message using the arguments of the old MovePrimitive
@@ -80,13 +80,13 @@ std::unique_ptr<TbotsProto::Primitive> createLegacyMovePrimitive(
  * @param final_speed_meters_per_second The speed at final destination
  * @param angular_velocity The angular velocity of the robot
  * of the movement
- * @param dribbler_speed_rpm The speed of how fast the dribbler runs
+ * @param dribbler_mode The dribbler mode
  *
  * @return Pointer to Spinning Move Primitive Message
  */
 std::unique_ptr<TbotsProto::Primitive> createSpinningMovePrimitive(
     const Point &dest, double final_speed_meters_per_second,
-    const AngularVelocity &angular_velocity, double dribbler_speed_rpm);
+    const AngularVelocity &angular_velocity, DribblerMode dribbler_mode);
 
 /**
  * Create an Autochip Move Primitive Message
@@ -95,7 +95,7 @@ std::unique_ptr<TbotsProto::Primitive> createSpinningMovePrimitive(
  * @param final_speed_meters_per_second The speed at final destination
  * @param final_angle The final orientation the robot should have at the end
  * of the movement
- * @param dribbler_speed_rpm The speed of how fast the dribbler runs
+ * @param dribbler_mode The dribbler mode
  * @param chip_distance_meters The distance between the starting location
  * of the chip and the location of the first bounce
  *
@@ -103,7 +103,7 @@ std::unique_ptr<TbotsProto::Primitive> createSpinningMovePrimitive(
  */
 std::unique_ptr<TbotsProto::Primitive> createAutochipMovePrimitive(
     const Point &dest, double final_speed_meters_per_second, const Angle &final_angle,
-    double dribbler_speed_rpm, double chip_distance_meters);
+    DribblerMode dribbler_mode, double chip_distance_meters);
 
 /**
  * Create an Autokick Move Primitive Message
@@ -112,7 +112,7 @@ std::unique_ptr<TbotsProto::Primitive> createAutochipMovePrimitive(
  * @param final_speed_meters_per_second The speed at final destination
  * @param final_angle The final orientation the robot should have at the end
  * of the movement
- * @param dribbler_speed_rpm The speed of how fast the dribbler runs
+ * @param dribbler_mode The dribbler mode
  * @param kick_speed_meters_per_second The speed of how fast the Robot
  * will kick the ball in meters per second
  *
@@ -120,7 +120,7 @@ std::unique_ptr<TbotsProto::Primitive> createAutochipMovePrimitive(
  */
 std::unique_ptr<TbotsProto::Primitive> createAutokickMovePrimitive(
     const Point &dest, double final_speed_meters_per_second, const Angle &final_angle,
-    double dribbler_speed_rpm, double kick_speed_meters_per_second);
+    DribblerMode dribbler_mode, double kick_speed_meters_per_second);
 
 /**
  * Create a Stop Move Primitive Message
@@ -130,3 +130,12 @@ std::unique_ptr<TbotsProto::Primitive> createAutokickMovePrimitive(
  * @return Pointer to Stop Primitive Message
  */
 std::unique_ptr<TbotsProto::Primitive> createStopPrimitive(bool coast);
+
+/**
+ * Convert dribbler mode to dribbler speed
+ *
+ * @param dribbler_mode The DribblerMode
+ *
+ * @return the dribbler speed
+ */
+double convertDribblerModeToDribblerSpeed(DribblerMode dribbler_mode);

--- a/src/software/proto/primitive/primitive_msg_factory.h
+++ b/src/software/proto/primitive/primitive_msg_factory.h
@@ -62,7 +62,7 @@ std::unique_ptr<TbotsProto::Primitive> createMovePrimitive(
  * of the movement
  * @param final_speed The final speed the Robot should have when it reaches
  * its destination at the end of the movement
- * @param dribbler_mode Whether or not to enable the dribbler
+ * @param dribbler_mode The dribbler mode
  * @param autochick A flag indicating if autokick should be enabled while the robot is
  * moving. This will enable the "break-beam" on the robot that will trigger the kicker
  * or chipper to fire as soon as the ball is in front of it

--- a/src/software/proto/primitive/primitive_msg_factory_test.cpp
+++ b/src/software/proto/primitive/primitive_msg_factory_test.cpp
@@ -47,7 +47,7 @@ TEST(PrimitiveFactoryTest, test_create_move_primitive)
 TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_no_chick)
 {
     auto move_primitive = createLegacyMovePrimitive(Point(-5, 1), Angle::threeQuarter(),
-                                                    3.0, DribblerEnable::ON,
+                                                    3.0, DribblerMode::INDEFINITE,
                                                     MoveType::SLOW, AutochickType::NONE);
 
     ASSERT_TRUE(move_primitive->has_move());
@@ -64,7 +64,7 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_no_chick)
 TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_kick)
 {
     auto move_primitive = createLegacyMovePrimitive(
-        Point(-5, 1), Angle::threeQuarter(), 3.0, DribblerEnable::ON, MoveType::SLOW,
+        Point(-5, 1), Angle::threeQuarter(), 3.0, DribblerMode::INDEFINITE, MoveType::SLOW,
         AutochickType::AUTOKICK);
 
     ASSERT_TRUE(move_primitive->has_autokick_move());
@@ -86,7 +86,7 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_kick)
 TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_chip)
 {
     auto move_primitive = createLegacyMovePrimitive(
-        Point(5, -1), Angle::threeQuarter(), 3.0, DribblerEnable::ON, MoveType::NORMAL,
+        Point(5, -1), Angle::threeQuarter(), 3.0, DribblerMode::INDEFINITE, MoveType::NORMAL,
         AutochickType::AUTOCHIP);
 
     ASSERT_TRUE(move_primitive->has_autochip_move());

--- a/src/software/proto/primitive/primitive_msg_factory_test.cpp
+++ b/src/software/proto/primitive/primitive_msg_factory_test.cpp
@@ -30,8 +30,8 @@ TEST(PrimitiveFactoryTest, test_create_kick_primitive)
 
 TEST(PrimitiveFactoryTest, test_create_move_primitive)
 {
-    auto move_primitive =
-        createMovePrimitive(Point(-5, 1), 3.0, Angle::threeQuarter(), 2.0);
+    auto move_primitive = createMovePrimitive(Point(-5, 1), 3.0, Angle::threeQuarter(),
+                                              DribblerMode::INDEFINITE);
 
     ASSERT_TRUE(move_primitive->has_move());
     EXPECT_EQ(move_primitive->move().position_params().destination().x_meters(), -5);
@@ -40,14 +40,14 @@ TEST(PrimitiveFactoryTest, test_create_move_primitive)
               3.0);
     EXPECT_EQ(move_primitive->move().final_angle().radians(),
               static_cast<float>(Angle::threeQuarter().toRadians()));
-    EXPECT_EQ(move_primitive->move().dribbler_speed_rpm(), 2.0);
+    EXPECT_EQ(move_primitive->move().dribbler_speed_rpm(), INDEFINITE_DRIBBLER_SPEED);
 }
 
 TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_no_chick)
 {
     auto move_primitive =
         createLegacyMovePrimitive(Point(-5, 1), Angle::threeQuarter(), 3.0,
-                                  DribblerMode::INDEFINITE, AutochickType::NONE);
+                                  DribblerMode::MAX_FORCE, AutochickType::NONE);
 
     ASSERT_TRUE(move_primitive->has_move());
     EXPECT_EQ(move_primitive->move().position_params().destination().x_meters(), -5);
@@ -56,14 +56,14 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_no_chick)
               3.0);
     EXPECT_EQ(move_primitive->move().final_angle().radians(),
               static_cast<float>(Angle::threeQuarter().toRadians()));
-    EXPECT_EQ(move_primitive->move().dribbler_speed_rpm(), 16000);
+    EXPECT_EQ(move_primitive->move().dribbler_speed_rpm(), MAX_FORCE_DRIBBLER_SPEED);
 }
 
 TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_kick)
 {
     auto move_primitive =
         createLegacyMovePrimitive(Point(-5, 1), Angle::threeQuarter(), 3.0,
-                                  DribblerMode::INDEFINITE, AutochickType::AUTOKICK);
+                                  DribblerMode::MAX_FORCE, AutochickType::AUTOKICK);
 
     ASSERT_TRUE(move_primitive->has_autokick_move());
     EXPECT_EQ(move_primitive->autokick_move().position_params().destination().x_meters(),
@@ -75,7 +75,8 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_kick)
         3.0);
     EXPECT_EQ(move_primitive->autokick_move().final_angle().radians(),
               static_cast<float>(Angle::threeQuarter().toRadians()));
-    EXPECT_EQ(move_primitive->autokick_move().dribbler_speed_rpm(), 16000);
+    EXPECT_EQ(move_primitive->autokick_move().dribbler_speed_rpm(),
+              MAX_FORCE_DRIBBLER_SPEED);
     EXPECT_EQ(move_primitive->autokick_move().kick_speed_meters_per_second(),
               BALL_MAX_SPEED_METERS_PER_SECOND - 1);
 }
@@ -84,7 +85,7 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_chip)
 {
     auto move_primitive =
         createLegacyMovePrimitive(Point(5, -1), Angle::threeQuarter(), 3.0,
-                                  DribblerMode::INDEFINITE, AutochickType::AUTOCHIP);
+                                  DribblerMode::MAX_FORCE, AutochickType::AUTOCHIP);
 
     ASSERT_TRUE(move_primitive->has_autochip_move());
     EXPECT_EQ(move_primitive->autochip_move().position_params().destination().x_meters(),
@@ -96,14 +97,15 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_chip)
         3.0);
     EXPECT_EQ(move_primitive->autochip_move().final_angle().radians(),
               static_cast<float>(Angle::threeQuarter().toRadians()));
-    EXPECT_EQ(move_primitive->autochip_move().dribbler_speed_rpm(), 16000);
+    EXPECT_EQ(move_primitive->autochip_move().dribbler_speed_rpm(),
+              MAX_FORCE_DRIBBLER_SPEED);
     EXPECT_EQ(move_primitive->autochip_move().chip_distance_meters(), 2);
 }
 
 TEST(PrimitiveFactoryTest, test_create_spinning_move_primitive)
 {
-    auto spinning_move_primitive =
-        createSpinningMovePrimitive(Point(1, -8), -6.0, AngularVelocity::full(), -1.0);
+    auto spinning_move_primitive = createSpinningMovePrimitive(
+        Point(1, -8), -6.0, AngularVelocity::full(), DribblerMode::OFF);
 
     ASSERT_TRUE(spinning_move_primitive->has_spinning_move());
     EXPECT_EQ(spinning_move_primitive->spinning_move()
@@ -123,13 +125,13 @@ TEST(PrimitiveFactoryTest, test_create_spinning_move_primitive)
     EXPECT_EQ(
         spinning_move_primitive->spinning_move().angular_velocity().radians_per_second(),
         static_cast<float>(AngularVelocity::full().toRadians()));
-    EXPECT_EQ(spinning_move_primitive->spinning_move().dribbler_speed_rpm(), -1.0);
+    EXPECT_EQ(spinning_move_primitive->spinning_move().dribbler_speed_rpm(), 0.0);
 }
 
 TEST(PrimitiveFactoryTest, test_create_autochip_move_primitive)
 {
-    auto autochip_move_primitive =
-        createAutochipMovePrimitive(Point(-4, -10), 6.0, Angle::quarter(), 1.0, 2.5);
+    auto autochip_move_primitive = createAutochipMovePrimitive(
+        Point(-4, -10), 6.0, Angle::quarter(), DribblerMode::MAX_FORCE, 2.5);
 
     ASSERT_TRUE(autochip_move_primitive->has_autochip_move());
     EXPECT_EQ(autochip_move_primitive->autochip_move()
@@ -148,14 +150,15 @@ TEST(PrimitiveFactoryTest, test_create_autochip_move_primitive)
               6.0);
     EXPECT_EQ(autochip_move_primitive->autochip_move().final_angle().radians(),
               static_cast<float>(Angle::quarter().toRadians()));
-    EXPECT_EQ(autochip_move_primitive->autochip_move().dribbler_speed_rpm(), 1.0);
+    EXPECT_EQ(autochip_move_primitive->autochip_move().dribbler_speed_rpm(),
+              MAX_FORCE_DRIBBLER_SPEED);
     EXPECT_EQ(autochip_move_primitive->autochip_move().chip_distance_meters(), 2.5);
 }
 
 TEST(PrimitiveFactoryTest, test_create_autokick_move_primitive)
 {
-    auto autokick_move_primitive =
-        createAutokickMovePrimitive(Point(5, 12), -2.0, Angle::half(), 5.5, 2.0);
+    auto autokick_move_primitive = createAutokickMovePrimitive(
+        Point(5, 12), -2.0, Angle::half(), DribblerMode::INDEFINITE, 2.0);
 
     ASSERT_TRUE(autokick_move_primitive->has_autokick_move());
     EXPECT_EQ(autokick_move_primitive->autokick_move()
@@ -174,7 +177,8 @@ TEST(PrimitiveFactoryTest, test_create_autokick_move_primitive)
               -2.0);
     EXPECT_EQ(autokick_move_primitive->autokick_move().final_angle().radians(),
               static_cast<float>(Angle::half().toRadians()));
-    EXPECT_EQ(autokick_move_primitive->autokick_move().dribbler_speed_rpm(), 5.5);
+    EXPECT_EQ(autokick_move_primitive->autokick_move().dribbler_speed_rpm(),
+              INDEFINITE_DRIBBLER_SPEED);
     EXPECT_EQ(autokick_move_primitive->autokick_move().kick_speed_meters_per_second(),
               2.0);
 }

--- a/src/software/proto/primitive/primitive_msg_factory_test.cpp
+++ b/src/software/proto/primitive/primitive_msg_factory_test.cpp
@@ -31,14 +31,13 @@ TEST(PrimitiveFactoryTest, test_create_kick_primitive)
 TEST(PrimitiveFactoryTest, test_create_move_primitive)
 {
     auto move_primitive =
-        createMovePrimitive(Point(-5, 1), 3.0, true, Angle::threeQuarter(), 2.0);
+        createMovePrimitive(Point(-5, 1), 3.0, Angle::threeQuarter(), 2.0);
 
     ASSERT_TRUE(move_primitive->has_move());
     EXPECT_EQ(move_primitive->move().position_params().destination().x_meters(), -5);
     EXPECT_EQ(move_primitive->move().position_params().destination().y_meters(), 1);
     EXPECT_EQ(move_primitive->move().position_params().final_speed_meters_per_second(),
               3.0);
-    EXPECT_TRUE(move_primitive->move().position_params().slow());
     EXPECT_EQ(move_primitive->move().final_angle().radians(),
               static_cast<float>(Angle::threeQuarter().toRadians()));
     EXPECT_EQ(move_primitive->move().dribbler_speed_rpm(), 2.0);
@@ -46,16 +45,15 @@ TEST(PrimitiveFactoryTest, test_create_move_primitive)
 
 TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_no_chick)
 {
-    auto move_primitive = createLegacyMovePrimitive(Point(-5, 1), Angle::threeQuarter(),
-                                                    3.0, DribblerMode::INDEFINITE,
-                                                    MoveType::SLOW, AutochickType::NONE);
+    auto move_primitive =
+        createLegacyMovePrimitive(Point(-5, 1), Angle::threeQuarter(), 3.0,
+                                  DribblerMode::INDEFINITE, AutochickType::NONE);
 
     ASSERT_TRUE(move_primitive->has_move());
     EXPECT_EQ(move_primitive->move().position_params().destination().x_meters(), -5);
     EXPECT_EQ(move_primitive->move().position_params().destination().y_meters(), 1);
     EXPECT_EQ(move_primitive->move().position_params().final_speed_meters_per_second(),
               3.0);
-    EXPECT_TRUE(move_primitive->move().position_params().slow());
     EXPECT_EQ(move_primitive->move().final_angle().radians(),
               static_cast<float>(Angle::threeQuarter().toRadians()));
     EXPECT_EQ(move_primitive->move().dribbler_speed_rpm(), 16000);
@@ -63,9 +61,9 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_no_chick)
 
 TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_kick)
 {
-    auto move_primitive = createLegacyMovePrimitive(
-        Point(-5, 1), Angle::threeQuarter(), 3.0, DribblerMode::INDEFINITE, MoveType::SLOW,
-        AutochickType::AUTOKICK);
+    auto move_primitive =
+        createLegacyMovePrimitive(Point(-5, 1), Angle::threeQuarter(), 3.0,
+                                  DribblerMode::INDEFINITE, AutochickType::AUTOKICK);
 
     ASSERT_TRUE(move_primitive->has_autokick_move());
     EXPECT_EQ(move_primitive->autokick_move().position_params().destination().x_meters(),
@@ -75,7 +73,6 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_kick)
     EXPECT_EQ(
         move_primitive->autokick_move().position_params().final_speed_meters_per_second(),
         3.0);
-    EXPECT_TRUE(move_primitive->autokick_move().position_params().slow());
     EXPECT_EQ(move_primitive->autokick_move().final_angle().radians(),
               static_cast<float>(Angle::threeQuarter().toRadians()));
     EXPECT_EQ(move_primitive->autokick_move().dribbler_speed_rpm(), 16000);
@@ -85,9 +82,9 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_kick)
 
 TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_chip)
 {
-    auto move_primitive = createLegacyMovePrimitive(
-        Point(5, -1), Angle::threeQuarter(), 3.0, DribblerMode::INDEFINITE, MoveType::NORMAL,
-        AutochickType::AUTOCHIP);
+    auto move_primitive =
+        createLegacyMovePrimitive(Point(5, -1), Angle::threeQuarter(), 3.0,
+                                  DribblerMode::INDEFINITE, AutochickType::AUTOCHIP);
 
     ASSERT_TRUE(move_primitive->has_autochip_move());
     EXPECT_EQ(move_primitive->autochip_move().position_params().destination().x_meters(),
@@ -97,7 +94,6 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_chip)
     EXPECT_EQ(
         move_primitive->autochip_move().position_params().final_speed_meters_per_second(),
         3.0);
-    EXPECT_FALSE(move_primitive->autochip_move().position_params().slow());
     EXPECT_EQ(move_primitive->autochip_move().final_angle().radians(),
               static_cast<float>(Angle::threeQuarter().toRadians()));
     EXPECT_EQ(move_primitive->autochip_move().dribbler_speed_rpm(), 16000);
@@ -106,8 +102,8 @@ TEST(PrimitiveFactoryTest, test_create_legacy_move_primitive_chip)
 
 TEST(PrimitiveFactoryTest, test_create_spinning_move_primitive)
 {
-    auto spinning_move_primitive = createSpinningMovePrimitive(
-        Point(1, -8), -6.0, false, AngularVelocity::full(), -1.0);
+    auto spinning_move_primitive =
+        createSpinningMovePrimitive(Point(1, -8), -6.0, AngularVelocity::full(), -1.0);
 
     ASSERT_TRUE(spinning_move_primitive->has_spinning_move());
     EXPECT_EQ(spinning_move_primitive->spinning_move()
@@ -124,7 +120,6 @@ TEST(PrimitiveFactoryTest, test_create_spinning_move_primitive)
                   .position_params()
                   .final_speed_meters_per_second(),
               -6.0);
-    EXPECT_FALSE(spinning_move_primitive->spinning_move().position_params().slow());
     EXPECT_EQ(
         spinning_move_primitive->spinning_move().angular_velocity().radians_per_second(),
         static_cast<float>(AngularVelocity::full().toRadians()));
@@ -133,8 +128,8 @@ TEST(PrimitiveFactoryTest, test_create_spinning_move_primitive)
 
 TEST(PrimitiveFactoryTest, test_create_autochip_move_primitive)
 {
-    auto autochip_move_primitive = createAutochipMovePrimitive(
-        Point(-4, -10), 6.0, true, Angle::quarter(), 1.0, 2.5);
+    auto autochip_move_primitive =
+        createAutochipMovePrimitive(Point(-4, -10), 6.0, Angle::quarter(), 1.0, 2.5);
 
     ASSERT_TRUE(autochip_move_primitive->has_autochip_move());
     EXPECT_EQ(autochip_move_primitive->autochip_move()
@@ -151,7 +146,6 @@ TEST(PrimitiveFactoryTest, test_create_autochip_move_primitive)
                   .position_params()
                   .final_speed_meters_per_second(),
               6.0);
-    EXPECT_TRUE(autochip_move_primitive->autochip_move().position_params().slow());
     EXPECT_EQ(autochip_move_primitive->autochip_move().final_angle().radians(),
               static_cast<float>(Angle::quarter().toRadians()));
     EXPECT_EQ(autochip_move_primitive->autochip_move().dribbler_speed_rpm(), 1.0);
@@ -161,7 +155,7 @@ TEST(PrimitiveFactoryTest, test_create_autochip_move_primitive)
 TEST(PrimitiveFactoryTest, test_create_autokick_move_primitive)
 {
     auto autokick_move_primitive =
-        createAutokickMovePrimitive(Point(5, 12), -2.0, false, Angle::half(), 5.5, 2.0);
+        createAutokickMovePrimitive(Point(5, 12), -2.0, Angle::half(), 5.5, 2.0);
 
     ASSERT_TRUE(autokick_move_primitive->has_autokick_move());
     EXPECT_EQ(autokick_move_primitive->autokick_move()
@@ -178,7 +172,6 @@ TEST(PrimitiveFactoryTest, test_create_autokick_move_primitive)
                   .position_params()
                   .final_speed_meters_per_second(),
               -2.0);
-    EXPECT_FALSE(autokick_move_primitive->autokick_move().position_params().slow());
     EXPECT_EQ(autokick_move_primitive->autokick_move().final_angle().radians(),
               static_cast<float>(Angle::half().toRadians()));
     EXPECT_EQ(autokick_move_primitive->autokick_move().dribbler_speed_rpm(), 5.5);

--- a/src/software/proto/ssl_gc_referee_message.proto
+++ b/src/software/proto/ssl_gc_referee_message.proto
@@ -116,7 +116,7 @@ message Referee
     }
     required Command command = 4;
 
-    // The number of commands issued since startup (mode 2^32).
+    // The number of commands issued since startup (mod 2^32).
     required uint32 command_counter = 5;
 
     // The UNIX timestamp when the command was issued, in microseconds.

--- a/src/software/proto/ssl_gc_referee_message.proto
+++ b/src/software/proto/ssl_gc_referee_message.proto
@@ -116,7 +116,7 @@ message Referee
     }
     required Command command = 4;
 
-    // The number of commands issued since startup (mod 2^32).
+    // The number of commands issued since startup (mode 2^32).
     required uint32 command_counter = 5;
 
     // The UNIX timestamp when the command was issued, in microseconds.

--- a/src/software/run_simulated_ai_vs_ai.sh
+++ b/src/software/run_simulated_ai_vs_ai.sh
@@ -24,7 +24,7 @@ fi
 
 # download SSL GameController if not downloaded already
 wget -nc https://github.com/RoboCup-SSL/ssl-game-controller/releases/download/v2.4.0/ssl-game-controller_v2.4.0_linux_amd64 -O /tmp/ssl-game-controller_v2.4.0_linux_amd64
-chmode +x /tmp/ssl-game-controller_v2.4.0_linux_amd64
+chmod +x /tmp/ssl-game-controller_v2.4.0_linux_amd64
 
 tmux new-session \; \
   set -g mouse on \; \

--- a/src/software/run_simulated_ai_vs_ai.sh
+++ b/src/software/run_simulated_ai_vs_ai.sh
@@ -24,7 +24,7 @@ fi
 
 # download SSL GameController if not downloaded already
 wget -nc https://github.com/RoboCup-SSL/ssl-game-controller/releases/download/v2.4.0/ssl-game-controller_v2.4.0_linux_amd64 -O /tmp/ssl-game-controller_v2.4.0_linux_amd64
-chmod +x /tmp/ssl-game-controller_v2.4.0_linux_amd64
+chmode +x /tmp/ssl-game-controller_v2.4.0_linux_amd64
 
 tmux new-session \; \
   set -g mouse on \; \

--- a/src/software/simulation/simulator_test.cpp
+++ b/src/software/simulation/simulator_test.cpp
@@ -340,7 +340,7 @@ TEST(SimulatorTest, simulate_single_yellow_robot_with_primitive)
 
     simulator.setYellowRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, 0), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(1, 0), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 120; i++)
@@ -408,7 +408,7 @@ TEST(SimulatorTest, simulate_single_blue_robot_with_primitive_defending_negative
 
     simulator.setBlueRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, 0), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(1, 0), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 120; i++)
@@ -449,7 +449,7 @@ TEST(SimulatorTest, simulate_single_blue_robot_with_primitive_defending_positive
 
     simulator.setBlueRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, -0.5), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(1, -0.5), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 240; i++)
@@ -491,7 +491,7 @@ TEST(SimulatorTest, simulate_single_yellow_robot_with_primitive_defending_negati
 
     simulator.setYellowRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, 0), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(1, 0), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 120; i++)
@@ -532,7 +532,7 @@ TEST(SimulatorTest, simulate_single_yellow_robot_with_primitive_defending_positi
 
     simulator.setYellowRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, -0.5), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(1, -0.5), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 240; i++)
@@ -583,20 +583,20 @@ TEST(SimulatorTest, simulate_multiple_blue_and_yellow_robots_with_primitives)
 
     simulator.setBlueRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(-1, -1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(-1, -1), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
     simulator.setBlueRobotPrimitive(
         2, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(-3, 0), Angle::half(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(-3, 0), Angle::half(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
 
     simulator.setYellowRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, 1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(1, 1), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
     simulator.setYellowRobotPrimitive(
         2, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(3, -2), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(3, -2), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 120; i++)

--- a/src/software/simulation/simulator_test.cpp
+++ b/src/software/simulation/simulator_test.cpp
@@ -340,8 +340,7 @@ TEST(SimulatorTest, simulate_single_yellow_robot_with_primitive)
 
     simulator.setYellowRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, 0), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+               Point(1, 0), Angle::zero(), 0.0, DribblerMode::OFF, AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 120; i++)
     {
@@ -408,8 +407,7 @@ TEST(SimulatorTest, simulate_single_blue_robot_with_primitive_defending_negative
 
     simulator.setBlueRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, 0), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+               Point(1, 0), Angle::zero(), 0.0, DribblerMode::OFF, AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 120; i++)
     {
@@ -447,10 +445,9 @@ TEST(SimulatorTest, simulate_single_blue_robot_with_primitive_defending_positive
     };
     simulator.addBlueRobots(states);
 
-    simulator.setBlueRobotPrimitive(
-        1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, -0.5), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+    simulator.setBlueRobotPrimitive(1, createNanoPbPrimitive(*createLegacyMovePrimitive(
+                                           Point(1, -0.5), Angle::zero(), 0.0,
+                                           DribblerMode::OFF, AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 240; i++)
     {
@@ -491,8 +488,7 @@ TEST(SimulatorTest, simulate_single_yellow_robot_with_primitive_defending_negati
 
     simulator.setYellowRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, 0), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+               Point(1, 0), Angle::zero(), 0.0, DribblerMode::OFF, AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 120; i++)
     {
@@ -530,10 +526,9 @@ TEST(SimulatorTest, simulate_single_yellow_robot_with_primitive_defending_positi
     };
     simulator.addYellowRobots(states);
 
-    simulator.setYellowRobotPrimitive(
-        1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, -0.5), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+    simulator.setYellowRobotPrimitive(1, createNanoPbPrimitive(*createLegacyMovePrimitive(
+                                             Point(1, -0.5), Angle::zero(), 0.0,
+                                             DribblerMode::OFF, AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 240; i++)
     {
@@ -581,23 +576,19 @@ TEST(SimulatorTest, simulate_multiple_blue_and_yellow_robots_with_primitives)
     };
     simulator.addYellowRobots(yellow_robot_states);
 
-    simulator.setBlueRobotPrimitive(
-        1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(-1, -1), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
-    simulator.setBlueRobotPrimitive(
-        2, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(-3, 0), Angle::half(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+    simulator.setBlueRobotPrimitive(1, createNanoPbPrimitive(*createLegacyMovePrimitive(
+                                           Point(-1, -1), Angle::zero(), 0.0,
+                                           DribblerMode::OFF, AutochickType::NONE)));
+    simulator.setBlueRobotPrimitive(2, createNanoPbPrimitive(*createLegacyMovePrimitive(
+                                           Point(-3, 0), Angle::half(), 0.0,
+                                           DribblerMode::OFF, AutochickType::NONE)));
 
     simulator.setYellowRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, 1), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
-    simulator.setYellowRobotPrimitive(
-        2, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(3, -2), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+               Point(1, 1), Angle::zero(), 0.0, DribblerMode::OFF, AutochickType::NONE)));
+    simulator.setYellowRobotPrimitive(2, createNanoPbPrimitive(*createLegacyMovePrimitive(
+                                             Point(3, -2), Angle::zero(), 0.0,
+                                             DribblerMode::OFF, AutochickType::NONE)));
 
     for (unsigned int i = 0; i < 120; i++)
     {

--- a/src/software/simulation/threaded_simulator_test.cpp
+++ b/src/software/simulation/threaded_simulator_test.cpp
@@ -170,22 +170,21 @@ TEST_F(ThreadedSimulatorTest, add_robots_and_primitives_while_simulation_running
     threaded_simulator.addYellowRobots(yellow_robot_states);
 
     threaded_simulator.setBlueRobotPrimitive(
-        1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(-1, -1), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+        1,
+        createNanoPbPrimitive(*createLegacyMovePrimitive(
+            Point(-1, -1), Angle::zero(), 0.0, DribblerMode::OFF, AutochickType::NONE)));
     threaded_simulator.setBlueRobotPrimitive(
-        2, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(-3, 0), Angle::half(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+        2,
+        createNanoPbPrimitive(*createLegacyMovePrimitive(
+            Point(-3, 0), Angle::half(), 0.0, DribblerMode::OFF, AutochickType::NONE)));
 
     threaded_simulator.setYellowRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, 1), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+               Point(1, 1), Angle::zero(), 0.0, DribblerMode::OFF, AutochickType::NONE)));
     threaded_simulator.setYellowRobotPrimitive(
-        2, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(3, -2), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
-               AutochickType::NONE)));
+        2,
+        createNanoPbPrimitive(*createLegacyMovePrimitive(
+            Point(3, -2), Angle::zero(), 0.0, DribblerMode::OFF, AutochickType::NONE)));
 
     std::this_thread::yield();
     std::this_thread::sleep_for(std::chrono::milliseconds(2500));

--- a/src/software/simulation/threaded_simulator_test.cpp
+++ b/src/software/simulation/threaded_simulator_test.cpp
@@ -171,20 +171,20 @@ TEST_F(ThreadedSimulatorTest, add_robots_and_primitives_while_simulation_running
 
     threaded_simulator.setBlueRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(-1, -1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(-1, -1), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
     threaded_simulator.setBlueRobotPrimitive(
         2, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(-3, 0), Angle::half(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(-3, 0), Angle::half(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
 
     threaded_simulator.setYellowRobotPrimitive(
         1, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(1, 1), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(1, 1), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
     threaded_simulator.setYellowRobotPrimitive(
         2, createNanoPbPrimitive(*createLegacyMovePrimitive(
-               Point(3, -2), Angle::zero(), 0.0, DribblerEnable::OFF, MoveType::NORMAL,
+               Point(3, -2), Angle::zero(), 0.0, DribblerMode::OFF, MoveType::NORMAL,
                AutochickType::NONE)));
 
     std::this_thread::yield();


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
* Added INDEFINITE and MAX_FORCE dribbler modes
* Removed slow flag from primitives
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
regression tests
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #1866 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
