### PR TITLE
reset the ball filter when we enter STOP referee command

### DIFF
--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -128,6 +128,11 @@ void SensorFusion::updateWorld(const SSLProto::SSL_GeometryData &geometry_packet
 
 void SensorFusion::updateWorld(const SSLProto::Referee &packet)
 {
+    // reset the ball filter when we transition to STOP referee command
+    if (packet.command() == SSLProto::Referee_Command_STOP && !game_state.isStopped()) {
+        resetBallFilter();
+    }
+
     if (sensor_fusion_config->getFriendlyColorYellow()->value())
     {
         game_state.updateRefereeCommand(createRefereeCommand(packet, TeamColour::YELLOW));
@@ -443,4 +448,9 @@ void SensorFusion::resetWorldComponents()
     friendly_team_filter = RobotTeamFilter();
     enemy_team_filter    = RobotTeamFilter();
     team_with_possession = TeamSide::ENEMY;
+}
+
+void SensorFusion::resetBallFilter() {
+    ball_filter =
+        BallFilter(sensor_fusion_config->getRollingFrictionAcceleration()->value());
 }

--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -115,6 +115,8 @@ class SensorFusion
      */
     void resetWorldComponents();
 
+    void resetBallFilter();
+
     /**
      * Determines if the team has control over the given ball
      *


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
