### PR TITLE
Log full filtered world state as SSL_WrapperPacket

### DIFF
--- a/src/software/BUILD
+++ b/src/software/BUILD
@@ -14,6 +14,7 @@ cc_binary(
         "//software/multithreading:observer_subject_adapter",
         "//software/parameter:dynamic_parameters",
         "//software/proto/logging:proto_logger",
+        "//software/proto/message_translation:ssl_wrapper",
         "//software/sensor_fusion:threaded_sensor_fusion",
         "//software/util/design_patterns:generic_factory",
         "@boost//:program_options",

--- a/src/software/full_system_main.cpp
+++ b/src/software/full_system_main.cpp
@@ -124,7 +124,9 @@ int main(int argc, char** argv)
                 bool friendly_colour_yellow = DynamicParameters->getSensorFusionConfig()
                                                   ->FriendlyColorYellow()
                                                   ->value();
-                return *createSSLWrapperPacket(world, friendly_colour_yellow);
+                auto friendly_team_colour =
+                    friendly_colour_yellow ? TeamColour::YELLOW : TeamColour::BLUE;
+                return *createSSLWrapperPacket(world, friendly_team_colour);
             };
 
             auto vision_logger =

--- a/src/software/proto/message_translation/BUILD
+++ b/src/software/proto/message_translation/BUILD
@@ -112,6 +112,7 @@ cc_test(
     srcs = ["ssl_wrapper_test.cpp"],
     deps = [
         ":ssl_wrapper",
+        "//software/test_util",
         "@gtest//:gtest_main",
     ],
 )

--- a/src/software/proto/message_translation/BUILD
+++ b/src/software/proto/message_translation/BUILD
@@ -101,7 +101,9 @@ cc_library(
     deps = [
         ":ssl_detection",
         ":ssl_geometry",
+        "//software/logger",
         "//software/proto:ssl_cc_proto",
+        "//software/world",
     ],
 )
 

--- a/src/software/proto/message_translation/ssl_wrapper.cpp
+++ b/src/software/proto/message_translation/ssl_wrapper.cpp
@@ -1,5 +1,10 @@
 #include "software/proto/message_translation/ssl_wrapper.h"
 
+#include "software/proto/message_translation/ssl_detection.h"
+#include "software/proto/message_translation/ssl_geometry.h"
+
+static constexpr float DEFAULT_FIELD_LINE_THICKNESS = 0.01f;
+
 std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
     std::unique_ptr<SSLProto::SSL_GeometryData> geometry_data,
     std::unique_ptr<SSLProto::SSL_DetectionFrame> detection_frame)
@@ -15,4 +20,42 @@ std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
     }
 
     return std::move(wrapper_packet);
+}
+std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
+    const World& world, bool friendly_team_colour_yellow)
+{
+    auto start_time = std::chrono::high_resolution_clock::now();
+    constexpr auto robot_to_robotstate_with_id_fn = [](const Robot& robot) {
+        return RobotStateWithId{.id = robot.id(), .robot_state = robot.currentState()};
+    };
+
+    std::vector<RobotStateWithId> friendly_robot_states;
+    friendly_robot_states.reserve(world.friendlyTeam().numRobots());
+    std::transform(world.friendlyTeam().getAllRobots().begin(),
+                   world.friendlyTeam().getAllRobots().end(),
+                   std::back_inserter(friendly_robot_states),
+                   robot_to_robotstate_with_id_fn);
+
+    std::vector<RobotStateWithId> enemy_robot_states;
+    enemy_robot_states.reserve(world.enemyTeam().numRobots());
+    std::transform(
+        world.enemyTeam().getAllRobots().begin(), world.enemyTeam().getAllRobots().end(),
+        std::back_inserter(enemy_robot_states), robot_to_robotstate_with_id_fn);
+
+    const auto& yellow_robot_states =
+        friendly_team_colour_yellow ? friendly_robot_states : enemy_robot_states;
+
+    const auto& blue_robot_states =
+        !friendly_team_colour_yellow ? friendly_robot_states : enemy_robot_states;
+
+    auto ssl_detectionframe = createSSLDetectionFrame(
+        std::numeric_limits<uint32_t>::max(), world.getMostRecentTimestamp(),
+        std::numeric_limits<uint32_t>::max(), {world.ball().currentState()},
+        yellow_robot_states, blue_robot_states);
+
+    auto ssl_geometrydata =
+        createGeometryData(world.field(), DEFAULT_FIELD_LINE_THICKNESS);
+
+    return createSSLWrapperPacket(std::move(ssl_geometrydata),
+                                  std::move(ssl_detectionframe));
 }

