### PR TITLE
added Estop Manager to read Estop from uart device

### DIFF
--- a/src/software/estop/BUILD
+++ b/src/software/estop/BUILD
@@ -1,8 +1,63 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "uart_communication",
-    srcs = ["uart_communication.cpp"],
+    name = "threaded_estop_reader",
+    srcs = ["threaded_estop_reader.cpp"],
+    hdrs = ["threaded_estop_reader.h"],
+    deps = [
+        "uart_communication_interface",
+        "//software/logger",
+        "//software/util/make_enum",
+        "@boost//:asio",
+    ],
+)
+
+cc_library(
+    name = "uart_communication_interface",
     hdrs = ["uart_communication.h"],
-    deps = ["@boost//:asio"],
+)
+
+cc_library(
+    name = "estop_manager",
+    srcs = ["estop_manager.cpp"],
+    hdrs = ["estop_manager.h"],
+    deps = [
+        "boost_uart_communication",
+        "threaded_estop_reader",
+        "//software/logger",
+    ],
+)
+
+cc_library(
+    name = "boost_uart_communication",
+    srcs = ["boost_uart_communication.cpp"],
+    hdrs = ["boost_uart_communication.h"],
+    deps = [
+        "uart_communication_interface",
+        "@boost//:asio",
+    ],
+)
+
+cc_test(
+    name = "estop_reader_test",
+    srcs = [
+        "mock_uart_communication.h",
+        "threaded_estop_reader_test.cpp",
+    ],
+    deps = [
+        ":threaded_estop_reader",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "estop_manager_test",
+    srcs = [
+        "estop_manager_test.cpp",
+        "mock_uart_communication.h",
+    ],
+    deps = [
+        ":estopManager",
+        "@gtest//:gtest_main",
+    ],
 )

--- a/src/software/estop/estop_manager.cpp
+++ b/src/software/estop/estop_manager.cpp
@@ -1,0 +1,59 @@
+
+#include <stdio.h>
+#include <string.h>
+#include "estop_manager.h"
+#include "threaded_estop_reader.h"
+#include "boost_uart_communication.h"
+#include "uart_communication.h"
+#include "software/logger/logger.h"
+
+
+EstopManager::EstopManager() : estop_state(EstopState::PLAY), estop_reader(nullptr)
+{}
+
+bool EstopManager::isEstopStatePlay() {
+    if(!is_estop_polling){
+        return estop_state == EstopState::PLAY;
+    }
+
+    EstopState new_state = estop_reader->getEstopState();
+
+    if(new_state != estop_state){
+        LOG(INFO) << "estop state has changed from "<<estop_state<<" to  "<< new_state;
+    }
+
+    estop_state = new_state;
+
+    switch(estop_state) {
+        case EstopState::PLAY:
+            status_error_counter = 0;
+            return true;
+        case EstopState::STOP:
+            status_error_counter = 0;
+            return false;
+        case EstopState::STATUS_ERROR:
+            if (status_error_counter >= STATUS_ERROR_THRESHOLD) {
+                LOG(FATAL) << "Estop state could not be determined, exiting";
+            } else {
+                status_error_counter++;
+                LOG(WARNING) << "Estop state could not be determined";
+            }
+            return false;
+        default:
+            return false;
+    }
+
+}
+
+void EstopManager::startEstopContinousPolling(int startup_time_ms, int polling_interval_ms, std::unique_ptr<UartCommunication> uart_reader) {
+
+    if(!is_estop_polling){
+        estop_reader = std::make_unique<ThreadedEstopReader>(startup_time_ms, polling_interval_ms, std::move(uart_reader));
+        is_estop_polling = true;
+    }
+}
+
+bool EstopManager::isEstopPolling() const {
+    return is_estop_polling;
+}
+

--- a/src/software/estop/estop_manager.h
+++ b/src/software/estop/estop_manager.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "uart_communication.h"
+#include <iostream>
+#include <boost/asio.hpp>
+#include <thread>
+#include <mutex>
+#include "threaded_estop_reader.h"
+
+
+class EstopManager
+{
+   public:
+    EstopManager();
+
+    /**
+    * returns whether estop is in PLAY state
+    */
+    bool isEstopStatePlay();
+
+    /**
+     * Starts estop continous polling if it is not currently started
+     * @param startup_time_ms time in milliseconds to wait before polling for first estop value
+     * @param polling_interval_ms time in milliseconds between consecutive estop polls
+     * @param uart_reader The UART connection that will be used to read estop from
+     */
+    void startEstopContinousPolling(int startup_time_ms, int polling_interval_ms, std::unique_ptr<UartCommunication> uart_reader);
+
+    /**
+     *
+     * @return whether Estop polling process has begun
+     */
+    bool isEstopPolling() const;
+
+private:
+
+    /*
+     * The number of consecutive unknown messages we can receive before throwing an error
+     */
+    static int constexpr STATUS_ERROR_THRESHOLD = 10;
+
+    enum EstopState estop_state;
+    std::unique_ptr<ThreadedEstopReader> estop_reader;
+    bool is_estop_polling = false;
+    int status_error_counter = 0;
+
+};
+
+
+

--- a/src/software/estop/estop_manager_test.cpp
+++ b/src/software/estop/estop_manager_test.cpp
@@ -1,0 +1,103 @@
+#include <gmock/gmock.h>
+#include "gtest/gtest.h"
+
+#include "uart_communication.h"
+#include "mock_uart_communication.h"
+#include "estop_manager.h"
+
+static constexpr unsigned char STOP = 0;
+static constexpr unsigned char PLAY = 1;
+
+using ::testing::_;
+using ::testing::AtLeast;
+using ::testing::Return;
+
+TEST(EstopManagerTest, is_play_state_returns_true_and_no_polling_by_default)
+{
+    EstopManager estopManager;
+
+    EXPECT_TRUE(estopManager.isEstopStatePlay());
+    EXPECT_FALSE(estopManager.isEstopPolling());
+}
+
+TEST(EstopManagerTest, is_play_state_is_false_for_polling_startup_and_changes_to_play_after_interval)
+{
+    std::unique_ptr<MockUart> mock_uart = std::make_unique<MockUart>();
+
+    std::vector<unsigned char> play_ret_val(1,PLAY);
+    std::vector<unsigned char> stop_ret_val(1,STOP);
+
+    int startup_interval_ms = 50;
+    int tick_interval_ms = 5;
+
+    auto mock_uart_ptr = mock_uart.get();
+    EXPECT_CALL(*mock_uart_ptr, serialRead(_)).WillRepeatedly(Return(play_ret_val));
+
+    EstopManager estopManager;
+    estopManager.startEstopContinousPolling(startup_interval_ms, tick_interval_ms, std::move(mock_uart));
+    EXPECT_FALSE(estopManager.isEstopStatePlay());
+    EXPECT_TRUE(estopManager.isEstopPolling());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(startup_interval_ms+tick_interval_ms+1));
+    EXPECT_TRUE(estopManager.isEstopStatePlay());
+}
+
+TEST(EstopManagerTest, is_play_state_is_changes_based_on_play_and_stop_message)
+{
+    std::unique_ptr<MockUart> mock_uart = std::make_unique<MockUart>();
+
+    std::vector<unsigned char> play_ret_val(1,PLAY);
+    std::vector<unsigned char> stop_ret_val(1,STOP);
+
+    int startup_interval_ms = 0;
+    int tick_interval_ms = 5;
+
+    auto mock_uart_ptr = mock_uart.get();
+    EXPECT_CALL(*mock_uart_ptr, serialRead(_)).WillRepeatedly(Return(play_ret_val));
+
+    EstopManager estopManager;
+
+    estopManager.startEstopContinousPolling(startup_interval_ms, startup_interval_ms, std::move(mock_uart));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(startup_interval_ms+tick_interval_ms+1));
+
+    //change uart return value to stop
+    EXPECT_CALL(*mock_uart_ptr, serialRead(_)).WillRepeatedly(Return(stop_ret_val));
+    std::this_thread::sleep_for(std::chrono::milliseconds(tick_interval_ms+1));
+    EXPECT_FALSE(estopManager.isEstopStatePlay());
+
+    //change uart return value back to play
+    EXPECT_CALL(*mock_uart_ptr, serialRead(_)).WillRepeatedly(Return(play_ret_val));
+    std::this_thread::sleep_for(std::chrono::milliseconds(tick_interval_ms+1));
+    EXPECT_TRUE(estopManager.isEstopStatePlay());
+
+    //change uart return value to stop
+    EXPECT_CALL(*mock_uart_ptr, serialRead(_)).WillRepeatedly(Return(stop_ret_val));
+    std::this_thread::sleep_for(std::chrono::milliseconds(tick_interval_ms+1));
+    EXPECT_FALSE(estopManager.isEstopStatePlay());
+}
+
+TEST(EstopManagerTest, is_play_state_is_false_after_reading_unexpected_message)
+{
+    std::unique_ptr<MockUart> mock_uart = std::make_unique<MockUart>();
+
+    unsigned char arbitrary_garbage_val = 'a';
+    std::vector<unsigned char> play_ret_val(1,PLAY);
+    std::vector<unsigned char> garbage_ret_val(1,arbitrary_garbage_val);
+
+    auto mock_uart_ptr = mock_uart.get();
+    EXPECT_CALL(*mock_uart_ptr, serialRead(_)).WillRepeatedly(Return(play_ret_val));
+
+    int startup_interval_ms = 0;
+    int tick_interval_ms = 5;
+
+    EstopManager estopManager;
+    estopManager.startEstopContinousPolling(startup_interval_ms, startup_interval_ms, std::move(mock_uart));
+    std::this_thread::sleep_for(std::chrono::milliseconds(startup_interval_ms+tick_interval_ms+1));
+
+    EXPECT_CALL(*mock_uart_ptr, serialRead(_)).WillRepeatedly(Return(garbage_ret_val));
+    std::this_thread::sleep_for(std::chrono::milliseconds(tick_interval_ms+1));
+
+    EXPECT_FALSE(estopManager.isEstopStatePlay());
+}
+


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Estop Manager contains allows us start polling for Estop only after certain conditions. It also has logic for dealing with reading errors from the Arduino. 
### Testing Done
Added unit tests using gmock. Also tested on Arduino Uno using push button. 
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #1455
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [] **Remove all commented out code**
- [] **Remove extra print statements**: for example, those just used for testing
- [] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
