### PR TITLE
Add Div A field option to Simulator

### DIFF
--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -137,3 +137,7 @@ const unsigned int MAX_ROBOT_IDS = 16;
 const float ROBOT_MAX_BATTERY_VOLTAGE = 16.0;
 
 const unsigned int ROBOT_CHIP_ANGLE_DEGREES = 45;
+
+// How many robots are allowed in each division
+const unsigned DIV_A_NUM_ROBOTS = 11;
+const unsigned DIV_B_NUM_ROBOTS = 6;

--- a/src/shared/parameter/config_definitions/standalone_simulator_main_command_line_args.yaml
+++ b/src/shared/parameter/config_definitions/standalone_simulator_main_command_line_args.yaml
@@ -3,9 +3,21 @@
     value: ""
     description: >-
         The interface to send and receive packets over (can be found through ifconfig)
+
 - string:
     name: logging_dir
     value: ""
     description: >-
         The directory to output logs to. Absolute paths are recommended as the working directory
         is inside the bazel-out directory.
+
+- string:
+    name: ssl_division
+    value: "div_b"
+    options:
+        - "div_a"
+        - "div_b"
+    description: >-
+        Which ssl_division to configure the simulator to. Changes the field size and the number
+        of initial robots.
+        

--- a/src/software/ai/hl/stp/play/example_play.cpp
+++ b/src/software/ai/hl/stp/play/example_play.cpp
@@ -20,15 +20,15 @@ bool ExamplePlay::invariantHolds(const World &world) const
 void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
 {
     // Create MoveTactics that will loop forever
-    auto move_tactic_1 = std::make_shared<MoveTactic>(true);
-    auto move_tactic_2 = std::make_shared<MoveTactic>(true);
-    auto move_tactic_3 = std::make_shared<MoveTactic>(true);
-    auto move_tactic_4 = std::make_shared<MoveTactic>(true);
-    auto move_tactic_5 = std::make_shared<MoveTactic>(true);
-    auto move_tactic_6 = std::make_shared<MoveTactic>(true);
-    auto move_tactic_7 = std::make_shared<MoveTactic>(true);
-    auto move_tactic_8 = std::make_shared<MoveTactic>(true);
-    auto move_tactic_9 = std::make_shared<MoveTactic>(true);
+    auto move_tactic_1  = std::make_shared<MoveTactic>(true);
+    auto move_tactic_2  = std::make_shared<MoveTactic>(true);
+    auto move_tactic_3  = std::make_shared<MoveTactic>(true);
+    auto move_tactic_4  = std::make_shared<MoveTactic>(true);
+    auto move_tactic_5  = std::make_shared<MoveTactic>(true);
+    auto move_tactic_6  = std::make_shared<MoveTactic>(true);
+    auto move_tactic_7  = std::make_shared<MoveTactic>(true);
+    auto move_tactic_8  = std::make_shared<MoveTactic>(true);
+    auto move_tactic_9  = std::make_shared<MoveTactic>(true);
     auto move_tactic_10 = std::make_shared<MoveTactic>(true);
     auto move_tactic_11 = std::make_shared<MoveTactic>(true);
 

--- a/src/software/ai/hl/stp/play/example_play.cpp
+++ b/src/software/ai/hl/stp/play/example_play.cpp
@@ -26,6 +26,11 @@ void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World 
     auto move_tactic_4 = std::make_shared<MoveTactic>(true);
     auto move_tactic_5 = std::make_shared<MoveTactic>(true);
     auto move_tactic_6 = std::make_shared<MoveTactic>(true);
+    auto move_tactic_7 = std::make_shared<MoveTactic>(true);
+    auto move_tactic_8 = std::make_shared<MoveTactic>(true);
+    auto move_tactic_9 = std::make_shared<MoveTactic>(true);
+    auto move_tactic_10 = std::make_shared<MoveTactic>(true);
+    auto move_tactic_11 = std::make_shared<MoveTactic>(true);
 
     // Continue to loop to demonstrate the example play indefinitely
     do
@@ -53,12 +58,28 @@ void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World 
         move_tactic_6->updateControlParams(
             world.ball().position() + Vector::createFromAngle(angle_between_robots * 6),
             (angle_between_robots * 6) + Angle::half(), 0);
+        move_tactic_7->updateControlParams(
+            world.ball().position() + Vector::createFromAngle(angle_between_robots * 7),
+            (angle_between_robots * 7) + Angle::half(), 0);
+        move_tactic_8->updateControlParams(
+            world.ball().position() + Vector::createFromAngle(angle_between_robots * 8),
+            (angle_between_robots * 8) + Angle::half(), 0);
+        move_tactic_9->updateControlParams(
+            world.ball().position() + Vector::createFromAngle(angle_between_robots * 9),
+            (angle_between_robots * 9) + Angle::half(), 0);
+        move_tactic_10->updateControlParams(
+            world.ball().position() + Vector::createFromAngle(angle_between_robots * 10),
+            (angle_between_robots * 10) + Angle::half(), 0);
+        move_tactic_11->updateControlParams(
+            world.ball().position() + Vector::createFromAngle(angle_between_robots * 11),
+            (angle_between_robots * 11) + Angle::half(), 0);
 
         // yield the Tactics this Play wants to run, in order of priority
         // If there are fewer robots in play, robots at the end of the list will not be
         // assigned
         yield({{move_tactic_1, move_tactic_2, move_tactic_3, move_tactic_4, move_tactic_5,
-                move_tactic_6}});
+                move_tactic_6, move_tactic_7, move_tactic_8, move_tactic_9,
+                move_tactic_10, move_tactic_11}});
     } while (true);
 }
 

