### PR TITLE
Fix ball placement unit bug

### DIFF
--- a/src/proto/message_translation/ssl_referee.cpp
+++ b/src/proto/message_translation/ssl_referee.cpp
@@ -1,5 +1,7 @@
 #include "proto/message_translation/ssl_referee.h"
 
+#include "shared/constants.h"
+
 // this maps a protobuf SSLProto::Referee_Command enum to its equivalent internal type
 // this map is used when we are on the blue team
 const static std::unordered_map<SSLProto::Referee::Command, RefereeCommand>
@@ -106,8 +108,8 @@ std::optional<Point> getBallPlacementPoint(const SSLProto::Referee &packet)
 {
     if (packet.has_designated_position())
     {
-        return Point(static_cast<double>(packet.designated_position().x()),
-                     static_cast<double>(packet.designated_position().y()));
+        return Point(static_cast<double>(packet.designated_position().x() * METERS_PER_MILLIMETER),
+                     static_cast<double>(packet.designated_position().y() * METERS_PER_MILLIMETER));
     }
     else
     {

--- a/src/proto/message_translation/ssl_referee.cpp
+++ b/src/proto/message_translation/ssl_referee.cpp
@@ -108,8 +108,10 @@ std::optional<Point> getBallPlacementPoint(const SSLProto::Referee &packet)
 {
     if (packet.has_designated_position())
     {
-        return Point(static_cast<double>(packet.designated_position().x() * METERS_PER_MILLIMETER),
-                     static_cast<double>(packet.designated_position().y() * METERS_PER_MILLIMETER));
+        return Point(
+            static_cast<double>(packet.designated_position().x() * METERS_PER_MILLIMETER),
+            static_cast<double>(packet.designated_position().y() *
+                                METERS_PER_MILLIMETER));
     }
     else
     {

--- a/src/proto/message_translation/ssl_referee_test.cpp
+++ b/src/proto/message_translation/ssl_referee_test.cpp
@@ -179,5 +179,5 @@ TEST(BallPlacementPointTest, test_ball_placement_point)
 
     *(ref.mutable_designated_position()) = *ref_point;
 
-    ASSERT_EQ(Point(100, 200), getBallPlacementPoint(ref));
+    ASSERT_EQ(Point(0.1, 0.2), getBallPlacementPoint(ref));
 }

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -624,7 +624,7 @@ TEST_F(SensorFusionTest, ball_placement_friendly_set_by_referee)
 {
     SensorProto sensor_msg;
 
-    // send Point(50, 75) to Referee message
+    // send (0.05, 0.075) to Referee message
     *(sensor_msg.mutable_ssl_referee_msg()) = *referee_ball_placement_yellow;
 
     auto ssl_wrapper_packet =
@@ -636,7 +636,7 @@ TEST_F(SensorFusionTest, ball_placement_friendly_set_by_referee)
     World result = *sensor_fusion.getWorld();
 
     Point returned_point = result.gameState().getBallPlacementPoint().value();
-    EXPECT_EQ(Point(50, 75), returned_point);
+    EXPECT_EQ(Point(0.05, 0.075), returned_point);
 }
 
 TEST_F(SensorFusionTest, ball_placement_enemy_set_by_referee)


### PR DESCRIPTION

## Please fill out the following before requesting review on this PR

### Description
Convert the millimeters into meters, as our codebase is based on meters and we received millimeters from the referee.

### Testing Done
Ran the tests that went along with them and edited the number so it was expecting meters. 

### Resolved Issues

Resolves #2285 

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Understand my logic**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

