### PR TITLE
[SSL Simulation Protocol] Add timeout for simulator feedback receive

### DIFF
--- a/src/software/networking/proto_udp_client.h
+++ b/src/software/networking/proto_udp_client.h
@@ -19,9 +19,10 @@ class ProtoUdpClient
      *  example IPv6: ff02::c3d0:42d2:bb8%wlp4s0 (the interface is specified after %)
      * @param port The port to send SendProtoT data to
      * @param multicast If true, joins the multicast group of given ip_address
+     * @param enable_timeout If true, sets a timeout value of 100ms for receiving proto
      */
-    ProtoUdpClient(boost::asio::io_service& io_service, const std::string& ip_address,
-                   unsigned short port, bool multicast);
+    ProtoUdpClient(const std::string& ip_address, unsigned short port, bool multicast,
+                   bool enable_timeout = false);
 
     virtual ~ProtoUdpClient();
 
@@ -55,6 +56,8 @@ class ProtoUdpClient
     ReceiveProtoT request(const SendProtoT& message);
 
    private:
+    boost::asio::io_service io_service;
+
     // A UDP socket to send data over
     boost::asio::ip::udp::socket socket_;
 
@@ -66,6 +69,10 @@ class ProtoUdpClient
 
     static constexpr unsigned int MAX_BUFFER_LENGTH = 9000;
     std::array<char, MAX_BUFFER_LENGTH> raw_received_data_;
+
+    boost::asio::io_service::work work;
+    bool enable_timeout;
+    std::thread io_service_thread;
 };
 
 #include "software/networking/proto_udp_client.tpp"

--- a/src/software/networking/proto_udp_client.tpp
+++ b/src/software/networking/proto_udp_client.tpp
@@ -68,7 +68,8 @@ ReceiveProtoT ProtoUdpClient<SendProtoT, ReceiveProtoT>::receiveProto()
             boost::asio::use_future);
 
         // Timeout occurs
-        if (read_result.wait_for(std::chrono::seconds(1)) == std::future_status::timeout)
+        if (read_result.wait_for(std::chrono::milliseconds(100)) ==
+            std::future_status::timeout)
         {
             socket_.cancel();
             return ReceiveProtoT();

--- a/src/software/networking/proto_udp_client.tpp
+++ b/src/software/networking/proto_udp_client.tpp
@@ -1,14 +1,16 @@
 #pragma once
 
+#include <chrono>
 #include <type_traits>
 
 #include "software/logger/logger.h"
 
 template <class SendProtoT, class ReceiveProtoT>
-ProtoUdpClient<SendProtoT, ReceiveProtoT>::ProtoUdpClient(
-    boost::asio::io_service& io_service, const std::string& ip_address,
-    const unsigned short port, bool multicast)
-    : socket_(io_service)
+ProtoUdpClient<SendProtoT, ReceiveProtoT>::ProtoUdpClient(const std::string& ip_address,
+                                                          const unsigned short port,
+                                                          bool multicast,
+                                                          bool enable_timeout)
+    : io_service(), socket_(io_service), work(io_service), enable_timeout(enable_timeout)
 {
     boost::asio::ip::address addr = boost::asio::ip::make_address(ip_address);
     endpoint                      = boost::asio::ip::udp::endpoint(addr, port);
@@ -40,6 +42,12 @@ ProtoUdpClient<SendProtoT, ReceiveProtoT>::ProtoUdpClient(
 
         socket_.set_option(boost::asio::ip::multicast::join_group(addr));
     }
+    if (enable_timeout)
+    {
+        // If timeout is enabled, asynchronous receive function is used.
+        // Start the thread to run the io_service in the background.
+        io_service_thread = std::thread([this]() { io_service.run(); });
+    }
 }
 
 template <class SendProtoT, class ReceiveProtoT>
@@ -52,8 +60,29 @@ void ProtoUdpClient<SendProtoT, ReceiveProtoT>::sendProto(const SendProtoT& mess
 template <class SendProtoT, class ReceiveProtoT>
 ReceiveProtoT ProtoUdpClient<SendProtoT, ReceiveProtoT>::receiveProto()
 {
-    size_t num_bytes_received = socket_.receive_from(
-        boost::asio::buffer(raw_received_data_, MAX_BUFFER_LENGTH), endpoint);
+    size_t num_bytes_received;
+    if (enable_timeout)
+    {
+        std::future<size_t> read_result = socket_.async_receive_from(
+            boost::asio::buffer(raw_received_data_, MAX_BUFFER_LENGTH), endpoint,
+            boost::asio::use_future);
+
+        // Timeout occurs
+        if (read_result.wait_for(std::chrono::seconds(1)) == std::future_status::timeout)
+        {
+            socket_.cancel();
+            return ReceiveProtoT();
+        }
+        else
+        {
+            num_bytes_received = read_result.get();
+        }
+    }
+    else
+    {
+        num_bytes_received = socket_.receive_from(
+            boost::asio::buffer(raw_received_data_, MAX_BUFFER_LENGTH), endpoint);
+    }
     auto packet_data = ReceiveProtoT();
 
     if (num_bytes_received > 0)
@@ -90,5 +119,19 @@ ReceiveProtoT ProtoUdpClient<SendProtoT, ReceiveProtoT>::request(
 template <class SendProtoT, class ReceiveProtoT>
 ProtoUdpClient<SendProtoT, ReceiveProtoT>::~ProtoUdpClient()
 {
+    if (enable_timeout)
+    {
+        // Stop the io_service. This is safe to call from another thread.
+        // https://stackoverflow.com/questions/4808848/boost-asio-stopping-io-service
+        // This MUST be done before attempting to join the thread because otherwise the
+        // io_service will not stop and the thread will not join
+        io_service.stop();
+
+        // Join the io_service_thread so that we wait for it to exit before destructing
+        // the thread object. If we do not wait for the thread to finish executing, it
+        // will call `std::terminate` when we deallocate the thread object and kill our
+        // whole program
+        io_service_thread.join();
+    }
     socket_.close();
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Receiving feedback is blocking, which causes `ssl_simulation_main` to get stuck if simulator is not running (even if it gets restarted later). Give a timeout of 100ms.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Works locally - start `ssl_simulation_main` and then start simulator
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