--- a/src/software/proto/message_translation/ssl_wrapper.cpp
+++ b/src/software/proto/message_translation/ssl_wrapper.cpp
@@ -24,7 +24,6 @@ std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
 std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
     const World& world, bool friendly_team_colour_yellow)
 {
-    auto start_time = std::chrono::high_resolution_clock::now();
     constexpr auto robot_to_robotstate_with_id_fn = [](const Robot& robot) {
         return RobotStateWithId{.id = robot.id(), .robot_state = robot.currentState()};
     };

--- a/src/software/proto/message_translation/ssl_wrapper.cpp
+++ b/src/software/proto/message_translation/ssl_wrapper.cpp
@@ -22,7 +22,7 @@ std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
     return std::move(wrapper_packet);
 }
 std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
-    const World& world, bool friendly_team_colour_yellow)
+    const World& world, TeamColour friendly_team_colour)
 {
     constexpr auto robot_to_robotstate_with_id_fn = [](const Robot& robot) {
         return RobotStateWithId{.id = robot.id(), .robot_state = robot.currentState()};
@@ -41,11 +41,13 @@ std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
         world.enemyTeam().getAllRobots().begin(), world.enemyTeam().getAllRobots().end(),
         std::back_inserter(enemy_robot_states), robot_to_robotstate_with_id_fn);
 
-    const auto& yellow_robot_states =
-        friendly_team_colour_yellow ? friendly_robot_states : enemy_robot_states;
+    const auto& yellow_robot_states = friendly_team_colour == TeamColour::YELLOW
+                                          ? friendly_robot_states
+                                          : enemy_robot_states;
 
-    const auto& blue_robot_states =
-        !friendly_team_colour_yellow ? friendly_robot_states : enemy_robot_states;
+    const auto& blue_robot_states = friendly_team_colour == TeamColour::BLUE
+                                        ? friendly_robot_states
+                                        : enemy_robot_states;
 
     auto ssl_detectionframe = createSSLDetectionFrame(
         std::numeric_limits<uint32_t>::max(), world.getMostRecentTimestamp(),

--- a/src/software/proto/message_translation/ssl_wrapper.h
+++ b/src/software/proto/message_translation/ssl_wrapper.h
@@ -30,4 +30,4 @@ std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
  * @return A WrapperPacket containing the given data.
  */
 std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
-    const World& world, bool friendly_team_colour_yellow);
+    const World& world, TeamColour friendly_team_colour);

--- a/src/software/proto/message_translation/ssl_wrapper.h
+++ b/src/software/proto/message_translation/ssl_wrapper.h
@@ -21,5 +21,13 @@ std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
     std::unique_ptr<SSLProto::SSL_GeometryData> geometry_data,
     std::unique_ptr<SSLProto::SSL_DetectionFrame> detection_frame);
 
+/**
+ * Creates a WrapperPacket from the given world state
+ *
+ * @param world the World to fill the WrapperPacket data from
+ * @param friendly_team_colour_yellow whether the friendly team is yellow
+ *
+ * @return A WrapperPacket containing the given data.
+ */
 std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
     const World& world, bool friendly_team_colour_yellow);

--- a/src/software/proto/message_translation/ssl_wrapper.h
+++ b/src/software/proto/message_translation/ssl_wrapper.h
@@ -5,6 +5,7 @@
 #include "software/proto/messages_robocup_ssl_detection.pb.h"
 #include "software/proto/messages_robocup_ssl_geometry.pb.h"
 #include "software/proto/messages_robocup_ssl_wrapper.pb.h"
