### PR TITLE
Create a new directory named with the time in the protolog output directory

### DIFF
--- a/src/software/full_system_main.cpp
+++ b/src/software/full_system_main.cpp
@@ -1,4 +1,5 @@
 #include <boost/program_options.hpp>
+#include <chrono>
 #include <experimental/filesystem>
 #include <iostream>
 #include <numeric>
@@ -124,11 +125,23 @@ int main(int argc, char** argv)
 
         if (!args->getProtoLogOutputDir()->value().empty())
         {
+            auto now_time_point  = std::chrono::system_clock::now();
+            std::time_t now_time = std::chrono::system_clock::to_time_t(now_time_point);
+            // unfortunately there is no way to go from time_point to formatted string
+            // in modern C++ until C++20
+            char time_c_str[50];
+            std::strftime(time_c_str, sizeof(time_c_str), "%d%m%Y_%H%M%S",
+                          std::localtime(&now_time));
+            std::string time_string(time_c_str);
+
+
             namespace fs = std::experimental::filesystem;
             // we want to log protos, make the parent directory and pass the
             // subdirectories to the ProtoLoggers for each message type
             fs::path proto_log_output_dir(args->getProtoLogOutputDir()->value());
-            fs::create_directory(proto_log_output_dir);
+            // create a folder with a date+time name to store replays in
+            proto_log_output_dir /= time_string;
+            fs::create_directories(proto_log_output_dir);
 
             // log incoming SensorMsg
             auto sensor_msg_logger = std::make_shared<ProtoLogger<SensorProto>>(


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
