### PR TITLE
Add ability to rotate robots in Standalone Simulator GUI. 

### DIFF
--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -9,13 +9,10 @@
 
 StandaloneSimulatorDrawFunctionVisualizer::StandaloneSimulatorDrawFunctionVisualizer(
     QWidget* parent)
-    : DrawFunctionVisualizer(parent)
+    : DrawFunctionVisualizer(parent), shift_clicked(false), ctrl_clicked(false)
 {
     // Let mouseMoveEvents be triggered even if a mouse button is not pressed
     this->setMouseTracking(true);
-
-    shift_clicked = false;
-    ctrl_clicked  = false;
 }
 
 void StandaloneSimulatorDrawFunctionVisualizer::setStandaloneSimulator(
@@ -61,8 +58,6 @@ void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* eve
     {
         initial_click_point = createPoint(mapToScene(event->pos()));
         robot = standalone_simulator->getRobotAtPosition(initial_click_point);
-        auto physics_robot  = robot.lock();
-        initial_click_point = physics_robot->position();
     }
     else
     {
@@ -103,7 +98,7 @@ void StandaloneSimulatorDrawFunctionVisualizer::mouseMoveEvent(QMouseEvent* even
             Vector vec        = Vector(final_click_point.x() - initial_click_point.x(),
                                 final_click_point.y() - initial_click_point.y());
             Angle angle       = vec.orientation();
-            physics_robot->setPositionAndOrientation(initial_click_point, angle);
+            physics_robot->setPositionAndOrientation(physics_robot->position(), angle);
         }
     }
     else if (ctrl_clicked && standalone_simulator)
@@ -118,6 +113,7 @@ WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocity
 {
     if (ctrl_clicked)
     {
+        //Draw function will draw a line if the user is adding velocity to ball
         auto draw_function = [this](QGraphicsScene* scene) {
             drawBallVelocity(scene, initial_click_point,
                              initial_click_point - final_click_point,
@@ -127,6 +123,8 @@ WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocity
     }
     else
     {
+        //Draw function draws a vector of magnitude 0 if user is not manipulating the ball
+        //This is necessary to prevent a line being drawn on screen when manipulating the robots.
         auto draw_function = [this](QGraphicsScene* scene) {
             drawBallVelocity(scene, initial_click_point, Vector(0, 0),
                              ball_speed_slow_color, ball_speed_fast_color);

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -124,8 +124,8 @@ WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocity
     else
     {
         // Draw function draws a vector of magnitude 0 if user is not manipulating the
-        // ball This is necessary to prevent a line being drawn on screen when manipulating
-        // the robots.
+        // ball This is necessary to prevent a line being drawn on screen when
+        // manipulating the robots.
         auto draw_function = [this](QGraphicsScene* scene) {
             drawBallVelocity(scene, initial_click_point, Vector(0, 0),
                              ball_speed_slow_color, ball_speed_fast_color);

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -15,8 +15,7 @@ StandaloneSimulatorDrawFunctionVisualizer::StandaloneSimulatorDrawFunctionVisual
     this->setMouseTracking(true);
 
     shift_clicked = false;
-    ctrl_clicked = false;
-
+    ctrl_clicked  = false;
 }
 
 void StandaloneSimulatorDrawFunctionVisualizer::setStandaloneSimulator(
@@ -33,12 +32,13 @@ void StandaloneSimulatorDrawFunctionVisualizer::keyPressEvent(QKeyEvent* event)
     }
 }
 
-void StandaloneSimulatorDrawFunctionVisualizer::resetFlags() {
+void StandaloneSimulatorDrawFunctionVisualizer::resetFlags()
+{
     initial_click_point = Point(0, 0);
     final_click_point   = Point(0, 0);
-    ctrl_clicked  = false;
-    shift_clicked = false;
-    r_clicked     = false;
+    ctrl_clicked        = false;
+    shift_clicked       = false;
+    r_clicked           = false;
 }
 
 void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* event)
@@ -46,7 +46,7 @@ void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* eve
     // If Ctrl is pressed, place the ball where the user clicks
     if (event->modifiers() & Qt::ControlModifier && standalone_simulator)
     {
-        ctrl_clicked  = true;
+        ctrl_clicked        = true;
         initial_click_point = createPoint(mapToScene(event->pos()));
         final_click_point   = createPoint(mapToScene(event->pos()));
         standalone_simulator->setBallState(BallState(initial_click_point, Vector(0, 0)));
@@ -60,8 +60,8 @@ void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* eve
     else if (r_clicked && standalone_simulator)
     {
         initial_click_point = createPoint(mapToScene(event->pos()));
-        robot         = standalone_simulator->getRobotAtPosition(initial_click_point);
-        auto physics_robot = robot.lock();
+        robot = standalone_simulator->getRobotAtPosition(initial_click_point);
+        auto physics_robot  = robot.lock();
         initial_click_point = physics_robot->position();
     }
     else
@@ -74,10 +74,11 @@ void StandaloneSimulatorDrawFunctionVisualizer::mousePressEvent(QMouseEvent* eve
 void StandaloneSimulatorDrawFunctionVisualizer::mouseReleaseEvent(QMouseEvent* event)
 {
     robot.reset();
-    if (ctrl_clicked) {
+    if (ctrl_clicked)
+    {
         final_click_point = createPoint(mapToScene(event->pos()));
         standalone_simulator->setBallState(
-                BallState(initial_click_point, initial_click_point - final_click_point));
+            BallState(initial_click_point, initial_click_point - final_click_point));
     }
 
     resetFlags();
@@ -93,14 +94,15 @@ void StandaloneSimulatorDrawFunctionVisualizer::mouseMoveEvent(QMouseEvent* even
         if (shift_clicked)
         {
             Point point_in_scene = createPoint(mapToScene(event->pos()));
-            physics_robot->setPositionAndOrientation(point_in_scene, physics_robot->orientation());
+            physics_robot->setPositionAndOrientation(point_in_scene,
+                                                     physics_robot->orientation());
         }
         else if (r_clicked)
         {
             final_click_point = createPoint(mapToScene(event->pos()));
-            Vector vec  = Vector(final_click_point.x() - initial_click_point.x(),
-                                 final_click_point.y() - initial_click_point.y());
-            Angle angle = vec.orientation();
+            Vector vec        = Vector(final_click_point.x() - initial_click_point.x(),
+                                final_click_point.y() - initial_click_point.y());
+            Angle angle       = vec.orientation();
             physics_robot->setPositionAndOrientation(initial_click_point, angle);
         }
     }
@@ -117,7 +119,8 @@ WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocity
     if (ctrl_clicked)
     {
         auto draw_function = [this](QGraphicsScene* scene) {
-            drawBallVelocity(scene, initial_click_point, initial_click_point - final_click_point,
+            drawBallVelocity(scene, initial_click_point,
+                             initial_click_point - final_click_point,
                              ball_speed_slow_color, ball_speed_fast_color);
         };
         return WorldDrawFunction(draw_function);
@@ -125,8 +128,8 @@ WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocity
     else
     {
         auto draw_function = [this](QGraphicsScene* scene) {
-            drawBallVelocity(scene, initial_click_point, Vector(0, 0), ball_speed_slow_color,
-                             ball_speed_fast_color);
+            drawBallVelocity(scene, initial_click_point, Vector(0, 0),
+                             ball_speed_slow_color, ball_speed_fast_color);
         };
         return WorldDrawFunction(draw_function);
     }

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.cpp
@@ -113,7 +113,7 @@ WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocity
 {
     if (ctrl_clicked)
     {
-        //Draw function will draw a line if the user is adding velocity to ball
+        // Draw function will draw a line if the user is adding velocity to ball
         auto draw_function = [this](QGraphicsScene* scene) {
             drawBallVelocity(scene, initial_click_point,
                              initial_click_point - final_click_point,
@@ -123,8 +123,9 @@ WorldDrawFunction StandaloneSimulatorDrawFunctionVisualizer::getDrawBallVelocity
     }
     else
     {
-        //Draw function draws a vector of magnitude 0 if user is not manipulating the ball
-        //This is necessary to prevent a line being drawn on screen when manipulating the robots.
+        // Draw function draws a vector of magnitude 0 if user is not manipulating the
+        // ball This is necessary to prevent a line being drawn on screen when manipulating
+        // the robots.
         auto draw_function = [this](QGraphicsScene* scene) {
             drawBallVelocity(scene, initial_click_point, Vector(0, 0),
                              ball_speed_slow_color, ball_speed_fast_color);

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
@@ -37,6 +37,7 @@ class StandaloneSimulatorDrawFunctionVisualizer : public DrawFunctionVisualizer
     WorldDrawFunction getDrawBallVelocityFunction();
 
    private:
+    void keyPressEvent(QKeyEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
@@ -45,13 +46,19 @@ class StandaloneSimulatorDrawFunctionVisualizer : public DrawFunctionVisualizer
     // The robot currently being placed by the user, if any
     std::weak_ptr<PhysicsRobot> robot;
 
+    // Boolean to check if user shift clicked
+    bool shift_clicked = false;
+
     // Boolean to check if the user ctrl clicked
     bool ctrl_clicked = false;
 
-    // The initial point when adding force to the ball, if any
+    // Boolean to check if user has r pressed
+    bool r_clicked = false;
+
+    // The final point when adding force to the ball, or rotating robot, if any
     Point initial_point;
 
-    // The final point when adding force to the ball, if any
+    // The final point when adding force to the ball, or rotating robot, if any
     Point final_point;
 
     std::shared_ptr<StandaloneSimulator> standalone_simulator;

--- a/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
+++ b/src/software/gui/standalone_simulator/widgets/standalone_simulator_draw_function_visualizer.h
@@ -43,23 +43,29 @@ class StandaloneSimulatorDrawFunctionVisualizer : public DrawFunctionVisualizer
     void mouseMoveEvent(QMouseEvent* event) override;
     void contextMenuEvent(QContextMenuEvent* event) override;
 
+    /**
+     * Resets all the fields in the simulator to their default values. Meant to be used
+     * after a click to restore the flags and the points.
+     */
+    void resetFlags();
+
     // The robot currently being placed by the user, if any
     std::weak_ptr<PhysicsRobot> robot;
 
     // Boolean to check if user shift clicked
-    bool shift_clicked = false;
+    bool shift_clicked;
 
     // Boolean to check if the user ctrl clicked
-    bool ctrl_clicked = false;
+    bool ctrl_clicked;
 
     // Boolean to check if user has r pressed
-    bool r_clicked = false;
+    bool r_clicked;
 
     // The final point when adding force to the ball, or rotating robot, if any
-    Point initial_point;
+    Point initial_click_point;
 
     // The final point when adding force to the ball, or rotating robot, if any
-    Point final_point;
+    Point final_click_point;
 
     std::shared_ptr<StandaloneSimulator> standalone_simulator;
 };

--- a/src/software/simulation/physics/physics_robot.cpp
+++ b/src/software/simulation/physics/physics_robot.cpp
@@ -353,7 +353,8 @@ float PhysicsRobot::getMotorBrakeForce(float motor_speed) const
     return -0.5f * robot_body->GetMass() * motor_speed;
 }
 
-void PhysicsRobot::setPosition(const Point& position)
+
+void PhysicsRobot::setPosition(const Point& position, const Angle& angle)
 {
     auto func = [=]() {
         b2World* world = robot_body->GetWorld();
@@ -361,7 +362,8 @@ void PhysicsRobot::setPosition(const Point& position)
         {
             robot_body->SetLinearVelocity(createVec2(Vector(0, 0)));
             robot_body->SetAngularVelocity(0.0);
-            robot_body->SetTransform(createVec2(position), robot_body->GetAngle());
+            robot_body->SetTransform(createVec2(position),
+                                     static_cast<float>(angle.toRadians()));
         }
     };
 

--- a/src/software/simulation/physics/physics_robot.cpp
+++ b/src/software/simulation/physics/physics_robot.cpp
@@ -354,7 +354,7 @@ float PhysicsRobot::getMotorBrakeForce(float motor_speed) const
 }
 
 
-void PhysicsRobot::setPosition(const Point& position, const Angle& angle)
+void PhysicsRobot::setPositionAndOrientation(const Point& position, const Angle& angle)
 {
     auto func = [=]() {
         b2World* world = robot_body->GetWorld();

--- a/src/software/simulation/physics/physics_robot.h
+++ b/src/software/simulation/physics/physics_robot.h
@@ -174,13 +174,13 @@ class PhysicsRobot
     void brakeMotorFrontRight();
 
     /**
-     * Sets the position of the PhysicsRobot to the given position. The robot
-     * will maintain its orientation, but will have its linear and angular
-     * velocity set to zero.
+     * Sets the position and orientation of the PhysicsRobot to the given position
+     * and angle. The robot will have its linear and angular velocity set to zero.
      *
      * @param position The new position of the robot
+     * @param angle The new angle of the robot
      */
-    void setPosition(const Point &position);
+    void setPosition(const Point &position, const Angle &angle);
 
     /**
      * Applies the given force vector to the robot at its center of mass

--- a/src/software/simulation/physics/physics_robot.h
+++ b/src/software/simulation/physics/physics_robot.h
@@ -180,7 +180,7 @@ class PhysicsRobot
      * @param position The new position of the robot
      * @param angle The new angle of the robot
      */
-    void setPosition(const Point &position, const Angle &angle);
+    void setPositionAndOrientation(const Point &position, const Angle &angle);
 
     /**
      * Applies the given force vector to the robot at its center of mass


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
The ability to rotate robots has been added. This can be done by pressing the R key, and then moving the mouse around. The robot will stay in place, and rotate to face the cursor. Upon release of R, the robot is locked at that orientation.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Tested in GUI. Made sure that pressing R while not on a robot does nothing, also made sure no other modifier combines with R to cause issues. 
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #1539 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
