### PR TITLE
Added strong damping between the simulated ball and field walls

### DIFF
--- a/src/software/simulation/force_wheel_simulator_robot_singleton_test.cpp
+++ b/src/software/simulation/force_wheel_simulator_robot_singleton_test.cpp
@@ -587,8 +587,10 @@ TEST_F(ForceWheelSimulatorRobotSingletonTest,
     for (unsigned int i = 0; i < 200; i++)
     {
         world->stepSimulation(Duration::fromSeconds(1.0 / 60.0));
-        // Don't let the ball bounce off the field goals/boundaries since then we have no guarantee about the speed
-        if(simulator_ball->position().x() >= world->getField().enemyGoalCenter().x()) {
+        // Don't let the ball bounce off the field goals/boundaries since then we have no
+        // guarantee about the speed
+        if (simulator_ball->position().x() >= world->getField().enemyGoalCenter().x())
+        {
             break;
         }
         if (i == 0)

--- a/src/software/simulation/force_wheel_simulator_robot_singleton_test.cpp
+++ b/src/software/simulation/force_wheel_simulator_robot_singleton_test.cpp
@@ -587,6 +587,10 @@ TEST_F(ForceWheelSimulatorRobotSingletonTest,
     for (unsigned int i = 0; i < 200; i++)
     {
         world->stepSimulation(Duration::fromSeconds(1.0 / 60.0));
+        // Don't let the ball bounce off the field goals/boundaries since then we have no guarantee about the speed
+        if(simulator_ball->position().x() >= world->getField().enemyGoalCenter().x()) {
+            break;
+        }
         if (i == 0)
         {
             initial_chip_speed = simulator_ball->velocity().length();

--- a/src/software/simulation/physics/BUILD
+++ b/src/software/simulation/physics/BUILD
@@ -74,6 +74,7 @@ cc_library(
     hdrs = ["physics_field.h"],
     deps = [
         ":box2d_util",
+        ":physics_object_user_data",
         "//software/time:timestamp",
         "//software/world:field",
         "@box2d",
@@ -180,6 +181,7 @@ cc_library(
     hdrs = ["simulation_contact_listener.h"],
     deps = [
         ":physics_ball",
+        ":physics_field",
         ":physics_object_user_data",
         ":physics_robot",
         "@box2d",

--- a/src/software/simulation/physics/physics_field.cpp
+++ b/src/software/simulation/physics/physics_field.cpp
@@ -26,7 +26,7 @@ PhysicsField::~PhysicsField()
             if (f->GetUserData() != NULL)
             {
                 PhysicsObjectUserData *user_data =
-                        static_cast<PhysicsObjectUserData *>(f->GetUserData());
+                    static_cast<PhysicsObjectUserData *>(f->GetUserData());
                 delete user_data;
                 f->SetUserData(NULL);
             }

--- a/src/software/simulation/physics/physics_field.cpp
+++ b/src/software/simulation/physics/physics_field.cpp
@@ -51,7 +51,8 @@ void PhysicsField::setupFieldBoundary(const Field &field)
     field_boundary_fixture_def.shape       = &field_boundary_shape;
     field_boundary_fixture_def.restitution = FIELD_WALL_RESTITUTION;
     field_boundary_fixture_def.friction    = FIELD_WALL_FRICTION;
-    field_boundary_fixture_def.userData = new PhysicsObjectUserData({PhysicsObjectType::FIELD_WALL, this});
+    field_boundary_fixture_def.userData =
+        new PhysicsObjectUserData({PhysicsObjectType::FIELD_WALL, this});
     field_body->CreateFixture(&field_boundary_fixture_def);
 }
 
@@ -67,7 +68,8 @@ void PhysicsField::setupEnemyGoal(const Field &field)
     enemy_goal_fixture_def.shape       = &enemy_goal_shape;
     enemy_goal_fixture_def.restitution = FIELD_WALL_RESTITUTION;
     enemy_goal_fixture_def.friction    = FIELD_WALL_FRICTION;
-    enemy_goal_fixture_def.userData = new PhysicsObjectUserData({PhysicsObjectType::FIELD_WALL, this});
+    enemy_goal_fixture_def.userData =
+        new PhysicsObjectUserData({PhysicsObjectType::FIELD_WALL, this});
     field_body->CreateFixture(&enemy_goal_fixture_def);
 }
 
@@ -83,7 +85,8 @@ void PhysicsField::setupFriendlyGoal(const Field &field)
     friendly_goal_fixture_def.shape       = &friendly_goal_shape;
     friendly_goal_fixture_def.restitution = FIELD_WALL_RESTITUTION;
     friendly_goal_fixture_def.friction    = FIELD_WALL_FRICTION;
-    friendly_goal_fixture_def.userData = new PhysicsObjectUserData({PhysicsObjectType::FIELD_WALL, this});
+    friendly_goal_fixture_def.userData =
+        new PhysicsObjectUserData({PhysicsObjectType::FIELD_WALL, this});
     field_body->CreateFixture(&friendly_goal_fixture_def);
 }
 

--- a/src/software/simulation/physics/physics_field.cpp
+++ b/src/software/simulation/physics/physics_field.cpp
@@ -1,6 +1,7 @@
 #include "software/simulation/physics/physics_field.h"
 
 #include "software/simulation/physics/box2d_util.h"
+#include "software/simulation/physics/physics_object_user_data.h"
 
 PhysicsField::PhysicsField(std::shared_ptr<b2World> world, const Field &field)
     : field(field)
@@ -50,6 +51,7 @@ void PhysicsField::setupFieldBoundary(const Field &field)
     field_boundary_fixture_def.shape       = &field_boundary_shape;
     field_boundary_fixture_def.restitution = FIELD_WALL_RESTITUTION;
     field_boundary_fixture_def.friction    = FIELD_WALL_FRICTION;
+    field_boundary_fixture_def.userData = new PhysicsObjectUserData({PhysicsObjectType::FIELD_WALL, this});
     field_body->CreateFixture(&field_boundary_fixture_def);
 }
 
@@ -65,6 +67,7 @@ void PhysicsField::setupEnemyGoal(const Field &field)
     enemy_goal_fixture_def.shape       = &enemy_goal_shape;
     enemy_goal_fixture_def.restitution = FIELD_WALL_RESTITUTION;
     enemy_goal_fixture_def.friction    = FIELD_WALL_FRICTION;
+    enemy_goal_fixture_def.userData = new PhysicsObjectUserData({PhysicsObjectType::FIELD_WALL, this});
     field_body->CreateFixture(&enemy_goal_fixture_def);
 }
 
@@ -80,6 +83,7 @@ void PhysicsField::setupFriendlyGoal(const Field &field)
     friendly_goal_fixture_def.shape       = &friendly_goal_shape;
     friendly_goal_fixture_def.restitution = FIELD_WALL_RESTITUTION;
     friendly_goal_fixture_def.friction    = FIELD_WALL_FRICTION;
+    friendly_goal_fixture_def.userData = new PhysicsObjectUserData({PhysicsObjectType::FIELD_WALL, this});
     field_body->CreateFixture(&friendly_goal_fixture_def);
 }
 

--- a/src/software/simulation/physics/physics_field.cpp
+++ b/src/software/simulation/physics/physics_field.cpp
@@ -21,6 +21,16 @@ PhysicsField::~PhysicsField()
     b2World *field_world = field_body->GetWorld();
     if (bodyExistsInWorld(field_body, field_world))
     {
+        for (b2Fixture *f = field_body->GetFixtureList(); f != NULL; f = f->GetNext())
+        {
+            if (f->GetUserData() != NULL)
+            {
+                PhysicsObjectUserData *user_data =
+                        static_cast<PhysicsObjectUserData *>(f->GetUserData());
+                delete user_data;
+                f->SetUserData(NULL);
+            }
+        }
         field_world->DestroyBody(field_body);
     }
 }

--- a/src/software/simulation/physics/physics_field.h
+++ b/src/software/simulation/physics/physics_field.h
@@ -94,8 +94,9 @@ class PhysicsField
     b2ChainShape friendly_goal_shape;
     b2FixtureDef friendly_goal_fixture_def;
 
-    // We set the field restitution to 0 so that behaviour of bouncing off walls is
-    // completely determined by the ball's restitution
+    // These values are somewhat arbitrary since the restitution and friction of the ball
+    // also affects any collision behavior. We implement custom collision logic in the
+    // contact listener to handle ball-field collisions
     static constexpr float FIELD_WALL_RESTITUTION = 0.0f;
     static constexpr float FIELD_WALL_FRICTION    = 0.0f;
 

--- a/src/software/simulation/physics/physics_object_user_data.h
+++ b/src/software/simulation/physics/physics_object_user_data.h
@@ -25,7 +25,7 @@ struct PhysicsObjectUserData
         : type(type), physics_object(object_ptr)
     {
     }
-    PhysicsObjectUserData() = delete;
+//    PhysicsObjectUserData() = delete;
 
     PhysicsObjectType type;
     void* physics_object;

--- a/src/software/simulation/physics/physics_object_user_data.h
+++ b/src/software/simulation/physics/physics_object_user_data.h
@@ -25,7 +25,6 @@ struct PhysicsObjectUserData
         : type(type), physics_object(object_ptr)
     {
     }
-    //    PhysicsObjectUserData() = delete;
 
     PhysicsObjectType type;
     void* physics_object;

--- a/src/software/simulation/physics/physics_object_user_data.h
+++ b/src/software/simulation/physics/physics_object_user_data.h
@@ -8,7 +8,8 @@ enum class PhysicsObjectType
     ROBOT_CHICKER,
     ROBOT_DRIBBLER,
     ROBOT_BODY,
-    BALL
+    BALL,
+    FIELD_WALL,
 };
 
 /**

--- a/src/software/simulation/physics/physics_object_user_data.h
+++ b/src/software/simulation/physics/physics_object_user_data.h
@@ -25,7 +25,7 @@ struct PhysicsObjectUserData
         : type(type), physics_object(object_ptr)
     {
     }
-//    PhysicsObjectUserData() = delete;
+    //    PhysicsObjectUserData() = delete;
 
     PhysicsObjectType type;
     void* physics_object;

--- a/src/software/simulation/physics/simulation_contact_listener.cpp
+++ b/src/software/simulation/physics/simulation_contact_listener.cpp
@@ -41,8 +41,8 @@ void SimulationContactListener::BeginContact(b2Contact *contact)
             // Apply an impulse to nearly stop the ball. It's preferable if it bounces
             // away from a wall very slightly for realism, and it should make it easier to
             // retrieve for ball placement
-            ball->applyImpulse(
-                -ball->momentum().normalize(ball->momentum().length() * 0.95));
+            ball->applyImpulse(-ball->momentum().normalize(
+                ball->momentum().length() * BALL_FIELD_WALL_COLLISION_DAMPING));
         }
     }
 }

--- a/src/software/simulation/physics/simulation_contact_listener.cpp
+++ b/src/software/simulation/physics/simulation_contact_listener.cpp
@@ -33,14 +33,16 @@ void SimulationContactListener::BeginContact(b2Contact *contact)
                 contact_callback(robot, ball);
             }
         }
-        if (auto ball_field_pair = isBallFieldWallContact(user_data_a, user_data_b)) {
-            // If the ball hits a wall it's out of bounds, so we stop it to make it easier to
-            // retrieve for ball placement (otherwise it will bounce around the field)
-            PhysicsBall *ball   = ball_field_pair->first;
-            // Apply an impulse to nearly stop the ball. It's preferable if it bounces away
-            // from a wall very slightly for realism, and it should make it easier to retrieve
-            // for ball placement
-            ball->applyImpulse(-ball->momentum().normalize(ball->momentum().length() * 0.95));
+        if (auto ball_field_pair = isBallFieldWallContact(user_data_a, user_data_b))
+        {
+            // If the ball hits a wall it's out of bounds, so we stop it to make it easier
+            // to retrieve for ball placement (otherwise it will bounce around the field)
+            PhysicsBall *ball = ball_field_pair->first;
+            // Apply an impulse to nearly stop the ball. It's preferable if it bounces
+            // away from a wall very slightly for realism, and it should make it easier to
+            // retrieve for ball placement
+            ball->applyImpulse(
+                -ball->momentum().normalize(ball->momentum().length() * 0.95));
         }
     }
 }
@@ -226,8 +228,10 @@ PhysicsBall *SimulationContactListener::isBallContact(PhysicsObjectUserData *use
 }
 
 
-std::optional<std::pair<PhysicsBall*, PhysicsField*>> SimulationContactListener::isBallFieldWallContact(PhysicsObjectUserData *user_data_a,
-                                                               PhysicsObjectUserData *user_data_b) {
+std::optional<std::pair<PhysicsBall *, PhysicsField *>>
+SimulationContactListener::isBallFieldWallContact(PhysicsObjectUserData *user_data_a,
+                                                  PhysicsObjectUserData *user_data_b)
+{
     if (!user_data_a || !user_data_b)
     {
         return std::nullopt;

--- a/src/software/simulation/physics/simulation_contact_listener.cpp
+++ b/src/software/simulation/physics/simulation_contact_listener.cpp
@@ -33,6 +33,15 @@ void SimulationContactListener::BeginContact(b2Contact *contact)
                 contact_callback(robot, ball);
             }
         }
+        if (auto ball_field_pair = isBallFieldWallContact(user_data_a, user_data_b)) {
+            // If the ball hits a wall it's out of bounds, so we stop it to make it easier to
+            // retrieve for ball placement (otherwise it will bounce around the field)
+            PhysicsBall *ball   = ball_field_pair->first;
+            // Apply an impulse to nearly stop the ball. It's preferable if it bounces away
+            // from a wall very slightly for realism, and it should make it easier to retrieve
+            // for ball placement
+            ball->applyImpulse(-ball->momentum().normalize(ball->momentum().length() * 0.95));
+        }
     }
 }
 
@@ -214,4 +223,44 @@ PhysicsBall *SimulationContactListener::isBallContact(PhysicsObjectUserData *use
     }
 
     return ball;
+}
+
+
+std::optional<std::pair<PhysicsBall*, PhysicsField*>> SimulationContactListener::isBallFieldWallContact(PhysicsObjectUserData *user_data_a,
+                                                               PhysicsObjectUserData *user_data_b) {
+    if (!user_data_a || !user_data_b)
+    {
+        return std::nullopt;
+    }
+
+    // NOTE: Box2D intelligently reports only one contact when 2 objects collide
+    // (ie. Does not report a contact for ObjectA touching ObjectB, and another
+    // contact for ObjectB touching ObjectA), which is why we do not need to worry
+    // about only detecting one contact per pair of colliding objects.
+    PhysicsBall *ball = nullptr;
+    if (user_data_a->type == PhysicsObjectType::BALL)
+    {
+        ball = static_cast<PhysicsBall *>(user_data_a->physics_object);
+    }
+    if (user_data_b->type == PhysicsObjectType::BALL)
+    {
+        ball = static_cast<PhysicsBall *>(user_data_b->physics_object);
+    }
+
+    PhysicsField *field = nullptr;
+    if (user_data_a->type == PhysicsObjectType::FIELD_WALL)
+    {
+        field = static_cast<PhysicsField *>(user_data_a->physics_object);
+    }
+    if (user_data_b->type == PhysicsObjectType::FIELD_WALL)
+    {
+        field = static_cast<PhysicsField *>(user_data_b->physics_object);
+    }
+
+    if (ball && field)
+    {
+        return std::make_pair(ball, field);
+    }
+
+    return std::nullopt;
 }

--- a/src/software/simulation/physics/simulation_contact_listener.h
+++ b/src/software/simulation/physics/simulation_contact_listener.h
@@ -5,6 +5,7 @@
 #include "software/simulation/physics/physics_ball.h"
 #include "software/simulation/physics/physics_object_user_data.h"
 #include "software/simulation/physics/physics_robot.h"
+#include "software/simulation/physics/physics_field.h"
 
 /**
  * This class implements a custom ContactListener for a Box2D world so that we
@@ -66,5 +67,20 @@ class SimulationContactListener : public b2ContactListener
      * otherwise
      */
     static PhysicsBall* isBallContact(PhysicsObjectUserData* user_data_a,
+                                      PhysicsObjectUserData* user_data_b);
+
+    /**
+     * Given the user data of 2 objects involved in a contact, returns a pair of
+     * pointers to the physics objects involved in the contact if there was a contact
+     * point between a ball and a field wall. Otherwise returns std::nullopt
+     *
+     * @param user_data_a The user data for the first object in the contact
+     * @param user_data_b The user data for the second object in the contact
+     *
+     * @return A pair of pointers to the physics objects involved in the constact if there
+     * was a contact point between a ball and field wall, and returns std::nullopt
+     * otherwise
+     */
+    static std::optional<std::pair<PhysicsBall*, PhysicsField*>> isBallFieldWallContact(PhysicsObjectUserData* user_data_a,
                                       PhysicsObjectUserData* user_data_b);
 };

--- a/src/software/simulation/physics/simulation_contact_listener.h
+++ b/src/software/simulation/physics/simulation_contact_listener.h
@@ -3,9 +3,9 @@
 #include <Box2D/Box2D.h>
 
 #include "software/simulation/physics/physics_ball.h"
+#include "software/simulation/physics/physics_field.h"
 #include "software/simulation/physics/physics_object_user_data.h"
 #include "software/simulation/physics/physics_robot.h"
-#include "software/simulation/physics/physics_field.h"
 
 /**
  * This class implements a custom ContactListener for a Box2D world so that we
@@ -81,6 +81,6 @@ class SimulationContactListener : public b2ContactListener
      * was a contact point between a ball and field wall, and returns std::nullopt
      * otherwise
      */
-    static std::optional<std::pair<PhysicsBall*, PhysicsField*>> isBallFieldWallContact(PhysicsObjectUserData* user_data_a,
-                                      PhysicsObjectUserData* user_data_b);
+    static std::optional<std::pair<PhysicsBall*, PhysicsField*>> isBallFieldWallContact(
+        PhysicsObjectUserData* user_data_a, PhysicsObjectUserData* user_data_b);
 };

--- a/src/software/simulation/physics/simulation_contact_listener.h
+++ b/src/software/simulation/physics/simulation_contact_listener.h
@@ -83,4 +83,8 @@ class SimulationContactListener : public b2ContactListener
      */
     static std::optional<std::pair<PhysicsBall*, PhysicsField*>> isBallFieldWallContact(
         PhysicsObjectUserData* user_data_a, PhysicsObjectUserData* user_data_b);
+
+   private:
+    // Damping factor for ball collisions with field walls or goals
+    static constexpr double BALL_FIELD_WALL_COLLISION_DAMPING = 0.8;
 };


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
While doing simulated testing, the ball can constantly go out of bounds (or go in the net). Right now these ball-wall collisions are very bouncy, which is both unrealistic and annoying. I've changed it so that these collisions are strongly damped, which has the following benefits:
1. It's more realistic. Walls IRL have relatively little bounce.
2. Related to the above, it makes ball placement much easier if the ball isn't bouncing around for 5 seconds after it goes out of bounds. It will stay closer to the wall like in reality.
3. It's easier to see when the ball went in the net (for a goal)

Note that this only affects collisions between the ball and walls, it does not affect how the ball bounces off robots.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
tested locally

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
None

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->
None

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
