### PR TITLE
More Precise Tick Time Tracking in Simulated Tests

### DIFF
--- a/src/software/simulated_tests/simulated_play_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_play_test_fixture.cpp
@@ -2,6 +2,7 @@
 
 #include "software/gui/drawing/navigator.h"
 #include "software/proto/message_translation/primitive_google_to_nanopb_converter.h"
+#include "software/test_util/test_util.h"
 
 SimulatedPlayTestFixture::SimulatedPlayTestFixture()
     : ai_config(mutable_thunderbots_config->getMutableAiConfig()),
@@ -61,7 +62,12 @@ void SimulatedPlayTestFixture::updatePrimitives(
 {
     auto world_with_updated_game_state = world;
     world_with_updated_game_state.updateGameState(game_state);
+
+    auto start_tick_time = std::chrono::system_clock::now();
+
     auto primitive_set_msg = ai.getPrimitives(world_with_updated_game_state);
+    double duration_ms     = ::TestUtil::millisecondsSince(start_tick_time);
+    registerTickTime(duration_ms);
     simulator_to_update->setYellowRobotPrimitiveSet(
         createNanoPbPrimitiveSet(*primitive_set_msg));
 }

--- a/src/software/simulated_tests/simulated_tactic_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_tactic_test_fixture.cpp
@@ -5,6 +5,7 @@
 #include "software/gui/drawing/navigator.h"
 #include "software/proto/message_translation/primitive_google_to_nanopb_converter.h"
 #include "software/proto/message_translation/tbots_protobuf.h"
+#include "software/test_util/test_util.h"
 
 SimulatedTacticTestFixture::SimulatedTacticTestFixture()
     : motion_constraints(),
@@ -59,6 +60,8 @@ void SimulatedTacticTestFixture::updatePrimitives(
     const World& world, std::shared_ptr<Simulator> simulator_to_update)
 {
     std::vector<std::unique_ptr<Intent>> intents;
+    auto start_tick_time = std::chrono::system_clock::now();
+
     if (!robot_id)
     {
         LOG(FATAL) << "No robot id set" << std::endl;
@@ -75,6 +78,8 @@ void SimulatedTacticTestFixture::updatePrimitives(
     }
 
     auto primitive_set_msg = navigator->getAssignedPrimitives(world, intents);
+    double duration_ms     = ::TestUtil::millisecondsSince(start_tick_time);
+    registerTickTime(duration_ms);
     simulator_to_update->setYellowRobotPrimitiveSet(
         createNanoPbPrimitiveSet(*primitive_set_msg));
 }

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -61,10 +61,13 @@ void SimulatedTestFixture::SetUp()
     }
     setupReplayLogging();
 
+    // Reset tick duration trackers
     total_tick_duration = 0.0;
-    max_tick_duration   = 0.0;
-    min_tick_duration   = std::numeric_limits<double>::max();
-    tick_count          = 0;
+    // all tick times should be greater than 0
+    max_tick_duration = 0.0;
+    // all tick times should be less than the max value of a double
+    min_tick_duration = std::numeric_limits<double>::max();
+    tick_count        = 0;
 }
 
 void SimulatedTestFixture::enableVisualizer()

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -60,6 +60,11 @@ void SimulatedTestFixture::SetUp()
         enableVisualizer();
     }
     setupReplayLogging();
+
+    total_tick_duration = 0.0;
+    max_tick_duration   = 0.0;
+    min_tick_duration   = std::numeric_limits<double>::max();
+    tick_count          = 0;
 }
 
 void SimulatedTestFixture::enableVisualizer()