--- a/src/software/ai/hl/stp/play/example_play.cpp
+++ b/src/software/ai/hl/stp/play/example_play.cpp
@@ -20,17 +20,19 @@ bool ExamplePlay::invariantHolds(const World &world) const
 void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
 {
     // Create MoveTactics that will loop forever
-    auto move_tactic_1  = std::make_shared<MoveTactic>(true);
-    auto move_tactic_2  = std::make_shared<MoveTactic>(true);
-    auto move_tactic_3  = std::make_shared<MoveTactic>(true);
-    auto move_tactic_4  = std::make_shared<MoveTactic>(true);
-    auto move_tactic_5  = std::make_shared<MoveTactic>(true);
-    auto move_tactic_6  = std::make_shared<MoveTactic>(true);
-    auto move_tactic_7  = std::make_shared<MoveTactic>(true);
-    auto move_tactic_8  = std::make_shared<MoveTactic>(true);
-    auto move_tactic_9  = std::make_shared<MoveTactic>(true);
-    auto move_tactic_10 = std::make_shared<MoveTactic>(true);
-    auto move_tactic_11 = std::make_shared<MoveTactic>(true);
+    TacticVector tactic_vector = {{
+        std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true),
+    }};
 
     // Continue to loop to demonstrate the example play indefinitely
     do
@@ -39,47 +41,18 @@ void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World 
         Angle angle_between_robots =
             Angle::full() / static_cast<double>(world.friendlyTeam().numRobots());
 
-        // Move the robots in a circle around the ball, facing the ball
-        move_tactic_1->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 1),
-            (angle_between_robots * 1) + Angle::half(), 0);
-        move_tactic_2->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 2),
-            (angle_between_robots * 2) + Angle::half(), 0);
-        move_tactic_3->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 3),
-            (angle_between_robots * 3) + Angle::half(), 0);
-        move_tactic_4->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 4),
-            (angle_between_robots * 4) + Angle::half(), 0);
-        move_tactic_5->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 5),
-            (angle_between_robots * 5) + Angle::half(), 0);
-        move_tactic_6->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 6),
-            (angle_between_robots * 6) + Angle::half(), 0);
-        move_tactic_7->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 7),
-            (angle_between_robots * 7) + Angle::half(), 0);
-        move_tactic_8->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 8),
-            (angle_between_robots * 8) + Angle::half(), 0);
-        move_tactic_9->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 9),
-            (angle_between_robots * 9) + Angle::half(), 0);
-        move_tactic_10->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 10),
-            (angle_between_robots * 10) + Angle::half(), 0);
-        move_tactic_11->updateControlParams(
-            world.ball().position() + Vector::createFromAngle(angle_between_robots * 11),
-            (angle_between_robots * 11) + Angle::half(), 0);
+        for (int k = 0; k < tactic_vector[0].length(); k++)
+        {
+            tactic_vector[0]->updateControlParams(
+                world.ball().position() +
+                    Vector::createFromAngle(angle_between_robots * (k + 1)),
+                (angle_between_robots * (k + 1)) + Angle::half(), 0);
+        }
 
         // yield the Tactics this Play wants to run, in order of priority
         // If there are fewer robots in play, robots at the end of the list will not be
         // assigned
