### PR TITLE
Added chip angle constant

### DIFF
--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -132,3 +132,5 @@ const unsigned int MAX_ROBOT_IDS = 16;
 // 16V, so we use 16 here to approximate a fully-charged battery
 // Makes the battery max voltage a constant now that we are simulating firmware
 const float ROBOT_MAX_BATTERY_VOLTAGE = 16.0;
+
+const unsigned int ROBOT_CHIP_ANGLE_DEGREES = 45;

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -168,11 +168,8 @@ void SimulatorRobot::chip(float distance_m)
     checkValidAndExecuteVoid([this, distance_m](auto robot) {
         if (ball_in_dribbler_area && ball_in_dribbler_area->can_be_controlled)
         {
-            auto ball = ball_in_dribbler_area->ball;
-            // Assume the ball is chipped at a 45 degree angle
-            // TODO: Use a robot-specific constant
-            // https://github.com/UBC-Thunderbots/Software/issues/1179
-            Angle chip_angle = Angle::fromDegrees(45);
+            auto ball        = ball_in_dribbler_area->ball;
+            Angle chip_angle = Angle::fromDegrees(ROBOT_CHIP_ANGLE_DEGREES);
 
             // Mark the ball as "in flight" so collisions are turned off
             // until it has travelled the desired chip distance.


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
as titled, mech is aiming for 45 degrees because it's optimal as we know from high school physics.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
should be functionally the same
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #1179 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
