### PR TITLE
Ballplacement move away when finished

### DIFF
--- a/src/software/ai/hl/stp/tactic/dribble/dribble_fsm.h
+++ b/src/software/ai/hl/stp/tactic/dribble/dribble_fsm.h
@@ -15,6 +15,7 @@ struct DribbleFSM
 {
    public:
     class GetPossessionState;
+    class LoseBallState;
     class DribbleState;
 
     /**
@@ -53,11 +54,14 @@ struct DribbleFSM
     // robot speed at which the robot is done dribbling
     static constexpr double ROBOT_DRIBBLING_DONE_SPEED = 0.2;  // m/s
     // if ball and front of robot are separated by this amount, then we've lost possession
-    static constexpr double LOSE_BALL_POSSESSION_THRESHOLD = 0.01;
+    static constexpr double LOSE_BALL_POSSESSION_THRESHOLD = 0.02;
     // when we think the ball is moving slow enough that we should go directly to it
     static constexpr double BALL_MOVING_SLOW_SPEED_THRESHOLD = 0.3;
     // if we are close to ball don't intercept
     static constexpr auto INTERCEPT_BALL_RADIUS = 0.2;
+    // we move away from the ball at some factor of the LOSE_BALL_POSSESSION_THRESHOLD to lose possession to avoid excessive dribbling
+    static constexpr double MOVE_AWAY_FROM_BALL_FACTOR = 1.3;
+
 
 
     /**
@@ -66,74 +70,17 @@ struct DribbleFSM
      *
      * @param ball_position The ball position
      * @param face_ball_angle The angle to face the ball
+     * @param additional_offset Additional offset from facing the ball
      *
      * @return the point that the robot should be positioned to face the ball and dribble
      * the ball
      */
     static Point robotPositionToFaceBall(const Point &ball_position,
-                                         const Angle &face_ball_angle)
+                                         const Angle &face_ball_angle, double additional_offset)
     {
         return ball_position - Vector::createFromAngle(face_ball_angle)
                                    .normalize(DIST_TO_FRONT_OF_ROBOT_METERS +
-                                              BALL_MAX_RADIUS_METERS - 0.005);
-    }
-
-	/**
-	 * Returns true if the ball is far enough that we can register a new continuous dribble start position.
-	 *
-	 * @param ball_position The ball position
-	 * @param robot The robot
-	 *
-	 * @return true if the ball is sufficiently far enough for us to consider the ball to be considered in
-	 *         a new start position
-	 */
-	static bool isRobotFarFromBall(const Point &ball_position,
-								   const Robot &robot)
-	{
-		double distance_robot_ball = (ball_position - robot.position()).length();
-		return distance_robot_ball >= LOSE_BALL_POSSESSION_THRESHOLD;
-	}
-
-    /**
-     * Calculates the interception point for intercepting balls
-     *
-     * @param robot The robot to do the interception
-     * @param ball The ball to intercept
-     * @field The field to intercept on
-     *
-     * @return the best interception point
-     */
-    // TODO (#1968): Merge this functionality with findBestInterceptForBall in the
-    // evaluation folder
-    static Point findInterceptionPoint(const Robot &robot, const Ball &ball,
-                                       const Field &field)
-    {
-        static constexpr double INTERCEPT_POSITION_SEARCH_INTERVAL = 0.1;
-        if (ball.velocity().length() < BALL_MOVING_SLOW_SPEED_THRESHOLD)
-        {
-            auto face_ball_vector = (ball.position() - robot.position());
-            auto point_in_front_of_ball =
-                robotPositionToFaceBall(ball.position(), face_ball_vector.orientation());
-            return point_in_front_of_ball;
-        }
-        Point intercept_position = ball.position();
-        while (contains(field.fieldLines(), intercept_position))
-        {
-            Duration ball_time_to_position = Duration::fromSeconds(
-                distance(intercept_position, ball.position()) / ball.velocity().length());
-            Duration robot_time_to_pos = getTimeToPositionForRobot(
-                robot.position(), intercept_position,
-                robot.robotConstants().robot_max_speed_m_per_s,
-                robot.robotConstants().robot_max_acceleration_m_per_s_2);
-
-            if (robot_time_to_pos < ball_time_to_position)
-            {
-                break;
-            }
-            intercept_position +=
-                ball.velocity().normalize(INTERCEPT_POSITION_SEARCH_INTERVAL);
-        }
-        return intercept_position;
+                                              BALL_MAX_RADIUS_METERS +additional_offset);
     }
 
     /**
@@ -198,7 +145,7 @@ struct DribbleFSM
         Angle target_orientation = getFinalDribbleOrientation(
             ball.position(), robot.position(), final_dribble_orientation_opt);
         Point target_destination =
-            robotPositionToFaceBall(dribble_destination, target_orientation);
+            robotPositionToFaceBall(dribble_destination, target_orientation, -0.005);
 
         return std::make_tuple(target_destination, target_orientation);
     }
@@ -208,6 +155,7 @@ struct DribbleFSM
         using namespace boost::sml;
 
         const auto get_possession_s = state<GetPossessionState>;
+        const auto lose_ball_s      = state<LoseBallState>;
         const auto dribble_s        = state<DribbleState>;
 
         const auto update_e = event<Update>;
@@ -221,7 +169,6 @@ struct DribbleFSM
          */
         const auto have_possession = [](auto event) {
             return event.common.robot.isNearDribbler(
-                // avoid cases where ball is exactly on the edge fo the robot
                 event.common.world.ball().position());
         };
 
