### PR TITLE
Fix codespell to work for Ubuntu 20 and 18

### DIFF
--- a/docs/coroutine_test_examples.cpp
+++ b/docs/coroutine_test_examples.cpp
@@ -554,7 +554,7 @@ int main(int argc, char** argv)
     //    moveFromStackToHeapNMO(); // BAD
     //    moveFromHeapToStack(); // OK
 
-    /* Because vectors (and other resizeable containers) actually store
+    /* Because vectors (and other resizable containers) actually store
      * data on the heap, moving coroutines into vectors only works
      * in certain cases.
      *
@@ -573,7 +573,7 @@ int main(int argc, char** argv)
 
 
     // ~~~~~~~~~~ Conclusions ~~~~~~~~~~ //
-    /* - Whether a resizeable container is used or not, moving coroutines
+    /* - Whether a resizable container is used or not, moving coroutines
      *   between the stack and the heap results in inconsistent behaviour
      *   (it works in some cases but not others, without any obviously
      *   consistent rules). Therefore, coroutines should never be
@@ -590,7 +590,7 @@ int main(int argc, char** argv)
      * COROUTINES BEST PRACTICES
      * - Avoid moving coroutines. If the absolutely must be moved,
      *   make sure they are not moved between the stack and heap.
-     * - Avoid using coroutines with resizeable containers. If they
+     * - Avoid using coroutines with resizable containers. If they
      *   must be used, make sure that the coroutines are allocated
      *   on the heap.
      * - Pass data to the coroutine on creation as much as possible,

--- a/docs/software-architecture-and-design.md
+++ b/docs/software-architecture-and-design.md
@@ -291,7 +291,7 @@ Coroutines are a complex feature, and the boost coroutines we use don't always b
 
 To summarize, the best practices are as follows:
 1. Avoid moving coroutines. If the absolutely must be moved, make sure they are not moved between the stack and heap.
-2. Avoid using coroutines with resizeable containers. If they must be used, make sure that the coroutines are allocated on the heap.
+2. Avoid using coroutines with resizable containers. If they must be used, make sure that the coroutines are allocated on the heap.
 3. Pass data to the coroutine on creation as much as possible, avoid using member variables.
 
 # Finite State Machines

--- a/formatting_scripts/fix_formatting.sh
+++ b/formatting_scripts/fix_formatting.sh
@@ -71,14 +71,20 @@ function run_black_formatting () {
 }
 
 function run_code_spell(){
-    curl https://raw.githubusercontent.com/codespell-project/codespell/v1.14.0/codespell_lib/data/dictionary.txt --output /tmp/dictionary.txt
+    http_code=$(curl -sw '%{http_code}' https://raw.githubusercontent.com/codespell-project/codespell/v1.14.0/codespell_lib/data/dictionary.txt --output /tmp/dictionary.txt)
+
+    if [[ "$http_code" != 200 ]]; then
+        printf "\n***Failed to download codespell dictionay!***\n\n"
+        exit 1
+    fi
 
     printf "Fixing spelling...\n\n"
-    cd $CURR_DIR/../src/software && codespell -w --skip="1,2,0" -D /tmp/dictionary.txt # Skip binaries
-    cd $CURR_DIR/../src/firmware_new && codespell -w -D /tmp/dictionary.txt
-    cd $CURR_DIR/../src/firmware/app && codespell -w -D /tmp/dictionary.txt
-    cd $CURR_DIR/../src/shared && codespell -w -D /tmp/dictionary.txt
-    cd $CURR_DIR/../docs && codespell -w --skip="*.png" -D /tmp/dictionary.txt # Skip images
+    # -q=4 suppresses all warnings that aren't going to fixed by the provided dictionary
+    cd $CURR_DIR/../src/software && codespell -w -q=4 --skip="1,2,0" -D /tmp/dictionary.txt # Skip binaries
+    cd $CURR_DIR/../src/firmware_new && codespell -w -q=4 -D /tmp/dictionary.txt
+    cd $CURR_DIR/../src/firmware/app && codespell -w -q=4 -D /tmp/dictionary.txt
+    cd $CURR_DIR/../src/shared && codespell -w -q=4 -D /tmp/dictionary.txt
+    cd $CURR_DIR/../docs && codespell -w -q=4 --skip="*.png" -D /tmp/dictionary.txt # Skip images
 
     if [[ "$?" != 0 ]]; then
         printf "\n***Failed to fix spelling!***\n\n"

--- a/formatting_scripts/fix_formatting.sh
+++ b/formatting_scripts/fix_formatting.sh
@@ -71,12 +71,14 @@ function run_black_formatting () {
 }
 
 function run_code_spell(){
+    curl https://raw.githubusercontent.com/codespell-project/codespell/v1.14.0/codespell_lib/data/dictionary.txt --output /tmp/dictionary.txt
+
     printf "Fixing spelling...\n\n"
-    cd $CURR_DIR/../src/software && codespell -w --skip="1,2,0" # Skip binaries
-    cd $CURR_DIR/../src/firmware_new && codespell -w
-    cd $CURR_DIR/../src/firmware/app && codespell -w
-    cd $CURR_DIR/../src/shared && codespell -w
-    cd $CURR_DIR/../docs && codespell -w --skip="*.png" # Skip images
+    cd $CURR_DIR/../src/software && codespell -w --skip="1,2,0" -D /tmp/dictionary.txt # Skip binaries
+    cd $CURR_DIR/../src/firmware_new && codespell -w -D /tmp/dictionary.txt
+    cd $CURR_DIR/../src/firmware/app && codespell -w -D /tmp/dictionary.txt
+    cd $CURR_DIR/../src/shared && codespell -w -D /tmp/dictionary.txt
+    cd $CURR_DIR/../docs && codespell -w --skip="*.png" -D /tmp/dictionary.txt # Skip images
 
     if [[ "$?" != 0 ]]; then
         printf "\n***Failed to fix spelling!***\n\n"

--- a/formatting_scripts/fix_formatting.sh
+++ b/formatting_scripts/fix_formatting.sh
@@ -74,7 +74,7 @@ function run_code_spell(){
     http_code=$(curl -sw '%{http_code}' https://raw.githubusercontent.com/codespell-project/codespell/v1.14.0/codespell_lib/data/dictionary.txt --output /tmp/dictionary.txt)
 
     if [[ "$http_code" != 200 ]]; then
-        printf "\n***Failed to download codespell dictionay!***\n\n"
+        printf "\n***Failed to download codespell dictionary!***\n\n"
         exit 1
     fi
 

--- a/formatting_scripts/fix_formatting.sh
+++ b/formatting_scripts/fix_formatting.sh
@@ -79,12 +79,11 @@ function run_code_spell(){
     fi
 
     printf "Fixing spelling...\n\n"
-    # -q=4 suppresses all warnings that aren't going to fixed by the provided dictionary
-    cd $CURR_DIR/../src/software && codespell -w -q=4 --skip="1,2,0" -D /tmp/dictionary.txt # Skip binaries
-    cd $CURR_DIR/../src/firmware_new && codespell -w -q=4 -D /tmp/dictionary.txt
-    cd $CURR_DIR/../src/firmware/app && codespell -w -q=4 -D /tmp/dictionary.txt
-    cd $CURR_DIR/../src/shared && codespell -w -q=4 -D /tmp/dictionary.txt
-    cd $CURR_DIR/../docs && codespell -w -q=4 --skip="*.png" -D /tmp/dictionary.txt # Skip images
+    cd $CURR_DIR/../src/software && codespell -w --skip="1,2,0" -D /tmp/dictionary.txt # Skip binaries
+    cd $CURR_DIR/../src/firmware_new && codespell -w -D /tmp/dictionary.txt
+    cd $CURR_DIR/../src/firmware/app && codespell -w -D /tmp/dictionary.txt
+    cd $CURR_DIR/../src/shared && codespell -w -D /tmp/dictionary.txt
+    cd $CURR_DIR/../docs && codespell -w --skip="*.png" -D /tmp/dictionary.txt # Skip images
 
     if [[ "$?" != 0 ]]; then
         printf "\n***Failed to fix spelling!***\n\n"

--- a/src/firmware/app/control/trajectory_planner.h
+++ b/src/firmware/app/control/trajectory_planner.h
@@ -115,7 +115,7 @@ typedef struct VelocityTrajectory
  *      - The generator will assume maximum acceleration for the robot between each
  * segment on the path. If using max acceleration breaches either the speed limit of the
  * robot, or the centripetal acceleration limit defined by the curvature and robot speed -
- * the planner will assume the max acceleration that will remain bellow this limit.
+ * the planner will assume the max acceleration that will remain below this limit.
  *
  *     - To ensure the robot is capable of decelerating to react to any sudden changes in
  *       the path, the trajectory is checked for backwards continuity

--- a/src/firmware_new/boards/frankie_v1/ethernetif.c
+++ b/src/firmware_new/boards/frankie_v1/ethernetif.c
@@ -440,7 +440,7 @@ static void low_level_init(struct netif *netif)
  *
  * @note Returning ERR_MEM here if a DMA queue of your MAC is full can lead to
  *       strange results. You might consider waiting for space in the DMA queue
- *       to become availale since the stack doesn't retry to send a packet
+ *       to become available since the stack doesn't retry to send a packet
  *       dropped because of memory failure (except for the TCP timers).
  */
 

