### PR TITLE
createBall and createRobot from simBall and simRobot protobuf

### DIFF
--- a/src/proto/message_translation/BUILD
+++ b/src/proto/message_translation/BUILD
@@ -211,3 +211,13 @@ cc_library(
         "//software/world:ball"
     ],
 )
+
+cc_test(
+    name = "er_force_world_test",
+    srcs = ["er_force_world_test.cpp"],
+    deps = [
+        ":er_force_world",
+        "//shared/test_util:tbots_gtest_main",
+        "//software/test_util",
+    ],
+)

--- a/src/proto/message_translation/BUILD
+++ b/src/proto/message_translation/BUILD
@@ -200,3 +200,14 @@ cc_test(
         "//shared/test_util:tbots_gtest_main",
     ],
 )
+
+cc_library(
+    name = "er_force_world",
+    srcs = ["er_force_world.cpp"],
+    hdrs = ["er_force_world.h"],
+    deps = [
+        "//extlibs/er_force_sim/src/protobuf:protobuf_cc_lib", 
+        "//software/world:robot", 
+        "//software/world:ball"
+    ],
+)

--- a/src/proto/message_translation/BUILD
+++ b/src/proto/message_translation/BUILD
@@ -206,9 +206,9 @@ cc_library(
     srcs = ["er_force_world.cpp"],
     hdrs = ["er_force_world.h"],
     deps = [
-        "//extlibs/er_force_sim/src/protobuf:protobuf_cc_lib", 
-        "//software/world:robot", 
-        "//software/world:ball"
+        "//extlibs/er_force_sim/src/protobuf:protobuf_cc_lib",
+        "//software/world:ball",
+        "//software/world:robot",
     ],
 )
 

--- a/src/proto/message_translation/er_force_world.cpp
+++ b/src/proto/message_translation/er_force_world.cpp
@@ -13,7 +13,13 @@ Robot createRobot(world::SimRobot sim_robot, Timestamp timestamp)
     const RobotId id(sim_robot.id());
     const Point position(sim_robot.p_x(), sim_robot.p_y());
     const Vector velocity(sim_robot.v_x(), sim_robot.v_y());
-    double angle = 2 * Angle::acos(sim_robot.rotation().real()).toRadians();
+
+    /* adopted conversion from
+     * https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles */
+    world::Quaternion q = sim_robot.rotation();
+    double siny_cosp    = 2 * (q.real() * q.k() + q.i() * q.j());
+    double cosy_cosp    = 1 - 2 * (q.j() * q.j() + q.k() * q.k());
+    double angle        = Angle::atan(siny_cosp / cosy_cosp).toRadians();
     const RobotState state(position, velocity, Angle::fromRadians(angle),
                            Angle::atan(sim_robot.r_y() / sim_robot.r_x()));
     const Robot robot(id, state, timestamp);

--- a/src/proto/message_translation/er_force_world.cpp
+++ b/src/proto/message_translation/er_force_world.cpp
@@ -19,8 +19,8 @@ Robot createRobot(world::SimRobot sim_robot, Timestamp timestamp)
     world::Quaternion q = sim_robot.rotation();
     double siny_cosp    = 2 * (q.real() * q.k() + q.i() * q.j());
     double cosy_cosp    = 1 - 2 * (q.j() * q.j() + q.k() * q.k());