@@ -236,6 +183,21 @@ struct DribbleFSM
             return !event.common.robot.isNearDribbler(
                 // avoid cases where ball is exactly on the edge fo the robot
                 event.common.world.ball().position(), LOSE_BALL_POSSESSION_THRESHOLD);
+        };
+
+        /**
+         * Guard that checks if the the robot should lose possession to avoid excessive dribbling
+         *
+         * @param event DribbleFSM::Update
+         *
+         * @return if the ball possession should be lost
+         */
+        const auto should_lose_ball = [this](auto event) {
+            Point ball_position = event.common.world.ball().position();
+            return (!event.control_params.allow_excessive_dribbling &&
+                    continuous_dribbling_start_point &&
+                    !comparePoints(ball_position, *continuous_dribbling_start_point,
+                                   MAX_CONTINUOUS_DRIBBLING_DISTANCE));
         };
 
         /**
@@ -273,39 +235,44 @@ struct DribbleFSM
          */
         const auto get_possession = [this](auto event) {
             auto ball_position = event.common.world.ball().position();
-			double robot_ball_distance = (ball_position - event.common.robot.position()).length();
             auto face_ball_orientation =
                 (ball_position - event.common.robot.position())
                     .orientation();
 
-            Point intercept_position =
-                findInterceptionPoint(event.common.robot, event.common.world.ball(),
-                                      event.common.world.field());
-			if (isRobotFarFromBall(ball_position, event.common.robot))
-			{
-				continuous_dribbling_start_point = nullptr;
-			}
-			
-			bool is_close_to_ball = robot_ball_distance <= ROBOT_MAX_RADIUS_METERS;
-			if (continuous_dribbling_start_point == nullptr && is_close_to_ball)
-			{
-				continuous_dribbling_start_point = std::make_shared<Point>(ball_position);
-			}
-
             auto speed_mode = MaxAllowedSpeedMode::PHYSICAL_LIMIT;
 
-             if ((event.common.world.ball().position() - event.common.robot.position()).length() <
-                     INTERCEPT_BALL_RADIUS)
-             {
-                // we are near the ball but not behind it, move slower
-                speed_mode = MaxAllowedSpeedMode::STOP_COMMAND;
-                intercept_position = event.common.world.ball().position();
-            }
+            auto intercept_result =
+                findBestInterceptForBall(event.common.world.ball(),
+                                         event.common.world.field(), event.common.robot)
+                    .value_or(
+                        std::make_pair(event.common.world.ball().position(), Duration()));
+            auto intercept_position = intercept_result.first;
 
             event.common.set_intent(std::make_unique<MoveIntent>(
                 event.common.robot.id(), intercept_position, face_ball_orientation, 0,
                 DribblerMode::MAX_FORCE, BallCollisionType::ALLOW,
                 AutoChipOrKick{AutoChipOrKickMode::OFF, 0}, speed_mode, 0.0,
+                event.common.robot.robotConstants()));
+        };
+
+        /**
+         * Action to lose possession of the ball
+         *
+         * @param event DribbleFSM::Update
+         */
+        const auto lose_ball = [this](auto event) {
+            Point ball_position = event.common.world.ball().position();
+            auto face_ball_orientation =
+                (ball_position - event.common.robot.position()).orientation();
+            Point away_from_ball_position =
+                robotPositionToFaceBall(ball_position, face_ball_orientation,
+                                        LOSE_BALL_POSSESSION_THRESHOLD * 1.5);
+
+            event.common.set_intent(std::make_unique<MoveIntent>(
+                event.common.robot.id(), away_from_ball_position, face_ball_orientation,
+                0, DribblerMode::OFF, BallCollisionType::AVOID,
+                AutoChipOrKick{AutoChipOrKickMode::OFF, 0},
+                MaxAllowedSpeedMode::PHYSICAL_LIMIT, 0.0,
                 event.common.robot.robotConstants()));
         };
 
