### PR TITLE
Changed Static Variables To Class Members In Sensor Fusion 

### DIFF
--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -15,7 +15,9 @@ SensorFusion::SensorFusion(std::shared_ptr<const SensorFusionConfig> sensor_fusi
       enemy_team_filter(),
       team_with_possession(TeamSide::ENEMY),
       friendly_goalie_id(0),
-      enemy_goalie_id(0)
+      enemy_goalie_id(0),
+      reset_time_vision_packets_detected(0),
+      last_t_capture(0)
 {
     if (!sensor_fusion_config)
     {
@@ -326,9 +328,6 @@ bool SensorFusion::teamHasBall(const Team &team, const Ball &ball)
 
 void SensorFusion::checkForVisionReset(double t_capture)
 {
-    static unsigned int reset_time_vision_packets_detected = 0;
-    static double last_t_capture                           = 0;
-
     if (t_capture < last_t_capture && t_capture < VISION_PACKET_RESET_TIME_THRESHOLD)
     {
         reset_time_vision_packets_detected++;

--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -141,4 +141,12 @@ class SensorFusion
 
     unsigned int friendly_goalie_id;
     unsigned int enemy_goalie_id;
+
+    // The number of "reset packets" we have received. These indicate that the
+    // vision time should be reset. Please see `checkForVisionReset` to see how
+    // this is defined.
+    unsigned int reset_time_vision_packets_detected;
+
+    // The timestamp, in seconds, of the most recently received vision packet
+    double last_t_capture;
 };


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Static variables in sensor fusion were breaking some simulated tests that Mat and I were working on. Regardless, these probably shouldn't have been static at all.

### Testing Done
Our local sim tests pass, we'll hand them over after the games next weekend :stuck_out_tongue_winking_eye: 

### Resolved Issues

None

### Length Justification
None

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
