### PR TITLE
Fixed attacker tactic test

### DIFF
--- a/src/software/ai/hl/stp/tactic/attacker/simulated_attacker_tactic_shoot_goal_test.cpp
+++ b/src/software/ai/hl/stp/tactic/attacker/simulated_attacker_tactic_shoot_goal_test.cpp
@@ -69,7 +69,7 @@ INSTANTIATE_TEST_CASE_P(
         // enemy goal blocked by enemy robots with enemy threat left
         std::make_tuple(BallState(Point(2, 1), Vector()), Point(1, 1),
                         TestUtil::createStationaryRobotStatesWithId(
-                            {Point(1.6, 1), Point(3, 0.4), Point(3, 0.8), Point(3.1, 0.6),
+                            {Point(1.5, 1), Point(3, 0.4), Point(3, 0.8), Point(3.1, 0.6),
                              Point(3.1, 1), Point(4.2, 1.2)}),
                         Angle::fromDegrees(210)),
         // small opening in enemy formation


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

Fixed one of the shoot goal tests for attacker tactic so CI can pass now.

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Slightly changed position of one robot, test still tests for the same functionality

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Ran bazel test //software/... 

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
