### PR TITLE
Fix MoveTactic Usage without updateControlParams call

### DIFF
--- a/src/software/ai/hl/stp/play/free_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/free_kick_play.cpp
@@ -191,6 +191,7 @@ PassWithRating FreeKickPlay::shootOrFindPassStage(
     while (!align_to_ball_tactic->getAssignedRobot())
     {
         LOG(DEBUG) << "Nothing assigned to align to ball yet";
+        updateAlignToBallTactic(align_to_ball_tactic, world);
 
         auto pass_eval = pass_generator.generatePassEvaluation(world);
         auto pass1     = pass_eval.getBestPassInZones(cherry_pick_region_1).pass;

--- a/src/software/ai/hl/stp/play/shoot_or_pass_play.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_pass_play.cpp
@@ -104,6 +104,13 @@ void ShootOrPassPlay::getNextTactics(TacticCoroutine::push_type &yield,
 
         auto cherry_pick_tactic_1 = std::make_shared<MoveTactic>(false);
         auto cherry_pick_tactic_2 = std::make_shared<MoveTactic>(false);
+        cherry_pick_tactic_1->updateControlParams(pass1.receiverPoint(),
+                                                  pass1.receiverOrientation(), 0.0,
+                                                  MaxAllowedSpeedMode::PHYSICAL_LIMIT);
+        cherry_pick_tactic_2->updateControlParams(pass2.receiverPoint(),
+                                                  pass2.receiverOrientation(), 0.0,
+                                                  MaxAllowedSpeedMode::PHYSICAL_LIMIT);
+
 
         do
         {
@@ -124,13 +131,6 @@ void ShootOrPassPlay::getNextTactics(TacticCoroutine::push_type &yield,
             }
             else
             {
-                cherry_pick_tactic_1->updateControlParams(
-                    pass1.receiverPoint(), pass1.receiverOrientation(), 0.0,
-                    MaxAllowedSpeedMode::PHYSICAL_LIMIT);
-                cherry_pick_tactic_2->updateControlParams(
-                    pass2.receiverPoint(), pass2.receiverOrientation(), 0.0,
-                    MaxAllowedSpeedMode::PHYSICAL_LIMIT);
-
                 yield({{receiver},
                        {cherry_pick_tactic_1, cherry_pick_tactic_2},
                        {std::get<0>(crease_defender_tactics),
@@ -191,10 +191,6 @@ PassWithRating ShootOrPassPlay::attemptToShootWhileLookingForAPass(
         std::get<1>(crease_defender_tactics)
             ->updateControlParams(world.ball().position(),
                                   CreaseDefenderAlignment::RIGHT);
-        yield({{shoot_tactic, cherry_pick_tactic_1, cherry_pick_tactic_2,
-                std::get<0>(crease_defender_tactics),
-                std::get<1>(crease_defender_tactics)}});
-
         pass_eval                  = pass_generator.generatePassEvaluation(world);
         best_pass_and_score_so_far = pass_eval.getBestPassOnField();
 
@@ -207,6 +203,10 @@ PassWithRating ShootOrPassPlay::attemptToShootWhileLookingForAPass(
         cherry_pick_tactic_2->updateControlParams(pass2.receiverPoint(),
                                                   pass2.receiverOrientation(), 0.0,
                                                   MaxAllowedSpeedMode::PHYSICAL_LIMIT);
+
+        yield({{shoot_tactic, cherry_pick_tactic_1, cherry_pick_tactic_2,
+                std::get<0>(crease_defender_tactics),
+                std::get<1>(crease_defender_tactics)}});
 
         // We're ready to pass if we have a robot assigned in the PassGenerator as the
         // passer and the PassGenerator has found a pass above our current threshold

--- a/src/software/ai/hl/stp/tactic/move/move_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/move/move_tactic.cpp
@@ -3,7 +3,16 @@
 #include <algorithm>
 
 MoveTactic::MoveTactic(bool loop_forever)
-    : Tactic(loop_forever, {RobotCapability::Move}), fsm()
+    : Tactic(loop_forever, {RobotCapability::Move}),
+      fsm(),
+      control_params{.destination            = Point(),
+                     .final_orientation      = Angle::zero(),
+                     .final_speed            = 0.0,
+                     .dribbler_mode          = DribblerMode::OFF,
+                     .ball_collision_type    = BallCollisionType::AVOID,
+                     .auto_chip_or_kick      = {AutoChipOrKickMode::OFF, 0},
+                     .max_allowed_speed_mode = MaxAllowedSpeedMode::PHYSICAL_LIMIT,
+                     .target_spin_rev_per_s  = 0.0}
 {
 }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Some plays yielded MoveTactics without updating control params first. This PR fixes those plays and also mitigates the problem by giving MoveTactic control params default values. The downstream problem this fixes is invalid DribbleMode/MaxAllowedSpeedMode values being set in the MoveIntent
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Existing tests pass. Ideally we should be able to stop this from happening at compile time
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