-        yield({{move_tactic_1, move_tactic_2, move_tactic_3, move_tactic_4, move_tactic_5,
-                move_tactic_6, move_tactic_7, move_tactic_8, move_tactic_9,
-                move_tactic_10, move_tactic_11}});
+        yield(tactic_vector);
     } while (true);
 }
 

--- a/src/software/ai/hl/stp/play/example_play.cpp
+++ b/src/software/ai/hl/stp/play/example_play.cpp
@@ -20,13 +20,8 @@ bool ExamplePlay::invariantHolds(const World &world) const
 void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
 {
     // Create MoveTactics that will loop forever
-    std::vector<std::shared_ptr<MoveTactic>> move_tactics = {
-        std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true)};
+    std::vector<std::shared_ptr<MoveTactic>> move_tactics(
+        DIV_A_NUM_ROBOTS, std::make_shared<MoveTactic>(true));
 
     // Continue to loop to demonstrate the example play indefinitely
     do

--- a/src/software/ai/hl/stp/play/example_play.cpp
+++ b/src/software/ai/hl/stp/play/example_play.cpp
@@ -20,19 +20,13 @@ bool ExamplePlay::invariantHolds(const World &world) const
 void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
 {
     // Create MoveTactics that will loop forever
-    TacticVector tactic_vector = {{
-        std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true),
-        std::make_shared<MoveTactic>(true),
-    }};
+    std::vector<std::shared_ptr<MoveTactic>> move_tactics = {
+        std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
+        std::make_shared<MoveTactic>(true)};
 
     // Continue to loop to demonstrate the example play indefinitely
     do
@@ -41,18 +35,22 @@ void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World 
         Angle angle_between_robots =
             Angle::full() / static_cast<double>(world.friendlyTeam().numRobots());
 
-        for (int k = 0; k < tactic_vector[0].length(); k++)
+        for (size_t k = 0; k < move_tactics.size(); k++)
         {
-            tactic_vector[0]->updateControlParams(
+            move_tactics[k]->updateControlParams(
                 world.ball().position() +
-                    Vector::createFromAngle(angle_between_robots * (k + 1)),
-                (angle_between_robots * (k + 1)) + Angle::half(), 0);
+                    Vector::createFromAngle(angle_between_robots *
+                                            static_cast<double>(k + 1)),
+                (angle_between_robots * static_cast<double>(k + 1)) + Angle::half(), 0);
         }
 
         // yield the Tactics this Play wants to run, in order of priority
         // If there are fewer robots in play, robots at the end of the list will not be
         // assigned
-        yield(tactic_vector);
+        TacticVector result = {};
+        result.insert(result.end(), move_tactics.begin(), move_tactics.end());
+        yield({result});
+
     } while (true);
 }
 

