### PR TITLE
Fix CI Failing due to PenaltyKickFSM Merge

### DIFF
--- a/src/software/ai/hl/stp/tactic/penalty_kick/BUILD
+++ b/src/software/ai/hl/stp/tactic/penalty_kick/BUILD
@@ -4,8 +4,8 @@ cc_library(
     name = "penalty_kick_tactic",
     srcs = ["penalty_kick_tactic.cpp"],
     hdrs = [
+        "penalty_kick_fsm.h",
         "penalty_kick_tactic.h",
-        "penalty_kick_tactic_fsm.h",
     ],
     deps = [
         "//shared:constants",
@@ -24,8 +24,8 @@ cc_library(
 )
 
 cc_test(
-    name = "penalty_kick_tactic_fsm_test",
-    srcs = ["penalty_kick_tactic_fsm_test.cpp"],
+    name = "penalty_kick_fsm_test",
+    srcs = ["penalty_kick_fsm_test.cpp"],
     deps = [
         ":penalty_kick_tactic",
         "//software/test_util",

--- a/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h
@@ -221,7 +221,9 @@ struct PenaltyKickFSM
                 DribbleFSM::ControlParams control_params{
                     .dribble_destination       = std::optional<Point>(position),
                     .final_dribble_orientation = std::optional<Angle>(shot_angle),
-                    .allow_excessive_dribbling = false};
+                    // TODO: change .allow_excessive_dribbling back to false once #2087
+                    // goes in
+                    .allow_excessive_dribbling = true};
                 processEvent(DribbleFSM::Update(control_params, event.common));
             };
 
@@ -272,11 +274,11 @@ struct PenaltyKickFSM
             std::optional<Robot> enemy_goalie = event.common.world.enemyTeam().goalie();
             Timestamp force_shoot_timestamp =
                 complete_approach.value() + PENALTY_FORCE_SHOOT_TIMEOUT;
-            bool shouldShoot =
+            bool should_shoot =
                 evaluatePenaltyShot(enemy_goalie, field, robot_shoot_position,
                                     event.common.robot) ||
                 (event.common.world.getMostRecentTimestamp() >= force_shoot_timestamp);
-            return shouldShoot;
+            return should_shoot;
         };
 
         /**

--- a/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h
@@ -9,8 +9,23 @@
 #include "software/geom/algorithms/closest_point.h"
 #include "software/geom/algorithms/intersection.h"
 
-struct PenaltyKickTacticFSM
+struct PenaltyKickFSM
 {
+    /**
+     * Constructor for DribbleFSM
+     *
+     * @param complete_approach pointer to complete approach timestamp
+     * @param robot_shoot_position position to shoot
+     * @param shot_angle angle to shoot at
+     */
+    explicit PenaltyKickFSM(std::optional<Timestamp> complete_approach,
+                            Point robot_shoot_position, Angle shot_angle)
+        : complete_approach(complete_approach),
+          robot_shoot_position(robot_shoot_position),
+          shot_angle(shot_angle)
+    {
+    }
+
     struct ControlParams
     {
     };
@@ -163,14 +178,10 @@ struct PenaltyKickTacticFSM
 
         const auto update_e = event<Update>;
 
-        static std::optional<Timestamp> complete_approach;
-        static Point robot_shoot_position;
-        static Angle shot_angle;
-
         /**
          * Action that causes the shooter to shoot the ball.
          *
-         * @param event          PenaltyKickTacticFSM::Update event
+         * @param event          PenaltyKickFSM::Update event
          * @param processEvent   processes the KickFSM::Update
          */
         const auto shoot = [this](auto event,
@@ -185,7 +196,7 @@ struct PenaltyKickTacticFSM
         /**
          * Action that updates the shooter's approach to the opposition net.
          *
-         * @param event          PenaltyKickTacticFSM::Update event
+         * @param event          PenaltyKickFSM::Update event
          * @param processEvent   processes the DribbleFSM::Update
          */
         const auto update_approach_keeper =
@@ -210,17 +221,14 @@ struct PenaltyKickTacticFSM
                 DribbleFSM::ControlParams control_params{
                     .dribble_destination       = std::optional<Point>(position),
                     .final_dribble_orientation = std::optional<Angle>(shot_angle),
-
-                    // TODO: change .allow_excessive_dribbling back to false once #2087
-                    // goes in
-                    .allow_excessive_dribbling = true};
+                    .allow_excessive_dribbling = false};
                 processEvent(DribbleFSM::Update(control_params, event.common));
             };
 
         /**
          * Action that orients the shooter to prepare for a shot.
          *
-         * @param event          PenaltyKickTacticFSM::Update
+         * @param event          PenaltyKickFSM::Update
          * @param processEvent   processes the DribbleFSM::Update
          */
         const auto adjust_orientation_for_shot =
