### PR TITLE
Penalty friendly is applicale and invariant holds test

### DIFF
--- a/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
@@ -119,7 +119,7 @@ TEST(PenaltyKickInvariantAndIsApplicableTest, test_invariant_and_is_applicable)
     // PenaltyKickPlay: the play under test
     auto penalty_kick_play = PenaltyKickPlay(play_config);
 
-    // Test 1: PREPARE_PENALTY_US to PREPARE_PENALTY_THEM
+    // Test 1
     world.updateGameState(::TestUtil::createGameState(
         RefereeCommand::PREPARE_PENALTY_US, RefereeCommand::PREPARE_PENALTY_US));
 
@@ -127,7 +127,7 @@ TEST(PenaltyKickInvariantAndIsApplicableTest, test_invariant_and_is_applicable)
     ASSERT_TRUE(penalty_kick_play.isApplicable(world));
     ASSERT_TRUE(penalty_kick_play.invariantHolds(world));
 
-    // testing with PREPARE_PENALTY_THEM
+    // Test 2: PREPARE_PENALTY_US to PREPARE_PENALTY_THEM
     world.updateGameState(::TestUtil::createGameState(
         RefereeCommand::PREPARE_PENALTY_THEM, RefereeCommand::PREPARE_PENALTY_US));
 
@@ -135,15 +135,17 @@ TEST(PenaltyKickInvariantAndIsApplicableTest, test_invariant_and_is_applicable)
     ASSERT_FALSE(penalty_kick_play.isApplicable(world));
     ASSERT_FALSE(penalty_kick_play.invariantHolds(world));
 
-    // test 2: NORMAL_START to PREPARE_PENALTY_US
-    world.updateGameState(::TestUtil::createGameState(RefereeCommand::NORMAL_START,
-                                                      RefereeCommand::NORMAL_START));
-
-    ASSERT_FALSE(penalty_kick_play.isApplicable(world));
-    ASSERT_FALSE(penalty_kick_play.invariantHolds(world));
-
+    // Test 3: NORMAL_START to PREPARE_PENALTY_US
     world.updateGameState(::TestUtil::createGameState(RefereeCommand::PREPARE_PENALTY_US,
                                                       RefereeCommand::NORMAL_START));
+
+    // making sure we run PenaltyKickPlay
+    ASSERT_TRUE(penalty_kick_play.isApplicable(world));
+    ASSERT_TRUE(penalty_kick_play.invariantHolds(world));
+
+    // Test 4: HALT to PREPARE_PENALTY_US
+    world.updateGameState(::TestUtil::createGameState(RefereeCommand::PREPARE_PENALTY_US,
+                                                      RefereeCommand::HALT));
 
     // making sure we run PenaltyKickPlay
     ASSERT_TRUE(penalty_kick_play.isApplicable(world));

--- a/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
@@ -126,7 +126,7 @@ TEST(PenaltyKickInvariantAndIsApplicableTest, test_invariant_and_is_applicable)
     // Lets make sure the play will start running and stay running
     ASSERT_TRUE(penalty_kick_play.isApplicable(world));
     ASSERT_TRUE(penalty_kick_play.invariantHolds(world));
-
+    
     world.updateGameState(::TestUtil::createGameState(
         RefereeCommand::NORMAL_START, RefereeCommand::PREPARE_PENALTY_US));
 

--- a/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
@@ -128,7 +128,7 @@ TEST(PenaltyKickInvariantAndIsApplicableTest, test_invariant_and_is_applicable)
     ASSERT_TRUE(penalty_kick_play.invariantHolds(world));
 
     world.updateGameState(::TestUtil::createGameState(
-        RefereeCommand::PREPARE_PENALTY_THEM, RefereeCommand::PREPARE_PENALTY_US));
+        RefereeCommand::NORMAL_START, RefereeCommand::PREPARE_PENALTY_US));
 
     // Making sure we don't run PenaltyKickPlay
     ASSERT_FALSE(penalty_kick_play.isApplicable(world));

--- a/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
@@ -130,7 +130,7 @@ TEST(PenaltyKickInvariantAndIsApplicableTest, test_invariant_and_is_applicable)
     world.updateGameState(::TestUtil::createGameState(
         RefereeCommand::NORMAL_START, RefereeCommand::PREPARE_PENALTY_US));
 
-    // Making sure we don't run PenaltyKickPlay
+    // Making sure we don't run PenaltyKickPlay 
     ASSERT_FALSE(penalty_kick_play.isApplicable(world));
     ASSERT_FALSE(penalty_kick_play.invariantHolds(world));
 }

--- a/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
@@ -121,19 +121,16 @@ TEST(PenaltyKickInvariantAndIsApplicableTest, test_invariant_and_is_applicable)
 
     // GameState: The game state to test with.
     world.updateGameState(::TestUtil::createGameState(
-            RefereeCommand::PREPARE_PENALTY_US, RefereeCommand::PREPARE_PENALTY_US));
+        RefereeCommand::PREPARE_PENALTY_US, RefereeCommand::PREPARE_PENALTY_US));
 
