### PR TITLE
Fail Simulated Tests on Error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,6 @@ jobs:
             //software/ai/hl/stp/play/...    \
             //software/ai/hl/stp/tactic/... 
 
-      
       - name: Upload simulated test artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -112,6 +111,16 @@ jobs:
           # we only care about the replay logs from the STP tests
           path: |
             src/bazel-out/k8-fastbuild/testlogs/software/ai/hl/stp
+
+      - name: Simulated Test
+        # Run Simulated Tests a second time to check for failures
+        run: |
+          cd src
+          bazel test --show_timestamps   \
+            //software/simulated_tests/...   \
+            //software/ai/hl/stp/play/...    \
+            //software/ai/hl/stp/tactic/... 
+
             
   memory-leak-checks:
     name: Memory Leak Checks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           "${GITHUB_WORKSPACE}"/environment_setup/setup_software.sh
 
-      - name: Simulated Test
+      - name: Simulated Test (Continue on error)
         # make sure that replays are uploaded even if tests fail
         continue-on-error: true
         run: |
@@ -112,7 +112,7 @@ jobs:
           path: |
             src/bazel-out/k8-fastbuild/testlogs/software/ai/hl/stp
 
-      - name: Simulated Test
+      - name: Simulated Test (Check for errors)
         # Run Simulated Tests a second time to check for failures
         run: |
           cd src

--- a/src/software/ai/hl/stp/play/corner_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/corner_kick_play_test.cpp
@@ -64,7 +64,7 @@ TEST_F(CornerKickPlayTest, test_corner_kick_play_top_right)
 
     std::vector<ValidationFunction> terminating_validation_functions = {
         [](std::shared_ptr<World> world_ptr, ValidationCoroutine::push_type& yield) {
-            robotReceivedBall(5, world_ptr, yield);
+            robotReceivedBall(4, world_ptr, yield);
             friendlyScored(world_ptr, yield);
         }};
 

--- a/src/software/ai/hl/stp/play/corner_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/corner_kick_play_test.cpp
@@ -64,7 +64,7 @@ TEST_F(CornerKickPlayTest, test_corner_kick_play_top_right)
 
     std::vector<ValidationFunction> terminating_validation_functions = {
         [](std::shared_ptr<World> world_ptr, ValidationCoroutine::push_type& yield) {
-            robotReceivedBall(4, world_ptr, yield);
+            robotReceivedBall(5, world_ptr, yield);
             friendlyScored(world_ptr, yield);
         }};
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Currently CI does not catch simulated test errors because of the continue-on-error flag meant to make sure that we always generate replay artifacts. This means that PRs with code that doesn't build can still pass CI. Here's an example: https://github.com/UBC-Thunderbots/Software/pull/2148/checks?check_run_id=2822800157 The fix is to run simulated tests again (result _should_ be cached and it shouldn't add time to CI)
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
See PR runs on commits in this PR
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
