### PR TITLE
Script for restarting full system on crash

### DIFF
--- a/src/software/BUILD
+++ b/src/software/BUILD
@@ -62,3 +62,11 @@ cc_library(
     name = "constants",
     hdrs = ["constants.h"],
 )
+
+sh_binary(
+    name = "restart_on_crash",
+    srcs = ["restart_on_crash.sh"],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/src/software/restart_on_crash.sh
+++ b/src/software/restart_on_crash.sh
@@ -20,7 +20,7 @@ if [ $NUM_ARGS -ne 1 ]; then
   exit 1
 fi
 
-if [[ "$1" == "help" ]]; then
+if [[ "$1" == "--help" ]]; then
   echo "Runs full system and restarts on any crash"
   echo "Usage: $THIS_SCRIPT_FILENAME [interface_name]"
   echo "Choose from the following interfaces:"

--- a/src/software/restart_on_crash.sh
+++ b/src/software/restart_on_crash.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# The directory this script is in
+CURR_DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+
+# the directory that contains the binary
+BIN_DIR=$(pwd)
+
 # The name of this script
 THIS_SCRIPT_FILENAME=$(basename "$0")
 
@@ -22,15 +28,11 @@ if [[ "$1" == "help" ]]; then
   exit 0
 fi
 
-#until bazel run //software:full_system -- --backend=WifiBackend --interface=$1; do
-#    echo "Full System crashed with exit code $?.  Respawning.." >&2
-#    sleep 1
-#done
-cd ../..
+cd "$CURR_DIR" || exit
+bazel build //software:full_system
+cd "$BIN_DIR/../.." || exit
 
 until ./full_system --backend=WifiBackend --interface=$1; do
     echo "Full System crashed with exit code $?.  Respawning.." >&2
     sleep 1
 done
-
-

--- a/src/software/restart_on_crash.sh
+++ b/src/software/restart_on_crash.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# The name of this script
+THIS_SCRIPT_FILENAME=$(basename "$0")
+
+# The number of arguments passed to this script
+NUM_ARGS=$#
+
+if [ $NUM_ARGS -ne 1 ]; then
+  echo "Error: Incorrect number of arguments to script"
+  echo "Usage: $THIS_SCRIPT_FILENAME [interface_name]"
+  echo "Choose from the following interfaces:"
+  ls /sys/class/net
+  exit 1
+fi
+
+if [[ "$1" == "help" ]]; then
+  echo "Runs full system and restarts on any crash"
+  echo "Usage: $THIS_SCRIPT_FILENAME [interface_name]"
+  echo "Choose from the following interfaces:"
+  ls /sys/class/net
+  exit 0
+fi
+
+#until bazel run //software:full_system -- --backend=WifiBackend --interface=$1; do
+#    echo "Full System crashed with exit code $?.  Respawning.." >&2
+#    sleep 1
+#done
+cd ../..
+
+until ./full_system --backend=WifiBackend --interface=$1; do
+    echo "Full System crashed with exit code $?.  Respawning.." >&2
+    sleep 1
+done
+
+


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
- After finding a few limitations with having a sink that throws an exception and catching that and restarting ai in full_system
- we instead found that it would be better to have a script that restarts the binary on crashes instead
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

- manually tested by adding LOG(FATAL) to ui buttons
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

resolves #1841 

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
