### PR TITLE
Fix Navigator and Path Planner Repeated Final Points Bug

### DIFF
--- a/src/software/ai/navigator/navigating_primitive_creator.cpp
+++ b/src/software/ai/navigator/navigating_primitive_creator.cpp
@@ -87,5 +87,9 @@ double NavigatingPrimitiveCreator::getEnemyObstacleProximityFactor(
 double NavigatingPrimitiveCreator::calculateTransitionSpeedBetweenSegments(
     const Point &p1, const Point &p2, const Point &p3, double final_speed)
 {
+    if (p1 == p2 || p2 == p3)
+    {
+        return final_speed;
+    }
     return final_speed * (p2 - p1).normalize().project((p3 - p2).normalize()).length();
 }

--- a/src/software/ai/navigator/navigating_primitive_creator_test.cpp
+++ b/src/software/ai/navigator/navigating_primitive_creator_test.cpp
@@ -97,7 +97,7 @@ TEST_F(NavigatingPrimitiveCreatorTest,
     testp2      = Point(0, 1);
     testp3      = Point(1, 2);
     final_speed = -2.2;
-    EXPECT_FALSE(
+    EXPECT_TRUE(
         isnormal(navigating_primitive_creator.calculateTransitionSpeedBetweenSegments(
             testp1, testp2, testp3, final_speed)));
 
@@ -106,7 +106,7 @@ TEST_F(NavigatingPrimitiveCreatorTest,
     testp2      = Point(2, 0);
     testp3      = Point(2, 0);
     final_speed = 2.2;
-    EXPECT_FALSE(
+    EXPECT_TRUE(
         isnormal(navigating_primitive_creator.calculateTransitionSpeedBetweenSegments(
             testp1, testp2, testp3, final_speed)));
 }

--- a/src/software/ai/navigator/path_planner/theta_star_path_planner.cpp
+++ b/src/software/ai/navigator/path_planner/theta_star_path_planner.cpp
@@ -220,7 +220,10 @@ std::optional<Path> ThetaStarPathPlanner::findPath(
     // The last point of path_points is the closest point on the grid to the end point, so
     // we need to replace that point with actual end point
     path_points.pop_back();
-    path_points.push_back(closest_end);
+    if (path_points.back() != closest_end)
+    {
+        path_points.push_back(closest_end);
+    }
 
     // The first point of path_points is the closest unblocked point on the grid to the
     // start point, so we need to replace that point with actual start point

--- a/src/software/ai/navigator/path_planner/theta_star_path_planner_test.cpp
+++ b/src/software/ai/navigator/path_planner/theta_star_path_planner_test.cpp
@@ -346,3 +346,25 @@ TEST_F(TestThetaStarPathPlanner,
     EXPECT_EQ(start, path->getStartPoint());
     EXPECT_EQ(dest, path->getEndPoint());
 }
+
+TEST_F(TestThetaStarPathPlanner,
+       test_theta_star_closest_dest_equals_penultimate_path_point)
+{
+    // This is a regression test for when closest dest equals the penultimate path point
+    Field field = Field::createSSLDivisionBField();
+    Point start{-1.4520030517578126, -1.3282811279296876},
+        dest{-1.3801560736390279, -2.5909120196973863};
+
+    std::vector<ObstaclePtr> obstacles = {std::make_shared<GeomObstacle<Circle>>(
+        Circle(Point(-1.48254052734375, -2.5885056152343751), 0.27150299999999999))};
+
+    Rectangle navigable_area = field.fieldBoundary();
+
+    auto path = planner->findPath(start, dest, navigable_area, obstacles);
+
+    ASSERT_TRUE(path != std::nullopt);
+
+    // Expect that the last two points are combined into one
+    EXPECT_EQ(2, path->getKnots().size());
+    EXPECT_EQ(start, path->getStartPoint());
+}


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
If the final two points of a 3-point paths are the same, then the final speed for the first segment can be `nan`, which causes when this `nan` propagates to being run on the robots as primitives. This PR fixes the issue in both the path planner and navigator.

![path_planner_bug](https://user-images.githubusercontent.com/31377876/117549525-b7c33400-afef-11eb-892e-2adb9dd6462d.png)
In this image, the closest_point == penultimate point
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
added regression tests
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
