### PR TITLE
Enable dynamic logging levels and set default level to >= INFO

### DIFF
--- a/src/external/g3log.BUILD
+++ b/src/external/g3log.BUILD
@@ -11,7 +11,7 @@ genrule(
     outs = ["include/g3log/generated_definitions.hpp"],
     cmd = "\n".join([
         # Run cmake, silencing both stdout (">") and stderr ("2>")
-        "cmake external/g3log > /dev/null 2> /dev/null",
+        "cmake -DUSE_DYNAMIC_LOGGING_LEVELS=ON external/g3log > /dev/null 2> /dev/null",
         # Copy the generated header to the location bazel expects it
         "mv include/g3log/generated_definitions.hpp $@",
     ]),

--- a/src/software/logger/logger.h
+++ b/src/software/logger/logger.h
@@ -93,6 +93,7 @@ class LoggerSingleton
             &LogRotateWithFilter::save);
 
         g3::initializeLogging(logWorker.get());
+        g3::log_levels::setHighest(INFO);
     }
 
     // levels is this vector are filtered out of the filtered log rotate sink


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
I wanted to hide DEBUG logs (because there were so many) but couldn't. It turns out we need to enable dynamic logging levels in g3log. I've done this and also changed the default level to `>= INFO` so debug logs are displayed by default.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
works on my machine

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
None

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
None

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