@@ -244,7 +252,7 @@ struct PenaltyKickTacticFSM
          *
          * Requires complete approach to already be set.
          *
-         * @param event  PenaltyKickTacticFSM::Update
+         * @param event  PenaltyKickFSM::Update
          */
         const auto take_penalty_shot = [this](auto event) {
             Field field = event.common.world.field();
@@ -277,7 +285,7 @@ struct PenaltyKickTacticFSM
          *
          * Requires complete approach to already be set.
          *
-         * @param event PenaltyKickTacticFSM::Update
+         * @param event PenaltyKickFSM::Update
          */
         const auto time_out_approach = [this](auto event) {
             return event.common.world.getMostRecentTimestamp() > complete_approach;
@@ -310,4 +318,9 @@ struct PenaltyKickTacticFSM
     static const inline Duration PENALTY_FORCE_SHOOT_TIMEOUT = Duration::fromSeconds(4);
     static const inline Duration PENALTY_FINISH_APPROACH_TIMEOUT =
         Duration::fromSeconds(4);
+
+   private:
+    std::optional<Timestamp> complete_approach;
+    Point robot_shoot_position;
+    Angle shot_angle;
 };

--- a/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm_test.cpp
@@ -1,21 +1,22 @@
-#include "software/ai/hl/stp/tactic/penalty_kick/penalty_kick_tactic_fsm.h"
+#include "software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h"
 
 #include <gtest/gtest.h>
 
 #include "software/test_util/test_util.h"
 
-TEST(PenaltyKickTacticFSM, test_transitions)
+TEST(PenaltyKickFSM, test_transitions)
 {
     World world = ::TestUtil::createBlankTestingWorld();
     world       = ::TestUtil::setBallPosition(world, world.field().friendlyPenaltyMark(),
                                         Timestamp::fromSeconds(0));
     Robot robot = ::TestUtil::createRobotAtPos(world.field().friendlyPenaltyMark());
 
-    FSM<PenaltyKickTacticFSM> fsm;
+    FSM<PenaltyKickFSM> fsm(DribbleFSM(std::make_shared<Point>()),
+                            PenaltyKickFSM(std::nullopt, Point(), Angle()));
 
-    PenaltyKickTacticFSM::ControlParams control_params{};
+    PenaltyKickFSM::ControlParams control_params{};
 
-    fsm.process_event(PenaltyKickTacticFSM::Update(
+    fsm.process_event(PenaltyKickFSM::Update(
         control_params, TacticUpdate(robot, world, [](std::unique_ptr<Intent>) {})));
     EXPECT_TRUE(fsm.is(boost::sml::state<DribbleFSM>));
 
@@ -23,13 +24,13 @@ TEST(PenaltyKickTacticFSM, test_transitions)
     robot          = ::TestUtil::createRobotAtPos(position);
     world          = ::TestUtil::setBallPosition(
         world, position + Vector(ROBOT_MAX_RADIUS_METERS, 0), Timestamp::fromSeconds(1));
-    fsm.process_event(PenaltyKickTacticFSM::Update(
+    fsm.process_event(PenaltyKickFSM::Update(
         control_params, TacticUpdate(robot, world, [](std::unique_ptr<Intent>) {})));
     EXPECT_TRUE(fsm.is(boost::sml::state<KickFSM>));
     EXPECT_TRUE(fsm.is<decltype(boost::sml::state<KickFSM>)>(
         boost::sml::state<GetBehindBallFSM>));
 
-    fsm.process_event(PenaltyKickTacticFSM::Update(
+    fsm.process_event(PenaltyKickFSM::Update(
         control_params, TacticUpdate(robot, world, [](std::unique_ptr<Intent>) {})));
     EXPECT_TRUE(fsm.is(boost::sml::state<KickFSM>));
     EXPECT_TRUE(fsm.is<decltype(boost::sml::state<KickFSM>)>(
@@ -38,13 +39,13 @@ TEST(PenaltyKickTacticFSM, test_transitions)
     world = ::TestUtil::setBallPosition(world, world.field().enemyGoalCenter(),
                                         Timestamp::fromSeconds(2));
     world = ::TestUtil::setBallVelocity(world, Vector(5, 0), Timestamp::fromSeconds(2));
-    fsm.process_event(PenaltyKickTacticFSM::Update(
+    fsm.process_event(PenaltyKickFSM::Update(
         control_params, TacticUpdate(robot, world, [](std::unique_ptr<Intent>) {})));
 
     EXPECT_TRUE(fsm.is(boost::sml::X));
 }
 
-TEST(PenaltyKickTacticFSMTest, no_enemy_goalie)
+TEST(PenaltyKickFSMTest, no_enemy_goalie)
 {
     World world = ::TestUtil::createBlankTestingWorld();
     world = ::TestUtil::setBallPosition(world, Point(4, 0), Timestamp::fromSeconds(0));
@@ -60,11 +61,11 @@ TEST(PenaltyKickTacticFSMTest, no_enemy_goalie)
         Robot(0, behind_ball, Vector(0, 0), behind_ball_direction.orientation(),
               AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
-    EXPECT_TRUE(PenaltyKickTacticFSM::evaluatePenaltyShot(
-        std::nullopt, world.field(), world.ball().position(), shooter));
+    EXPECT_TRUE(PenaltyKickFSM::evaluatePenaltyShot(std::nullopt, world.field(),
+                                                    world.ball().position(), shooter));
 }
 
-TEST(PenaltyKickTacticFSMTest, enemy_goalie_offset_left_no_viable_shot)
+TEST(PenaltyKickFSMTest, enemy_goalie_offset_left_no_viable_shot)
 {
     World world = ::TestUtil::createBlankTestingWorld();
     world       = ::TestUtil::setBallPosition(world, world.field().friendlyPenaltyMark(),
@@ -90,12 +91,12 @@ TEST(PenaltyKickTacticFSMTest, enemy_goalie_offset_left_no_viable_shot)
     Team friendly({shooter});
     world.updateFriendlyTeamState(friendly);
 
-    EXPECT_FALSE(PenaltyKickTacticFSM::evaluatePenaltyShot(
-        std::optional<Robot>(enemy_goalie), world.field(), world.ball().position(),
-        shooter));
+    EXPECT_FALSE(PenaltyKickFSM::evaluatePenaltyShot(std::optional<Robot>(enemy_goalie),
+                                                     world.field(),
+                                                     world.ball().position(), shooter));
 }
 
-TEST(PenaltyKickTacticFSMTest, enemy_goalie_offset_right_no_viable_shot)
+TEST(PenaltyKickFSMTest, enemy_goalie_offset_right_no_viable_shot)
 {
     World world = ::TestUtil::createBlankTestingWorld();
     world       = ::TestUtil::setBallPosition(world,
@@ -122,12 +123,12 @@ TEST(PenaltyKickTacticFSMTest, enemy_goalie_offset_right_no_viable_shot)
     Team friendly({shooter});
     world.updateFriendlyTeamState(friendly);
 
-    EXPECT_FALSE(PenaltyKickTacticFSM::evaluatePenaltyShot(
-        std::optional<Robot>(enemy_goalie), world.field(), world.ball().position(),
-        shooter));
+    EXPECT_FALSE(PenaltyKickFSM::evaluatePenaltyShot(std::optional<Robot>(enemy_goalie),
+                                                     world.field(),
+                                                     world.ball().position(), shooter));
 }
 
-TEST(PenaltyKickTacticFSMTest, enemy_goalie_right_viable_shot_left)
+TEST(PenaltyKickFSMTest, enemy_goalie_right_viable_shot_left)
 {
     World world = ::TestUtil::createBlankTestingWorld();
     world = ::TestUtil::setBallPosition(world, Point(4, 0), Timestamp::fromSeconds(0));
@@ -152,12 +153,12 @@ TEST(PenaltyKickTacticFSMTest, enemy_goalie_right_viable_shot_left)
     Team friendly({shooter});
     world.updateFriendlyTeamState(friendly);
 
-    EXPECT_TRUE(PenaltyKickTacticFSM::evaluatePenaltyShot(
-        std::optional<Robot>(enemy_goalie), world.field(), world.ball().position(),
-        shooter));
+    EXPECT_TRUE(PenaltyKickFSM::evaluatePenaltyShot(std::optional<Robot>(enemy_goalie),
+                                                    world.field(),
+                                                    world.ball().position(), shooter));
 }
 
-TEST(PenaltyKickTacticFSMTest, enemy_goalie_left_viable_shot_right)
+TEST(PenaltyKickFSMTest, enemy_goalie_left_viable_shot_right)
 {
     World world = ::TestUtil::createBlankTestingWorld();
     world = ::TestUtil::setBallPosition(world, Point(4, 0), Timestamp::fromSeconds(0));
@@ -182,23 +183,23 @@ TEST(PenaltyKickTacticFSMTest, enemy_goalie_left_viable_shot_right)
     Team friendly({shooter});
     world.updateFriendlyTeamState(friendly);
 
-    EXPECT_TRUE(PenaltyKickTacticFSM::evaluatePenaltyShot(
-        std::optional<Robot>(enemy_goalie), world.field(), world.ball().position(),
-        shooter));
+    EXPECT_TRUE(PenaltyKickFSM::evaluatePenaltyShot(std::optional<Robot>(enemy_goalie),
+                                                    world.field(),
+                                                    world.ball().position(), shooter));
 }
 
-TEST(PenaltyKickTacticFSMTest, no_enemy_goalie_shot_position)
+TEST(PenaltyKickFSMTest, no_enemy_goalie_shot_position)
 {
     World world = ::TestUtil::createBlankTestingWorld();
     world       = ::TestUtil::setBallPosition(world, world.field().friendlyPenaltyMark(),
                                         Timestamp::fromSeconds(0));
     world = ::TestUtil::setBallVelocity(world, Vector(0, 0), Timestamp::fromSeconds(0));
 
-    EXPECT_EQ(PenaltyKickTacticFSM::evaluateNextShotPosition(std::nullopt, world.field()),
+    EXPECT_EQ(PenaltyKickFSM::evaluateNextShotPosition(std::nullopt, world.field()),
               world.field().enemyGoalCenter());
 }
 
-TEST(PenaltyKickTacticFSMTest, enemy_goalie_left_shot_right)
+TEST(PenaltyKickFSMTest, enemy_goalie_left_shot_right)
 {
     World world = ::TestUtil::createBlankTestingWorld();
     world       = ::TestUtil::setBallPosition(world, world.field().friendlyPenaltyMark(),
@@ -209,13 +210,13 @@ TEST(PenaltyKickTacticFSMTest, enemy_goalie_left_shot_right)
     Robot enemy_goalie     = Robot(0, enemy_goalie_pos, Vector(0, 0), Angle::half(),
                                AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
-    Point shot_position = PenaltyKickTacticFSM::evaluateNextShotPosition(
+    Point shot_position = PenaltyKickFSM::evaluateNextShotPosition(
         std::optional<Robot>(enemy_goalie), world.field());
     EXPECT_LE(shot_position.y(), 0);
     EXPECT_EQ(shot_position.x(), world.field().enemyGoalCenter().x());
 }
 
-TEST(PenaltyKickTacticFSMTest, enemy_goalie_right_shot_left)
+TEST(PenaltyKickFSMTest, enemy_goalie_right_shot_left)
 {
     World world = ::TestUtil::createBlankTestingWorld();
     world       = ::TestUtil::setBallPosition(world, world.field().friendlyPenaltyMark(),
@@ -226,7 +227,7 @@ TEST(PenaltyKickTacticFSMTest, enemy_goalie_right_shot_left)
     Robot enemy_goalie     = Robot(0, enemy_goalie_pos, Vector(0, 0), Angle::half(),
                                AngularVelocity::zero(), Timestamp::fromSeconds(0));
 
-    Point shot_position = PenaltyKickTacticFSM::evaluateNextShotPosition(
+    Point shot_position = PenaltyKickFSM::evaluateNextShotPosition(
         std::optional<Robot>(enemy_goalie), world.field());
     EXPECT_GE(shot_position.y(), 0);
     EXPECT_EQ(shot_position.x(), world.field().enemyGoalCenter().x());

--- a/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_tactic.cpp
@@ -1,11 +1,10 @@
-/**
- * Implementation of the PenaltyKickTactic
- */
 #include "software/ai/hl/stp/tactic/penalty_kick/penalty_kick_tactic.h"
 
 PenaltyKickTactic::PenaltyKickTactic()
     : Tactic(false,
-             {RobotCapability::Move, RobotCapability::Dribble, RobotCapability::Kick})
+             {RobotCapability::Move, RobotCapability::Dribble, RobotCapability::Kick}),
+      fsm(DribbleFSM(std::make_shared<Point>()),
+          PenaltyKickFSM(std::nullopt, Point(), Angle()))
 {
 }
 
@@ -45,5 +44,5 @@ bool PenaltyKickTactic::done() const
 
 void PenaltyKickTactic::updateIntent(const TacticUpdate& tactic_update)
 {
-    fsm.process_event(PenaltyKickTacticFSM::Update({}, tactic_update));
+    fsm.process_event(PenaltyKickFSM::Update({}, tactic_update));
 }

--- a/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_tactic.h
+++ b/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_tactic.h
@@ -5,7 +5,7 @@
 #include "software/ai/hl/stp/action/kick_action.h"
 #include "software/ai/hl/stp/action/move_action.h"
 #include "software/ai/hl/stp/action/stop_action.h"
-#include "software/ai/hl/stp/tactic/penalty_kick/penalty_kick_tactic_fsm.h"
+#include "software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h"
 #include "software/ai/hl/stp/tactic/tactic.h"
 #include "software/logger/logger.h"
 
@@ -45,5 +45,5 @@ class PenaltyKickTactic : public Tactic
     void updateIntent(const TacticUpdate &tactic_update) override;
 
     // Tactic parameters
-    FSM<PenaltyKickTacticFSM> fsm;
+    FSM<PenaltyKickFSM> fsm;
 };


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
There was bad merge between https://github.com/UBC-Thunderbots/Software/pull/2087 and the penaltykickfsm, so just trying to fix that.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
CI should pass now
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