-    // Lets make sure the play will start running and stay running.
+    // Lets make sure the play will start running and stay running
     ASSERT_TRUE(penalty_kick_play.isApplicable(world));
     ASSERT_TRUE(penalty_kick_play.invariantHolds(world));
 
     world.updateGameState(::TestUtil::createGameState(
-            RefereeCommand::PREPARE_PENALTY_THEM, RefereeCommand::PREPARE_PENALTY_US));
+        RefereeCommand::PREPARE_PENALTY_THEM, RefereeCommand::PREPARE_PENALTY_US));
 
     // Making sure we don't run PenaltyKickPlay
     ASSERT_FALSE(penalty_kick_play.isApplicable(world));
     ASSERT_FALSE(penalty_kick_play.invariantHolds(world));
-
 }
-
-

--- a/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
@@ -119,18 +119,33 @@ TEST(PenaltyKickInvariantAndIsApplicableTest, test_invariant_and_is_applicable)
     // PenaltyKickPlay: the play under test
     auto penalty_kick_play = PenaltyKickPlay(play_config);
 
-    // GameState: The game state to test with.
+    // Test 1: PREPARE_PENALTY_US to PREPARE_PENALTY_THEM
     world.updateGameState(::TestUtil::createGameState(
         RefereeCommand::PREPARE_PENALTY_US, RefereeCommand::PREPARE_PENALTY_US));
 
     // Lets make sure the play will start running and stay running
     ASSERT_TRUE(penalty_kick_play.isApplicable(world));
-    ASSERT_TRUE(penalty_kick_play.invariantHolds(world)); 
+    ASSERT_TRUE(penalty_kick_play.invariantHolds(world));
 
+    // testing with PREPARE_PENALTY_THEM
     world.updateGameState(::TestUtil::createGameState(
-        RefereeCommand::NORMAL_START, RefereeCommand::PREPARE_PENALTY_US));
+        RefereeCommand::PREPARE_PENALTY_THEM, RefereeCommand::PREPARE_PENALTY_US));
 
-    // Making sure we don't run PenaltyKickPlay 
+    // Making sure we don't run PenaltyKickPlay
     ASSERT_FALSE(penalty_kick_play.isApplicable(world));
     ASSERT_FALSE(penalty_kick_play.invariantHolds(world));
+
+    // test 2: NORMAL_START to PREPARE_PENALTY_US
+    world.updateGameState(::TestUtil::createGameState(RefereeCommand::NORMAL_START,
+                                                      RefereeCommand::NORMAL_START));
+
+    ASSERT_FALSE(penalty_kick_play.isApplicable(world));
+    ASSERT_FALSE(penalty_kick_play.invariantHolds(world));
+
+    world.updateGameState(::TestUtil::createGameState(RefereeCommand::PREPARE_PENALTY_US,
+                                                      RefereeCommand::NORMAL_START));
+
+    // making sure we run PenaltyKickPlay
+    ASSERT_TRUE(penalty_kick_play.isApplicable(world));
+    ASSERT_TRUE(penalty_kick_play.invariantHolds(world));
 }

--- a/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
@@ -108,3 +108,32 @@ TEST_F(PenaltyKickPlayTest, DISABLED_test_penalty_kick_take)
             terminating_validation_functions, non_terminating_validation_functions,
             Duration::fromSeconds(10));
 }
+
+TEST(PenaltyKickInvariantAndIsApplicableTest, test_invariant_and_is_applicable)
+{
+    auto play_config = std::make_shared<ThunderbotsConfig>()->getPlayConfig();
+
+    // World: A blank testing world we will manipulate for the test
+    auto world = ::TestUtil::createBlankTestingWorld();
+
+    // PenaltyKickPlay: the play under test
+    auto penalty_kick_play = PenaltyKickPlay(play_config);
+
+    // GameState: The game state to test with.
+    world.updateGameState(::TestUtil::createGameState(
+            RefereeCommand::PREPARE_PENALTY_US, RefereeCommand::PREPARE_PENALTY_US));
+
+    // Lets make sure the play will start running and stay running.
+    ASSERT_TRUE(penalty_kick_play.isApplicable(world));
+    ASSERT_TRUE(penalty_kick_play.invariantHolds(world));
+
+    world.updateGameState(::TestUtil::createGameState(
+            RefereeCommand::PREPARE_PENALTY_THEM, RefereeCommand::PREPARE_PENALTY_US));
+
+    // Making sure we don't run PenaltyKickPlay
+    ASSERT_FALSE(penalty_kick_play.isApplicable(world));
+    ASSERT_FALSE(penalty_kick_play.invariantHolds(world));
+
+}
+
+

--- a/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_play_test.cpp
@@ -125,8 +125,8 @@ TEST(PenaltyKickInvariantAndIsApplicableTest, test_invariant_and_is_applicable)
 
     // Lets make sure the play will start running and stay running
     ASSERT_TRUE(penalty_kick_play.isApplicable(world));
-    ASSERT_TRUE(penalty_kick_play.invariantHolds(world));
-    
+    ASSERT_TRUE(penalty_kick_play.invariantHolds(world)); 
+
     world.updateGameState(::TestUtil::createGameState(
         RefereeCommand::NORMAL_START, RefereeCommand::PREPARE_PENALTY_US));
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

Implemented isApplicable and invariantHolds tests for PenaltyKickPlay. 
isApplicable() determines if the play should start running. invariantHolds() determines if the play should continue running. 

### Testing Done

Unit tests

### Resolved Issues

resolved #2254 

### Length Justification

---

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