-    double angle        = Angle::atan(siny_cosp / cosy_cosp).toRadians();
-    const RobotState state(position, velocity, Angle::fromRadians(angle),
+    Angle angle         = Angle::atan(siny_cosp / cosy_cosp);
+    const RobotState state(position, velocity, angle,
                            Angle::atan(sim_robot.r_y() / sim_robot.r_x()));
     const Robot robot(id, state, timestamp);
     return robot;

--- a/src/proto/message_translation/er_force_world.cpp
+++ b/src/proto/message_translation/er_force_world.cpp
@@ -1,0 +1,20 @@
+#include <btBulletinDynamicsCommon.h>
+
+#include "software/world/ball_state.h"
+#include "software/world/robot_state.h"
+#include "software/time/timestamp.h"
+#include "proto/message_translation/er_force_world.h"
+
+Ball createBall(world::SimBall sim_ball){
+    const btVector3 position = sim_ball.position();
+    const btVector3 velocity = sim_ball.speed();
+    return Ball(
+        {position[0], position[1]}, 
+        {velocity[0], velocity[1]}, 
+        TimeStamp::fromSeconds(0)
+    );
+}
+
+Robot createRobot(world::SimRobot sim_robot){
+
+}

--- a/src/proto/message_translation/er_force_world.cpp
+++ b/src/proto/message_translation/er_force_world.cpp
@@ -1,18 +1,21 @@
 #include "proto/message_translation/er_force_world.h"
 
-Ball createBall(world::SimBall sim_ball, Timestamp timestamp){
+Ball createBall(world::SimBall sim_ball, Timestamp timestamp)
+{
     const Point position(sim_ball.p_x(), sim_ball.p_y());
     const Vector velocity(sim_ball.v_x(), sim_ball.v_y());
     const BallState state(position, velocity);
     const Ball ball(state, timestamp);
     return ball;
 }
-Robot createRobot(world::SimRobot sim_robot, Timestamp timestamp){
+Robot createRobot(world::SimRobot sim_robot, Timestamp timestamp)
+{
     const RobotId id(sim_robot.id());
     const Point position(sim_robot.p_x(), sim_robot.p_y());
     const Vector velocity(sim_robot.v_x(), sim_robot.v_y());
     double angle = 2 * Angle::acos(sim_robot.rotation().real()).toRadians();
-    const RobotState state(position, velocity, Angle::fromRadians(angle), Angle::atan(sim_robot.r_y()/sim_robot.r_x()));
+    const RobotState state(position, velocity, Angle::fromRadians(angle),
+                           Angle::atan(sim_robot.r_y() / sim_robot.r_x()));
     const Robot robot(id, state, timestamp);
     return robot;
 }

--- a/src/proto/message_translation/er_force_world.cpp
+++ b/src/proto/message_translation/er_force_world.cpp
@@ -1,24 +1,21 @@
-#include <btBulletinDynamicsCommon.h>
-
-#include "software/time/timestamp.h"
 #include "software/world/robot_state.h"
 #include "software/world/ball_state.h"
 #include "proto/message_translation/er_force_world.h"
-#include "extlibs/er_force_sim/src/protobuf/robot.pb.h"
 
-Ball createBall(world::SimBall sim_ball, TimeStamp timestamp){
+Ball createBall(world::SimBall sim_ball, Timestamp timestamp){
     Point position(sim_ball.p_x(), sim_ball.p_y());
     Vector velocity(sim_ball.v_x(), sim_ball.v_y());
     BallState state(position, velocity);
-    return Ball(state, timestamp);
+    Ball ball(state, timestamp);
+    return ball;
 }
-
-Robot createRobot(world::SimRobot sim_robot, TimeStamp timestamp){
+Robot createRobot(world::SimRobot sim_robot, Timestamp timestamp){
     RobotId id(sim_robot.id());
     Point position(sim_robot.p_x(), sim_robot.p_y());
     Vector velocity(sim_robot.v_x(), sim_robot.v_y());
-    AngularVelocity omega(sim_robot.r_x(), sim_robot.r_y());
-    Angle angle(2 * acos(sim_robot.rotation().real()));
-    RobotState state(position, velocity, angle, omega);
-    return Robot(id, state, timestamp);
+    double angular_velocity = atan(sim_robot.r_y()/sim_robot.r_x());
+    double angle = 2 * acos(sim_robot.rotation().real());
+    RobotState state(position, velocity, Angle::fromRadians(angle), Angle::fromRadians(angular_velocity));
+    Robot robot(id, state, timestamp);
+    return robot;
 }

--- a/src/proto/message_translation/er_force_world.cpp
+++ b/src/proto/message_translation/er_force_world.cpp
@@ -1,20 +1,24 @@
 #include <btBulletinDynamicsCommon.h>
 
-#include "software/world/ball_state.h"
-#include "software/world/robot_state.h"
 #include "software/time/timestamp.h"
+#include "software/world/robot_state.h"
+#include "software/world/ball_state.h"
 #include "proto/message_translation/er_force_world.h"
+#include "extlibs/er_force_sim/src/protobuf/robot.pb.h"
 
-Ball createBall(world::SimBall sim_ball){
-    const btVector3 position = sim_ball.position();
-    const btVector3 velocity = sim_ball.speed();
-    return Ball(
-        {position[0], position[1]}, 
-        {velocity[0], velocity[1]}, 
-        TimeStamp::fromSeconds(0)
-    );
+Ball createBall(world::SimBall sim_ball, TimeStamp timestamp){
+    Point position(sim_ball.p_x(), sim_ball.p_y());
+    Vector velocity(sim_ball.v_x(), sim_ball.v_y());
+    BallState state(position, velocity);
+    return Ball(state, timestamp);
 }
 
-Robot createRobot(world::SimRobot sim_robot){
-
+Robot createRobot(world::SimRobot sim_robot, TimeStamp timestamp){
+    RobotId id(sim_robot.id());
+    Point position(sim_robot.p_x(), sim_robot.p_y());
+    Vector velocity(sim_robot.v_x(), sim_robot.v_y());
+    AngularVelocity omega(sim_robot.r_x(), sim_robot.r_y());
+    Angle angle(2 * acos(sim_robot.rotation().real()));
+    RobotState state(position, velocity, angle, omega);
+    return Robot(id, state, timestamp);
 }

--- a/src/proto/message_translation/er_force_world.cpp
+++ b/src/proto/message_translation/er_force_world.cpp
@@ -1,21 +1,18 @@
-#include "software/world/robot_state.h"
-#include "software/world/ball_state.h"
 #include "proto/message_translation/er_force_world.h"
 
 Ball createBall(world::SimBall sim_ball, Timestamp timestamp){
-    Point position(sim_ball.p_x(), sim_ball.p_y());
-    Vector velocity(sim_ball.v_x(), sim_ball.v_y());
-    BallState state(position, velocity);
-    Ball ball(state, timestamp);
+    const Point position(sim_ball.p_x(), sim_ball.p_y());
+    const Vector velocity(sim_ball.v_x(), sim_ball.v_y());
+    const BallState state(position, velocity);
+    const Ball ball(state, timestamp);
     return ball;
 }
 Robot createRobot(world::SimRobot sim_robot, Timestamp timestamp){
-    RobotId id(sim_robot.id());
-    Point position(sim_robot.p_x(), sim_robot.p_y());
-    Vector velocity(sim_robot.v_x(), sim_robot.v_y());
-    double angular_velocity = atan(sim_robot.r_y()/sim_robot.r_x());
-    double angle = 2 * acos(sim_robot.rotation().real());
-    RobotState state(position, velocity, Angle::fromRadians(angle), Angle::fromRadians(angular_velocity));
-    Robot robot(id, state, timestamp);
+    const RobotId id(sim_robot.id());
+    const Point position(sim_robot.p_x(), sim_robot.p_y());
+    const Vector velocity(sim_robot.v_x(), sim_robot.v_y());
+    double angle = 2 * Angle::acos(sim_robot.rotation().real()).toRadians();
+    const RobotState state(position, velocity, Angle::fromRadians(angle), Angle::atan(sim_robot.r_y()/sim_robot.r_x()));
+    const Robot robot(id, state, timestamp);
     return robot;
 }

--- a/src/proto/message_translation/er_force_world.h
+++ b/src/proto/message_translation/er_force_world.h
@@ -2,8 +2,8 @@
 
 #include "software/world/ball.h"
 #include "software/world/robot.h"
-#include "extlibs/er_force_sim/src/amun/simulator/simball.h"
-#include "extlibs/er_force_sim/src/amun/simulator/simrobot.h"
+#include "software/time/timestamp.h"
+#include "extlibs/er_force_sim/src/protobuf/world.pb.h"
 
 /**
  * convert a er force simulator ball to a ball object
@@ -13,7 +13,7 @@
  * @return the corresponding ball object to the er simulator ball 
  */
 
-Ball createBall(world::SimBall sim_ball);
+Ball createBall(world::SimBall sim_ball, Timestamp timestamp);
 
 /**
  * Convert a er force simulator robot to a robot object
@@ -22,4 +22,4 @@ Ball createBall(world::SimBall sim_ball);
  * 
  * @return the corresponding robot object to the er simulator robot 
  */
-Robot createRobot(world::SimRobot sim_robot);
+Robot createRobot(world::SimRobot sim_robot, Timestamp timestamp);

--- a/src/proto/message_translation/er_force_world.h
+++ b/src/proto/message_translation/er_force_world.h
@@ -4,6 +4,8 @@
 #include "software/world/robot.h"
 #include "software/time/timestamp.h"
 #include "extlibs/er_force_sim/src/protobuf/world.pb.h"
+#include "software/world/ball_state.h"
+#include "software/world/robot_state.h"
 
 /**
  * convert a er force simulator ball to a ball object

--- a/src/proto/message_translation/er_force_world.h
+++ b/src/proto/message_translation/er_force_world.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "software/world/ball.h"
+#include "software/world/robot.h"
+#include "extlibs/er_force_sim/src/amun/simulator/simball.h"
+#include "extlibs/er_force_sim/src/amun/simulator/simrobot.h"
+
+/**
+ * convert a er force simulator ball to a ball object
+ * 
+ * @param sim_ball: the ball information retrieved from the er force simulator
+ * 
+ * @return the corresponding ball object to the er simulator ball 
+ */
+
+Ball createBall(world::SimBall sim_ball);
+
+/**
+ * Convert a er force simulator robot to a robot object
+ * 
+ * @param sim_robot: the robot information retrieved from the er force simulator 
+ * 
+ * @return the corresponding robot object to the er simulator robot 
+ */
+Robot createRobot(world::SimRobot sim_robot);

--- a/src/proto/message_translation/er_force_world.h
+++ b/src/proto/message_translation/er_force_world.h
@@ -1,27 +1,27 @@
 #pragma once
 
-#include "software/world/ball.h"
-#include "software/world/robot.h"
-#include "software/time/timestamp.h"
 #include "extlibs/er_force_sim/src/protobuf/world.pb.h"
+#include "software/time/timestamp.h"
+#include "software/world/ball.h"
 #include "software/world/ball_state.h"
+#include "software/world/robot.h"
 #include "software/world/robot_state.h"
 
 /**
  * convert a er force simulator ball to a ball object
- * 
+ *
  * @param sim_ball: the ball information retrieved from the er force simulator
- * 
- * @return the corresponding ball object to the er simulator ball 
+ *
+ * @return the corresponding ball object to the er simulator ball
  */
 
 Ball createBall(world::SimBall sim_ball, Timestamp timestamp);
 
 /**
  * Convert a er force simulator robot to a robot object
- * 
- * @param sim_robot: the robot information retrieved from the er force simulator 
- * 
- * @return the corresponding robot object to the er simulator robot 
+ *
+ * @param sim_robot: the robot information retrieved from the er force simulator
+ *
+ * @return the corresponding robot object to the er simulator robot
  */
 Robot createRobot(world::SimRobot sim_robot, Timestamp timestamp);

--- a/src/proto/message_translation/er_force_world.h
+++ b/src/proto/message_translation/er_force_world.h
@@ -1,16 +1,14 @@
 #pragma once
 
 #include "extlibs/er_force_sim/src/protobuf/world.pb.h"
-#include "software/time/timestamp.h"
 #include "software/world/ball.h"
-#include "software/world/ball_state.h"
 #include "software/world/robot.h"
-#include "software/world/robot_state.h"
 
 /**
  * convert a er force simulator ball to a ball object
  *
  * @param sim_ball: the ball information retrieved from the er force simulator
+ * @param timestamp: the timestamp of the newly created ball
  *
  * @return the corresponding ball object to the er simulator ball
  */
@@ -21,6 +19,7 @@ Ball createBall(world::SimBall sim_ball, Timestamp timestamp);
  * Convert a er force simulator robot to a robot object
  *
  * @param sim_robot: the robot information retrieved from the er force simulator
+ * @param timestamp: the timestamp of the newly created ball
  *
  * @return the corresponding robot object to the er simulator robot
  */

--- a/src/proto/message_translation/er_force_world_test.cpp
+++ b/src/proto/message_translation/er_force_world_test.cpp
@@ -25,9 +25,9 @@ TEST(ErForceWorldTest, test_create_robot)
 {
     auto quater = std::make_unique<world::Quaternion>();
     quater->set_real(1.0);
-    quater->set_i(2.0);
-    quater->set_j(3.0);
-    quater->set_k(4.0);
+    quater->set_i(0.0);
+    quater->set_j(0.0);
+    quater->set_k(0.0);
 
     auto sim_robot = std::make_unique<world::SimRobot>();
     sim_robot->set_id(0);

--- a/src/proto/message_translation/er_force_world_test.cpp
+++ b/src/proto/message_translation/er_force_world_test.cpp
@@ -1,0 +1,46 @@
+#include "proto/message_translation/er_force_world.h"
+#include "software/test_util/test_util.h"
+#include <gtest/gtest.h>
+
+
+TEST(ErForceWorldTest, test_create_ball){
+   auto sim_ball = std::make_unique<world::SimBall>();
+   sim_ball -> set_p_x(1.0);
+   sim_ball -> set_p_y(2.0);
+   sim_ball -> set_p_z(3.0);
+   sim_ball -> set_v_x(4.0);
+   sim_ball -> set_v_y(5.0);
+   sim_ball -> set_v_z(6.0);
+   const Ball test_ball = createBall(*sim_ball, Timestamp::fromSeconds(0));
+   const Point pos(sim_ball -> p_x(), sim_ball -> p_y());
+   const Vector vel(sim_ball -> v_x(), sim_ball-> v_y());
+   BallState expected_state(pos, vel);
+   EXPECT_TRUE(TestUtil::equalWithinTolerance(test_ball.currentState(), expected_state, 1e-6));
+}
+TEST(ErForceWorldTest, test_create_robot){
+   auto quater = std::make_unique<world::Quaternion>();
+   quater -> set_real(1.0);
+   quater -> set_i(2.0);
+   quater -> set_j(3.0);
+   quater -> set_k(4.0);
+
+   auto sim_robot = std::make_unique<world::SimRobot>();
+   sim_robot -> set_id(0);
+   sim_robot -> set_p_x(2.0);
+   sim_robot -> set_p_y(4.0);
+   sim_robot -> set_p_z(6.0);
+   *(sim_robot -> mutable_rotation()) = *quater;
+   sim_robot -> set_v_x(8.0);
+   sim_robot -> set_v_y(10.0);
+   sim_robot -> set_v_z(12.0);
+   sim_robot -> set_r_x(1.0);
+   sim_robot -> set_r_y(1.0);
+   sim_robot -> set_r_z(5.0);
+
+   const Robot test_robot = createRobot(*sim_robot, Timestamp::fromSeconds(0));
+   const Point expected_pos(sim_robot -> p_x(), sim_robot -> p_y());
+   const Vector expected_vel(sim_robot -> v_x(), sim_robot -> v_y());
+   RobotState expected_state(expected_pos, expected_vel, Angle::fromRadians(0), Angle::fromDegrees(45));
+   EXPECT_EQ(0, test_robot.id());
+   EXPECT_TRUE(TestUtil::equalWithinTolerance(test_robot.currentState(), expected_state, 1e-6, Angle::fromDegrees(5)));
+}

--- a/src/proto/message_translation/er_force_world_test.cpp
+++ b/src/proto/message_translation/er_force_world_test.cpp
@@ -1,46 +1,53 @@
 #include "proto/message_translation/er_force_world.h"
-#include "software/test_util/test_util.h"
+
 #include <gtest/gtest.h>
 
+#include "software/test_util/test_util.h"
 
-TEST(ErForceWorldTest, test_create_ball){
-   auto sim_ball = std::make_unique<world::SimBall>();
-   sim_ball -> set_p_x(1.0);
-   sim_ball -> set_p_y(2.0);
-   sim_ball -> set_p_z(3.0);
-   sim_ball -> set_v_x(4.0);
-   sim_ball -> set_v_y(5.0);
-   sim_ball -> set_v_z(6.0);
-   const Ball test_ball = createBall(*sim_ball, Timestamp::fromSeconds(0));
-   const Point pos(sim_ball -> p_x(), sim_ball -> p_y());
-   const Vector vel(sim_ball -> v_x(), sim_ball-> v_y());
-   BallState expected_state(pos, vel);
-   EXPECT_TRUE(TestUtil::equalWithinTolerance(test_ball.currentState(), expected_state, 1e-6));
+
+TEST(ErForceWorldTest, test_create_ball)
+{
+    auto sim_ball = std::make_unique<world::SimBall>();
+    sim_ball->set_p_x(1.0);
+    sim_ball->set_p_y(2.0);
+    sim_ball->set_p_z(3.0);
+    sim_ball->set_v_x(4.0);
+    sim_ball->set_v_y(5.0);
+    sim_ball->set_v_z(6.0);
+    const Ball test_ball = createBall(*sim_ball, Timestamp::fromSeconds(0));
+    const Point pos(sim_ball->p_x(), sim_ball->p_y());
+    const Vector vel(sim_ball->v_x(), sim_ball->v_y());
+    BallState expected_state(pos, vel);
+    EXPECT_TRUE(
+        TestUtil::equalWithinTolerance(test_ball.currentState(), expected_state, 1e-6));
 }
-TEST(ErForceWorldTest, test_create_robot){
-   auto quater = std::make_unique<world::Quaternion>();
-   quater -> set_real(1.0);
-   quater -> set_i(2.0);
-   quater -> set_j(3.0);
-   quater -> set_k(4.0);
+TEST(ErForceWorldTest, test_create_robot)
+{
+    auto quater = std::make_unique<world::Quaternion>();
+    quater->set_real(1.0);
+    quater->set_i(2.0);
+    quater->set_j(3.0);
+    quater->set_k(4.0);
 
-   auto sim_robot = std::make_unique<world::SimRobot>();
-   sim_robot -> set_id(0);
-   sim_robot -> set_p_x(2.0);
-   sim_robot -> set_p_y(4.0);
-   sim_robot -> set_p_z(6.0);
-   *(sim_robot -> mutable_rotation()) = *quater;
-   sim_robot -> set_v_x(8.0);
-   sim_robot -> set_v_y(10.0);
-   sim_robot -> set_v_z(12.0);
-   sim_robot -> set_r_x(1.0);
-   sim_robot -> set_r_y(1.0);
-   sim_robot -> set_r_z(5.0);
+    auto sim_robot = std::make_unique<world::SimRobot>();
+    sim_robot->set_id(0);
+    sim_robot->set_p_x(2.0);
+    sim_robot->set_p_y(4.0);
+    sim_robot->set_p_z(6.0);
+    *(sim_robot->mutable_rotation()) = *quater;
+    sim_robot->set_v_x(8.0);
+    sim_robot->set_v_y(10.0);
+    sim_robot->set_v_z(12.0);
+    sim_robot->set_r_x(1.0);
+    sim_robot->set_r_y(1.0);
+    sim_robot->set_r_z(5.0);
 
-   const Robot test_robot = createRobot(*sim_robot, Timestamp::fromSeconds(0));
-   const Point expected_pos(sim_robot -> p_x(), sim_robot -> p_y());
-   const Vector expected_vel(sim_robot -> v_x(), sim_robot -> v_y());
-   RobotState expected_state(expected_pos, expected_vel, Angle::fromRadians(0), Angle::fromDegrees(45));
-   EXPECT_EQ(0, test_robot.id());
-   EXPECT_TRUE(TestUtil::equalWithinTolerance(test_robot.currentState(), expected_state, 1e-6, Angle::fromDegrees(5)));
+    const Robot test_robot = createRobot(*sim_robot, Timestamp::fromSeconds(0));
+    const Point expected_pos(sim_robot->p_x(), sim_robot->p_y());
+    const Vector expected_vel(sim_robot->v_x(), sim_robot->v_y());
+    RobotState expected_state(expected_pos, expected_vel, Angle::fromRadians(0),
+                              Angle::fromDegrees(45));
+    EXPECT_EQ(0, test_robot.id());
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(test_robot.currentState(), expected_state,
+                                               1e-6, Angle::fromDegrees(5)));
 }

--- a/src/proto/message_translation/er_force_world_test.cpp
+++ b/src/proto/message_translation/er_force_world_test.cpp
@@ -25,9 +25,9 @@ TEST(ErForceWorldTest, test_create_robot)
 {
     auto quater = std::make_unique<world::Quaternion>();
     quater->set_real(1.0);
-    quater->set_i(0.0);
-    quater->set_j(0.0);
-    quater->set_k(0.0);
+    quater->set_i(2.0);
+    quater->set_j(3.0);
+    quater->set_k(4.0);
 
     auto sim_robot = std::make_unique<world::SimRobot>();
     sim_robot->set_id(0);
@@ -45,9 +45,9 @@ TEST(ErForceWorldTest, test_create_robot)
     const Robot test_robot = createRobot(*sim_robot, Timestamp::fromSeconds(0));
     const Point expected_pos(sim_robot->p_x(), sim_robot->p_y());
     const Vector expected_vel(sim_robot->v_x(), sim_robot->v_y());
-    RobotState expected_state(expected_pos, expected_vel, Angle::fromRadians(0),
+    RobotState expected_state(expected_pos, expected_vel, Angle::atan((double)20 / -49),
                               Angle::fromDegrees(45));
     EXPECT_EQ(0, test_robot.id());
     EXPECT_TRUE(TestUtil::equalWithinTolerance(test_robot.currentState(), expected_state,
-                                               1e-6, Angle::fromDegrees(5)));
+                                               1e-6, Angle::fromDegrees(1)));
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Basic Conversion of SimBall and SimRobot

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
resolves #2328 
### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [x] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
