### PR TITLE
Added support for setting ball velocity in Simulation

### DIFF
--- a/src/software/gui/standalone_simulator/widgets/BUILD
+++ b/src/software/gui/standalone_simulator/widgets/BUILD
@@ -14,7 +14,8 @@ qt_cc_library(
         "//software/simulation/physics:physics_robot",
         "//software/world:robot_state",
         "//software/world:team_colour",
-        "@qt//:qt_widgets",
+        "//software/gui/drawing:ball",
+        "@qt//:qt_widgets"
     ],
 )
 

--- a/src/software/gui/standalone_simulator/widgets/BUILD
+++ b/src/software/gui/standalone_simulator/widgets/BUILD
@@ -9,13 +9,13 @@ qt_cc_library(
     deps = [
         "//software/geom:point",
         "//software/gui:geometry_conversion",
+        "//software/gui/drawing:ball",
         "//software/gui/generic_widgets/draw_function_visualizer",
         "//software/simulation:standalone_simulator",
         "//software/simulation/physics:physics_robot",
         "//software/world:robot_state",
         "//software/world:team_colour",
-        "//software/gui/drawing:ball",
-        "@qt//:qt_widgets"
+        "@qt//:qt_widgets",
     ],
 )
 

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -1,9 +1,10 @@
 #include "software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h"
 
 #include <QtWidgets/QMenu>
+
+#include "software/gui/drawing/ball.h"
 #include "software/gui/geometry_conversion.h"
 #include "software/simulation/simulator.h"
