### PR TITLE
End Simulated Test when Non Terminating Validation Functions Fail

### DIFF
--- a/src/software/simulated_tests/non_terminating_validation_functions/robots_avoid_ball_validation.cpp
+++ b/src/software/simulated_tests/non_terminating_validation_functions/robots_avoid_ball_validation.cpp
@@ -7,7 +7,7 @@ void robotsAvoidBall(double min_distance, std::vector<RobotId> excluded_robots,
                      std::shared_ptr<World> world_ptr,
                      ValidationCoroutine::push_type& yield)
 {
-    for (auto robot : world_ptr->friendlyTeam().getAllRobots())
+    for (const auto& robot : world_ptr->friendlyTeam().getAllRobots())
     {
         double current_distance =
             (robot.position() - world_ptr->ball().position()).length() -

--- a/src/software/simulated_tests/simulated_er_force_sim_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_er_force_sim_test_fixture.cpp
@@ -255,7 +255,7 @@ void SimulatedErForceSimTestFixture::runTest(
                 failure_message += fun.currentErrorMessage() + std::string("\n");
             }
         }
-        FAIL() << failure_message;
+        ADD_FAILURE() << failure_message;
     }
 }
 

--- a/src/software/simulated_tests/simulated_er_force_sim_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_er_force_sim_test_fixture.cpp
@@ -233,6 +233,10 @@ void SimulatedErForceSimTestFixture::runTest(
 
         validation_functions_done =
             tickTest(simulation_time_step, ai_time_step, world, simulator);
+        if (::testing::Test::HasFailure())
+        {
+            FAIL();
+        }
     }
     // Output the tick duration results
     double avg_tick_duration = total_tick_duration / tick_count;

--- a/src/software/simulated_tests/simulated_er_force_sim_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_er_force_sim_test_fixture.cpp
@@ -255,7 +255,7 @@ void SimulatedErForceSimTestFixture::runTest(
                 failure_message += fun.currentErrorMessage() + std::string("\n");
             }
         }
-        ADD_FAILURE() << failure_message;
+        FAIL() << failure_message;
     }
 }
 

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -320,7 +320,7 @@ void SimulatedTestFixture::runTest(
                 failure_message += fun.currentErrorMessage() + std::string("\n");
             }
         }
-        FAIL() << failure_message;
+        ADD_FAILURE() << failure_message;
     }
 }
 

--- a/src/software/simulated_tests/simulated_test_fixture.cpp
+++ b/src/software/simulated_tests/simulated_test_fixture.cpp
@@ -282,6 +282,10 @@ void SimulatedTestFixture::runTest(
 
         validation_functions_done = tickTest(simulation_time_step, ai_time_step,
                                              friendly_world, enemy_world, simulator);
+        if (::testing::Test::HasFailure())
+        {
+            FAIL();
+        }
     }
     // Output the tick duration results
     double avg_friendly_tick_duration =
@@ -316,7 +320,7 @@ void SimulatedTestFixture::runTest(
                 failure_message += fun.currentErrorMessage() + std::string("\n");
             }
         }
-        ADD_FAILURE() << failure_message;
+        FAIL() << failure_message;
     }
 }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Currently, when Non Terminating Validation Functions Fail, the test keeps track of it but it continues until timeout before reporting the failure. This PR will cause simulated tests to end immediately
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
manually broke some tests and checked that they ended immediately
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #2003 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
