### PR TITLE
EnlsvgPathPlanner fix for requesting close points

### DIFF
--- a/src/software/ai/navigator/path_planner/enlsvg_path_planner.cpp
+++ b/src/software/ai/navigator/path_planner/enlsvg_path_planner.cpp
@@ -78,6 +78,12 @@ std::optional<Path> EnlsvgPathPlanner::findPath(const Point &start,
             << "within the navigable area; no path found" << std::endl;
         return std::nullopt;
     }
+    
+    // If the start and end points are very close together and are unblocked, just return a straight line path
+    if ((start != end) && (enlsvg_start == enlsvg_end) && (new_start == new_end))
+    {
+        return Path({start, end});
+    }
 
     EnlsvgPath enlsvgPath =
         enlsvg_algo->computePath(*enlsvg_mem, new_start.value().x, new_start.value().y,

--- a/src/software/ai/navigator/path_planner/enlsvg_path_planner.cpp
+++ b/src/software/ai/navigator/path_planner/enlsvg_path_planner.cpp
@@ -64,10 +64,10 @@ bool EnlsvgPathPlanner::isCoordNavigable(const EnlsvgPoint &ep) const
 std::optional<Path> EnlsvgPathPlanner::findPath(const Point &start,
                                                 const Point &end) const
 {
-    // Find closest unblocked points in case the start and end positions are inside
-    // obstacles
     EnlsvgPoint enlsvg_start = convertPointToEnlsvgPoint(start);
     EnlsvgPoint enlsvg_end   = convertPointToEnlsvgPoint(end);
+    
+    // closest unblocked points to requested start and end
     auto new_start           = findClosestUnblockedEnlsvgPoint(enlsvg_start);
     auto new_end             = findClosestUnblockedEnlsvgPoint(enlsvg_end);
 
@@ -80,7 +80,7 @@ std::optional<Path> EnlsvgPathPlanner::findPath(const Point &start,
     }
     
     // If the start and end points are very close together and are unblocked, just return a straight line path
-    if ((start != end) && (enlsvg_start == enlsvg_end) && (new_start == new_end))
+    if ((start != end) && (enlsvg_start == enlsvg_end) && (new_start == enlsvg_start) && (new_end == enlsvg_end))
     {
         return Path({start, end});
     }

--- a/src/software/ai/navigator/path_planner/enlsvg_path_planner.cpp
+++ b/src/software/ai/navigator/path_planner/enlsvg_path_planner.cpp
@@ -66,10 +66,10 @@ std::optional<Path> EnlsvgPathPlanner::findPath(const Point &start,
 {
     EnlsvgPoint enlsvg_start = convertPointToEnlsvgPoint(start);
     EnlsvgPoint enlsvg_end   = convertPointToEnlsvgPoint(end);
-    
+
     // closest unblocked points to requested start and end
-    auto new_start           = findClosestUnblockedEnlsvgPoint(enlsvg_start);
-    auto new_end             = findClosestUnblockedEnlsvgPoint(enlsvg_end);
+    auto new_start = findClosestUnblockedEnlsvgPoint(enlsvg_start);
+    auto new_end   = findClosestUnblockedEnlsvgPoint(enlsvg_end);
 
     if (new_start == std::nullopt || new_end == std::nullopt)
     {
@@ -78,9 +78,11 @@ std::optional<Path> EnlsvgPathPlanner::findPath(const Point &start,
             << "within the navigable area; no path found" << std::endl;
         return std::nullopt;
     }
-    
-    // If the start and end points are very close together and are unblocked, just return a straight line path
-    if ((start != end) && (enlsvg_start == enlsvg_end) && (new_start == enlsvg_start) && (new_end == enlsvg_end))
+
+    // If the start and end points are very close together and are unblocked, just return
+    // a straight line path
+    if ((start != end) && (enlsvg_start == enlsvg_end) && (new_start == enlsvg_start) &&
+        (new_end == enlsvg_end))
     {
         return Path({start, end});
     }

--- a/src/software/ai/navigator/path_planner/enlsvg_path_planner_test.cpp
+++ b/src/software/ai/navigator/path_planner/enlsvg_path_planner_test.cpp
@@ -755,3 +755,30 @@ TEST_F(TestEnlsvgPathPlanner, test_enlsvg_path_planner_close_start_end)
     EXPECT_EQ(start, path->getStartPoint());
     EXPECT_EQ(dest, path->getEndPoint());
 }
+
+TEST_F(TestEnlsvgPathPlanner, test_enlsvg_path_planner_close_start_end_but_blocked)
+{
+    Field field = Field::createSSLDivisionBField();
+    Point start{4.39, -2.88},dest {4.37, -2.86};
+    std::vector<ObstaclePtr> obstacles = {
+        robot_navigation_obstacle_factory.createFromShape(
+            Rectangle(Point(4.36, -2.85), Point(4.4, -2.89))),
+    };
+    Rectangle navigable_area           = field.fieldBoundary();
+    EnlsvgPathPlanner planner =
+        EnlsvgPathPlanner(navigable_area, obstacles, field.boundaryMargin());
+    auto path = planner.findPath(start, dest);
+    EXPECT_TRUE(path != std::nullopt);
+    std::vector<Point> path_points = path->getKnots();
+
+    EXPECT_EQ(start, path->getStartPoint());
+    EXPECT_LE(0.1, distance(path->getEndPoint(), dest));
+    
+    // Make sure path does not exceed a bounding box;
+    Rectangle bounding_box = Rectangle(Point(4.3, -2.57), Point(4.5, -2.9));
+    TestUtil::checkPathDoesNotExceedBoundingBox(path_points, bounding_box);
+    // Make sure path does not go through any obstacles, except for the first point, which
+    // is in the obstacle blocking the start position
+    TestUtil::checkPathDoesNotIntersectObstacle(
+        {path_points.begin() + 1, path_points.end()}, obstacles);
+}

--- a/src/software/ai/navigator/path_planner/enlsvg_path_planner_test.cpp
+++ b/src/software/ai/navigator/path_planner/enlsvg_path_planner_test.cpp
@@ -739,3 +739,19 @@ TEST_F(TestEnlsvgPathPlanner, test_enlsvg_path_planner_speed_test)
     std::cout << "Took " << duration_ms << "ms to run, average time of " << avg_ms << "ms"
               << std::endl;
 }
+
+TEST_F(TestEnlsvgPathPlanner, test_enlsvg_path_planner_close_start_end)
+{
+    Field field = Field::createSSLDivisionBField();
+    Point start{4.39, -2.88},dest {4.37, -2.86};
+    std::vector<ObstaclePtr> obstacles = {};
+    Rectangle navigable_area           = field.fieldBoundary();
+    EnlsvgPathPlanner planner =
+        EnlsvgPathPlanner(navigable_area, obstacles, field.boundaryMargin());
+    auto path = planner.findPath(start, dest);
+    EXPECT_TRUE(path != std::nullopt);
+    std::vector<Point> path_points = path->getKnots();
+    EXPECT_EQ(2, path_points.size());
+    EXPECT_EQ(start, path->getStartPoint());
+    EXPECT_EQ(dest, path->getEndPoint());
+}

--- a/src/software/ai/navigator/path_planner/enlsvg_path_planner_test.cpp
+++ b/src/software/ai/navigator/path_planner/enlsvg_path_planner_test.cpp
@@ -743,7 +743,7 @@ TEST_F(TestEnlsvgPathPlanner, test_enlsvg_path_planner_speed_test)
 TEST_F(TestEnlsvgPathPlanner, test_enlsvg_path_planner_close_start_end)
 {
     Field field = Field::createSSLDivisionBField();
-    Point start{4.39, -2.88},dest {4.37, -2.86};
+    Point start{4.39, -2.88}, dest{4.37, -2.86};
     std::vector<ObstaclePtr> obstacles = {};
     Rectangle navigable_area           = field.fieldBoundary();
     EnlsvgPathPlanner planner =
@@ -759,12 +759,12 @@ TEST_F(TestEnlsvgPathPlanner, test_enlsvg_path_planner_close_start_end)
 TEST_F(TestEnlsvgPathPlanner, test_enlsvg_path_planner_close_start_end_but_blocked)
 {
     Field field = Field::createSSLDivisionBField();
-    Point start{4.39, -2.88},dest {4.37, -2.86};
+    Point start{4.39, -2.88}, dest{4.37, -2.86};
     std::vector<ObstaclePtr> obstacles = {
         robot_navigation_obstacle_factory.createFromShape(
             Rectangle(Point(4.36, -2.85), Point(4.4, -2.89))),
     };
-    Rectangle navigable_area           = field.fieldBoundary();
+    Rectangle navigable_area = field.fieldBoundary();
     EnlsvgPathPlanner planner =
         EnlsvgPathPlanner(navigable_area, obstacles, field.boundaryMargin());
     auto path = planner.findPath(start, dest);
@@ -773,7 +773,7 @@ TEST_F(TestEnlsvgPathPlanner, test_enlsvg_path_planner_close_start_end_but_block
 
     EXPECT_EQ(start, path->getStartPoint());
     EXPECT_LE(0.1, distance(path->getEndPoint(), dest));
-    
+
     // Make sure path does not exceed a bounding box;
     Rectangle bounding_box = Rectangle(Point(4.3, -2.57), Point(4.5, -2.9));
     TestUtil::checkPathDoesNotExceedBoundingBox(path_points, bounding_box);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
If the start and end points were too close, enlsvg path planner would return a path with only one point instead of a straight line path with the start and end points as expected. This fixes it. 
### Testing Done

- added a test that Jon brought up, existing enlsvg tests pass

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
