### PR TITLE
freekickplay fix, dribble fsm revert slow down, isplaying 3 -> 5 cm

### DIFF
--- a/src/software/ai/hl/stp/play/ball_placement_play.cpp
+++ b/src/software/ai/hl/stp/play/ball_placement_play.cpp
@@ -13,7 +13,7 @@ BallPlacementPlay::BallPlacementPlay(std::shared_ptr<const PlayConfig> config)
 
 bool BallPlacementPlay::isApplicable(const World &world) const
 {
-    return world.gameState().isOurBallPlacement() && distanceSquared(world.ball().position(), world.gameState().getBallPlacementPoint().value()) > 0.005;
+    return world.gameState().isOurBallPlacement();
 }
 
 bool BallPlacementPlay::invariantHolds(const World &world) const
@@ -25,6 +25,7 @@ void BallPlacementPlay::getNextTactics(TacticCoroutine::push_type &yield,
                                        const World &world)
 {
     auto place_ball_tactic = std::make_shared<DribbleTactic>();
+    auto move_away_tactic = std::make_shared<MoveTactic>(false);
 
     std::vector<std::shared_ptr<MoveTactic>> move_tactics = {
         std::make_shared<MoveTactic>(true), std::make_shared<MoveTactic>(true),
@@ -53,7 +54,7 @@ void BallPlacementPlay::getNextTactics(TacticCoroutine::push_type &yield,
         TacticVector result = {place_ball_tactic};
         result.insert(result.end(), move_tactics.begin(), move_tactics.end());
         yield({result});
-    } while (true);
+    } while (!place_ball_tactic->done());
 }
 
 // Register this play in the genericFactory

--- a/src/software/ai/hl/stp/play/free_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/free_kick_play.cpp
@@ -88,13 +88,13 @@ void FreeKickPlay::getNextTactics(TacticCoroutine::push_type &yield, const World
 
     // We want the kicker to get into position behind the ball facing the center
     // of the field
-    Vector ball_to_center_vec = world.field().enemyGoalCenter().toVector() - world.ball().position().toVector();
+    Vector ball_to_enemy_goal_vec = world.field().enemyGoalCenter().toVector() - world.ball().position().toVector();
 
     do {
         align_to_ball_tactic->updateControlParams(
                 world.ball().position() -
-                ball_to_center_vec.normalize(ROBOT_MAX_RADIUS_METERS * 2.5),
-                ball_to_center_vec.orientation(), 0);
+                ball_to_enemy_goal_vec.normalize(ROBOT_MAX_RADIUS_METERS * 2.5),
+                ball_to_enemy_goal_vec.orientation(), 0);
 
 
         auto pass_eval = pass_generator.generatePassEvaluation(world);

--- a/src/software/ai/hl/stp/play/free_kick_play.h
+++ b/src/software/ai/hl/stp/play/free_kick_play.h
@@ -34,7 +34,7 @@ class FreeKickPlay : public Play
      * @param crease_defender_tactics The crease defender tactics to use
      * @param world The current state of the world
      */
-    void lastResortChipStage(
+    static void lastResortChipStage(
         TacticCoroutine::push_type &yield,
         std::array<std::shared_ptr<CreaseDefenderTactic>, 2> crease_defender_tactics,
         const World &world);
@@ -50,7 +50,7 @@ class FreeKickPlay : public Play
     void performPassStage(
         TacticCoroutine::push_type &yield,
         std::array<std::shared_ptr<CreaseDefenderTactic>, 2> crease_defender_tactics,
-        PassWithRating best_pass_and_score_so_far, const World &world);
+        const PassWithRating& best_pass_and_score_so_far, const World &world);
 
     /**
      * Tries to find a good pass on the field. This function starts with a high threshold

--- a/src/software/ai/hl/stp/tactic/dribble/dribble_fsm.h
+++ b/src/software/ai/hl/stp/tactic/dribble/dribble_fsm.h
@@ -42,9 +42,6 @@ struct DribbleFSM
 
     // Threshold to determine if the ball is at the destination determined experimentally
     static constexpr double BALL_CLOSE_TO_DEST_THRESHOLD = 0.1;
-    // Threshold to determine if the robot has the expected orientation when dribbling the
-    // ball
-    static constexpr Angle FACE_DESTINATION_CLOSE_THRESHOLD = Angle::fromDegrees(5);
     // Threshold to determine if the robot has the expected orientation when completing
     // the dribble
     static constexpr Angle FINAL_DESTINATION_CLOSE_THRESHOLD = Angle::fromDegrees(1);
@@ -256,14 +253,6 @@ struct DribbleFSM
                     .value_or(
                         std::make_pair(event.common.world.ball().position(), Duration()));
             auto intercept_position = intercept_result.first;
-
-             if ((event.common.world.ball().position() - event.common.robot.position()).length() <
-                     INTERCEPT_BALL_RADIUS)
-             {
-                // we are near the ball but not behind it, move slower
-                speed_mode = MaxAllowedSpeedMode::STOP_COMMAND;
-                intercept_position = event.common.world.ball().position();
-            }
 
             event.common.set_intent(std::make_unique<MoveIntent>(
                 event.common.robot.id(), intercept_position, face_ball_orientation, 0,

--- a/src/software/world/game_state.cpp
+++ b/src/software/world/game_state.cpp
@@ -264,7 +264,7 @@ void GameState::updateBall(const Ball& ball)
             // Save the ball play_state_ so we can tell once it moves
             ball_state_ = ball;
         }
-        else if ((ball.position() - ball_state_->position()).length() > 0.03)
+        else if ((ball.position() - ball_state_->position()).length() > 0.05)
         {
             // Once the ball has moved enough, the restart is finished
             setRestartCompleted();


### PR DESCRIPTION



<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

freekick play will try and shoot, pass, or chip only in that order, no longer dribbles.
dribble fsm will no longer slow down before contacting the ball
the isplaying gamestate will now trigger after 5 cm ball change instead of 3

### Testing Done

eagle-eye ai vs ai testing
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