+#include "software/world/world.h"
 
 /**
  * Creates a WrapperPacket from the given data
@@ -19,3 +20,6 @@
 std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
     std::unique_ptr<SSLProto::SSL_GeometryData> geometry_data,
     std::unique_ptr<SSLProto::SSL_DetectionFrame> detection_frame);
+
+std::unique_ptr<SSLProto::SSL_WrapperPacket> createSSLWrapperPacket(
+    const World& world, bool friendly_team_colour_yellow);

--- a/src/software/proto/message_translation/ssl_wrapper_test.cpp
+++ b/src/software/proto/message_translation/ssl_wrapper_test.cpp
@@ -2,6 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include "software/test_util/test_util.h"
+#include "software/world/world.h"
+
 TEST(SSLWrapperTest, test_create_empty_message)
 {
     auto wrapper_packet = createSSLWrapperPacket(nullptr, nullptr);
@@ -36,4 +39,60 @@ TEST(SSLWrapperTest, test_create_wrapper_with_all_data)
         createSSLWrapperPacket(std::move(geometry_data), std::move(detection_frame));
     EXPECT_TRUE(wrapper_packet->has_geometry());
     EXPECT_TRUE(wrapper_packet->has_detection());
+}
+
+TEST(SSLWrapperTest, test_create_wrapper_with_world_friendly_yellow)
+{
+    Robot yellow_robot1(1, Point(1, 0), Vector(0, 0), Angle::quarter(),
+                        AngularVelocity::half(), Timestamp());
+    Robot yellow_robot2(2, Point(0, 0), Vector(3, 0), Angle::half(),
+                        AngularVelocity::quarter(), Timestamp());
+    std::vector<Robot> yellow_robots = {yellow_robot1, yellow_robot2};
+
+    Robot blue_robot1(3, Point(1, 0), Vector(0, 0), Angle::quarter(),
+                      AngularVelocity::half(), Timestamp());
+    Robot blue_robot2(4, Point(0, 0), Vector(3, 0), Angle::half(),
+                      AngularVelocity::quarter(), Timestamp());
+    Robot blue_robot3(5, Point(-1, -1), Vector(0, 2), Angle::half(),
+                      AngularVelocity::quarter(), Timestamp());
+    std::vector<Robot> blue_robots = {blue_robot1, blue_robot2, blue_robot3};
+
+    bool friendly_robots_are_yellow = true;
+
+    World world = TestUtil::createBlankTestingWorld();
+    world.updateFriendlyTeamState(Team(yellow_robots));
+    world.updateEnemyTeamState(Team(blue_robots));
+
+    auto wrapper_packet_ptr = createSSLWrapperPacket(world, friendly_robots_are_yellow);
+
+    EXPECT_EQ(2, wrapper_packet_ptr->detection().robots_yellow_size());
+    EXPECT_EQ(3, wrapper_packet_ptr->detection().robots_blue_size());
+}
+
+TEST(SSLWrapperTest, test_create_wrapper_with_world_friendly_not_yellow)
+{
+    Robot yellow_robot1(1, Point(1, 0), Vector(0, 0), Angle::quarter(),
+                        AngularVelocity::half(), Timestamp());
+    Robot yellow_robot2(2, Point(0, 0), Vector(3, 0), Angle::half(),
+                        AngularVelocity::quarter(), Timestamp());
+    std::vector<Robot> yellow_robots = {yellow_robot1, yellow_robot2};
+
+    Robot blue_robot1(3, Point(1, 0), Vector(0, 0), Angle::quarter(),
+                      AngularVelocity::half(), Timestamp());
+    Robot blue_robot2(4, Point(0, 0), Vector(3, 0), Angle::half(),
+                      AngularVelocity::quarter(), Timestamp());
+    Robot blue_robot3(5, Point(-1, -1), Vector(0, 2), Angle::half(),
+                      AngularVelocity::quarter(), Timestamp());
+    std::vector<Robot> blue_robots = {blue_robot1, blue_robot2, blue_robot3};
+
+    bool friendly_robots_are_yellow = false;
+
+    World world = TestUtil::createBlankTestingWorld();
+    world.updateFriendlyTeamState(Team(blue_robots));
+    world.updateEnemyTeamState(Team(yellow_robots));
+
+    auto wrapper_packet_ptr = createSSLWrapperPacket(world, friendly_robots_are_yellow);
+
+    EXPECT_EQ(2, wrapper_packet_ptr->detection().robots_yellow_size());
+    EXPECT_EQ(3, wrapper_packet_ptr->detection().robots_blue_size());
 }

--- a/src/software/proto/message_translation/ssl_wrapper_test.cpp
+++ b/src/software/proto/message_translation/ssl_wrapper_test.cpp
@@ -57,13 +57,13 @@ TEST(SSLWrapperTest, test_create_wrapper_with_world_friendly_yellow)
                       AngularVelocity::quarter(), Timestamp());
     std::vector<Robot> blue_robots = {blue_robot1, blue_robot2, blue_robot3};
 
-    bool friendly_robots_are_yellow = true;
+    TeamColour friendly_team_colour = TeamColour::YELLOW;
 
     World world = TestUtil::createBlankTestingWorld();
     world.updateFriendlyTeamState(Team(yellow_robots));
     world.updateEnemyTeamState(Team(blue_robots));
 
-    auto wrapper_packet_ptr = createSSLWrapperPacket(world, friendly_robots_are_yellow);
+    auto wrapper_packet_ptr = createSSLWrapperPacket(world, friendly_team_colour);
 
     EXPECT_EQ(2, wrapper_packet_ptr->detection().robots_yellow_size());
     EXPECT_EQ(3, wrapper_packet_ptr->detection().robots_blue_size());
@@ -85,13 +85,13 @@ TEST(SSLWrapperTest, test_create_wrapper_with_world_friendly_not_yellow)
                       AngularVelocity::quarter(), Timestamp());
     std::vector<Robot> blue_robots = {blue_robot1, blue_robot2, blue_robot3};
 
-    bool friendly_robots_are_yellow = false;
+    TeamColour friendly_team_colour = TeamColour::BLUE;
 
     World world = TestUtil::createBlankTestingWorld();
     world.updateFriendlyTeamState(Team(blue_robots));
     world.updateEnemyTeamState(Team(yellow_robots));
 
-    auto wrapper_packet_ptr = createSSLWrapperPacket(world, friendly_robots_are_yellow);
+    auto wrapper_packet_ptr = createSSLWrapperPacket(world, friendly_team_colour);
 
     EXPECT_EQ(2, wrapper_packet_ptr->detection().robots_yellow_size());
     EXPECT_EQ(3, wrapper_packet_ptr->detection().robots_blue_size());


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Log full filtered world state as SSL_WrapperPacket

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Unit tests

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
Resolves #1898 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
