### PR TITLE
Replace case conversion function in C writer

### DIFF
--- a/src/shared/parameter_v2/generation_scripts/c_writer.py
+++ b/src/shared/parameter_v2/generation_scripts/c_writer.py
@@ -3,6 +3,7 @@ from c_parameter import CParameter
 from typing import List, Set
 from dynamic_parameter_schema import PARAMETER_KEY, INCLUDE_KEY, CONSTANT_KEY
 from type_map import C_TYPE_MAP
+from case_conversion import to_pascal_case
 
 #######################################################################
 #                              C Writer                               #
@@ -50,9 +51,9 @@ class CWriter(object):
 
         for config, metadata in config_metadata.items():
 
-            # we convert the yaml file name to camel case
+            # we convert the yaml file name to pascal case
             # and store that as the config_name
-            config_name = CWriter.to_camel_case(config.split(".")[0])
+            config_name = to_pascal_case(config.split(".")[0])
 
             config = CConfig(
                 config_name, "{}_ptr->{}".format(top_level_config_name, config_name)
@@ -95,9 +96,7 @@ class CWriter(object):
             # add all the valid included configs to the CConfig
             if INCLUDE_KEY in metadata:
                 for included_yaml in metadata["include"]:
-                    config.include_config(
-                        CWriter.to_camel_case(included_yaml.split(".")[0])
-                    )
+                    config.include_config(to_pascal_case(included_yaml.split(".")[0]))
                     config_empty = False
 
             if not config_empty:
@@ -159,7 +158,3 @@ class CWriter(object):
                     app_dynamic_parameters_destroy_impl=app_dynamic_parameters_destroy_impl,
                 )
             )
-
-    @staticmethod
-    def to_camel_case(snake_str):
-        return "".join(x.title() for x in snake_str.split("_"))

--- a/src/shared/parameter_v2/generation_scripts/case_conversion.py
+++ b/src/shared/parameter_v2/generation_scripts/case_conversion.py
@@ -6,8 +6,8 @@ def to_pascal_case(snake_str):
 
 
 def to_camel_case(snake_str):
-    upper_camel_case = to_pascal_case(snake_str)
-    return upper_camel_case[0].lower() + upper_camel_case[1:]
+    pascal_case = to_pascal_case(snake_str)
+    return pascal_case[0].lower() + pascal_case[1:]
 
 
 def to_snake_case(camel_str):


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Replace usage of `to_camel_case` with `to_pascal_case` defined in `case_conversion.py`

### Testing Done
Passes existing unit tests
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #1887 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