--- a/src/firmware_new/boards/frankie_v1/main.c
+++ b/src/firmware_new/boards/frankie_v1/main.c
@@ -176,7 +176,7 @@ void SystemClock_Config(void)
     while (!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY))
     {
     }
-    /** Initializes the CPU, AHB and APB busses clocks
+    /** Initializes the CPU, AHB and APB buses clocks
      */
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.HSEState       = RCC_HSE_BYPASS;
@@ -194,7 +194,7 @@ void SystemClock_Config(void)
     {
         Error_Handler();
     }
-    /** Initializes the CPU, AHB and APB busses clocks
+    /** Initializes the CPU, AHB and APB buses clocks
      */
     RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK |
                                   RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2 |

--- a/src/shared/parameter/cpp_config_test.cpp
+++ b/src/shared/parameter/cpp_config_test.cpp
@@ -260,7 +260,7 @@ class TestAutogenParameterList : public YamlLoadFixture
      * checks that the yaml was generated correctly into the expected
      * parameter.
      *
-     * Interally asserts and creates failures
+     * Internally asserts and creates failures
      */
     template <typename T>
     void assert_parameter(const std::shared_ptr<const Parameter<T>>& param,

--- a/src/software/ai/navigator/path_planner/theta_star_path_planner.h
+++ b/src/software/ai/navigator/path_planner/theta_star_path_planner.h
@@ -130,7 +130,7 @@ class ThetaStarPathPlanner : public PathPlanner
        private:
         /**
          * Calculate the key value given a pair of coordinates. The key of the coordinate
-         * with smaller row value, or smaller col value when row values are equal wil
+         * with smaller row value, or smaller col value when row values are equal will
          * occupy the low 32 bits in the key for this CoordinatePair. The key value of the
          * other coordinate will occupy the high 32 bits in the key for this
          * CoordinatePair.


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Codespell's dictionaries are different between the versions on ubuntu 20 and 18, we freeze the dictionary here to the most up-to-date one that both versions support.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Manual testing
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
N/A
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification
N/A
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
