### PR TITLE
Added stop_ai_on_start flag for simulated tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,19 +102,11 @@ jobs:
       - name: Simulated Test
         run: |
           cd src
-          bazel coverage //software/simulated_tests/... \
+          bazel test //software/simulated_tests/... \
             //software/simulated_tests/... \
             //software/ai/hl/stp/play/... \
             //software/ai/hl/stp/tactic/... \
           
-      # uploads coverage data to codecov
-      - name: Upload Coverage
-        run: |
-         cd src
-         bash <(curl -s https://codecov.io/bash) -s bazel-testlogs/ > codecov.log
-         cat codecov.log | head -n100
-         cat codecov.log | tail -n100
-         
   memory-leak-checks:
     name: Memory Leak Checks
     runs-on: ubuntu-18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,11 +102,19 @@ jobs:
       - name: Simulated Test
         run: |
           cd src
-          bazel test //software/simulated_tests/... \
+          bazel coverage //software/simulated_tests/... \
             //software/simulated_tests/... \
             //software/ai/hl/stp/play/... \
             //software/ai/hl/stp/tactic/... \
           
+      # uploads coverage data to codecov
+      - name: Upload Coverage
+        run: |
+         cd src
+         bash <(curl -s https://codecov.io/bash) -s bazel-testlogs/ > codecov.log
+         cat codecov.log | head -n100
+         cat codecov.log | tail -n100
+         
   memory-leak-checks:
     name: Memory Leak Checks
     runs-on: ubuntu-18.04

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -187,6 +187,8 @@ Now that you're setup, if you can run it on the command line, you can run it in 
 6. Run our SimulatedTests in the visualizer: `bazel test //software/simulated_tests:[some_target_here] --test_arg="--enable_visualizer"` or `bazel run //software/simulated_tests:[some_target_here] -- --enable_visualizer`
     - This will launch the visualizer and simulate AI Plays, allowing us to visually see the robots acting according to their roles.
 
+** NOTE: If we want to run SimulatedTests with the AI initially stopped, then use the `--stop_ai_on_start` flag ** 
+
 ### Running AI vs AI
 1. Open your terminal, `cd` into `Software/src`
 2. Run `./software/run_ai_vs_ai.sh interface_name`, using the same interface as from [above](#running-our-ai-simulator-or-robot-diagnostics)

--- a/src/shared/parameter_v2/config_definitions/simulated_test_main_command_line_args.yaml
+++ b/src/shared/parameter_v2/config_definitions/simulated_test_main_command_line_args.yaml
@@ -8,7 +8,7 @@
     name: stop_ai_on_start
     value: false
     description: >-
-        Displays simulated test on visualizer
+        If enable_visualizer is true, then stops the AI when the test starts
 
 - string:
     name: logging_dir

--- a/src/shared/parameter_v2/config_definitions/simulated_test_main_command_line_args.yaml
+++ b/src/shared/parameter_v2/config_definitions/simulated_test_main_command_line_args.yaml
@@ -4,6 +4,12 @@
     description: >-
         Displays simulated test on visualizer
 
+- bool:
+    name: stop_ai_on_start
+    value: false
+    description: >-
+        Displays simulated test on visualizer
+
 - string:
     name: logging_dir
     value: ""

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -28,7 +28,7 @@ void SimulatedTestFixture::SetUp()
     sensor_fusion = SensorFusion(DynamicParameters->getSensorFusionConfig());
 
     MutableDynamicParameters->getMutableAiControlConfig()->getMutableRunAi()->setValue(
-        true);
+        !SimulatedTestFixture::stop_ai_on_start);
 
     // The simulated test abstracts and maintains the invariant that the friendly team
     // is always the yellow team

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -170,52 +170,20 @@ void SimulatedTestFixture::runTest(
         Duration::fromSeconds(1.0 / SIMULATED_CAMERA_FPS);
     const Duration ai_time_step = Duration::fromSeconds(simulation_time_step.toSeconds() *
                                                         CAMERA_FRAMES_PER_AI_TICK);
-    bool validation_functions_done = false;
+
+    // Tick one frame to aid with visualization
+    bool validation_functions_done =
+        tickTest(terminating_validation_functions, non_terminating_validation_functions,
+                 simulation_time_step, ai_time_step, world);
     while (simulator->getTimestamp() < timeout_time)
     {
         if (!DynamicParameters->getAiControlConfig()->getRunAi()->value())
         {
             continue;
         }
-        auto wall_start_time = std::chrono::steady_clock::now();
-        for (size_t i = 0; i < CAMERA_FRAMES_PER_AI_TICK; i++)
-        {
-            simulator->stepSimulation(simulation_time_step);
-            updateSensorFusion();
-        }
-
-        if (auto world_opt = sensor_fusion.getWorld())
-        {
-            *world = world_opt.value();
-
-            validation_functions_done = validateAndCheckCompletion(
-                terminating_function_validators, non_terminating_function_validators);
-            if (validation_functions_done)
-            {
-                break;
-            }
-
-            updatePrimitives(*world_opt, simulator);
-
-            if (run_simulation_in_realtime)
-            {
-                sleep(wall_start_time, ai_time_step);
-            }
-
-            if (full_system_gui)
-            {
-                full_system_gui->onValueReceived(*world);
-                if (auto play_info = getPlayInfo())
-                {
-                    full_system_gui->onValueReceived(*play_info);
-                }
-                full_system_gui->onValueReceived(getDrawFunctions());
-            }
-        }
-        else
-        {
-            LOG(WARNING) << "SensorFusion did not output a valid World";
-        }
+        validation_functions_done = tickTest(terminating_validation_functions,
+                                             non_terminating_validation_functions,
+                                             simulation_time_step, ai_time_step, world);
     }
 
     if (!validation_functions_done && !terminating_validation_functions.empty())
@@ -223,4 +191,52 @@ void SimulatedTestFixture::runTest(
         ADD_FAILURE()
             << "Not all validation functions passed within the timeout duration";
     }
+}
+
+bool SimulatedTestFixture::tickTest(
+    const std::vector<ValidationFunction> &terminating_validation_functions,
+    const std::vector<ValidationFunction> &non_terminating_validation_functions,
+    Duration simulation_time_step, Duration ai_time_step, std::shared_ptr<World> world)
+{
+    auto wall_start_time           = std::chrono::steady_clock::now();
+    bool validation_functions_done = false;
+    for (size_t i = 0; i < CAMERA_FRAMES_PER_AI_TICK; i++)
+    {
+        simulator->stepSimulation(simulation_time_step);
+        updateSensorFusion();
+    }
+
+    if (auto world_opt = sensor_fusion.getWorld())
+    {
+        *world = world_opt.value();
+
+        validation_functions_done = validateAndCheckCompletion(
+            terminating_function_validators, non_terminating_function_validators);
+        if (validation_functions_done)
+        {
+            return validation_functions_done;
+        }
+
+        updatePrimitives(*world_opt, simulator);
+
+        if (run_simulation_in_realtime)
+        {
+            sleep(wall_start_time, ai_time_step);
+        }
+
+        if (full_system_gui)
+        {
+            full_system_gui->onValueReceived(*world);
+            if (auto play_info = getPlayInfo())
+            {
+                full_system_gui->onValueReceived(*play_info);
+            }
+            full_system_gui->onValueReceived(getDrawFunctions());
+        }
+    }
+    else
+    {
+        LOG(WARNING) << "SensorFusion did not output a valid World";
+    }
+    return validation_functions_done;
 }

--- a/src/software/simulated_tests/simulated_test_fixture.h
+++ b/src/software/simulated_tests/simulated_test_fixture.h
@@ -108,6 +108,25 @@ class SimulatedTestFixture : public ::testing::Test
 
    private:
     /**
+     * Runs one tick of the test and checks if the validation function is done
+     *
+     * @param terminating_validation_functions The terminating validation functions
+     * to check during the test
+     * @param non_terminating_validation_functions The non-terminating validation
+     * functions to check during the test
+     * @param simulation_time_step time step for stepping the simulation
+     * @param ai_time_step minimum time for one tick of AI
+     * @param world the shared_ptr to the world that is updated by this function
+     *
+     * @return if validation functions are done
+     */
+    bool tickTest(
+        const std::vector<ValidationFunction>& terminating_validation_functions,
+        const std::vector<ValidationFunction>& non_terminating_validation_functions,
+        Duration simulation_time_step, Duration ai_time_step,
+        std::shared_ptr<World> world);
+
+    /**
      * A helper function that updates SensorFusion with the latest data from the Simulator
      */
     void updateSensorFusion();

--- a/src/software/simulated_tests/simulated_test_fixture.h
+++ b/src/software/simulated_tests/simulated_test_fixture.h
@@ -23,6 +23,9 @@ class SimulatedTestFixture : public ::testing::Test
     // if false, visualizer does not run during simulated tests
     // if true, running tests are displayed on the visualizer
     static bool enable_visualizer;
+
+    // Controls whether the AI will be stopped when the simulated test starts
+    // only if enable_visualizer is true
     static bool stop_ai_on_start;
 
    protected:

--- a/src/software/simulated_tests/simulated_test_fixture.h
+++ b/src/software/simulated_tests/simulated_test_fixture.h
@@ -23,6 +23,7 @@ class SimulatedTestFixture : public ::testing::Test
     // if false, visualizer does not run during simulated tests
     // if true, running tests are displayed on the visualizer
     static bool enable_visualizer;
+    static bool stop_ai_on_start;
 
    protected:
     void SetUp() override;

--- a/src/software/simulated_tests/simulated_test_main.cpp
+++ b/src/software/simulated_tests/simulated_test_main.cpp
@@ -20,7 +20,10 @@ int main(int argc, char **argv)
     if (!help_requested)
     {
         SimulatedTestFixture::enable_visualizer = args->getEnableVisualizer()->value();
-        SimulatedTestFixture::stop_ai_on_start  = args->getStopAiOnStart()->value();
+        if (SimulatedTestFixture::enable_visualizer)
+        {
+            SimulatedTestFixture::stop_ai_on_start = args->getStopAiOnStart()->value();
+        }
     }
 
     return RUN_ALL_TESTS();

--- a/src/software/simulated_tests/simulated_test_main.cpp
+++ b/src/software/simulated_tests/simulated_test_main.cpp
@@ -5,6 +5,7 @@
 #include "software/simulated_tests/simulated_test_fixture.h"
 
 bool SimulatedTestFixture::enable_visualizer = false;
+bool SimulatedTestFixture::stop_ai_on_start  = false;
 
 int main(int argc, char **argv)
 {
@@ -19,6 +20,7 @@ int main(int argc, char **argv)
     if (!help_requested)
     {
         SimulatedTestFixture::enable_visualizer = args->getEnableVisualizer()->value();
+        SimulatedTestFixture::stop_ai_on_start  = args->getStopAiOnStart()->value();
     }
 
     return RUN_ALL_TESTS();


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
When visualizing simulated tests, it can be helpful for the test to be stopped at the beginning, so that the user can start the AI when they are ready to view it. 
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
manual testing
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #1941 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