--- a/src/software/ai/hl/stp/play/example_play.cpp
+++ b/src/software/ai/hl/stp/play/example_play.cpp
@@ -20,8 +20,9 @@ bool ExamplePlay::invariantHolds(const World &world) const
 void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield, const World &world)
 {
     // Create MoveTactics that will loop forever
-    std::vector<std::shared_ptr<MoveTactic>> move_tactics(
-        DIV_A_NUM_ROBOTS, std::make_shared<MoveTactic>(true));
+    std::vector<std::shared_ptr<MoveTactic>> move_tactics(DIV_A_NUM_ROBOTS);
+    std::generate(move_tactics.begin(), move_tactics.end(),
+                  []() { return std::make_shared<MoveTactic>(true); });
 
     // Continue to loop to demonstrate the example play indefinitely
     do

--- a/src/software/simulation/standalone_simulator.cpp
+++ b/src/software/simulation/standalone_simulator.cpp
@@ -115,48 +115,27 @@ void StandaloneSimulator::setupNetworking(int blue_team_channel, int yellow_team
 
 void StandaloneSimulator::setupInitialSimulationStateDivB()
 {
-    RobotState blue_robot_state1(Point(3, 2.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
-    RobotState blue_robot_state2(Point(3, 1.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
-    RobotState blue_robot_state3(Point(3, 0.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
-    RobotState blue_robot_state4(Point(3, -0.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
-    RobotState blue_robot_state5(Point(3, -1.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
-    RobotState blue_robot_state6(Point(3, -2.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
-    std::vector<RobotStateWithId> blue_robot_states = {
-        RobotStateWithId{.id = 0, .robot_state = blue_robot_state1},
-        RobotStateWithId{.id = 1, .robot_state = blue_robot_state2},
-        RobotStateWithId{.id = 2, .robot_state = blue_robot_state3},
-        RobotStateWithId{.id = 3, .robot_state = blue_robot_state4},
-        RobotStateWithId{.id = 4, .robot_state = blue_robot_state5},
-        RobotStateWithId{.id = 5, .robot_state = blue_robot_state6},
-    };
-    simulator.addBlueRobots(blue_robot_states);
+    std::vector<RobotStateWithId> blue_robot_states;
+    std::vector<RobotStateWithId> yellow_robot_states;
 
-    RobotState yellow_robot_state1(Point(-3, 2.5), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    RobotState yellow_robot_state2(Point(-3, 1.5), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    RobotState yellow_robot_state3(Point(-3, 0.5), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    RobotState yellow_robot_state4(Point(-3, -0.5), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    RobotState yellow_robot_state5(Point(-3, -1.5), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    RobotState yellow_robot_state6(Point(-3, -2.5), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    std::vector<RobotStateWithId> yellow_robot_states = {
-        RobotStateWithId{.id = 0, .robot_state = yellow_robot_state1},
-        RobotStateWithId{.id = 1, .robot_state = yellow_robot_state2},
-        RobotStateWithId{.id = 2, .robot_state = yellow_robot_state3},
-        RobotStateWithId{.id = 3, .robot_state = yellow_robot_state4},
-        RobotStateWithId{.id = 4, .robot_state = yellow_robot_state5},
-        RobotStateWithId{.id = 5, .robot_state = yellow_robot_state6},
-    };
+    const double y_start   = 2.5;
+    const double y_spacing = 1.0;
+
+    for (unsigned i = 0; i < DIV_B_NUM_ROBOTS; i++)
+    {
+        blue_robot_states.emplace_back(RobotStateWithId{
+            .id          = i,
+            .robot_state = RobotState(Point(3, y_start - y_spacing * i), Vector(0, 0),
+                                      Angle::half(), AngularVelocity::zero()),
+        });
+        yellow_robot_states.emplace_back(RobotStateWithId{
+            .id          = i,
+            .robot_state = RobotState(Point(-3, y_start - y_spacing * i), Vector(0, 0),
+                                      Angle::full(), AngularVelocity::zero()),
+        });
+    }
+
+    simulator.addBlueRobots(blue_robot_states);
     simulator.addYellowRobots(yellow_robot_states);
 }
 
@@ -164,50 +143,32 @@ void StandaloneSimulator::setupInitialSimulationStateDivA()
 {
     setupInitialSimulationStateDivB();
 
-    RobotState blue_robot_state6(Point(2, 2.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
-    RobotState blue_robot_state7(Point(2, 1.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
-    RobotState blue_robot_state8(Point(2, 0.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
-    RobotState blue_robot_state9(Point(2, -0.5), Vector(0, 0), Angle::half(),
-                                 AngularVelocity::zero());
-    RobotState blue_robot_state10(Point(2, -1.5), Vector(0, 0), Angle::half(),
-                                  AngularVelocity::zero());
-    RobotState blue_robot_state11(Point(2, -2.5), Vector(0, 0), Angle::half(),
-                                  AngularVelocity::zero());
+    std::vector<RobotStateWithId> blue_robot_states;
+    std::vector<RobotStateWithId> yellow_robot_states;
 
-    std::vector<RobotStateWithId> blue_robot_states = {
-        RobotStateWithId{.id = 6, .robot_state = blue_robot_state6},
-        RobotStateWithId{.id = 7, .robot_state = blue_robot_state7},
-        RobotStateWithId{.id = 8, .robot_state = blue_robot_state8},
-        RobotStateWithId{.id = 9, .robot_state = blue_robot_state9},
-        RobotStateWithId{.id = 10, .robot_state = blue_robot_state10},
-        RobotStateWithId{.id = 11, .robot_state = blue_robot_state11},
-    };
+    const double y_start      = 2.5;
+    const double y_spacing    = 1.0;
+    const int robot_id_offset = DIV_B_NUM_ROBOTS;
+
+    static_assert(DIV_A_NUM_ROBOTS > DIV_B_NUM_ROBOTS,
+                  "More robots in Div A than Div B!");
+
+    for (unsigned i = 0; i < DIV_A_NUM_ROBOTS - DIV_B_NUM_ROBOTS; i++)
+    {
+        blue_robot_states.emplace_back(RobotStateWithId{
+            .id          = i + robot_id_offset,
+            .robot_state = RobotState(Point(2, y_start - y_spacing * i), Vector(0, 0),
+                                      Angle::half(), AngularVelocity::zero()),
+        });
+        yellow_robot_states.emplace_back(RobotStateWithId{
+            .id          = i + robot_id_offset,
+            .robot_state = RobotState(Point(-2, y_start - y_spacing * i), Vector(0, 0),
+                                      Angle::full(), AngularVelocity::zero()),
+        });
+    }
+
+
     simulator.addBlueRobots(blue_robot_states);
-
-    RobotState yellow_robot_state6(Point(-2, 2.5), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    RobotState yellow_robot_state7(Point(-2, 1.5), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    RobotState yellow_robot_state8(Point(-2, 0.5), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    RobotState yellow_robot_state9(Point(-2, -0.5), Vector(0, 0), Angle::zero(),
-                                   AngularVelocity::zero());
-    RobotState yellow_robot_state10(Point(-2, -1.5), Vector(0, 0), Angle::zero(),
-                                    AngularVelocity::zero());
-    RobotState yellow_robot_state11(Point(-2, -2.5), Vector(0, 0), Angle::zero(),
-                                    AngularVelocity::zero());
-
-    std::vector<RobotStateWithId> yellow_robot_states = {
-        RobotStateWithId{.id = 6, .robot_state = yellow_robot_state6},
-        RobotStateWithId{.id = 7, .robot_state = yellow_robot_state7},
-        RobotStateWithId{.id = 8, .robot_state = yellow_robot_state8},
-        RobotStateWithId{.id = 9, .robot_state = yellow_robot_state9},
-        RobotStateWithId{.id = 10, .robot_state = yellow_robot_state10},
-        RobotStateWithId{.id = 11, .robot_state = yellow_robot_state11},
-    };
     simulator.addYellowRobots(yellow_robot_states);
 }
 

--- a/src/software/simulation/standalone_simulator.cpp
+++ b/src/software/simulation/standalone_simulator.cpp
@@ -113,60 +113,37 @@ void StandaloneSimulator::setupNetworking(int blue_team_channel, int yellow_team
         boost::bind(&StandaloneSimulator::setBlueTeamDefendingSide, this, _1)));
 }
 
-void StandaloneSimulator::setupInitialSimulationStateDivB()
+void StandaloneSimulator::setupInitialSimulationState(unsigned num_robots)
 {
     std::vector<RobotStateWithId> blue_robot_states;
     std::vector<RobotStateWithId> yellow_robot_states;
 
-    const double y_start   = 2.5;
-    const double y_spacing = 1.0;
+    // The angle between each robot spaced out in a circle around
+    // the two points on either side of the field.
+    Angle angle_between_robots     = Angle::full() / num_robots;
+    Point center_for_yellow_robots = Point(2, 0);
+    Point center_for_blue_robots   = Point(-2, 0);
 
-    for (unsigned i = 0; i < DIV_B_NUM_ROBOTS; i++)
+    for (unsigned i = 0; i < num_robots; i++)
     {
         blue_robot_states.emplace_back(RobotStateWithId{
-            .id          = i,
-            .robot_state = RobotState(Point(3, y_start - y_spacing * i), Vector(0, 0),
-                                      Angle::half(), AngularVelocity::zero()),
+            .id = i,
+            .robot_state =
+                RobotState(center_for_blue_robots +
+                               Vector::createFromAngle(angle_between_robots * i),
+                           Vector(0, 0), angle_between_robots * i + Angle::half(),
+                           AngularVelocity::zero()),
         });
+
         yellow_robot_states.emplace_back(RobotStateWithId{
-            .id          = i,
-            .robot_state = RobotState(Point(-3, y_start - y_spacing * i), Vector(0, 0),
-                                      Angle::full(), AngularVelocity::zero()),
+            .id = i,
+            .robot_state =
+                RobotState(center_for_yellow_robots +
+                               Vector::createFromAngle(angle_between_robots * i),
+                           Vector(0, 0), angle_between_robots * i + Angle::half(),
+                           AngularVelocity::zero()),
         });
     }
-
-    simulator.addBlueRobots(blue_robot_states);
-    simulator.addYellowRobots(yellow_robot_states);
-}
-
-void StandaloneSimulator::setupInitialSimulationStateDivA()
-{
-    setupInitialSimulationStateDivB();
-
-    std::vector<RobotStateWithId> blue_robot_states;
-    std::vector<RobotStateWithId> yellow_robot_states;
-
-    const double y_start      = 2.5;
-    const double y_spacing    = 1.0;
-    const int robot_id_offset = DIV_B_NUM_ROBOTS;
-
-    static_assert(DIV_A_NUM_ROBOTS > DIV_B_NUM_ROBOTS,
-                  "More robots in Div A than Div B!");
-
-    for (unsigned i = 0; i < DIV_A_NUM_ROBOTS - DIV_B_NUM_ROBOTS; i++)
-    {
-        blue_robot_states.emplace_back(RobotStateWithId{
-            .id          = i + robot_id_offset,
-            .robot_state = RobotState(Point(2, y_start - y_spacing * i), Vector(0, 0),
-                                      Angle::half(), AngularVelocity::zero()),
-        });
-        yellow_robot_states.emplace_back(RobotStateWithId{
-            .id          = i + robot_id_offset,
-            .robot_state = RobotState(Point(-2, y_start - y_spacing * i), Vector(0, 0),
-                                      Angle::full(), AngularVelocity::zero()),
-        });
-    }
-
 
     simulator.addBlueRobots(blue_robot_states);
     simulator.addYellowRobots(yellow_robot_states);

--- a/src/software/simulation/standalone_simulator.cpp
+++ b/src/software/simulation/standalone_simulator.cpp
@@ -9,9 +9,9 @@ extern "C"
 
 StandaloneSimulator::StandaloneSimulator(
     std::shared_ptr<StandaloneSimulatorConfig> standalone_simulator_config,
-    std::shared_ptr<SimulatorConfig> simulator_config)
+    std::shared_ptr<SimulatorConfig> simulator_config, const Field& field)
     : standalone_simulator_config(standalone_simulator_config),
-      simulator(Field::createSSLDivisionBField(), simulator_config),
+      simulator(field, simulator_config),
       most_recent_ssl_wrapper_packet(SSLProto::SSL_WrapperPacket())
 {
     standalone_simulator_config->getMutableBlueTeamChannel()->registerCallbackFunction(
@@ -113,7 +113,7 @@ void StandaloneSimulator::setupNetworking(int blue_team_channel, int yellow_team
         boost::bind(&StandaloneSimulator::setBlueTeamDefendingSide, this, _1)));
 }
 
-void StandaloneSimulator::setupInitialSimulationState()
+void StandaloneSimulator::setupInitialSimulationStateDivB()
 {
     RobotState blue_robot_state1(Point(3, 2.5), Vector(0, 0), Angle::half(),
                                  AngularVelocity::zero());
@@ -156,6 +156,57 @@ void StandaloneSimulator::setupInitialSimulationState()
         RobotStateWithId{.id = 3, .robot_state = yellow_robot_state4},
         RobotStateWithId{.id = 4, .robot_state = yellow_robot_state5},
         RobotStateWithId{.id = 5, .robot_state = yellow_robot_state6},
+    };
+    simulator.addYellowRobots(yellow_robot_states);
+}
+
+void StandaloneSimulator::setupInitialSimulationStateDivA()
+{
+    setupInitialSimulationStateDivB();
+
+    RobotState blue_robot_state6(Point(2, 2.5), Vector(0, 0), Angle::half(),
+                                 AngularVelocity::zero());
+    RobotState blue_robot_state7(Point(2, 1.5), Vector(0, 0), Angle::half(),
+                                 AngularVelocity::zero());
+    RobotState blue_robot_state8(Point(2, 0.5), Vector(0, 0), Angle::half(),
+                                 AngularVelocity::zero());
+    RobotState blue_robot_state9(Point(2, -0.5), Vector(0, 0), Angle::half(),
+                                 AngularVelocity::zero());
+    RobotState blue_robot_state10(Point(2, -1.5), Vector(0, 0), Angle::half(),
+                                  AngularVelocity::zero());
+    RobotState blue_robot_state11(Point(2, -2.5), Vector(0, 0), Angle::half(),
+                                  AngularVelocity::zero());
+
+    std::vector<RobotStateWithId> blue_robot_states = {
+        RobotStateWithId{.id = 6, .robot_state = blue_robot_state6},
+        RobotStateWithId{.id = 7, .robot_state = blue_robot_state7},
+        RobotStateWithId{.id = 8, .robot_state = blue_robot_state8},
+        RobotStateWithId{.id = 9, .robot_state = blue_robot_state9},
+        RobotStateWithId{.id = 10, .robot_state = blue_robot_state10},
+        RobotStateWithId{.id = 11, .robot_state = blue_robot_state11},
+    };
+    simulator.addBlueRobots(blue_robot_states);
+
+    RobotState yellow_robot_state6(Point(-2, 2.5), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero());
+    RobotState yellow_robot_state7(Point(-2, 1.5), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero());
+    RobotState yellow_robot_state8(Point(-2, 0.5), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero());
+    RobotState yellow_robot_state9(Point(-2, -0.5), Vector(0, 0), Angle::zero(),
+                                   AngularVelocity::zero());
+    RobotState yellow_robot_state10(Point(-2, -1.5), Vector(0, 0), Angle::zero(),
+                                    AngularVelocity::zero());
+    RobotState yellow_robot_state11(Point(-2, -2.5), Vector(0, 0), Angle::zero(),
+                                    AngularVelocity::zero());
+
+    std::vector<RobotStateWithId> yellow_robot_states = {
+        RobotStateWithId{.id = 6, .robot_state = yellow_robot_state6},
+        RobotStateWithId{.id = 7, .robot_state = yellow_robot_state7},
+        RobotStateWithId{.id = 8, .robot_state = yellow_robot_state8},
+        RobotStateWithId{.id = 9, .robot_state = yellow_robot_state9},
+        RobotStateWithId{.id = 10, .robot_state = yellow_robot_state10},
+        RobotStateWithId{.id = 11, .robot_state = yellow_robot_state11},
     };
     simulator.addYellowRobots(yellow_robot_states);
 }

--- a/src/software/simulation/standalone_simulator.h
+++ b/src/software/simulation/standalone_simulator.h
@@ -47,9 +47,10 @@ class StandaloneSimulator
 
     /**
      * Adds robots to predefined locations on the field
+     *
+     * @param num_robots How many robots to setup
      */
-    void setupInitialSimulationStateDivA();
-    void setupInitialSimulationStateDivB();
+    void setupInitialSimulationState(unsigned num_robots);
 
     SSLProto::SSL_WrapperPacket getSSLWrapperPacket() const;
 

--- a/src/software/simulation/standalone_simulator.h
+++ b/src/software/simulation/standalone_simulator.h
@@ -28,10 +28,11 @@ class StandaloneSimulator
      *
      * @param standalone_simulator_config The config for the StandaloneSimulator
      * @param simulator_config The config for the Simulator
+     * @param field The field to simulate
      */
     explicit StandaloneSimulator(
         std::shared_ptr<StandaloneSimulatorConfig> standalone_simulator_config,
-        std::shared_ptr<SimulatorConfig> simulator_config);
+        std::shared_ptr<SimulatorConfig> simulator_config, const Field& field);
     StandaloneSimulator() = delete;
 
     /**
@@ -47,7 +48,8 @@ class StandaloneSimulator
     /**
      * Adds robots to predefined locations on the field
      */
-    void setupInitialSimulationState();
+    void setupInitialSimulationStateDivA();
+    void setupInitialSimulationStateDivB();
 
     SSLProto::SSL_WrapperPacket getSSLWrapperPacket() const;
 

--- a/src/software/standalone_simulator_main.cpp
+++ b/src/software/standalone_simulator_main.cpp
@@ -63,8 +63,6 @@ int main(int argc, char **argv)
             standalone_simulator->setupInitialSimulationStateDivB();
         }
 
-        Field::createSSLDivisionAField();
-
         ThreadedStandaloneSimulatorGUI threaded_standalone_simulator_gui(
             standalone_simulator, mutable_thunderbots_config->getMutableSimulatorConfig(),
             mutable_thunderbots_config->getMutableStandaloneSimulatorConfig());

--- a/src/software/standalone_simulator_main.cpp
+++ b/src/software/standalone_simulator_main.cpp
@@ -41,10 +41,29 @@ int main(int argc, char **argv)
             ->getMutableRollingFrictionAcceleration()
             ->setValue(0.5);
 
-        auto standalone_simulator = std::make_shared<StandaloneSimulator>(
-            mutable_thunderbots_config->getMutableStandaloneSimulatorConfig(),
-            mutable_thunderbots_config->getMutableSimulatorConfig());
-        standalone_simulator->setupInitialSimulationState();
+        std::shared_ptr<StandaloneSimulator> standalone_simulator;
+
+        // Setup the field
+        if (args->getSslDivision()->value() == "div_a")
+        {
+            standalone_simulator = std::make_shared<StandaloneSimulator>(
+                mutable_thunderbots_config->getMutableStandaloneSimulatorConfig(),
+                mutable_thunderbots_config->getMutableSimulatorConfig(),
+                Field::createSSLDivisionAField());
+
+            standalone_simulator->setupInitialSimulationStateDivA();
+        }
+        else
+        {
+            standalone_simulator = std::make_shared<StandaloneSimulator>(
+                mutable_thunderbots_config->getMutableStandaloneSimulatorConfig(),
+                mutable_thunderbots_config->getMutableSimulatorConfig(),
+                Field::createSSLDivisionBField());
+
+            standalone_simulator->setupInitialSimulationStateDivB();
+        }
+
+        Field::createSSLDivisionAField();
 
         ThreadedStandaloneSimulatorGUI threaded_standalone_simulator_gui(
             standalone_simulator, mutable_thunderbots_config->getMutableSimulatorConfig(),

--- a/src/software/standalone_simulator_main.cpp
+++ b/src/software/standalone_simulator_main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
                 mutable_thunderbots_config->getMutableSimulatorConfig(),
                 Field::createSSLDivisionAField());
 
-            standalone_simulator->setupInitialSimulationStateDivA();
+            standalone_simulator->setupInitialSimulationState(DIV_A_NUM_ROBOTS);
         }
         else
         {
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
                 mutable_thunderbots_config->getMutableSimulatorConfig(),
                 Field::createSSLDivisionBField());
 
-            standalone_simulator->setupInitialSimulationStateDivB();
+            standalone_simulator->setupInitialSimulationState(DIV_B_NUM_ROBOTS);
         }
 
         ThreadedStandaloneSimulatorGUI threaded_standalone_simulator_gui(


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Add Div A field size + 11 robots to our custom sim and update example play to scale to 11 robots
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Manual testing
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
partially implements #2009 (doesn't touch the simulated tests)
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification
N/A
<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
