### PR TITLE
[SSL Simulation Protocol] Allow optional values for robot command messages

### DIFF
--- a/src/software/proto/message_translation/ssl_simulation_robot_control.cpp
+++ b/src/software/proto/message_translation/ssl_simulation_robot_control.cpp
@@ -25,14 +25,25 @@ std::unique_ptr<SSLSimulationProto::RobotMoveCommand> createRobotMoveCommand(
 
 std::unique_ptr<SSLSimulationProto::RobotCommand> createRobotCommand(
     unsigned robot_id, std::unique_ptr<SSLSimulationProto::RobotMoveCommand> move_command,
-    double kick_speed, double kick_angle, double dribbler_speed)
+    std::optional<double> kick_speed, std::optional<double> kick_angle,
+    std::optional<double> dribbler_speed)
 {
     auto robot_command = std::make_unique<SSLSimulationProto::RobotCommand>();
 
     robot_command->set_id(robot_id);
-    robot_command->set_kick_speed(static_cast<float>(kick_speed));
-    robot_command->set_kick_angle(static_cast<float>(kick_angle));
-    robot_command->set_dribbler_speed(static_cast<float>(dribbler_speed));
+
+    if (kick_speed.has_value())
+    {
+        robot_command->set_kick_speed(static_cast<float>(kick_speed.value()));
+    }
+    if (kick_angle.has_value())
+    {
+        robot_command->set_kick_angle(static_cast<float>(kick_angle.value()));
+    }
+    if (dribbler_speed.has_value())
+    {
+        robot_command->set_dribbler_speed(static_cast<float>(dribbler_speed.value()));
+    }
 
     *(robot_command->mutable_move_command()) = *move_command;
 

--- a/src/software/proto/message_translation/ssl_simulation_robot_control.h
+++ b/src/software/proto/message_translation/ssl_simulation_robot_control.h
@@ -41,7 +41,8 @@ std::unique_ptr<SSLSimulationProto::RobotMoveCommand> createRobotMoveCommand(
  */
 std::unique_ptr<SSLSimulationProto::RobotCommand> createRobotCommand(
     unsigned robot_id, std::unique_ptr<SSLSimulationProto::RobotMoveCommand> move_command,
-    double kick_speed, double kick_angle, double dribbler_speed);
+    std::optional<double> kick_speed, std::optional<double> kick_angle,
+    std::optional<double> dribbler_speed);
 
 /**
  * Creates a RobotControl proto

--- a/src/software/proto/message_translation/ssl_simulation_robot_control_test.cpp
+++ b/src/software/proto/message_translation/ssl_simulation_robot_control_test.cpp
@@ -47,6 +47,27 @@ TEST(SSLSimulationProtoTest, test_create_robot_command)
     EXPECT_FLOAT_EQ(4.0, robot_command->move_command().wheel_velocity().back_right());
 }
 
+TEST(SSLSimulationProtoTest, test_create_robot_command_unset_optional_fields)
+{
+    auto move_wheel_velocity = createMoveWheelVelocity(1.0, 2.0, 3.0, 4.0);
+    auto move_command        = createRobotMoveCommand(std::move(move_wheel_velocity));
+    auto robot_command = createRobotCommand(1, std::move(move_command), std::nullopt,
+                                            std::nullopt, std::nullopt);
+
+    ASSERT_TRUE(robot_command);
+    ASSERT_TRUE(robot_command->has_move_command());
+
+    EXPECT_EQ(1, robot_command->id());
+    EXPECT_FALSE(robot_command->has_kick_speed());
+    EXPECT_FALSE(robot_command->has_kick_angle());
+    EXPECT_FALSE(robot_command->has_dribbler_speed());
+
+    EXPECT_FLOAT_EQ(1.0, robot_command->move_command().wheel_velocity().front_right());
+    EXPECT_FLOAT_EQ(2.0, robot_command->move_command().wheel_velocity().front_left());
+    EXPECT_FLOAT_EQ(3.0, robot_command->move_command().wheel_velocity().back_left());
+    EXPECT_FLOAT_EQ(4.0, robot_command->move_command().wheel_velocity().back_right());
+}
+
 TEST(SSLSimulationProtoTest, test_create_robot_control)
 {
     auto move_wheel_velocity_1 = createMoveWheelVelocity(1.0, 2.0, 3.0, 4.0);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

SSL simulation protocol robot commands have optional fields, where "unset variables should be interpreted as unmodified". Change the translation function to accommodate optional values.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Unit test

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