@@ -324,24 +291,8 @@ struct DribbleFSM
                     event.common.world.ball(), event.common.robot,
                     event.control_params.dribble_destination,
                     event.control_params.final_dribble_orientation);
-            AutoChipOrKick auto_chip_or_kick = AutoChipOrKick{AutoChipOrKickMode::OFF, 0};
 
-            if (!event.control_params.allow_excessive_dribbling &&
-                !comparePoints(ball_position, *continuous_dribbling_start_point,
-                               MAX_CONTINUOUS_DRIBBLING_DISTANCE))
-            {
-                auto kick_speed = DRIBBLE_KICK_SPEED;
-                if (acuteAngle(event.common.robot.velocity(),
-                               ball_position - event.common.robot.position()) <
-                    Angle::quarter())
-                {
-                    kick_speed *= 2;
-                }
-                // give the ball a little kick
-                auto_chip_or_kick =
-                    AutoChipOrKick{AutoChipOrKickMode::AUTOKICK, kick_speed};
-            }
-
+            // T Defense
             for (const auto &enemy_robot : event.common.world.enemyTeam().getAllRobots())
             {
                 if (enemy_robot.isNearDribbler(ball_position, 0.005))
@@ -357,7 +308,8 @@ struct DribbleFSM
 
             event.common.set_intent(std::make_unique<MoveIntent>(
                 event.common.robot.id(), target_destination, target_orientation, 0,
-                DribblerMode::MAX_FORCE, BallCollisionType::ALLOW, auto_chip_or_kick,
+                DribblerMode::MAX_FORCE, BallCollisionType::ALLOW,
+                AutoChipOrKick{AutoChipOrKickMode::OFF, 0},
                 MaxAllowedSpeedMode::PHYSICAL_LIMIT, 0.0,
                 event.common.robot.robotConstants()));
         };
@@ -368,11 +320,9 @@ struct DribbleFSM
          * @param event DribbleFSM::Update
          */
         const auto start_dribble = [this, dribble](auto event) {
-			if (continuous_dribbling_start_point == nullptr)
-			{
-				// update continuous_dribbling_start_point once we start dribbling
-				continuous_dribbling_start_point = std::make_shared<Point>(event.common.world.ball().position());
-			}
+            // update continuous_dribbling_start_point once we start dribbling
+            continuous_dribbling_start_point =
+                std::make_shared<Point>(event.common.world.ball().position());
             dribble(event);
         };
 
@@ -381,9 +331,12 @@ struct DribbleFSM
             *get_possession_s + update_e[have_possession] / start_dribble = dribble_s,
             get_possession_s + update_e[!have_possession] / get_possession,
             dribble_s + update_e[lost_possession] / get_possession = get_possession_s,
+            dribble_s + update_e[should_lose_ball] / lose_ball     = lose_ball_s,
             dribble_s + update_e[!dribbling_done] / dribble,
-            dribble_s + update_e[dribbling_done] / dribble  = X,
-            X + update_e[!have_possession] / get_possession = get_possession_s,
+            dribble_s + update_e[dribbling_done] / dribble = X,
+            lose_ball_s + update_e[!lost_possession] / lose_ball,
+            lose_ball_s + update_e[lost_possession] / get_possession = get_possession_s,
+            X + update_e[!have_possession] / get_possession          = get_possession_s,
             X + update_e[!dribbling_done] / dribble = dribble_s, X + update_e / dribble);
     }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
we don't move away after we've completed ball placement which makes the ball placement play never terminate. We now move away

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

eagle eya testing!!!
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