@@ -193,18 +198,9 @@ void SimulatedTestFixture::runTest(
     const Duration ai_time_step = Duration::fromSeconds(simulation_time_step.toSeconds() *
                                                         CAMERA_FRAMES_PER_AI_TICK);
 
-    auto start_tick_time = std::chrono::system_clock::now();
-
     // Tick one frame to aid with visualization
     bool validation_functions_done =
         tickTest(simulation_time_step, ai_time_step, world, simulator);
-
-    // Logging duration of each tick
-    unsigned int tick_count    = 1;
-    double duration_ms         = ::TestUtil::millisecondsSince(start_tick_time);
-    double total_tick_duration = duration_ms;
-    double max_tick_duration   = duration_ms;
-    double min_tick_duration   = duration_ms;
 
     while (simulator->getTimestamp() < timeout_time && !validation_functions_done)
     {
@@ -216,18 +212,8 @@ void SimulatedTestFixture::runTest(
             continue;
         }
 
-        // Record starting time
-        start_tick_time = std::chrono::system_clock::now();
-
         validation_functions_done =
             tickTest(simulation_time_step, ai_time_step, world, simulator);
-
-        // Calculate tick durations
-        duration_ms = ::TestUtil::millisecondsSince(start_tick_time);
-        total_tick_duration += duration_ms;
-        max_tick_duration = std::max(max_tick_duration, duration_ms);
-        min_tick_duration = std::min(min_tick_duration, duration_ms);
-        tick_count++;
     }
     // Output the tick duration results
     double avg_tick_duration = total_tick_duration / tick_count;
@@ -248,6 +234,14 @@ void SimulatedTestFixture::runTest(
         }
         ADD_FAILURE() << failure_message;
     }
+}
+
+void SimulatedTestFixture::registerTickTime(double tick_time_ms)
+{
+    total_tick_duration += tick_time_ms;
+    max_tick_duration = std::max(max_tick_duration, tick_time_ms);
+    min_tick_duration = std::min(min_tick_duration, tick_time_ms);
+    tick_count++;
 }
 
 bool SimulatedTestFixture::tickTest(Duration simulation_time_step, Duration ai_time_step,

--- a/src/software/simulated_tests/simulated_test_fixture.h
+++ b/src/software/simulated_tests/simulated_test_fixture.h
@@ -92,6 +92,11 @@ class SimulatedTestFixture : public ::testing::Test
         const std::vector<ValidationFunction> &non_terminating_validation_functions,
         const Duration &timeout);
 
+    /**
+     * Registers a new tick time for calculating tick time statistics
+     *
+     * @param tick_time_ms The tick time in milliseconds
+     */
     void registerTickTime(double tick_time_ms);
 
     // The dynamic params being used in the tests
@@ -192,9 +197,14 @@ class SimulatedTestFixture : public ::testing::Test
     // time passes at the same speed a real life time
     bool run_simulation_in_realtime;
 
+    // These variables track tick time statistics
+    // Total duration of all ticks registered
     double total_tick_duration;
+    // The max tick duration registered
     double max_tick_duration;
+    // The min tick duration registered
     double min_tick_duration;
+    // Total number of ticks registered
     unsigned int tick_count;
 
     // The rate at which camera data will be simulated and given to SensorFusion.

--- a/src/software/simulated_tests/simulated_test_fixture.h
+++ b/src/software/simulated_tests/simulated_test_fixture.h
@@ -92,6 +92,8 @@ class SimulatedTestFixture : public ::testing::Test
         const std::vector<ValidationFunction> &non_terminating_validation_functions,
         const Duration &timeout);
 
+    void registerTickTime(double tick_time_ms);
+
     // The dynamic params being used in the tests
     std::shared_ptr<ThunderbotsConfig> mutable_thunderbots_config;
     std::shared_ptr<const ThunderbotsConfig> thunderbots_config;
@@ -189,6 +191,11 @@ class SimulatedTestFixture : public ::testing::Test
     // If true, introduces artificial delay so that simulation
     // time passes at the same speed a real life time
     bool run_simulation_in_realtime;
+
+    double total_tick_duration;
+    double max_tick_duration;
+    double min_tick_duration;
+    unsigned int tick_count;
 
     // The rate at which camera data will be simulated and given to SensorFusion.
     // Each sequential "camera frame" will be 1 / SIMULATED_CAMERA_FPS time step


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
More Precise Tick Time Tracking in Simulated Tests around the AI part rather than including the simulator and simulated test time. This means that we can relatively accurate performance numbers even when running the test with the visualizer.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
manual testing
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