-#include "software/gui/drawing/ball.h"
 
 
 StandaloneSimulatorDrawFunctionVisualizer::StandaloneSimulatorDrawFunctionVisualizer(
@@ -25,12 +26,10 @@ void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* eve
     // If Ctrl is pressed, place the ball where the user clicks
     if (event->modifiers() & Qt::ControlModifier && standalone_simulator)
     {
-        ctrl_clicked = true;
+        ctrl_clicked         = true;
         Point point_in_scene = createPoint(mapToScene(event->pos()));
         initial_point        = createPoint(mapToScene(event->pos()));
         standalone_simulator->setBallState(BallState(point_in_scene, Vector(0, 0)));
-        
-
     }
     else if (event->modifiers() & Qt::ShiftModifier && standalone_simulator)
     {
@@ -47,12 +46,14 @@ void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* eve
 void StandaloneSimulatorDrawFunctionVisualizer::mouseReleaseEvent(QMouseEvent* event)
 {
     robot.reset();
-    if(ctrl_clicked){
+    if (ctrl_clicked)
+    {
         final_point = createPoint(mapToScene(event->pos()));
-        standalone_simulator->setBallState(BallState(initial_point, initial_point - final_point));
-        initial_point = Point(0,0);
-        final_point = Point(0,0);
-        ctrl_clicked = false;
+        standalone_simulator->setBallState(
+            BallState(initial_point, initial_point - final_point));
+        initial_point = Point(0, 0);
+        final_point   = Point(0, 0);
+        ctrl_clicked  = false;
     }
 
     DrawFunctionVisualizer::mouseReleaseEvent(event);
@@ -69,17 +70,18 @@ void StandaloneSimulatorDrawFunctionVisualizer::mouseMoveEvent(QMouseEvent* even
     if (ctrl_clicked && standalone_simulator)
     {
         final_point = createPoint(mapToScene(event->pos()));
-
     }
     DrawFunctionVisualizer::mouseMoveEvent(event);
 }
 
-WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocityFunction(){
-    Point position = initial_point;
+WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocityFunction()
+{
+    Point position  = initial_point;
     Vector velocity = initial_point - final_point;
 
-    auto draw_function = [position,velocity](QGraphicsScene* scene){
-        drawBallVelocity(scene, position,velocity,ball_speed_slow_color,ball_speed_fast_color);
+    auto draw_function = [position, velocity](QGraphicsScene* scene) {
+        drawBallVelocity(scene, position, velocity, ball_speed_slow_color,
+                         ball_speed_fast_color);
     };
     return WorldDrawFunction(draw_function);
 }

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -26,10 +26,10 @@ void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* eve
     // If Ctrl is pressed, place the ball where the user clicks
     if (event->modifiers() & Qt::ControlModifier && standalone_simulator)
     {
-        ctrl_clicked         = true;
-        Point point_in_scene = createPoint(mapToScene(event->pos()));
-        initial_point        = createPoint(mapToScene(event->pos()));
-        standalone_simulator->setBallState(BallState(point_in_scene, Vector(0, 0)));
+        ctrl_clicked  = true;
+        initial_point = createPoint(mapToScene(event->pos()));
+        final_point   = createPoint(mapToScene(event->pos()));
+        standalone_simulator->setBallState(BallState(initial_point, Vector(0, 0)));
     }
     else if (event->modifiers() & Qt::ShiftModifier && standalone_simulator)
     {
@@ -76,12 +76,9 @@ void StandaloneSimulatorDrawFunctionVisualizer::mouseMoveEvent(QMouseEvent* even
 
 WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocityFunction()
 {
-    Point position  = initial_point;
-    Vector velocity = initial_point - final_point;
-
-    auto draw_function = [position, velocity](QGraphicsScene* scene) {
-        drawBallVelocity(scene, position, velocity, ball_speed_slow_color,
-                         ball_speed_fast_color);
+    auto draw_function = [this](QGraphicsScene* scene) {
+        drawBallVelocity(scene, initial_point, initial_point - final_point,
+                         ball_speed_slow_color, ball_speed_fast_color);
     };
     return WorldDrawFunction(draw_function);
 }

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -1,8 +1,10 @@
 #include "software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h"
 
 #include <QtWidgets/QMenu>
-
 #include "software/gui/geometry_conversion.h"
+#include "software/simulation/simulator.h"
+#include "software/gui/drawing/ball.h"
+
 
 StandaloneSimulatorDrawFunctionVisualizer::StandaloneSimulatorDrawFunctionVisualizer(
     QWidget* parent)
@@ -23,8 +25,12 @@ void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* eve
     // If Ctrl is pressed, place the ball where the user clicks
     if (event->modifiers() & Qt::ControlModifier && standalone_simulator)
     {
+        ctrl_clicked = true;
         Point point_in_scene = createPoint(mapToScene(event->pos()));
+        initial_point        = createPoint(mapToScene(event->pos()));
         standalone_simulator->setBallState(BallState(point_in_scene, Vector(0, 0)));
+        
+
     }
     else if (event->modifiers() & Qt::ShiftModifier && standalone_simulator)
     {
@@ -41,6 +47,14 @@ void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* eve
 void StandaloneSimulatorDrawFunctionVisualizer::mouseReleaseEvent(QMouseEvent* event)
 {
     robot.reset();
+    if(ctrl_clicked){
+        final_point = createPoint(mapToScene(event->pos()));
+        standalone_simulator->setBallState(BallState(initial_point, initial_point - final_point));
+        initial_point = Point(0,0);
+        final_point = Point(0,0);
+        ctrl_clicked = false;
+    }
+
     DrawFunctionVisualizer::mouseReleaseEvent(event);
 }
 
@@ -52,7 +66,22 @@ void StandaloneSimulatorDrawFunctionVisualizer::mouseMoveEvent(QMouseEvent* even
         Point point_in_scene = createPoint(mapToScene(event->pos()));
         physics_robot->setPosition(point_in_scene);
     }
+    if (ctrl_clicked && standalone_simulator)
+    {
+        final_point = createPoint(mapToScene(event->pos()));
+
+    }
     DrawFunctionVisualizer::mouseMoveEvent(event);
+}
+
+WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocityFunction(){
+    Point position = initial_point;
+    Vector velocity = initial_point - final_point;
+
+    auto draw_function = [position,velocity](QGraphicsScene* scene){
+        drawBallVelocity(scene, position,velocity,ball_speed_slow_color,ball_speed_fast_color);
+    };
+    return WorldDrawFunction(draw_function);
 }
 
 void StandaloneSimulatorDrawFunctionVisualizer::contextMenuEvent(QContextMenuEvent* event)

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
@@ -10,6 +10,7 @@
 #include "software/world/robot_state.h"
 #include "software/world/team_types.h"
 
+
 /**
  * A custom version of the DrawFunctionVisualizer widget that allows the user to
  * interact with the simulation, such as clicking to place the ball
@@ -28,6 +29,14 @@ class StandaloneSimulatorDrawFunctionVisualizer : public DrawFunctionVisualizer
      */
     void setStandaloneSimulator(std::shared_ptr<StandaloneSimulator> simulator);
 
+
+    /**
+     * Gets the WorldDrawFunction for the Simulator to draw the
+     * vector when the ball is moving
+     *
+     */
+    WorldDrawFunction getDrawBallVelocityFunction();
+
    private:
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
@@ -36,5 +45,15 @@ class StandaloneSimulatorDrawFunctionVisualizer : public DrawFunctionVisualizer
 
     // The robot currently being placed by the user, if any
     std::weak_ptr<PhysicsRobot> robot;
+
+    // Boolean to check if the user ctrl clicked
+    bool ctrl_clicked = false;
+
+    //The initial point when adding force to the ball, if any
+    Point initial_point;
+
+    //The final point when adding force to the ball, if any
+    Point final_point;
+
     std::shared_ptr<StandaloneSimulator> standalone_simulator;
 };

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
@@ -10,7 +10,6 @@
 #include "software/world/robot_state.h"
 #include "software/world/team_types.h"
 
-
 /**
  * A custom version of the DrawFunctionVisualizer widget that allows the user to
  * interact with the simulation, such as clicking to place the ball

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
@@ -49,10 +49,10 @@ class StandaloneSimulatorDrawFunctionVisualizer : public DrawFunctionVisualizer
     // Boolean to check if the user ctrl clicked
     bool ctrl_clicked = false;
 
-    //The initial point when adding force to the ball, if any
+    // The initial point when adding force to the ball, if any
     Point initial_point;
 
-    //The final point when adding force to the ball, if any
+    // The final point when adding force to the ball, if any
     Point final_point;
 
     std::shared_ptr<StandaloneSimulator> standalone_simulator;

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_gui.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_gui.cpp
@@ -76,7 +76,7 @@ void StandaloneSimulatorGUI::draw()
     auto ssl_wrapper_packet = standalone_simulator->getSSLWrapperPacket();
     auto draw_function      = getDrawSSLWrapperPacketFunction(ssl_wrapper_packet);
     main_widget->simulation_graphics_view->clearAndDraw(
-        {draw_function.getDrawFunction()});
+        {main_widget->simulation_graphics_view->getDrawBallVelocityFunction().getDrawFunction(),draw_function.getDrawFunction()});
 }
 
 void StandaloneSimulatorGUI::updateDrawViewArea()

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_gui.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_gui.cpp
@@ -76,7 +76,9 @@ void StandaloneSimulatorGUI::draw()
     auto ssl_wrapper_packet = standalone_simulator->getSSLWrapperPacket();
     auto draw_function      = getDrawSSLWrapperPacketFunction(ssl_wrapper_packet);
     main_widget->simulation_graphics_view->clearAndDraw(
-        {main_widget->simulation_graphics_view->getDrawBallVelocityFunction().getDrawFunction(),draw_function.getDrawFunction()});
+        {main_widget->simulation_graphics_view->getDrawBallVelocityFunction()
+             .getDrawFunction(),
+         draw_function.getDrawFunction()});
 }
 
 void StandaloneSimulatorGUI::updateDrawViewArea()

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_gui.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_gui.cpp
@@ -74,11 +74,10 @@ void StandaloneSimulatorGUI::handleUpdate()
 void StandaloneSimulatorGUI::draw()
 {
     auto ssl_wrapper_packet = standalone_simulator->getSSLWrapperPacket();
-    auto draw_function      = getDrawSSLWrapperPacketFunction(ssl_wrapper_packet);
     main_widget->simulation_graphics_view->clearAndDraw(
         {main_widget->simulation_graphics_view->getDrawBallVelocityFunction()
              .getDrawFunction(),
-         draw_function.getDrawFunction()});
+         getDrawSSLWrapperPacketFunction(ssl_wrapper_packet).getDrawFunction()});
 }
 
 void StandaloneSimulatorGUI::updateDrawViewArea()


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Added support for ball movement in simulation. When you hold ctrl+click in the simulator, you are now able to impart a velocity on the ball. The velocity vector should be shown in the AI.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
#1542 
### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
