### PR TITLE
Rename ErForce Vector to avoid same name clash with our own Vector type

### DIFF
--- a/src/extlibs/er_force_sim/src/amun/simulator/simball.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simball.cpp
@@ -142,7 +142,7 @@ void SimBall::begin()
     {
         if (m_move.by_force())
         {
-            Vector pos;
+            ErForceVector pos;
             coordinates::fromVision(m_move, pos);
             // move ball by hand
             btVector3 force(pos.x, pos.y, m_move.z() + BALL_RADIUS);
@@ -156,7 +156,7 @@ void SimBall::begin()
             if (m_move.has_x())
             {
                 // set position
-                Vector cPos;
+                ErForceVector cPos;
                 coordinates::fromVision(m_move, cPos);
                 float height = BALL_RADIUS;
                 if (m_move.has_z())
@@ -170,7 +170,7 @@ void SimBall::begin()
             }
             if (m_move.has_vx())
             {
-                Vector vel;
+                ErForceVector vel;
                 coordinates::fromVisionVelocity(m_move, vel);
                 float vz = 0;
                 if (m_move.has_vz())
@@ -345,8 +345,8 @@ bool SimBall::addDetection(SSLProto::SSL_DetectionBall *ball, btVector3 pos, flo
     // add noise to coordinates
     // to convert from bullet coordinate system to ssl-vision rotate by 90 degree
     // ccw
-    const Vector noise = m_rng->normalVector(stddev);
-    coordinates::toVision(Vector(modX, modY) + noise, *ball);
+    const ErForceVector noise = m_rng->normalVector(stddev);
+    coordinates::toVision(ErForceVector(modX, modY) + noise, *ball);
     return true;
 }
 

--- a/src/extlibs/er_force_sim/src/amun/simulator/simrobot.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simrobot.cpp
@@ -639,7 +639,7 @@ void SimRobot::update(SSLProto::SSL_DetectionRobot *robot, float stddev_p,
     btTransform transform;
     m_motionState->getWorldTransform(transform);
     const btVector3 p    = transform.getOrigin() / SIMULATOR_SCALE + positionOffset;
-    const Vector p_noise = m_rng->normalVector(stddev_p);
+    const ErForceVector p_noise = m_rng->normalVector(stddev_p);
     robot->set_x((p.y() + p_noise.x) * 1000.0f);
     robot->set_y(-(p.x() + p_noise.y) * 1000.0f);
 

--- a/src/extlibs/er_force_sim/src/amun/simulator/simrobot.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simrobot.cpp
@@ -638,7 +638,7 @@ void SimRobot::update(SSLProto::SSL_DetectionRobot *robot, float stddev_p,
     // add noise
     btTransform transform;
     m_motionState->getWorldTransform(transform);
-    const btVector3 p    = transform.getOrigin() / SIMULATOR_SCALE + positionOffset;
+    const btVector3 p = transform.getOrigin() / SIMULATOR_SCALE + positionOffset;
     const ErForceVector p_noise = m_rng->normalVector(stddev_p);
     robot->set_x((p.y() + p_noise.x) * 1000.0f);
     robot->set_y(-(p.x() + p_noise.y) * 1000.0f);

--- a/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
@@ -132,8 +132,8 @@ Simulator::Simulator(const amun::SimulatorSetup &setup)
     for (const auto &camera : setup.camera_setup())
     {
         m_data->reportedCameraSetup.append(camera);
-        Vector visionPosition(camera.derived_camera_world_tx(),
-                              camera.derived_camera_world_ty());
+        ErForceVector visionPosition(camera.derived_camera_world_tx(),
+                                     camera.derived_camera_world_ty());
         btVector3 truePosition;
         coordinates::fromVision(visionPosition, truePosition);
         truePosition.setZ(camera.derived_camera_world_tz() / 1000.0f);
@@ -712,7 +712,7 @@ void Simulator::moveRobot(const sslsim::TeleportRobot &robot)
             }
             else
             {
-                Vector targetPos;
+                ErForceVector targetPos;
                 coordinates::fromVision(robot, targetPos);
                 // TODO: check if the given position is fine
                 createRobot(list, targetPos.x, targetPos.y, robot.id().id(), m_aggregator,

--- a/src/extlibs/er_force_sim/src/core/rng.cpp
+++ b/src/extlibs/er_force_sim/src/core/rng.cpp
@@ -110,7 +110,7 @@ double RNG::uniformPositive()
  * normal distribution \param sigma Standard deviation \param mean Expected
  * value \return A random vector drawn from a normal distribution
  */
-Vector RNG::normalVector(double sigma, double mean)
+ErForceVector RNG::normalVector(double sigma, double mean)
 {
     double u;
     double v;
@@ -127,5 +127,5 @@ Vector RNG::normalVector(double sigma, double mean)
     // Box-Muller transform (polar)
     const double tmp = sigma * std::sqrt(-2.0 * std::log(s) / s);
 
-    return Vector(tmp * u + mean, tmp * v + mean);
+    return ErForceVector(tmp * u + mean, tmp * v + mean);
 }

--- a/src/extlibs/er_force_sim/src/core/rng.h
+++ b/src/extlibs/er_force_sim/src/core/rng.h
@@ -36,9 +36,9 @@ class RNG
     double uniform();
     double uniformPositive();
     float uniformFloat(float min, float max);
-    Vector uniformVector();
+    ErForceVector uniformVector();
     double normal(double sigma, double mean = 0.0);
-    Vector normalVector(double sigma, double mean = 0.0);
+    ErForceVector normalVector(double sigma, double mean = 0.0);
 
    private:
     uint32_t m_s1;
@@ -66,9 +66,9 @@ inline float RNG::uniformFloat(float min, float max)
  * \sa uniform
  * \return A random vector drawn from a uniform distribution
  */
-inline Vector RNG::uniformVector()
+inline ErForceVector RNG::uniformVector()
 {
-    return Vector(uniform(), uniform());
+    return ErForceVector(uniform(), uniform());
 }
 
 /*!

--- a/src/extlibs/er_force_sim/src/core/vector.h
+++ b/src/extlibs/er_force_sim/src/core/vector.h
@@ -28,7 +28,7 @@
  * \ingroup path
  * \brief 2-dimensional vector class
  */
-class Vector
+class ErForceVector
 {
    public:
     /*!
@@ -36,14 +36,14 @@ class Vector
      *
      * This constructor does not initialize any members
      */
-    Vector() {}
+    ErForceVector() {}
 
     /*!
      * \brief Initializing constructor
      * \param x x-coordinate of the vector
      * \param y y-coordinate of the vector
      */
-    Vector(float x, float y)
+    ErForceVector(float x, float y)
     {
         d[0] = x;
         d[1] = y;
@@ -52,32 +52,32 @@ class Vector
    public:
     float &operator[](unsigned int index);
     float operator[](unsigned int index) const;
-    Vector operator+(const Vector &rho) const;
-    Vector operator-(const Vector &rho) const;
-    Vector operator*(float scalar) const;
-    Vector operator/(float scalar) const;
-    Vector &operator*=(float scalar);
-    Vector &operator+=(const Vector &other);
-    float operator*(const Vector &rho) const;
-    bool operator==(const Vector &rho) const;
-    bool operator!=(const Vector &rho) const;
+    ErForceVector operator+(const ErForceVector &rho) const;
+    ErForceVector operator-(const ErForceVector &rho) const;
+    ErForceVector operator*(float scalar) const;
+    ErForceVector operator/(float scalar) const;
+    ErForceVector &operator*=(float scalar);
+    ErForceVector &operator+=(const ErForceVector &other);
+    float operator*(const ErForceVector &rho) const;
+    bool operator==(const ErForceVector &rho) const;
+    bool operator!=(const ErForceVector &rho) const;
 
-    Vector perpendicular() const;
-    Vector normalized() const;
+    ErForceVector perpendicular() const;
+    ErForceVector normalized() const;
     float length() const;
     float lengthSquared() const;
-    float distance(const Vector &rho) const;
-    float distanceSq(const Vector &rho) const
+    float distance(const ErForceVector &rho) const;
+    float distanceSq(const ErForceVector &rho) const
     {
         return (*this - rho).lengthSquared();
     }
 
-    float dot(const Vector &other) const
+    float dot(const ErForceVector &other) const
     {
         return x * other.x + y * other.y;
     }
 
-    static float det(const Vector &a, const Vector &b, const Vector &c)
+    static float det(const ErForceVector &a, const ErForceVector &b, const ErForceVector &c)
     {
         return a.x * b.y + b.x * c.y + c.x * a.y - a.x * c.y - b.x * a.y - c.x * b.y;
     }
@@ -88,7 +88,7 @@ class Vector
         return std::atan2(x, y) + float(2 * M_PI);
     }
 
-    friend std::ostream &operator<<(std::ostream &stream, const Vector v);
+    friend std::ostream &operator<<(std::ostream &stream, const ErForceVector v);
 
    public:
     union
@@ -102,59 +102,59 @@ class Vector
     };
 };
 
-inline float &Vector::operator[](unsigned int index)
+inline float &ErForceVector::operator[](unsigned int index)
 {
     return d[index];
 }
 
-inline float Vector::operator[](unsigned int index) const
+inline float ErForceVector::operator[](unsigned int index) const
 {
     return d[index];
 }
 
-inline Vector Vector::operator+(const Vector &rho) const
+inline ErForceVector ErForceVector::operator+(const ErForceVector &rho) const
 {
-    return Vector(x + rho.x, y + rho.y);
+    return ErForceVector(x + rho.x, y + rho.y);
 }
 
-inline Vector Vector::operator-(const Vector &rho) const
+inline ErForceVector ErForceVector::operator-(const ErForceVector &rho) const
 {
-    return Vector(x - rho.x, y - rho.y);
+    return ErForceVector(x - rho.x, y - rho.y);
 }
 
-inline Vector Vector::operator*(float scalar) const
+inline ErForceVector ErForceVector::operator*(float scalar) const
 {
-    return Vector(x * scalar, y * scalar);
+    return ErForceVector(x * scalar, y * scalar);
 }
 
-inline Vector Vector::operator/(float scalar) const
+inline ErForceVector ErForceVector::operator/(float scalar) const
 {
-    return Vector(x / scalar, y / scalar);
+    return ErForceVector(x / scalar, y / scalar);
 }
 
-inline float Vector::operator*(const Vector &rho) const
+inline float ErForceVector::operator*(const ErForceVector &rho) const
 {
     return x * rho.x + y * rho.y;
 }
 
-inline bool Vector::operator==(const Vector &rho) const
+inline bool ErForceVector::operator==(const ErForceVector &rho) const
 {
     return x == rho.x && y == rho.y;
 }
 
-inline bool Vector::operator!=(const Vector &rho) const
+inline bool ErForceVector::operator!=(const ErForceVector &rho) const
 {
     return x != rho.x || y != rho.y;
 }
 
-inline Vector &Vector::operator+=(const Vector &other)
+inline ErForceVector &ErForceVector::operator+=(const ErForceVector &other)
 {
     x += other.x;
     y += other.y;
     return *this;
 }
 
-inline Vector &Vector::operator*=(float scalar)
+inline ErForceVector &ErForceVector::operator*=(float scalar)
 {
     x *= scalar;
     y *= scalar;
@@ -166,18 +166,18 @@ inline Vector &Vector::operator*=(float scalar)
  * Returns perpendicular which is reached first when rotating clockwise.
  * \return A vector perpendicular to this one
  */
-inline Vector Vector::perpendicular() const
+inline ErForceVector ErForceVector::perpendicular() const
 {
-    return Vector(y, -x);
+    return ErForceVector(y, -x);
 }
 
 /*!
  * \brief Normalize the vector
  * \return A normalized copy of the vector
  */
-inline Vector Vector::normalized() const
+inline ErForceVector ErForceVector::normalized() const
 {
-    Vector v      = *this;
+    ErForceVector v      = *this;
     const float l = length();
     if (l > 0)
     {
@@ -191,7 +191,7 @@ inline Vector Vector::normalized() const
  * \brief Calculate the length of the vector
  * \return The length of the vector
  */
-inline float Vector::length() const
+inline float ErForceVector::length() const
 {
     return std::sqrt(lengthSquared());
 }
@@ -200,7 +200,7 @@ inline float Vector::length() const
  * \brief Calculate the squared length of the vector
  * \return The squared length of the vector
  */
-inline float Vector::lengthSquared() const
+inline float ErForceVector::lengthSquared() const
 {
     return d[0] * d[0] + d[1] * d[1];
 }
@@ -210,14 +210,14 @@ inline float Vector::lengthSquared() const
  * \param rho Another vector
  * \return The distance to the other vector
  */
-inline float Vector::distance(const Vector &rho) const
+inline float ErForceVector::distance(const ErForceVector &rho) const
 {
     return (*this - rho).length();
 }
 
-inline std::ostream &operator<<(std::ostream &stream, const Vector v)
+inline std::ostream &operator<<(std::ostream &stream, const ErForceVector v)
 {
-    stream << "Vector(" << v.x << ", " << v.y << ")";
+    stream << "ErForceVector(" << v.x << ", " << v.y << ")";
     return stream;
 }
 

--- a/src/extlibs/er_force_sim/src/core/vector.h
+++ b/src/extlibs/er_force_sim/src/core/vector.h
@@ -77,7 +77,8 @@ class ErForceVector
         return x * other.x + y * other.y;
     }
 
-    static float det(const ErForceVector &a, const ErForceVector &b, const ErForceVector &c)
+    static float det(const ErForceVector &a, const ErForceVector &b,
+                     const ErForceVector &c)
     {
         return a.x * b.y + b.x * c.y + c.x * a.y - a.x * c.y - b.x * a.y - c.x * b.y;
     }
@@ -177,8 +178,8 @@ inline ErForceVector ErForceVector::perpendicular() const
  */
 inline ErForceVector ErForceVector::normalized() const
 {
-    ErForceVector v      = *this;
-    const float l = length();
+    ErForceVector v = *this;
+    const float l   = length();
     if (l > 0)
     {
         v.x /= l;


### PR DESCRIPTION
### Description
Renamed the `Vector` type used by ErForceSim to avoid it from having the same name as our own `Vector` type.

### Original Bug
When running some ErForce tests (e.g. `SimulatedHRVOTest.test_zig_zag_movement`) we noticed a bug where the robot moves slightly when it is given a `stop` command. After debugging, we noticed that the Vector created [here](https://github.com/UBC-Thunderbots/Software/blob/7f4e18a9237470fe713e93558f12ba61576f0780/src/software/jetson_nano/primitive_executor.cpp#L108) tries to call the default constructor, however, given that both `Vector` types had a default constructor with that name the behaviour was being [undefined](https://stackoverflow.com/questions/10671956/same-class-name-in-different-c-files). As a result, the created `Vector` was not being initialised properly with the expected `(0,0)` values.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Used print statements and observed that the default constructor of our own `Vector` is called now.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Hopefully some failing tests being ported to ErForceSim
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
