### PR TITLE
[SSL Simulation Protocol] Split simulator ball and robot into interfaces and implementations

### DIFF
--- a/src/software/simulation/BUILD
+++ b/src/software/simulation/BUILD
@@ -2,8 +2,10 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "simulator_robot",
+    srcs = ["simulator_robot.cpp"],
     hdrs = ["simulator_robot.h"],
     deps = [
+        ":firmware_object_deleter",
         "//firmware/app/world:firmware_world",
     ],
 )

--- a/src/software/simulation/BUILD
+++ b/src/software/simulation/BUILD
@@ -2,10 +2,19 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "simulator_robot",
-    srcs = ["simulator_robot.cpp"],
     hdrs = ["simulator_robot.h"],
     deps = [
+        "//firmware/app/world:firmware_world",
+    ],
+)
+
+cc_library(
+    name = "physics_simulator_robot",
+    srcs = ["physics_simulator_robot.cpp"],
+    hdrs = ["physics_simulator_robot.h"],
+    deps = [
         ":firmware_object_deleter",
+        ":simulator_robot",
         "//firmware/app/primitives:primitive_manager",
         "//firmware/app/world:firmware_world",
         "//software/geom/algorithms",
@@ -17,11 +26,11 @@ cc_library(
 )
 
 cc_test(
-    name = "simulator_robot_test",
-    srcs = ["simulator_robot_test.cpp"],
+    name = "physics_simulator_robot_test",
+    srcs = ["physics_simulator_robot_test.cpp"],
     deps = [
-        ":simulator_ball",
-        ":simulator_robot",
+        ":physics_simulator_ball",
+        ":physics_simulator_robot",
         "//software/simulation/physics:physics_world",
         "//software/test_util",
         "//software/world",
@@ -33,19 +42,29 @@ cc_test(
 
 cc_library(
     name = "simulator_ball",
-    srcs = ["simulator_ball.cpp"],
     hdrs = ["simulator_ball.h"],
     deps = [
+        "//software/geom:point",
+        "//software/geom:vector",
+    ],
+)
+
+cc_library(
+    name = "physics_simulator_ball",
+    srcs = ["physics_simulator_ball.cpp"],
+    hdrs = ["physics_simulator_ball.h"],
+    deps = [
+        ":simulator_ball",
         "//software/logger",
         "//software/simulation/physics:physics_ball",
     ],
 )
 
 cc_test(
-    name = "simulator_ball_test",
-    srcs = ["simulator_ball_test.cpp"],
+    name = "physics_simulator_ball_test",
+    srcs = ["physics_simulator_ball_test.cpp"],
     deps = [
-        ":simulator_ball",
+        ":physics_simulator_ball",
         "//software/simulation/physics:physics_ball",
         "//software/simulation/physics:physics_world",
         "//software/test_util",
@@ -77,6 +96,8 @@ cc_test(
     name = "simulator_robot_singleton_test",
     srcs = ["simulator_robot_singleton_test.cpp"],
     deps = [
+        ":physics_simulator_ball",
+        ":physics_simulator_robot",
         ":simulator_ball",
         ":simulator_robot",
         ":simulator_robot_singleton",
@@ -112,6 +133,7 @@ cc_test(
     name = "simulator_ball_singleton_test",
     srcs = ["simulator_ball_singleton_test.cpp"],
     deps = [
+        ":physics_simulator_ball",
         ":simulator_ball",
         ":simulator_ball_singleton",
         "//firmware/app/world:firmware_ball",
@@ -130,9 +152,9 @@ cc_library(
     hdrs = ["simulator.h"],
     deps = [
         ":firmware_object_deleter",
-        ":simulator_ball",
+        ":physics_simulator_ball",
+        ":physics_simulator_robot",
         ":simulator_ball_singleton",
-        ":simulator_robot",
         ":simulator_robot_singleton",
         "//firmware/app/primitives:primitive_manager",
         "//firmware/app/world:firmware_world",

--- a/src/software/simulation/physics_simulator_ball.cpp
+++ b/src/software/simulation/physics_simulator_ball.cpp
@@ -1,40 +1,42 @@
-#include "software/simulation/simulator_ball.h"
+#include "software/simulation/physics_simulator_ball.h"
 
 #include "software/logger/logger.h"
 
-SimulatorBall::SimulatorBall(std::weak_ptr<PhysicsBall> physics_ball)
+PhysicsSimulatorBall::PhysicsSimulatorBall(std::weak_ptr<PhysicsBall> physics_ball)
     : physics_ball(physics_ball)
 {
 }
 
-Point SimulatorBall::checkValidAndReturnPoint(
+Point PhysicsSimulatorBall::checkValidAndReturnPoint(
     std::function<Point(const std::shared_ptr<PhysicsBall>)> func) const
 {
     if (auto ball = physics_ball.lock())
     {
         return func(ball);
     }
-    LOG(WARNING) << "SimulatorBall being used with invalid PhysicsBall" << std::endl;
+    LOG(WARNING) << "PhysicsSimulatorBall being used with invalid PhysicsBall"
+                 << std::endl;
     return Point(0, 0);
 }
 
-Vector SimulatorBall::checkValidAndReturnVector(
+Vector PhysicsSimulatorBall::checkValidAndReturnVector(
     std::function<Vector(const std::shared_ptr<PhysicsBall>)> func) const
 {
     if (auto ball = physics_ball.lock())
     {
         return func(ball);
     }
-    LOG(WARNING) << "SimulatorBall being used with invalid PhysicsBall" << std::endl;
+    LOG(WARNING) << "PhysicsSimulatorBall being used with invalid PhysicsBall"
+                 << std::endl;
     return Vector(0, 0);
 }
 
-Point SimulatorBall::position() const
+Point PhysicsSimulatorBall::position() const
 {
     return checkValidAndReturnPoint([](auto ball) { return ball->position(); });
 }
 
-Vector SimulatorBall::velocity() const
+Vector PhysicsSimulatorBall::velocity() const
 {
     return checkValidAndReturnVector([](auto ball) { return ball->velocity(); });
 }

--- a/src/software/simulation/physics_simulator_ball.h
+++ b/src/software/simulation/physics_simulator_ball.h
@@ -7,7 +7,7 @@
 #include "software/simulation/simulator_ball.h"
 
 /**
- * The SimulatorBall class acts as a wrapper for a PhysicsBall that deals with more
+ * The PhysicsSimulatorBall class acts as a wrapper for a PhysicsBall that deals with more
  * logic-focused elements for simulation.
  */
 class PhysicsSimulatorBall : public SimulatorBall

--- a/src/software/simulation/physics_simulator_ball.h
+++ b/src/software/simulation/physics_simulator_ball.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include "software/simulation/physics/physics_ball.h"
+#include "software/simulation/simulator_ball.h"
+
+/**
+ * The SimulatorBall class acts as a wrapper for a PhysicsBall that deals with more
+ * logic-focused elements for simulation.
+ */
+class PhysicsSimulatorBall : public SimulatorBall
+{
+   public:
+    /**
+     * Create a new PhysicsSimulatorBall given a PhysicsBall
+     *
+     * @param physics_ball the PhysicsBall to simulate and control
+     */
+    explicit PhysicsSimulatorBall(std::weak_ptr<PhysicsBall> physics_ball);
+    explicit PhysicsSimulatorBall() = delete;
+
+    /**
+     * Returns the current position of the ball, in global field coordinates, in meters
+     *
+     * @return the current position of the ball, in global field coordinates, in meters
+     */
+    Point position() const override;
+
+    /**
+     * Returns the current velocity of the ball, in global field coordinates, in m/s
+     *
+     * @return the current velocity of the ball, in global field coordinates, in m/s
+     */
+    Vector velocity() const override;
+
+   private:
+    /**
+     * Helper functions that check if the current pointer to the physics_ball is valid
+     * before calling the given function. If the physics_ball is invalid, a warning is
+     * logged and a default value is returned;
+     *
+     * @param func The function to perform on the physics ball
+     */
+    Point checkValidAndReturnPoint(
+        std::function<Point(const std::shared_ptr<PhysicsBall>)> func) const;
+    Vector checkValidAndReturnVector(
+        std::function<Vector(const std::shared_ptr<PhysicsBall>)> func) const;
+
+    std::weak_ptr<PhysicsBall> physics_ball;
+};

--- a/src/software/simulation/physics_simulator_ball.h
+++ b/src/software/simulation/physics_simulator_ball.h
@@ -21,18 +21,8 @@ class PhysicsSimulatorBall : public SimulatorBall
     explicit PhysicsSimulatorBall(std::weak_ptr<PhysicsBall> physics_ball);
     explicit PhysicsSimulatorBall() = delete;
 
-    /**
-     * Returns the current position of the ball, in global field coordinates, in meters
-     *
-     * @return the current position of the ball, in global field coordinates, in meters
-     */
     Point position() const override;
 
-    /**
-     * Returns the current velocity of the ball, in global field coordinates, in m/s
-     *
-     * @return the current velocity of the ball, in global field coordinates, in m/s
-     */
     Vector velocity() const override;
 
    private:

--- a/src/software/simulation/physics_simulator_ball_test.cpp
+++ b/src/software/simulation/physics_simulator_ball_test.cpp
@@ -1,4 +1,4 @@
-#include "software/simulation/simulator_ball.h"
+#include "software/simulation/physics_simulator_ball.h"
 
 #include <Box2D/Box2D.h>
 #include <gtest/gtest.h>
@@ -7,7 +7,7 @@
 #include "software/simulation/physics/physics_world.h"
 #include "software/test_util/test_util.h"
 
-class SimulatorBallTest : public testing::Test
+class PhysicsSimulatorBallTest : public testing::Test
 {
    protected:
     virtual void SetUp()
@@ -19,7 +19,7 @@ class SimulatorBallTest : public testing::Test
         auto physics_ball = physics_world->getPhysicsBall();
         if (physics_ball.lock())
         {
-            simulator_ball = std::make_unique<SimulatorBall>(physics_ball);
+            simulator_ball = std::make_unique<PhysicsSimulatorBall>(physics_ball);
         }
         else
         {
@@ -29,18 +29,18 @@ class SimulatorBallTest : public testing::Test
         }
     }
 
-    std::unique_ptr<SimulatorBall> simulator_ball;
+    std::unique_ptr<PhysicsSimulatorBall> simulator_ball;
 
    private:
     std::unique_ptr<PhysicsWorld> physics_world;
 };
 
-TEST_F(SimulatorBallTest, test_get_position)
+TEST_F(PhysicsSimulatorBallTest, test_get_position)
 {
     EXPECT_LT((simulator_ball->position() - Point(1.01, -0.4)).length(), 0.001);
 }
 
-TEST_F(SimulatorBallTest, test_get_linear_velocity)
+TEST_F(PhysicsSimulatorBallTest, test_get_linear_velocity)
 {
     EXPECT_LT((simulator_ball->velocity() - Vector(0.02, -4.5)).length(), 0.001);
 }

--- a/src/software/simulation/physics_simulator_robot.cpp
+++ b/src/software/simulation/physics_simulator_robot.cpp
@@ -6,10 +6,7 @@
 #include "software/math/math_functions.h"
 
 PhysicsSimulatorRobot::PhysicsSimulatorRobot(std::weak_ptr<PhysicsRobot> physics_robot)
-    : physics_robot(physics_robot),
-      autokick_speed_m_per_s(std::nullopt),
-      autochip_distance_m(std::nullopt),
-      dribbler_rpm(0)
+    : physics_robot(physics_robot), dribbler_rpm(0)
 {
     if (auto robot = this->physics_robot.lock())
     {
@@ -26,10 +23,6 @@ PhysicsSimulatorRobot::PhysicsSimulatorRobot(std::weak_ptr<PhysicsRobot> physics
                 this->onDribblerBallEndContact(robot, ball);
             });
     }
-
-    primitive_manager =
-        std::unique_ptr<PrimitiveManager, FirmwarePrimitiveManagerDeleter>(
-            app_primitive_manager_create(), FirmwarePrimitiveManagerDeleter());
 }
 
 void PhysicsSimulatorRobot::checkValidAndExecuteVoid(

--- a/src/software/simulation/physics_simulator_robot.cpp
+++ b/src/software/simulation/physics_simulator_robot.cpp
@@ -1,11 +1,11 @@
-#include "software/simulation/simulator_robot.h"
+#include "software/simulation/physics_simulator_robot.h"
 
 #include "shared/constants.h"
 #include "software/geom/algorithms/acute_angle.h"
 #include "software/logger/logger.h"
 #include "software/math/math_functions.h"
 
-SimulatorRobot::SimulatorRobot(std::weak_ptr<PhysicsRobot> physics_robot)
+PhysicsSimulatorRobot::PhysicsSimulatorRobot(std::weak_ptr<PhysicsRobot> physics_robot)
     : physics_robot(physics_robot),
       autokick_speed_m_per_s(std::nullopt),
       autochip_distance_m(std::nullopt),
@@ -32,7 +32,7 @@ SimulatorRobot::SimulatorRobot(std::weak_ptr<PhysicsRobot> physics_robot)
             app_primitive_manager_create(), FirmwarePrimitiveManagerDeleter());
 }
 
-void SimulatorRobot::checkValidAndExecuteVoid(
+void PhysicsSimulatorRobot::checkValidAndExecuteVoid(
     std::function<void(std::shared_ptr<PhysicsRobot>)> func)
 {
     if (auto robot = physics_robot.lock())
@@ -41,76 +41,78 @@ void SimulatorRobot::checkValidAndExecuteVoid(
     }
     else
     {
-        LOG(WARNING) << "SimulatorRobot being used with invalid PhysicsRobot"
+        LOG(WARNING) << "PhysicsSimulatorRobot being used with invalid PhysicsRobot"
                      << std::endl;
     }
 }
 
-float SimulatorRobot::checkValidAndReturnFloat(
+float PhysicsSimulatorRobot::checkValidAndReturnFloat(
     std::function<float(std::shared_ptr<PhysicsRobot>)> func)
 {
     if (auto robot = physics_robot.lock())
     {
         return func(robot);
     }
-    LOG(WARNING) << "SimulatorRobot being used with invalid PhysicsRobot" << std::endl;
+    LOG(WARNING) << "PhysicsSimulatorRobot being used with invalid PhysicsRobot"
+                 << std::endl;
     return 0.0f;
 }
 
-unsigned int SimulatorRobot::checkValidAndReturnUint(
+unsigned int PhysicsSimulatorRobot::checkValidAndReturnUint(
     std::function<unsigned int(std::shared_ptr<PhysicsRobot>)> func)
 {
     if (auto robot = physics_robot.lock())
     {
         return func(robot);
     }
-    LOG(WARNING) << "SimulatorRobot being used with invalid PhysicsRobot" << std::endl;
+    LOG(WARNING) << "PhysicsSimulatorRobot being used with invalid PhysicsRobot"
+                 << std::endl;
     return 0;
 }
 
-unsigned int SimulatorRobot::getRobotId()
+unsigned int PhysicsSimulatorRobot::getRobotId()
 {
     return checkValidAndReturnUint([](auto robot) { return robot->getRobotId(); });
 }
 
-float SimulatorRobot::getPositionX()
+float PhysicsSimulatorRobot::getPositionX()
 {
     return checkValidAndReturnFloat([](auto robot) { return robot->position().x(); });
 }
 
-float SimulatorRobot::getPositionY()
+float PhysicsSimulatorRobot::getPositionY()
 {
     return checkValidAndReturnFloat([](auto robot) { return robot->position().y(); });
 }
 
-float SimulatorRobot::getOrientation()
+float PhysicsSimulatorRobot::getOrientation()
 {
     return checkValidAndReturnFloat(
         [](auto robot) { return robot->orientation().toRadians(); });
 }
 
-float SimulatorRobot::getVelocityX()
+float PhysicsSimulatorRobot::getVelocityX()
 {
     return checkValidAndReturnFloat([](auto robot) { return robot->velocity().x(); });
 }
 
-float SimulatorRobot::getVelocityY()
+float PhysicsSimulatorRobot::getVelocityY()
 {
     return checkValidAndReturnFloat([](auto robot) { return robot->velocity().y(); });
 }
 
-float SimulatorRobot::getVelocityAngular()
+float PhysicsSimulatorRobot::getVelocityAngular()
 {
     return checkValidAndReturnFloat(
         [](auto robot) { return robot->angularVelocity().toRadians(); });
 }
 
-float SimulatorRobot::getBatteryVoltage()
+float PhysicsSimulatorRobot::getBatteryVoltage()
 {
     return ROBOT_MAX_BATTERY_VOLTAGE;
 }
 
-void SimulatorRobot::kick(float speed_m_per_s)
+void PhysicsSimulatorRobot::kick(float speed_m_per_s)
 {
     checkValidAndExecuteVoid([this, speed_m_per_s](auto robot) {
         if (ball_in_dribbler_area && ball_in_dribbler_area->can_be_controlled)
@@ -163,7 +165,7 @@ void SimulatorRobot::kick(float speed_m_per_s)
     });
 }
 
-void SimulatorRobot::chip(float distance_m)
+void PhysicsSimulatorRobot::chip(float distance_m)
 {
     checkValidAndExecuteVoid([this, distance_m](auto robot) {
         if (ball_in_dribbler_area && ball_in_dribbler_area->can_be_controlled)
@@ -194,7 +196,7 @@ void SimulatorRobot::chip(float distance_m)
     });
 }
 
-void SimulatorRobot::enableAutokick(float speed_m_per_s)
+void PhysicsSimulatorRobot::enableAutokick(float speed_m_per_s)
 {
     autokick_speed_m_per_s = speed_m_per_s;
     disableAutochip();
@@ -202,7 +204,7 @@ void SimulatorRobot::enableAutokick(float speed_m_per_s)
     kick(speed_m_per_s);
 }
 
-void SimulatorRobot::enableAutochip(float distance_m)
+void PhysicsSimulatorRobot::enableAutochip(float distance_m)
 {
     autochip_distance_m = distance_m;
     disableAutokick();
@@ -210,137 +212,137 @@ void SimulatorRobot::enableAutochip(float distance_m)
     chip(distance_m);
 }
 
-void SimulatorRobot::disableAutokick()
+void PhysicsSimulatorRobot::disableAutokick()
 {
     autokick_speed_m_per_s = std::nullopt;
 }
 
-void SimulatorRobot::disableAutochip()
+void PhysicsSimulatorRobot::disableAutochip()
 {
     autochip_distance_m = std::nullopt;
 }
 
-bool SimulatorRobot::isAutokickEnabled()
+bool PhysicsSimulatorRobot::isAutokickEnabled()
 {
     return autokick_speed_m_per_s.has_value();
 }
 
-bool SimulatorRobot::isAutochipEnabled()
+bool PhysicsSimulatorRobot::isAutochipEnabled()
 {
     return autochip_distance_m.has_value();
 }
 
-void SimulatorRobot::setDribblerSpeed(uint32_t rpm)
+void PhysicsSimulatorRobot::setDribblerSpeed(uint32_t rpm)
 {
     dribbler_rpm = rpm;
 }
 
-unsigned int SimulatorRobot::getDribblerTemperatureDegC()
+unsigned int PhysicsSimulatorRobot::getDribblerTemperatureDegC()
 {
     // Return a somewhat arbitrary "room temperature" temperature.
     // This is an ideal simulation so the dribbler will not overheat
     return 25;
 }
 
-void SimulatorRobot::dribblerCoast()
+void PhysicsSimulatorRobot::dribblerCoast()
 {
     setDribblerSpeed(0);
 }
 
-void SimulatorRobot::applyWheelForceFrontLeft(float force_in_newtons)
+void PhysicsSimulatorRobot::applyWheelForceFrontLeft(float force_in_newtons)
 {
     checkValidAndExecuteVoid([force_in_newtons](auto robot) {
         robot->applyWheelForceFrontLeft(force_in_newtons);
     });
 }
 
-void SimulatorRobot::applyWheelForceBackLeft(float force_in_newtons)
+void PhysicsSimulatorRobot::applyWheelForceBackLeft(float force_in_newtons)
 {
     checkValidAndExecuteVoid([force_in_newtons](auto robot) {
         robot->applyWheelForceBackLeft(force_in_newtons);
     });
 }
 
-void SimulatorRobot::applyWheelForceBackRight(float force_in_newtons)
+void PhysicsSimulatorRobot::applyWheelForceBackRight(float force_in_newtons)
 {
     checkValidAndExecuteVoid([force_in_newtons](auto robot) {
         robot->applyWheelForceBackRight(force_in_newtons);
     });
 }
 
-void SimulatorRobot::applyWheelForceFrontRight(float force_in_newtons)
+void PhysicsSimulatorRobot::applyWheelForceFrontRight(float force_in_newtons)
 {
     checkValidAndExecuteVoid([force_in_newtons](auto robot) {
         robot->applyWheelForceFrontRight(force_in_newtons);
     });
 }
 
-float SimulatorRobot::getMotorSpeedFrontLeft()
+float PhysicsSimulatorRobot::getMotorSpeedFrontLeft()
 {
     return checkValidAndReturnFloat(
         [](auto robot) { return robot->getMotorSpeedFrontLeft(); });
 }
 
-float SimulatorRobot::getMotorSpeedBackLeft()
+float PhysicsSimulatorRobot::getMotorSpeedBackLeft()
 {
     return checkValidAndReturnFloat(
         [](auto robot) { return robot->getMotorSpeedBackLeft(); });
 }
 
-float SimulatorRobot::getMotorSpeedBackRight()
+float PhysicsSimulatorRobot::getMotorSpeedBackRight()
 {
     return checkValidAndReturnFloat(
         [](auto robot) { return robot->getMotorSpeedBackRight(); });
 }
 
-float SimulatorRobot::getMotorSpeedFrontRight()
+float PhysicsSimulatorRobot::getMotorSpeedFrontRight()
 {
     return checkValidAndReturnFloat(
         [](auto robot) { return robot->getMotorSpeedFrontRight(); });
 }
 
-void SimulatorRobot::coastMotorFrontLeft()
+void PhysicsSimulatorRobot::coastMotorFrontLeft()
 {
     // We coast by simply doing nothing and not applying wheel force
 }
 
-void SimulatorRobot::coastMotorBackLeft()
+void PhysicsSimulatorRobot::coastMotorBackLeft()
 {
     // We coast by simply doing nothing and not applying wheel force
 }
 
-void SimulatorRobot::coastMotorBackRight()
+void PhysicsSimulatorRobot::coastMotorBackRight()
 {
     // We coast by simply doing nothing and not applying wheel force
 }
 
-void SimulatorRobot::coastMotorFrontRight()
+void PhysicsSimulatorRobot::coastMotorFrontRight()
 {
     // We coast by simply doing nothing and not applying wheel force
 }
 
-void SimulatorRobot::brakeMotorFrontLeft()
+void PhysicsSimulatorRobot::brakeMotorFrontLeft()
 {
     checkValidAndExecuteVoid([](auto robot) { robot->brakeMotorFrontLeft(); });
 }
 
-void SimulatorRobot::brakeMotorBackLeft()
+void PhysicsSimulatorRobot::brakeMotorBackLeft()
 {
     checkValidAndExecuteVoid([](auto robot) { robot->brakeMotorBackLeft(); });
 }
 
-void SimulatorRobot::brakeMotorBackRight()
+void PhysicsSimulatorRobot::brakeMotorBackRight()
 {
     checkValidAndExecuteVoid([](auto robot) { robot->brakeMotorBackRight(); });
 }
 
-void SimulatorRobot::brakeMotorFrontRight()
+void PhysicsSimulatorRobot::brakeMotorFrontRight()
 {
     checkValidAndExecuteVoid([](auto robot) { robot->brakeMotorFrontRight(); });
 }
 
-void SimulatorRobot::onDribblerBallContact(PhysicsRobot *physics_robot,
-                                           PhysicsBall *physics_ball)
+void PhysicsSimulatorRobot::onDribblerBallContact(PhysicsRobot *physics_robot,
+                                                  PhysicsBall *physics_ball)
 {
     if (dribbler_rpm > 0 && ball_in_dribbler_area)
     {
@@ -356,8 +358,8 @@ void SimulatorRobot::onDribblerBallContact(PhysicsRobot *physics_robot,
     }
 }
 
-void SimulatorRobot::onDribblerBallStartContact(PhysicsRobot *physics_robot,
-                                                PhysicsBall *physics_ball)
+void PhysicsSimulatorRobot::onDribblerBallStartContact(PhysicsRobot *physics_robot,
+                                                       PhysicsBall *physics_ball)
 {
     // Damp the ball when it collides with the dribbler. We damp each component
     // of the ball's momentum separately so we have the flexibility to tune this
@@ -397,32 +399,34 @@ void SimulatorRobot::onDribblerBallStartContact(PhysicsRobot *physics_robot,
     }
 }
 
-void SimulatorRobot::onDribblerBallEndContact(PhysicsRobot *physics_robot,
-                                              PhysicsBall *physics_ball)
+void PhysicsSimulatorRobot::onDribblerBallEndContact(PhysicsRobot *physics_robot,
+                                                     PhysicsBall *physics_ball)
 {
     clearBallInDribblerArea();
 }
 
-void SimulatorRobot::startNewPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world,
-                                       const TbotsProto_Primitive &primitive_msg)
+void PhysicsSimulatorRobot::startNewPrimitive(
+    std::shared_ptr<FirmwareWorld_t> firmware_world,
+    const TbotsProto_Primitive &primitive_msg)
 {
     app_primitive_manager_startNewPrimitive(primitive_manager.get(), firmware_world.get(),
                                             primitive_msg);
 }
 
-void SimulatorRobot::runCurrentPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world)
+void PhysicsSimulatorRobot::runCurrentPrimitive(
+    std::shared_ptr<FirmwareWorld_t> firmware_world)
 {
     app_primitive_manager_runCurrentPrimitive(primitive_manager.get(),
                                               firmware_world.get());
 }
 
-void SimulatorRobot::clearBallInDribblerArea()
+void PhysicsSimulatorRobot::clearBallInDribblerArea()
 {
     ball_in_dribbler_area = std::nullopt;
 }
 
-void SimulatorRobot::applyDribblerForce(PhysicsRobot *physics_robot,
-                                        PhysicsBall *physics_ball)
+void PhysicsSimulatorRobot::applyDribblerForce(PhysicsRobot *physics_robot,
+                                               PhysicsBall *physics_ball)
 {
     auto robot = physics_robot->getRobotState();
     auto ball  = physics_ball->getBallState();

--- a/src/software/simulation/physics_simulator_robot.h
+++ b/src/software/simulation/physics_simulator_robot.h
@@ -1,0 +1,311 @@
+#pragma once
+
+#include <cinttypes>
+#include <memory>
+
+#include "software/simulation/firmware_object_deleter.h"
+#include "software/simulation/physics/physics_ball.h"
+#include "software/simulation/physics/physics_robot.h"
+#include "software/simulation/simulator_robot.h"
+
+extern "C"
+{
+#include "firmware/app/primitives/primitive_manager.h"
+#include "shared/proto/primitive.nanopb.h"
+}
+
+/**
+ * The PhysicsSimulatorRobot class acts as a wrapper for a PhysicsRobot that deals with
+ * more logic-focused elements for simulation, such as whether or not autokick is enabled.
+ *
+ * All members of this class are intentionally protected or private to force this class
+ * to only be controlled by the SimulatorRobotSingleton.
+ */
+class PhysicsSimulatorRobot : public SimulatorRobot
+{
+   public:
+    /**
+     * Create a new SimulatorRobot given a PhysicsRobot
+     *
+     * @param physics_robot the PhysicsRobot to simulate and control
+     */
+    explicit PhysicsSimulatorRobot(std::weak_ptr<PhysicsRobot> physics_robot);
+    explicit PhysicsSimulatorRobot() = delete;
+
+    /**
+     * Returns the ID of this robot
+     *
+     * @return the ID of this robot
+     */
+    unsigned int getRobotId() override;
+
+    /**
+     * Clears balls tracked as being in dribbler area
+     */
+    void clearBallInDribblerArea();
+
+   protected:
+    /**
+     * Returns the x-position of the robot, in global field coordinates, in meters
+     *
+     * @return the x-position of the robot, in global field coordinates, in meters
+     */
+    float getPositionX() override;
+
+    /**
+     * Returns the y-position of the robot, in global field coordinates, in meters
+     *
+     * @return the y-position of the robot, in global field coordinates, in meters
+     */
+    float getPositionY() override;
+
+    /**
+     * Returns the orientation of the robot, in global field coordinates, in radians
+     *
+     * @return the orientation of the robot, in global field coordinates, in radians
+     */
+    float getOrientation() override;
+
+    /**
+     * Returns the x-velocity of the robot, in global field coordinates, in m/s
+     *
+     * @return the x-velocity of the robot, in global field coordinates, in m/s
+     */
+    float getVelocityX() override;
+
+    /**
+     * Returns the y-velocity of the robot, in global field coordinates, in m/s
+     *
+     * @return the y-velocity of the robot, in global field coordinates, in m/s
+     */
+    float getVelocityY() override;
+
+    /**
+     * Returns the angular velocity of the robot, in rad/s
+     *
+     * @return the angular of the robot, in rad/s
+     */
+    float getVelocityAngular() override;
+
+    /**
+     * Returns the battery voltage, in volts
+     *
+     * @return the battery voltage, in volts
+     */
+    float getBatteryVoltage() override;
+
+    /**
+     * Fires the kicker, kicking the ball in the direction the robot is facing
+     * at the given speed if the ball is very close to the kicker
+     *
+     * @param speed_m_per_s How fast to kick the ball, in meters per second
+     */
+    void kick(float speed_m_per_s) override;
+
+    /**
+     * Fires the chipper, chipping the ball in the direction the robot is facing
+     * for the given distance if the ball is very close to the chipper
+     *
+     * @param speed_m_per_s How far to chip the ball (the distance to the first bounce)
+     * in meters
+     */
+    void chip(float distance_m) override;
+
+    /**
+     * Enables autokick on the robot. If the ball touches the kicker, the robot will
+     * kick the ball with the given speed.
+     *
+     * @param speed_m_per_s How fast to kick the ball in meters per second when
+     * the kicker is fired
+     */
+    void enableAutokick(float speed_m_per_s) override;
+
+    /**
+     * Enables autochip on the robot. If the ball touches the chipper, the robot will
+     * chip the ball the given distance.
+     *
+     * @param speed_m_per_s How far to chip the ball (distance to the first bounce)
+     * when the chipper is fired
+     */
+    void enableAutochip(float distance_m) override;
+
+    /**
+     * Disables autokick
+     */
+    void disableAutokick() override;
+
+    /**
+     * Disables autochip
+     */
+    void disableAutochip() override;
+
+    /**
+     * Returns true if autokick is enabled and false otherwise
+     *
+     * @return true if autokick is enabled and false otherwise
+     */
+    bool isAutokickEnabled() override;
+
+    /**
+     * Returns true if autochip is enabled and false otherwise
+     *
+     * @return true if autochip is enabled and false otherwise
+     */
+    bool isAutochipEnabled() override;
+
+    /**
+     * Sets the speed of the dribbler
+     *
+     * @param rpm The rpm to set for the dribbler
+     */
+    void setDribblerSpeed(uint32_t rpm) override;
+
+    /**
+     * Makes the dribbler coast until another operation is applied to it
+     */
+    void dribblerCoast() override;
+
+    /**
+     * Returns the temperature of the dribbler, in degrees C
+     *
+     * @return the temperature of the dribbler, in degrees C
+     */
+    unsigned int getDribblerTemperatureDegC() override;
+
+    /**
+     * Applies the given force to the wheel
+     *
+     * @param force_in_newtons the force to apply to the wheel
+     */
+    void applyWheelForceFrontLeft(float force_in_newtons) override;
+    void applyWheelForceBackLeft(float force_in_newtons) override;
+    void applyWheelForceBackRight(float force_in_newtons) override;
+    void applyWheelForceFrontRight(float force_in_newtons) override;
+
+    /**
+     * Gets the motor speed for the wheel, in RPM
+     */
+    float getMotorSpeedFrontLeft() override;
+    float getMotorSpeedBackLeft() override;
+    float getMotorSpeedBackRight() override;
+    float getMotorSpeedFrontRight() override;
+
+    /**
+     * Sets the motor to coast (spin freely)
+     */
+    void coastMotorBackLeft() override;
+    void coastMotorBackRight() override;
+    void coastMotorFrontLeft() override;
+    void coastMotorFrontRight() override;
+
+    /**
+     * Sets the motor to brake (act against the current direction of rotation)
+     */
+    void brakeMotorBackLeft() override;
+    void brakeMotorBackRight() override;
+    void brakeMotorFrontLeft() override;
+    void brakeMotorFrontRight() override;
+
+    /**
+     * Sets the current primitive this robot is running to a new one
+     *
+     * @param firmware_world The world to run the primitive in
+     * @param primitive_msg The primitive to start
+     */
+    void startNewPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world,
+                           const TbotsProto_Primitive& primitive_msg) override;
+
+    /**
+     * Runs the current primitive
+     *
+     * @param world The world to run the primitive in
+     */
+    void runCurrentPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world) override;
+
+   private:
+    /**
+     * A function that is called during every physics step for as long as the ball
+     * is touching this robot's dribbler
+     *
+     * @param physics_robot The robot involved in the contact
+     * @param physics_ball The ball invovled in the contact
+     */
+    void onDribblerBallContact(PhysicsRobot* physics_robot, PhysicsBall* physics_ball);
+
+    /**
+     * A function that is called during once when the ball starts touching
+     * this robot's dribbler.
+     *
+     * @param physics_robot The robot involved in the contact
+     * @param physics_ball The ball invovled in the contact
+     */
+    void onDribblerBallStartContact(PhysicsRobot* physics_robot,
+                                    PhysicsBall* physics_ball);
+
+    /**
+     * A function that is called during once when the ball stops touching
+     * this robot's dribbler.
+     *
+     * @param physics_robot The robot involved in the contact
+     * @param physics_ball The ball invovled in the contact
+     */
+    void onDribblerBallEndContact(PhysicsRobot* physics_robot, PhysicsBall* physics_ball);
+
+    /**
+     * Helper functions that check if the current pointer to the physics_robot is valid
+     * before calling the given function. If the physics_robot is invalid, a warning is
+     * logged and a default value is returned.
+     *
+     * @param func The function to perform on the physics robot
+     */
+    void checkValidAndExecuteVoid(
+        std::function<void(std::shared_ptr<PhysicsRobot>)> func);
+    float checkValidAndReturnFloat(
+        std::function<float(std::shared_ptr<PhysicsRobot>)> func);
+    unsigned int checkValidAndReturnUint(
+        std::function<unsigned int(std::shared_ptr<PhysicsRobot>)> func);
+
+    /**
+     * Applies force to the physics ball to simulate it being dribbled by the
+     * physics robot.
+     *
+     * @param physics_robot The robot that should dribble the ball
+     * @param physics_ball The ball to be dribbled
+     */
+    void applyDribblerForce(PhysicsRobot* physics_robot, PhysicsBall* physics_ball);
+
+    std::weak_ptr<PhysicsRobot> physics_robot;
+    std::optional<float> autokick_speed_m_per_s;
+    std::optional<float> autochip_distance_m;
+    uint32_t dribbler_rpm;
+
+    typedef struct DribblerBall_t
+    {
+        PhysicsBall* ball;
+        // We keep track of whether or not the ball can be controlled
+        // in any way by the robot. This includes kicking, chipping,
+        // and dribbling. This extra information is used to
+        // prevent edge cases like the ball getting kicked/chipped
+        // multiple times, and to prevent the dribbler from affecting
+        // kicking
+        bool can_be_controlled;
+    } DribblerBall;
+
+    std::optional<DribblerBall> ball_in_dribbler_area;
+
+    std::unique_ptr<PrimitiveManager, FirmwarePrimitiveManagerDeleter> primitive_manager;
+
+    // How much the dribbler damps the ball when they collide. Each component
+    // of the damping can be changed separately so we have the flexibility to tune
+    // this behavior to match real life. These values have been manually tuned
+    // such that the robots are able to hit one-time shots in simulation with
+    // sufficient accuracy.
+    static constexpr double DRIBBLER_HEAD_ON_DAMPING       = 0.7;
+    static constexpr double DRIBBLER_PERPENDICULAR_DAMPING = 0.61;
+    // A value in the range [0, 1] that indicates how much momentum is conserved when the
+    // ball is kicked. Higher values will cause the ball to be kicked with an even greater
+    // velocity if it had an initial non-zero velocity when being kicked.
+    // This value is a very rough estimate of real-world behaviour, so that the ball
+    // will be kicked slightly faster it it entered the kicker with some initial velocity.
+    static constexpr double MOMENTUM_CONSERVED_DURING_KICK = 0.1;
+};

--- a/src/software/simulation/physics_simulator_robot.h
+++ b/src/software/simulation/physics_simulator_robot.h
@@ -25,18 +25,13 @@ class PhysicsSimulatorRobot : public SimulatorRobot
 {
    public:
     /**
-     * Create a new SimulatorRobot given a PhysicsRobot
+     * Create a new PhysicsSimulatorRobot given a PhysicsRobot
      *
      * @param physics_robot the PhysicsRobot to simulate and control
      */
     explicit PhysicsSimulatorRobot(std::weak_ptr<PhysicsRobot> physics_robot);
     explicit PhysicsSimulatorRobot() = delete;
 
-    /**
-     * Returns the ID of this robot
-     *
-     * @return the ID of this robot
-     */
     unsigned int getRobotId() override;
 
     /**
@@ -45,181 +40,65 @@ class PhysicsSimulatorRobot : public SimulatorRobot
     void clearBallInDribblerArea();
 
    protected:
-    /**
-     * Returns the x-position of the robot, in global field coordinates, in meters
-     *
-     * @return the x-position of the robot, in global field coordinates, in meters
-     */
     float getPositionX() override;
 
-    /**
-     * Returns the y-position of the robot, in global field coordinates, in meters
-     *
-     * @return the y-position of the robot, in global field coordinates, in meters
-     */
     float getPositionY() override;
 
-    /**
-     * Returns the orientation of the robot, in global field coordinates, in radians
-     *
-     * @return the orientation of the robot, in global field coordinates, in radians
-     */
     float getOrientation() override;
 
-    /**
-     * Returns the x-velocity of the robot, in global field coordinates, in m/s
-     *
-     * @return the x-velocity of the robot, in global field coordinates, in m/s
-     */
     float getVelocityX() override;
 
-    /**
-     * Returns the y-velocity of the robot, in global field coordinates, in m/s
-     *
-     * @return the y-velocity of the robot, in global field coordinates, in m/s
-     */
     float getVelocityY() override;
 
-    /**
-     * Returns the angular velocity of the robot, in rad/s
-     *
-     * @return the angular of the robot, in rad/s
-     */
     float getVelocityAngular() override;
 
-    /**
-     * Returns the battery voltage, in volts
-     *
-     * @return the battery voltage, in volts
-     */
     float getBatteryVoltage() override;
 
-    /**
-     * Fires the kicker, kicking the ball in the direction the robot is facing
-     * at the given speed if the ball is very close to the kicker
-     *
-     * @param speed_m_per_s How fast to kick the ball, in meters per second
-     */
     void kick(float speed_m_per_s) override;
 
-    /**
-     * Fires the chipper, chipping the ball in the direction the robot is facing
-     * for the given distance if the ball is very close to the chipper
-     *
-     * @param speed_m_per_s How far to chip the ball (the distance to the first bounce)
-     * in meters
-     */
     void chip(float distance_m) override;
 
-    /**
-     * Enables autokick on the robot. If the ball touches the kicker, the robot will
-     * kick the ball with the given speed.
-     *
-     * @param speed_m_per_s How fast to kick the ball in meters per second when
-     * the kicker is fired
-     */
     void enableAutokick(float speed_m_per_s) override;
 
-    /**
-     * Enables autochip on the robot. If the ball touches the chipper, the robot will
-     * chip the ball the given distance.
-     *
-     * @param speed_m_per_s How far to chip the ball (distance to the first bounce)
-     * when the chipper is fired
-     */
     void enableAutochip(float distance_m) override;
 
-    /**
-     * Disables autokick
-     */
     void disableAutokick() override;
 
-    /**
-     * Disables autochip
-     */
     void disableAutochip() override;
 
-    /**
-     * Returns true if autokick is enabled and false otherwise
-     *
-     * @return true if autokick is enabled and false otherwise
-     */
     bool isAutokickEnabled() override;
 
-    /**
-     * Returns true if autochip is enabled and false otherwise
-     *
-     * @return true if autochip is enabled and false otherwise
-     */
     bool isAutochipEnabled() override;
 
-    /**
-     * Sets the speed of the dribbler
-     *
-     * @param rpm The rpm to set for the dribbler
-     */
     void setDribblerSpeed(uint32_t rpm) override;
 
-    /**
-     * Makes the dribbler coast until another operation is applied to it
-     */
     void dribblerCoast() override;
 
-    /**
-     * Returns the temperature of the dribbler, in degrees C
-     *
-     * @return the temperature of the dribbler, in degrees C
-     */
     unsigned int getDribblerTemperatureDegC() override;
 
-    /**
-     * Applies the given force to the wheel
-     *
-     * @param force_in_newtons the force to apply to the wheel
-     */
     void applyWheelForceFrontLeft(float force_in_newtons) override;
     void applyWheelForceBackLeft(float force_in_newtons) override;
     void applyWheelForceBackRight(float force_in_newtons) override;
     void applyWheelForceFrontRight(float force_in_newtons) override;
 
-    /**
-     * Gets the motor speed for the wheel, in RPM
-     */
     float getMotorSpeedFrontLeft() override;
     float getMotorSpeedBackLeft() override;
     float getMotorSpeedBackRight() override;
     float getMotorSpeedFrontRight() override;
 
-    /**
-     * Sets the motor to coast (spin freely)
-     */
     void coastMotorBackLeft() override;
     void coastMotorBackRight() override;
     void coastMotorFrontLeft() override;
     void coastMotorFrontRight() override;
 
-    /**
-     * Sets the motor to brake (act against the current direction of rotation)
-     */
     void brakeMotorBackLeft() override;
     void brakeMotorBackRight() override;
     void brakeMotorFrontLeft() override;
     void brakeMotorFrontRight() override;
 
-    /**
-     * Sets the current primitive this robot is running to a new one
-     *
-     * @param firmware_world The world to run the primitive in
-     * @param primitive_msg The primitive to start
-     */
     void startNewPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world,
                            const TbotsProto_Primitive& primitive_msg) override;
 
-    /**
-     * Runs the current primitive
-     *
-     * @param world The world to run the primitive in
-     */
     void runCurrentPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world) override;
 
    private:
@@ -275,8 +154,6 @@ class PhysicsSimulatorRobot : public SimulatorRobot
     void applyDribblerForce(PhysicsRobot* physics_robot, PhysicsBall* physics_ball);
 
     std::weak_ptr<PhysicsRobot> physics_robot;
-    std::optional<float> autokick_speed_m_per_s;
-    std::optional<float> autochip_distance_m;
     uint32_t dribbler_rpm;
 
     typedef struct DribblerBall_t
@@ -292,8 +169,6 @@ class PhysicsSimulatorRobot : public SimulatorRobot
     } DribblerBall;
 
     std::optional<DribblerBall> ball_in_dribbler_area;
-
-    std::unique_ptr<PrimitiveManager, FirmwarePrimitiveManagerDeleter> primitive_manager;
 
     // How much the dribbler damps the ball when they collide. Each component
     // of the damping can be changed separately so we have the flexibility to tune

--- a/src/software/simulation/physics_simulator_robot_test.cpp
+++ b/src/software/simulation/physics_simulator_robot_test.cpp
@@ -1,20 +1,20 @@
-#include "software/simulation/simulator_robot.h"
+#include "software/simulation/physics_simulator_robot.h"
 
 #include <Box2D/Box2D.h>
 #include <gtest/gtest.h>
 
 #include "shared/constants.h"
 #include "software/simulation/physics/physics_world.h"
-#include "software/simulation/simulator_ball.h"
+#include "software/simulation/physics_simulator_ball.h"
 #include "software/test_util/test_util.h"
 #include "software/world/robot.h"
 #include "software/world/world.h"
 
-class SimulatorRobotTest : public testing::Test
+class PhysicsSimulatorRobotTest : public testing::Test
 {
    protected:
-    std::tuple<std::shared_ptr<PhysicsWorld>, std::shared_ptr<SimulatorRobot>,
-               std::shared_ptr<SimulatorBall>>
+    std::tuple<std::shared_ptr<PhysicsWorld>, std::shared_ptr<PhysicsSimulatorRobot>,
+               std::shared_ptr<PhysicsSimulatorBall>>
     createWorld(Robot robot, Ball ball)
     {
         auto physics_world = std::make_shared<PhysicsWorld>(
@@ -23,29 +23,29 @@ class SimulatorRobotTest : public testing::Test
         physics_world->addYellowRobots(
             {RobotStateWithId{.id = robot.id(), .robot_state = robot.currentState()}});
 
-        std::shared_ptr<SimulatorRobot> simulator_robot;
+        std::shared_ptr<PhysicsSimulatorRobot> simulator_robot;
         auto physics_robot = physics_world->getYellowPhysicsRobots().at(0);
         if (physics_robot.lock())
         {
-            simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
+            simulator_robot = std::make_shared<PhysicsSimulatorRobot>(physics_robot);
         }
         else
         {
             ADD_FAILURE()
-                << "Failed to create a SimulatorRobot because a PhysicsRobot was invalid"
+                << "Failed to create a PhysicsSimulatorRobot because a PhysicsRobot was invalid"
                 << std::endl;
         }
 
-        std::shared_ptr<SimulatorBall> simulator_ball;
+        std::shared_ptr<PhysicsSimulatorBall> simulator_ball;
         auto physics_ball = physics_world->getPhysicsBall();
         if (physics_ball.lock())
         {
-            simulator_ball = std::make_shared<SimulatorBall>(physics_ball);
+            simulator_ball = std::make_shared<PhysicsSimulatorBall>(physics_ball);
         }
         else
         {
             ADD_FAILURE()
-                << "Failed to create a SimulatorRobot because a PhysicsRobot was invalid"
+                << "Failed to create a PhysicsSimulatorRobot because a PhysicsRobot was invalid"
                 << std::endl;
         }
 
@@ -59,7 +59,7 @@ class SimulatorRobotTest : public testing::Test
         Ball(Point(0, 0), Vector(0, 0), Timestamp::fromSeconds(0));
 };
 
-TEST_F(SimulatorRobotTest, test_robot_id)
+TEST_F(PhysicsSimulatorRobotTest, test_robot_id)
 {
     auto [world, simulator_robot, simulator_ball] =
         createWorld(robot_non_zero_state, ball_zero_state);

--- a/src/software/simulation/simulator.cpp
+++ b/src/software/simulation/simulator.cpp
@@ -30,7 +30,8 @@ Simulator::Simulator(const Field& field,
 void Simulator::setBallState(const BallState& ball_state)
 {
     physics_world.setBallState(ball_state);
-    simulator_ball = std::make_shared<SimulatorBall>(physics_world.getPhysicsBall());
+    simulator_ball =
+        std::make_shared<PhysicsSimulatorBall>(physics_world.getPhysicsBall());
 
     for (auto& robot_pair : yellow_simulator_robots)
     {
@@ -65,13 +66,13 @@ void Simulator::addBlueRobots(const std::vector<RobotStateWithId>& robots)
 
 void Simulator::updateSimulatorRobots(
     const std::vector<std::weak_ptr<PhysicsRobot>>& physics_robots,
-    std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
+    std::map<std::shared_ptr<PhysicsSimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
         simulator_robots,
     TeamColour team_colour)
 {
     for (const auto& physics_robot : physics_robots)
     {
-        auto simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
+        auto simulator_robot = std::make_shared<PhysicsSimulatorRobot>(physics_robot);
 
         // we initialize the logger with the appropriate logging function based
         // on the team color and the robot id to propagate any logs when creating
@@ -135,9 +136,9 @@ void Simulator::setBlueRobotPrimitiveSet(const TbotsProto_PrimitiveSet& primitiv
 
 void Simulator::setRobotPrimitive(
     RobotId id, const TbotsProto_Primitive& primitive_msg,
-    std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
+    std::map<std::shared_ptr<PhysicsSimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
         simulator_robots,
-    const std::shared_ptr<SimulatorBall>& simulator_ball, FieldSide defending_side)
+    const std::shared_ptr<PhysicsSimulatorBall>& simulator_ball, FieldSide defending_side)
 {
     SimulatorBallSingleton::setSimulatorBall(simulator_ball, defending_side);
     auto simulator_robots_iter =

--- a/src/software/simulation/simulator.h
+++ b/src/software/simulation/simulator.h
@@ -5,8 +5,8 @@
 #include "software/proto/messages_robocup_ssl_wrapper.pb.h"
 #include "software/simulation/firmware_object_deleter.h"
 #include "software/simulation/physics/physics_world.h"
-#include "software/simulation/simulator_ball.h"
-#include "software/simulation/simulator_robot.h"
+#include "software/simulation/physics_simulator_ball.h"
+#include "software/simulation/physics_simulator_robot.h"
 #include "software/world/field.h"
 #include "software/world/team_types.h"
 #include "software/world/world.h"
@@ -189,8 +189,8 @@ class Simulator
      */
     static void updateSimulatorRobots(
         const std::vector<std::weak_ptr<PhysicsRobot>>& physics_robots,
-        std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
-            simulator_robots,
+        std::map<std::shared_ptr<PhysicsSimulatorRobot>,
+                 std::shared_ptr<FirmwareWorld_t>>& simulator_robots,
         TeamColour team_colour);
 
     /**
@@ -204,15 +204,16 @@ class Simulator
      */
     static void setRobotPrimitive(
         RobotId id, const TbotsProto_Primitive& primitive_msg,
-        std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>&
-            simulator_robots,
-        const std::shared_ptr<SimulatorBall>& simulator_ball, FieldSide defending_side);
+        std::map<std::shared_ptr<PhysicsSimulatorRobot>,
+                 std::shared_ptr<FirmwareWorld_t>>& simulator_robots,
+        const std::shared_ptr<PhysicsSimulatorBall>& simulator_ball,
+        FieldSide defending_side);
 
     PhysicsWorld physics_world;
-    std::shared_ptr<SimulatorBall> simulator_ball;
-    std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>
+    std::shared_ptr<PhysicsSimulatorBall> simulator_ball;
+    std::map<std::shared_ptr<PhysicsSimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>
         yellow_simulator_robots;
-    std::map<std::shared_ptr<SimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>
+    std::map<std::shared_ptr<PhysicsSimulatorRobot>, std::shared_ptr<FirmwareWorld_t>>
         blue_simulator_robots;
     FieldSide yellow_team_defending_side;
     FieldSide blue_team_defending_side;

--- a/src/software/simulation/simulator_ball.h
+++ b/src/software/simulation/simulator_ball.h
@@ -1,51 +1,25 @@
 #pragma once
 
-#include <functional>
-#include <memory>
-
-#include "software/simulation/physics/physics_ball.h"
+#include "software/geom/point.h"
+#include "software/geom/vector.h"
 
 /**
- * The SimulatorBall class acts as a wrapper for a PhysicsBall that deals with more
- * logic-focused elements for simulation.
+ * The SimulatorBall is an abstract class for simulator ball implementations
  */
 class SimulatorBall
 {
    public:
     /**
-     * Create a new SimulatorBall given a PhysicsBall
-     *
-     * @param physics_ball the PhysicsBall to simulate and control
-     */
-    explicit SimulatorBall(std::weak_ptr<PhysicsBall> physics_ball);
-    explicit SimulatorBall() = delete;
-
-    /**
      * Returns the current position of the ball, in global field coordinates, in meters
      *
      * @return the current position of the ball, in global field coordinates, in meters
      */
-    Point position() const;
+    virtual Point position() const = 0;
 
     /**
      * Returns the current velocity of the ball, in global field coordinates, in m/s
      *
      * @return the current velocity of the ball, in global field coordinates, in m/s
      */
-    Vector velocity() const;
-
-   private:
-    /**
-     * Helper functions that check if the current pointer to the physics_ball is valid
-     * before calling the given function. If the physics_ball is invalid, a warning is
-     * logged and a default value is returned;
-     *
-     * @param func The function to perform on the physics ball
-     */
-    Point checkValidAndReturnPoint(
-        std::function<Point(const std::shared_ptr<PhysicsBall>)> func) const;
-    Vector checkValidAndReturnVector(
-        std::function<Vector(const std::shared_ptr<PhysicsBall>)> func) const;
-
-    std::weak_ptr<PhysicsBall> physics_ball;
+    virtual Vector velocity() const = 0;
 };

--- a/src/software/simulation/simulator_ball_singleton.h
+++ b/src/software/simulation/simulator_ball_singleton.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <functional>
+#include <memory>
+
 #include "software/simulation/firmware_object_deleter.h"
 #include "software/simulation/simulator_ball.h"
 

--- a/src/software/simulation/simulator_ball_singleton_test.cpp
+++ b/src/software/simulation/simulator_ball_singleton_test.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 
 #include "software/simulation/physics/physics_world.h"
+#include "software/simulation/physics_simulator_ball.h"
 #include "software/simulation/simulator_ball.h"
 #include "software/world/ball.h"
 #include "software/world/world.h"
@@ -20,7 +21,7 @@ TEST(SimulatorBallSingletonTest, test_create_firmware_ball_with_single_simulator
         Field::createSSLDivisionBField(), std::make_shared<const SimulatorConfig>());
     physics_world->setBallState(BallState(Point(0.4, 0), Vector(-1.3, 2.01)));
     auto simulator_ball =
-        std::make_shared<SimulatorBall>(physics_world->getPhysicsBall());
+        std::make_shared<PhysicsSimulatorBall>(physics_world->getPhysicsBall());
 
     SimulatorBallSingleton::setSimulatorBall(simulator_ball, FieldSide::NEG_X);
     auto firmware_ball = SimulatorBallSingleton::createFirmwareBall();
@@ -36,14 +37,14 @@ TEST(SimulatorBallSingletonTest, test_change_simulator_ball)
         Field::createSSLDivisionBField(), std::make_shared<const SimulatorConfig>());
     physics_world_1->setBallState(BallState(Point(0.4, 0), Vector(-1.3, 2.01)));
     auto simulator_ball_1 =
-        std::make_shared<SimulatorBall>(physics_world_1->getPhysicsBall());
+        std::make_shared<PhysicsSimulatorBall>(physics_world_1->getPhysicsBall());
 
     auto physics_world_2 = std::make_unique<PhysicsWorld>(
         Field::createSSLDivisionBField(), std::make_shared<const SimulatorConfig>());
     physics_world_2->setBallState(BallState(Point(0, -3), Vector(0, 1)));
 
     auto simulator_ball_2 =
-        std::make_shared<SimulatorBall>(physics_world_2->getPhysicsBall());
+        std::make_shared<PhysicsSimulatorBall>(physics_world_2->getPhysicsBall());
 
     SimulatorBallSingleton::setSimulatorBall(simulator_ball_1, FieldSide::NEG_X);
     auto firmware_ball = SimulatorBallSingleton::createFirmwareBall();

--- a/src/software/simulation/simulator_robot.cpp
+++ b/src/software/simulation/simulator_robot.cpp
@@ -1,0 +1,9 @@
+#include "software/simulation/simulator_robot.h"
+
+SimulatorRobot::SimulatorRobot()
+    : autokick_speed_m_per_s(std::nullopt), autochip_distance_m(std::nullopt)
+{
+    primitive_manager =
+        std::unique_ptr<PrimitiveManager, FirmwarePrimitiveManagerDeleter>(
+            app_primitive_manager_create(), FirmwarePrimitiveManagerDeleter());
+}

--- a/src/software/simulation/simulator_robot.h
+++ b/src/software/simulation/simulator_robot.h
@@ -1,11 +1,6 @@
 #pragma once
 
-#include <cinttypes>
 #include <memory>
-
-#include "software/simulation/firmware_object_deleter.h"
-#include "software/simulation/physics/physics_ball.h"
-#include "software/simulation/physics/physics_robot.h"
 
 extern "C"
 {
@@ -14,11 +9,7 @@ extern "C"
 }
 
 /**
- * The SimulatorRobot class acts as a wrapper for a PhysicsRobot that deals with more
- * logic-focused elements for simulation, such as whether or not autokick is enabled.
- *
- * All members of this class are intentionally protected or private to force this class
- * to only be controlled by the SimulatorRobotSingleton.
+ *  The SimulatorRobot is an abstract class for simulator robot implementations
  */
 class SimulatorRobot
 {
@@ -26,24 +17,11 @@ class SimulatorRobot
 
    public:
     /**
-     * Create a new SimulatorRobot given a PhysicsRobot
-     *
-     * @param physics_robot the PhysicsRobot to simulate and control
-     */
-    explicit SimulatorRobot(std::weak_ptr<PhysicsRobot> physics_robot);
-    explicit SimulatorRobot() = delete;
-
-    /**
      * Returns the ID of this robot
      *
      * @return the ID of this robot
      */
-    unsigned int getRobotId();
-
-    /**
-     * Clears balls tracked as being in dribbler area
-     */
-    void clearBallInDribblerArea();
+    virtual unsigned int getRobotId() = 0;
 
    protected:
     /**
@@ -51,49 +29,49 @@ class SimulatorRobot
      *
      * @return the x-position of the robot, in global field coordinates, in meters
      */
-    float getPositionX();
+    virtual float getPositionX() = 0;
 
     /**
      * Returns the y-position of the robot, in global field coordinates, in meters
      *
      * @return the y-position of the robot, in global field coordinates, in meters
      */
-    float getPositionY();
+    virtual float getPositionY() = 0;
 
     /**
      * Returns the orientation of the robot, in global field coordinates, in radians
      *
      * @return the orientation of the robot, in global field coordinates, in radians
      */
-    float getOrientation();
+    virtual float getOrientation() = 0;
 
     /**
      * Returns the x-velocity of the robot, in global field coordinates, in m/s
      *
      * @return the x-velocity of the robot, in global field coordinates, in m/s
      */
-    float getVelocityX();
+    virtual float getVelocityX() = 0;
 
     /**
      * Returns the y-velocity of the robot, in global field coordinates, in m/s
      *
      * @return the y-velocity of the robot, in global field coordinates, in m/s
      */
-    float getVelocityY();
+    virtual float getVelocityY() = 0;
 
     /**
      * Returns the angular velocity of the robot, in rad/s
      *
      * @return the angular of the robot, in rad/s
      */
-    float getVelocityAngular();
+    virtual float getVelocityAngular() = 0;
 
     /**
      * Returns the battery voltage, in volts
      *
      * @return the battery voltage, in volts
      */
-    float getBatteryVoltage();
+    virtual float getBatteryVoltage() = 0;
 
     /**
      * Fires the kicker, kicking the ball in the direction the robot is facing
@@ -101,7 +79,7 @@ class SimulatorRobot
      *
      * @param speed_m_per_s How fast to kick the ball, in meters per second
      */
-    void kick(float speed_m_per_s);
+    virtual void kick(float speed_m_per_s) = 0;
 
     /**
      * Fires the chipper, chipping the ball in the direction the robot is facing
@@ -110,7 +88,7 @@ class SimulatorRobot
      * @param speed_m_per_s How far to chip the ball (the distance to the first bounce)
      * in meters
      */
-    void chip(float distance_m);
+    virtual void chip(float distance_m) = 0;
 
     /**
      * Enables autokick on the robot. If the ball touches the kicker, the robot will
@@ -119,7 +97,7 @@ class SimulatorRobot
      * @param speed_m_per_s How fast to kick the ball in meters per second when
      * the kicker is fired
      */
-    void enableAutokick(float speed_m_per_s);
+    virtual void enableAutokick(float speed_m_per_s) = 0;
 
     /**
      * Enables autochip on the robot. If the ball touches the chipper, the robot will
@@ -128,84 +106,84 @@ class SimulatorRobot
      * @param speed_m_per_s How far to chip the ball (distance to the first bounce)
      * when the chipper is fired
      */
-    void enableAutochip(float distance_m);
+    virtual void enableAutochip(float distance_m) = 0;
 
     /**
      * Disables autokick
      */
-    void disableAutokick();
+    virtual void disableAutokick() = 0;
 
     /**
      * Disables autochip
      */
-    void disableAutochip();
+    virtual void disableAutochip() = 0;
 
     /**
      * Returns true if autokick is enabled and false otherwise
      *
      * @return true if autokick is enabled and false otherwise
      */
-    bool isAutokickEnabled();
+    virtual bool isAutokickEnabled() = 0;
 
     /**
      * Returns true if autochip is enabled and false otherwise
      *
      * @return true if autochip is enabled and false otherwise
      */
-    bool isAutochipEnabled();
+    virtual bool isAutochipEnabled() = 0;
 
     /**
      * Sets the speed of the dribbler
      *
      * @param rpm The rpm to set for the dribbler
      */
-    void setDribblerSpeed(uint32_t rpm);
+    virtual void setDribblerSpeed(uint32_t rpm) = 0;
 
     /**
      * Makes the dribbler coast until another operation is applied to it
      */
-    void dribblerCoast();
+    virtual void dribblerCoast() = 0;
 
     /**
      * Returns the temperature of the dribbler, in degrees C
      *
      * @return the temperature of the dribbler, in degrees C
      */
-    unsigned int getDribblerTemperatureDegC();
+    virtual unsigned int getDribblerTemperatureDegC() = 0;
 
     /**
      * Applies the given force to the wheel
      *
      * @param force_in_newtons the force to apply to the wheel
      */
-    void applyWheelForceFrontLeft(float force_in_newtons);
-    void applyWheelForceBackLeft(float force_in_newtons);
-    void applyWheelForceBackRight(float force_in_newtons);
-    void applyWheelForceFrontRight(float force_in_newtons);
+    virtual void applyWheelForceFrontLeft(float force_in_newtons)  = 0;
+    virtual void applyWheelForceBackLeft(float force_in_newtons)   = 0;
+    virtual void applyWheelForceBackRight(float force_in_newtons)  = 0;
+    virtual void applyWheelForceFrontRight(float force_in_newtons) = 0;
 
     /**
      * Gets the motor speed for the wheel, in RPM
      */
-    float getMotorSpeedFrontLeft();
-    float getMotorSpeedBackLeft();
-    float getMotorSpeedBackRight();
-    float getMotorSpeedFrontRight();
+    virtual float getMotorSpeedFrontLeft()  = 0;
+    virtual float getMotorSpeedBackLeft()   = 0;
+    virtual float getMotorSpeedBackRight()  = 0;
+    virtual float getMotorSpeedFrontRight() = 0;
 
     /**
      * Sets the motor to coast (spin freely)
      */
-    void coastMotorBackLeft();
-    void coastMotorBackRight();
-    void coastMotorFrontLeft();
-    void coastMotorFrontRight();
+    virtual void coastMotorBackLeft()   = 0;
+    virtual void coastMotorBackRight()  = 0;
+    virtual void coastMotorFrontLeft()  = 0;
+    virtual void coastMotorFrontRight() = 0;
 
     /**
      * Sets the motor to brake (act against the current direction of rotation)
      */
-    void brakeMotorBackLeft();
-    void brakeMotorBackRight();
-    void brakeMotorFrontLeft();
-    void brakeMotorFrontRight();
+    virtual void brakeMotorBackLeft()   = 0;
+    virtual void brakeMotorBackRight()  = 0;
+    virtual void brakeMotorFrontLeft()  = 0;
+    virtual void brakeMotorFrontRight() = 0;
 
     /**
      * Sets the current primitive this robot is running to a new one
@@ -213,100 +191,13 @@ class SimulatorRobot
      * @param firmware_world The world to run the primitive in
      * @param primitive_msg The primitive to start
      */
-    void startNewPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world,
-                           const TbotsProto_Primitive& primitive_msg);
+    virtual void startNewPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world,
+                                   const TbotsProto_Primitive& primitive_msg) = 0;
 
     /**
      * Runs the current primitive
      *
      * @param world The world to run the primitive in
      */
-    void runCurrentPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world);
-
-   private:
-    /**
-     * A function that is called during every physics step for as long as the ball
-     * is touching this robot's dribbler
-     *
-     * @param physics_robot The robot involved in the contact
-     * @param physics_ball The ball invovled in the contact
-     */
-    void onDribblerBallContact(PhysicsRobot* physics_robot, PhysicsBall* physics_ball);
-
-    /**
-     * A function that is called during once when the ball starts touching
-     * this robot's dribbler.
-     *
-     * @param physics_robot The robot involved in the contact
-     * @param physics_ball The ball invovled in the contact
-     */
-    void onDribblerBallStartContact(PhysicsRobot* physics_robot,
-                                    PhysicsBall* physics_ball);
-
-    /**
-     * A function that is called during once when the ball stops touching
-     * this robot's dribbler.
-     *
-     * @param physics_robot The robot involved in the contact
-     * @param physics_ball The ball invovled in the contact
-     */
-    void onDribblerBallEndContact(PhysicsRobot* physics_robot, PhysicsBall* physics_ball);
-
-    /**
-     * Helper functions that check if the current pointer to the physics_robot is valid
-     * before calling the given function. If the physics_robot is invalid, a warning is
-     * logged and a default value is returned.
-     *
-     * @param func The function to perform on the physics robot
-     */
-    void checkValidAndExecuteVoid(
-        std::function<void(std::shared_ptr<PhysicsRobot>)> func);
-    float checkValidAndReturnFloat(
-        std::function<float(std::shared_ptr<PhysicsRobot>)> func);
-    unsigned int checkValidAndReturnUint(
-        std::function<unsigned int(std::shared_ptr<PhysicsRobot>)> func);
-
-    /**
-     * Applies force to the physics ball to simulate it being dribbled by the
-     * physics robot.
-     *
-     * @param physics_robot The robot that should dribble the ball
-     * @param physics_ball The ball to be dribbled
-     */
-    void applyDribblerForce(PhysicsRobot* physics_robot, PhysicsBall* physics_ball);
-
-    std::weak_ptr<PhysicsRobot> physics_robot;
-    std::optional<float> autokick_speed_m_per_s;
-    std::optional<float> autochip_distance_m;
-    uint32_t dribbler_rpm;
-
-    typedef struct DribblerBall_t
-    {
-        PhysicsBall* ball;
-        // We keep track of whether or not the ball can be controlled
-        // in any way by the robot. This includes kicking, chipping,
-        // and dribbling. This extra information is used to
-        // prevent edge cases like the ball getting kicked/chipped
-        // multiple times, and to prevent the dribbler from affecting
-        // kicking
-        bool can_be_controlled;
-    } DribblerBall;
-
-    std::optional<DribblerBall> ball_in_dribbler_area;
-
-    std::unique_ptr<PrimitiveManager, FirmwarePrimitiveManagerDeleter> primitive_manager;
-
-    // How much the dribbler damps the ball when they collide. Each component
-    // of the damping can be changed separately so we have the flexibility to tune
-    // this behavior to match real life. These values have been manually tuned
-    // such that the robots are able to hit one-time shots in simulation with
-    // sufficient accuracy.
-    static constexpr double DRIBBLER_HEAD_ON_DAMPING       = 0.7;
-    static constexpr double DRIBBLER_PERPENDICULAR_DAMPING = 0.61;
-    // A value in the range [0, 1] that indicates how much momentum is conserved when the
-    // ball is kicked. Higher values will cause the ball to be kicked with an even greater
-    // velocity if it had an initial non-zero velocity when being kicked.
-    // This value is a very rough estimate of real-world behaviour, so that the ball
-    // will be kicked slightly faster it it entered the kicker with some initial velocity.
-    static constexpr double MOMENTUM_CONSERVED_DURING_KICK = 0.1;
+    virtual void runCurrentPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world) = 0;
 };

--- a/src/software/simulation/simulator_robot.h
+++ b/src/software/simulation/simulator_robot.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <memory>
+#include <optional>
+
+#include "software/simulation/firmware_object_deleter.h"
 
 extern "C"
 {
@@ -16,6 +19,11 @@ class SimulatorRobot
     friend class SimulatorRobotSingleton;
 
    public:
+    /**
+     * Create a new SimulatorRobot
+     */
+    explicit SimulatorRobot();
+
     /**
      * Returns the ID of this robot
      *
@@ -200,4 +208,8 @@ class SimulatorRobot
      * @param world The world to run the primitive in
      */
     virtual void runCurrentPrimitive(std::shared_ptr<FirmwareWorld_t> firmware_world) = 0;
+
+    std::optional<float> autokick_speed_m_per_s;
+    std::optional<float> autochip_distance_m;
+    std::unique_ptr<PrimitiveManager, FirmwarePrimitiveManagerDeleter> primitive_manager;
 };

--- a/src/software/simulation/simulator_robot_singleton.h
+++ b/src/software/simulation/simulator_robot_singleton.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cinttypes>
+#include <functional>
 #include <optional>
 
 #include "software/simulation/simulator_robot.h"

--- a/src/software/simulation/simulator_robot_singleton_test.cpp
+++ b/src/software/simulation/simulator_robot_singleton_test.cpp
@@ -7,6 +7,8 @@
 #include "shared/proto/robot_log_msg.nanopb.h"
 #include "shared/proto/robot_log_msg.pb.h"
 #include "software/simulation/physics/physics_world.h"
+#include "software/simulation/physics_simulator_ball.h"
+#include "software/simulation/physics_simulator_robot.h"
 #include "software/simulation/simulator_ball.h"
 #include "software/simulation/simulator_robot.h"
 
@@ -59,7 +61,7 @@ class SimulatorRobotSingletonTest : public testing::Test
         auto physics_robot = physics_world->getYellowPhysicsRobots().at(0);
         if (physics_robot.lock())
         {
-            simulator_robot = std::make_shared<SimulatorRobot>(physics_robot);
+            simulator_robot = std::make_shared<PhysicsSimulatorRobot>(physics_robot);
             SimulatorRobotSingleton::setSimulatorRobot(simulator_robot, FieldSide::NEG_X);
         }
         else
@@ -73,7 +75,7 @@ class SimulatorRobotSingletonTest : public testing::Test
         auto physics_ball = physics_world->getPhysicsBall();
         if (physics_ball.lock())
         {
-            simulator_ball = std::make_shared<SimulatorBall>(physics_ball);
+            simulator_ball = std::make_shared<PhysicsSimulatorBall>(physics_ball);
         }
         else
         {
@@ -1427,7 +1429,7 @@ TEST_F(SimulatorRobotSingletonTest, test_change_simulator_robot)
     auto friendly_physics_robots = physics_world->getYellowPhysicsRobots();
     ASSERT_EQ(2, friendly_physics_robots.size());
     auto simulator_robot_7 =
-        std::make_shared<SimulatorRobot>(friendly_physics_robots.at(0));
+        std::make_shared<PhysicsSimulatorRobot>(friendly_physics_robots.at(0));
 
     SimulatorRobotSingleton::setSimulatorRobot(simulator_robot_7, FieldSide::NEG_X);
     auto firmware_robot_7 = SimulatorRobotSingleton::createFirmwareRobot();
@@ -1440,7 +1442,7 @@ TEST_F(SimulatorRobotSingletonTest, test_change_simulator_robot)
     // The firmware functions should now return the data for simulator_robot_2, even
     // though we didn't need to create a new FirmwareRobot_t
     auto simulator_robot_2 =
-        std::make_shared<SimulatorRobot>(friendly_physics_robots.at(1));
+        std::make_shared<PhysicsSimulatorRobot>(friendly_physics_robots.at(1));
     SimulatorRobotSingleton::setSimulatorRobot(simulator_robot_2, FieldSide::NEG_X);
     auto firmware_robot_2 = SimulatorRobotSingleton::createFirmwareRobot();
     EXPECT_FLOAT_EQ(0.0f, app_firmware_robot_getPositionX(firmware_robot_2.get()));


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Renames the current `SimulatorBall` and `SimulatorRobot` to `PhysicsSimulatorBall` and `PhysicsSimulatorRobot` respectively, and replace them with abstract base classes, which `PhysicsSimulatorBall` and `PhysicsSimulatorRobot` implement.

The purpose of this is to be able to reuse `SimulatorBallSingleton` and `SimulatorRobotSingleton` for the purposes of supporting the SSL Simulation protocol, and will be followed with `SslSimulatorBall` and `SslSimulatorRobot` implementations of the abstract base classes.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Doesn't change any existing functionality, and passes existing unit tests

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
