### PR TITLE
Fix bug with enemy risk reaction time

### DIFF
--- a/src/shared/parameter/config_definitions/passing_config.yaml
+++ b/src/shared/parameter/config_definitions/passing_config.yaml
@@ -10,7 +10,7 @@
      name: static_field_position_quality_y_offset
      min: 0
      max: 1
-     value: 0.3
+     value: 0.4
      description: >-
                 The offset from the sides of the field to place the rectangular
                 sigmoid we use to determine what areas to pass to
@@ -18,7 +18,7 @@
      name: static_field_position_quality_friendly_goal_distance_weight
      min: 0
      max: 1
-     value: 0.3
+     value: 0.1
      description: >-
          The weight that being close to the goal will have on the static
          position quality. Lower, more negative weights result in the distance
@@ -61,9 +61,23 @@
      description: >-
        How long we think the enemy will take to recognize we're passing and start
        moving to intercept
+ - double:
+     name: enemy_reaction_time_scaling_time_diff
+     min: 0
+     max: 3.0
+     value: 0.5
+     description: >-
+       Enemy reaction time will scale from 0-1 as the initial estimated time to position increases to this value
  - int:
      name: number_of_gradient_descent_steps_per_iter
      min: 0
      max: 1000
      value: 2 # TODO (#1987) find optimal iterations after tuning, for now 2 does the trick
      description: "The number of steps of gradient descent to perform in each iteration"
+
+# - int:
+#     name: ball_deceleration_m_s
+#     min: 0
+#     max: 1
+#     value: 0.1
+#     description: "An estimate of the ball's linear deceleration, used for ball prediction"

--- a/src/software/ai/passing/cost_function.cpp
+++ b/src/software/ai/passing/cost_function.cpp
@@ -10,6 +10,7 @@
 #include "software/geom/algorithms/closest_point.h"
 #include "software/geom/algorithms/contains.h"
 #include "software/logger/logger.h"
+#include "software/geom/algorithms/distance.h"
 
 double ratePass(const World& world, const Pass& pass, const Rectangle& zone,
                 std::shared_ptr<const PassingConfig> passing_config)
@@ -25,18 +26,26 @@ double ratePass(const World& world, const Pass& pass, const Rectangle& zone,
     double shoot_pass_rating =
         ratePassShootScore(world.field(), world.enemyTeam(), pass, passing_config);
 
-    double in_region_quality = rectangleSigmoid(zone, pass.receiverPoint(), 0.2);
+//    double in_region_quality = rectangleSigmoid(zone, pass.receiverPoint(), 0.2);
 
     // Place strict limits on the ball speed
     double min_pass_speed     = passing_config->getMinPassSpeedMPerS()->value();
     double max_pass_speed     = passing_config->getMaxPassSpeedMPerS()->value();
     double pass_speed_quality = sigmoid(pass.speed(), min_pass_speed, 0.2) *
                                 (1 - sigmoid(pass.speed(), max_pass_speed, 0.2));
-
+//    double weighted_average = (
+//            (1.0 * static_pass_quality) +
+//            (1.0 * friendly_pass_rating) +
+//            (1.0 * enemy_pass_rating) +
+//            (1.0 * shoot_pass_rating) +
+//            (1.0 * pass_speed_quality)
+//            ) / 5.0;
+//    return weighted_average;
     return static_pass_quality * friendly_pass_rating * enemy_pass_rating *
-           shoot_pass_rating * pass_speed_quality * in_region_quality;
+           shoot_pass_rating * pass_speed_quality;
 }
 
+// FUTURE TODO: DON'T USE DIFFERENT APPROXIMATIONS FOR CHERRY PICKING!!!!!!!
 double rateZone(const Field& field, const Team& enemy_team, const Rectangle& zone,
                 const Point& ball_position,
                 std::shared_ptr<const PassingConfig> passing_config)
