### PR TITLE
don't log replays in simulated tests if TEST_UNDECLARED_OUTPUTS_DIR is unset

### DIFF
--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -12,6 +12,7 @@ SimulatedTestFixture::SimulatedTestFixture()
       thunderbots_config(
           std::const_pointer_cast<const ThunderbotsConfig>(mutable_thunderbots_config)),
       sensor_fusion(thunderbots_config->getSensorFusionConfig()),
+      should_log_replay(false),
       run_simulation_in_realtime(false)
 {
 }
@@ -76,7 +77,14 @@ void SimulatedTestFixture::setupReplayLogging()
     namespace fs = std::experimental::filesystem;
     static constexpr auto SIMULATED_TEST_OUTPUT_DIR_SUFFIX = "simulated_test_outputs";
 
-    fs::path bazel_test_outputs_dir(std::getenv("TEST_UNDECLARED_OUTPUTS_DIR"));
+    const char *test_outputs_dir_or_null = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR");
+    if (!test_outputs_dir_or_null)
+    {
+        // we're not running with the Bazel test env vars set, don't set up replay logging
+        return;
+    }
+
+    fs::path bazel_test_outputs_dir(test_outputs_dir_or_null);
     fs::path out_dir =
         bazel_test_outputs_dir / SIMULATED_TEST_OUTPUT_DIR_SUFFIX / test_name;
     fs::create_directories(out_dir);
@@ -90,6 +98,7 @@ void SimulatedTestFixture::setupReplayLogging()
         std::make_shared<ProtoLogger<SensorProto>>(sensorproto_out_dir);
     sensorfusion_wrapper_logger =
         std::make_shared<ProtoLogger<SSLProto::SSL_WrapperPacket>>(ssl_wrapper_out_dir);
+    should_log_replay = true;
 }
 
 bool SimulatedTestFixture::validateAndCheckCompletion(
@@ -119,17 +128,20 @@ void SimulatedTestFixture::updateSensorFusion(std::shared_ptr<Simulator> simulat
 
     auto sensor_msg                        = SensorProto();
     *(sensor_msg.mutable_ssl_vision_msg()) = *ssl_wrapper_packet;
-    simulator_sensorproto_logger->onValueReceived(sensor_msg);
 
     sensor_fusion.processSensorProto(sensor_msg);
 
-    auto world_or_null = sensor_fusion.getWorld();
-
-    if (world_or_null)
+    if (should_log_replay)
     {
-        auto filtered_ssl_wrapper =
-            *createSSLWrapperPacket(*sensor_fusion.getWorld(), TeamColour::YELLOW);
-        sensorfusion_wrapper_logger->onValueReceived(filtered_ssl_wrapper);
+        simulator_sensorproto_logger->onValueReceived(sensor_msg);
+        auto world_or_null = sensor_fusion.getWorld();
+
+        if (world_or_null)
+        {
+            auto filtered_ssl_wrapper =
+                *createSSLWrapperPacket(*sensor_fusion.getWorld(), TeamColour::YELLOW);
+            sensorfusion_wrapper_logger->onValueReceived(filtered_ssl_wrapper);
+        }
     }
 }
 

--- a/src/software/simulated_tests/simulated_test_fixture.h
+++ b/src/software/simulated_tests/simulated_test_fixture.h
@@ -177,6 +177,10 @@ class SimulatedTestFixture : public ::testing::Test
     // The SensorFusion being tested and used in simulation
     SensorFusion sensor_fusion;
 
+    // whether we should log the filtered and unfiltered world states as replay logs
+    // this will only be set to true if the environment variable
+    // TEST_UNDECLARED_OUTPUTS_DIR is set, usually by running as a Bazel test
+    bool should_log_replay;
     // ProtoLoggers for the simulator and SensorFusion, respectively
     std::shared_ptr<ProtoLogger<SensorProto>> simulator_sensorproto_logger;
     std::shared_ptr<ProtoLogger<SSLProto::SSL_WrapperPacket>> sensorfusion_wrapper_logger;


### PR DESCRIPTION


<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

don't log replays in simulated tests if TEST_UNDECLARED_OUTPUTS_DIR is unset

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Tested on my machine, generates replay logs when run with Bazel and does not crash or generate replay logs when run directly on the command line

Note: this is impossible to test in a unit test, as running the test with Bazel will set TEST_UNDECLARED_OUTPUTS_DIR. Since the replay setup occurs during `SetUp()`, unsetting the variable in the test body will do nothing w.r.t. replay logging. It is also impossible to use a `SimulatedTestFixture` standalone as a non-test-fixture, as it involves overriding `TestBody()` which is unsupported by gtest. 

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

Resolves #2084 

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