@@ -92,6 +101,7 @@ double ratePassShootScore(const Field& field, const Team& enemy_team, const Pass
     if (shot_opt && shot_opt->getOpenAngle().abs() > Angle::fromDegrees(0))
     {
         open_angle_to_goal = shot_opt->getOpenAngle();
+        shot_target = shot_opt->getPointToShootAt();
     }
 
     // Figure out what the maximum open angle of the goal could be from the receiver pos.
@@ -116,15 +126,16 @@ double ratePassShootScore(const Field& field, const Team& enemy_team, const Pass
     // locations on the friendly side
     //
     // TODO (#1987) This creates a very steep slope, find a better way to do this
-    if (pass.receiverPoint().x() < 0 || pass.passerPoint().x() < 0)
-    {
-        ideal_max_rotation_to_shoot_degrees = 180;
-    }
+//    if (pass.receiverPoint().x() < 0 || pass.passerPoint().x() < 0)
+//    {
+//        ideal_max_rotation_to_shoot_degrees = 180;
+//    }
     Angle rotation_to_shot_target_after_pass = pass.receiverOrientation().minDiff(
         (shot_target - pass.receiverPoint()).orientation());
+    double width = (Angle::half()-Angle::fromDegrees(ideal_max_rotation_to_shoot_degrees)).toDegrees();
     double required_rotation_for_shot_score =
         1 - sigmoid(rotation_to_shot_target_after_pass.abs().toDegrees(),
-                    ideal_max_rotation_to_shoot_degrees, 4);
+                    Angle::fromDegrees(ideal_max_rotation_to_shoot_degrees).toDegrees() + width/2.0, width);
 
     return shot_openness_score * required_rotation_for_shot_score;
 }
@@ -213,12 +224,18 @@ double calculateInterceptRisk(const Robot& enemy_robot, const Pass& pass,
     Duration enemy_reaction_time =
         Duration::fromSeconds(passing_config->getEnemyReactionTime()->value());
 
+    // FUTURE TODO: IMPORTANT!!!
+    // Previously we were always just adding the enemy reaction time to the estimated time to destination. This meant
+    // that even if there was a robot right in front of the passer, we would think we could get the ball past them
+    // before they could intercept (which is obviously wrong). REMOVE THIS FIX, MAKE A TEST FAIL, AND ADD A PROPER REGRESSION TEST
+    double scaled_enemy_reaction_time_closest_pass_point = std::clamp(enemy_robot_time_to_closest_pass_point.toSeconds() / passing_config->getEnemyReactionTimeScalingTimeDiff()->value(), 0.0, enemy_reaction_time.toSeconds());
     double robot_ball_time_diff_at_closest_pass_point =
-        ((enemy_robot_time_to_closest_pass_point + enemy_reaction_time) -
+        ((enemy_robot_time_to_closest_pass_point + Duration::fromSeconds(scaled_enemy_reaction_time_closest_pass_point)) -
          (ball_time_to_closest_pass_point))
             .toSeconds();
+    double scaled_enemy_reaction_time_receive_point = std::clamp(enemy_robot_time_to_pass_receive_position.toSeconds() / passing_config->getEnemyReactionTimeScalingTimeDiff()->value(), 0.0, enemy_reaction_time.toSeconds());
     double robot_ball_time_diff_at_pass_receive_point =
-        ((enemy_robot_time_to_pass_receive_position + enemy_reaction_time) -
+        ((enemy_robot_time_to_pass_receive_position + Duration::fromSeconds(scaled_enemy_reaction_time_receive_point)) -
          (ball_time_to_pass_receive_position))
             .toSeconds();
 
@@ -230,7 +247,9 @@ double calculateInterceptRisk(const Robot& enemy_robot, const Pass& pass,
     // the pass does. As such, we place the time difference between the robot and ball
     // on a sigmoid that is centered at 0, and goes to 1 at positive values, 0 at
     // negative values.
-    return 1 - sigmoid(min_time_diff, 0, 1);
+
+    // If an enemy can intercept, we want a risk very close to 1
+    return 1 - sigmoid(min_time_diff, 0.5, 1);
 }
 
 double ratePassFriendlyCapability(Team friendly_team, const Pass& pass,
@@ -264,7 +283,7 @@ double ratePassFriendlyCapability(Team friendly_team, const Pass& pass,
     // Figure out what time the robot would have to receive the ball at
     Duration ball_travel_time = Duration::fromSeconds(
         (pass.receiverPoint() - pass.passerPoint()).length() / pass.speed());
-    Timestamp receive_time = best_receiver.timestamp() + ball_travel_time;
+    Timestamp receive_time = best_receiver.timestamp() + ball_travel_time + Duration::fromSeconds(0.25);
 
     // Figure out how long it would take our robot to get there
     Duration min_robot_travel_time = getTimeToPositionForRobot(
@@ -287,12 +306,12 @@ double ratePassFriendlyCapability(Team friendly_team, const Pass& pass,
 
     // Create a sigmoid that goes to 0 as the time required to get to the reception
     // point exceeds the time we would need to get there by
-    double sigmoid_width                  = 0.4;
-    double time_to_receiver_state_slack_s = 0.25;
+    double sigmoid_width                  = 0.5;
+    double time_to_receiver_state_slack_s = 0.19;
 
     return sigmoid(
         receive_time.toSeconds(),
-        latest_time_to_reciever_state.toSeconds() + time_to_receiver_state_slack_s,
+        latest_time_to_reciever_state.toSeconds() + sigmoid_width/2 + time_to_receiver_state_slack_s,
         sigmoid_width);
 }
 
@@ -321,9 +340,14 @@ double getStaticPositionQuality(const Field& field, const Point& position,
     Vector vec_to_friendly_goal = Vector(field.friendlyGoalCenter().x() - position.x(),
                                          field.friendlyGoalCenter().y() - position.y());
     double distance_to_friendly_goal = vec_to_friendly_goal.length();
+    double near_friendly_goal_min_shift = 2;
+    double near_friendly_goal_max_shift = 4.5;
+    double near_friendly_goal_half_shift = (near_friendly_goal_max_shift + near_friendly_goal_min_shift) / 2.0;
+    double near_friendly_goal_shift_length = near_friendly_goal_max_shift - near_friendly_goal_min_shift;
+    double near_friendly_goal_shift = near_friendly_goal_min_shift + sigmoid(position.x(), near_friendly_goal_half_shift, near_friendly_goal_shift_length)*near_friendly_goal_shift_length;
     double near_friendly_goal_quality =
         (1 -
-         std::exp(-friendly_goal_weight * (std::pow(5, -2 + distance_to_friendly_goal))));
+         std::exp(-friendly_goal_weight * (std::pow(10, -near_friendly_goal_shift + distance_to_friendly_goal))));
 
     // Add a strong negative weight for positions within the enemy defense area, as we
     // cannot pass there
@@ -331,4 +355,25 @@ double getStaticPositionQuality(const Field& field, const Point& position,
         1 - rectangleSigmoid(field.enemyDefenseArea(), position, sig_width);
 
     return on_field_quality * near_friendly_goal_quality * in_enemy_defense_area_quality;
+}
+
+
+Duration estimateBallTimeToPosition(const Ball& ball, const Point& pos, double ball_decel) {
+    /**
+     * Using kinematics to roughly model ball decel, since we have a tendency
+     * to take long passes where the ball slows down a lot and enemies can intercept
+     *
+     * vf^2 = vi^2 + 2*a*d
+     * vf = vi + a*t
+     *
+     * t = (sqrt(vi^2 + 2ad) -vi) / a
+     */
+
+    double dist = distance(pos, ball.position());
+    double vi = ball.velocity().length();
+    double a = -ball_decel; // acceleration is in opposite direction of motion
+    Duration time = Duration::fromSeconds(
+            (std::sqrt(vi*vi + 2*a*dist) - vi) / a
+            );
+    return time;
 }

--- a/src/software/ai/passing/cost_function.h
+++ b/src/software/ai/passing/cost_function.h
@@ -131,3 +131,5 @@ double ratePassFriendlyCapability(Team friendly_team, const Pass& pass,
  */
 double getStaticPositionQuality(const Field& field, const Point& position,
                                 std::shared_ptr<const PassingConfig> passing_config);
+
+Duration estimateBallTimeToPosition(const Ball& ball, const Point& pos);


### PR DESCRIPTION
* Do not have shoot score go to zero if the deflection angle is bad.
Should be a smoother way of handling both passes and shots
* Fixed bug where we would always add the enemy reaction time to their
time to intercept, resulting in us passing directly into enemies in
front of us
* Made the static position quality slightly track the ball up the
field, so we are less likely to pass super far back to the friendly side
* SHifted a few sigmoids so if we absolutely can't receive a pass or an
enemy can intercept, the score goes very close to 0

<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
There was a bug in the `enemyRisk` pass evaluation functions that caused us to sometimes try pass right through an enemy robot right in front of us.

Because we _always_ add the `enemy_reaction_time` to the time we calculate it would take the enemy to intercept a pass, if the enemy is very close to the pass origin we would think we could kick the ball past them before they could reach it, despite them already being in the way.

My (questionable) fix for this was to apply the enemy reaction time based on how long we already thought it would take the enemy to intercept. If the enemy was already really close to intercepting (or could intercept by being in the way), we won't apply reaction time. The further away an enemy gets, the more reaction time we apply.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
haha

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
