### PR TITLE
Thunderscope: Named value plotter performance improvements

### DIFF
--- a/src/software/thunderscope/arbitrary_plot/named_value_plotter.py
+++ b/src/software/thunderscope/arbitrary_plot/named_value_plotter.py
@@ -34,13 +34,16 @@ class NamedValuePlotter(object):
         self.legend.setParentItem(self.win.graphicsItem())
         self.time = time.time()
         self.named_value_buffer = ThreadSafeBuffer(buffer_size, NamedValue)
-        # self.win.disableAutoRange()
+        self.total_time = 0
+        self.times_visualized = 0
+        self.win.disableAutoRange()
 
     def refresh(self):
         """Refreshes NamedValuePlotter and updates data in the respective
         plots.
 
         """
+        self.times_visualized += 1
         start_time = time.time()
 
         # Dump the entire buffer into a deque. This operation is fast because
@@ -85,16 +88,25 @@ class NamedValuePlotter(object):
         print("Plotting time: {}".format(t2 - t1))
 
         t1 = time.time()
+        self.win.setRange(
+            xRange=[
+                time.time() - self.time - TIME_WINDOW_TO_DISPLAY_S,
+                time.time() - self.time,
+            ],
+        )
         # self.win.autoRange()
-        # self.win.setRange(
-        #     xRange=[
-        #         time.time() - self.time - TIME_WINDOW_TO_DISPLAY_S,
-        #         time.time() - self.time,
-        #     ],
-        # )
         t2 = time.time()
         print("Setting range time: {}".format(t2 - t1))
 
         end_time = time.time()
-        print("Refresh time: {}".format(end_time - start_time))
+        self.total_time += end_time - start_time
+        print("Avg Refresh time: {}".format(self.total_time / self.times_visualized))
         print("================")
+
+# 0.045 No disable autorange, and no autorange, and no setrange
+# 0.016    disable autorange, and no autorange, and no setrange
+# 0.020    disable autorange, and no autorange, and    setrange
+# 0.029    disable autorange, and    autorange, and    setrange
+# 0.039 No disable autorange, and no autorange, and    setrange
+
+# Can auto range, it will automatically get updated by new data, but will also show all data instead of a certain window

--- a/src/software/thunderscope/arbitrary_plot/named_value_plotter.py
+++ b/src/software/thunderscope/arbitrary_plot/named_value_plotter.py
@@ -1,23 +1,20 @@
 import random
 import time
 from collections import deque
-import numpy
 
 import pyqtgraph as pg
 from proto.visualization_pb2 import NamedValue
 from pyqtgraph.Qt import QtGui
 
-from software.networking.threaded_unix_listener import ThreadedUnixListener
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
 
-DEQUE_SIZE = 100000
-MIN_Y_RANGE = 0
-MAX_Y_RANGE = 100
+DEQUE_SIZE = 1000
+INITIAL_Y_MIN = 0
+INITIAL_Y_MAX = 100
 TIME_WINDOW_TO_DISPLAY_S = 20
 
 
 class NamedValuePlotter(object):
-
     """ Plot named values in real time with a scrolling plot """
 
     def __init__(self, buffer_size=1000):
@@ -27,6 +24,8 @@ class NamedValuePlotter(object):
 
         """
         self.win = pg.plot()
+        self.win.disableAutoRange()
+        self.win.setYRange(INITIAL_Y_MIN, INITIAL_Y_MAX)
         self.plots = {}
         self.data_x = {}
         self.data_y = {}
@@ -34,9 +33,6 @@ class NamedValuePlotter(object):
         self.legend.setParentItem(self.win.graphicsItem())
         self.time = time.time()
         self.named_value_buffer = ThreadSafeBuffer(buffer_size, NamedValue)
-        self.total_time = 0
-        self.times_visualized = 0
-        self.win.disableAutoRange()
 
     def refresh(self):
         """Refreshes NamedValuePlotter and updates data in the respective
@@ -45,7 +41,6 @@ class NamedValuePlotter(object):
         """
         self.times_visualized += 1
         start_time = time.time()
-
         # Dump the entire buffer into a deque. This operation is fast because
         # its just consuming data from the buffer and appending it to a deque.
         for _ in range(self.named_value_buffer.queue.qsize()):
@@ -66,47 +61,23 @@ class NamedValuePlotter(object):
                 )
 
                 self.plots[named_value.name].setDownsampling(method="peak")
-                self.data_x[named_value.name] = numpy.zeros(DEQUE_SIZE)
-                self.data_y[named_value.name] = numpy.zeros(DEQUE_SIZE)
+                self.data_x[named_value.name] = deque([], DEQUE_SIZE)
+                self.data_y[named_value.name] = deque([], DEQUE_SIZE)
                 self.legend.addItem(self.plots[named_value.name], named_value.name)
 
             # Add incoming data to existing deques of data
-            self.data_x[named_value.name][0:-1] = self.data_x[named_value.name][1:]
-            self.data_x[named_value.name][-1] = (time.time() - self.time)
+            self.data_x[named_value.name].append(time.time() - self.time)
+            self.data_y[named_value.name].append(named_value.value)
 
-            self.data_y[named_value.name][0:-1] = self.data_y[named_value.name][1:]
-            self.data_y[named_value.name][-1] = named_value.value
-
-        t1 = time.time()
         for named_value, plot in self.plots.items():
             # Update the data
             plot.setData(
                 self.data_x[named_value], self.data_y[named_value]
             )
 
-        t2 = time.time()
-        print("Plotting time: {}".format(t2 - t1))
-
-        t1 = time.time()
         self.win.setRange(
             xRange=[
                 time.time() - self.time - TIME_WINDOW_TO_DISPLAY_S,
                 time.time() - self.time,
             ],
         )
-        # self.win.autoRange()
-        t2 = time.time()
-        print("Setting range time: {}".format(t2 - t1))
-
-        end_time = time.time()
-        self.total_time += end_time - start_time
-        print("Avg Refresh time: {}".format(self.total_time / self.times_visualized))
-        print("================")
-
-# 0.045 No disable autorange, and no autorange, and no setrange
-# 0.016    disable autorange, and no autorange, and no setrange
-# 0.020    disable autorange, and no autorange, and    setrange
-# 0.029    disable autorange, and    autorange, and    setrange
-# 0.039 No disable autorange, and no autorange, and    setrange
-
-# Can auto range, it will automatically get updated by new data, but will also show all data instead of a certain window

--- a/src/software/thunderscope/arbitrary_plot/named_value_plotter.py
+++ b/src/software/thunderscope/arbitrary_plot/named_value_plotter.py
@@ -1,6 +1,7 @@
 import random
 import time
 from collections import deque
+import numpy
 
 import pyqtgraph as pg
 from proto.visualization_pb2 import NamedValue
@@ -9,7 +10,7 @@ from pyqtgraph.Qt import QtGui
 from software.networking.threaded_unix_listener import ThreadedUnixListener
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
 
-DEQUE_SIZE = 1000
+DEQUE_SIZE = 100000
 MIN_Y_RANGE = 0
 MAX_Y_RANGE = 100
 TIME_WINDOW_TO_DISPLAY_S = 20
@@ -33,12 +34,14 @@ class NamedValuePlotter(object):
         self.legend.setParentItem(self.win.graphicsItem())
         self.time = time.time()
         self.named_value_buffer = ThreadSafeBuffer(buffer_size, NamedValue)
+        # self.win.disableAutoRange()
 
     def refresh(self):
         """Refreshes NamedValuePlotter and updates data in the respective
         plots.
 
         """
+        start_time = time.time()
 
         # Dump the entire buffer into a deque. This operation is fast because
         # its just consuming data from the buffer and appending it to a deque.
@@ -60,22 +63,38 @@ class NamedValuePlotter(object):
                 )
 
                 self.plots[named_value.name].setDownsampling(method="peak")
-                self.data_x[named_value.name] = deque([], DEQUE_SIZE)
-                self.data_y[named_value.name] = deque([], DEQUE_SIZE)
+                self.data_x[named_value.name] = numpy.zeros(DEQUE_SIZE)
+                self.data_y[named_value.name] = numpy.zeros(DEQUE_SIZE)
                 self.legend.addItem(self.plots[named_value.name], named_value.name)
 
             # Add incoming data to existing deques of data
-            self.data_x[named_value.name].append(time.time() - self.time)
-            self.data_y[named_value.name].append(named_value.value)
+            self.data_x[named_value.name][0:-1] = self.data_x[named_value.name][1:]
+            self.data_x[named_value.name][-1] = (time.time() - self.time)
 
+            self.data_y[named_value.name][0:-1] = self.data_y[named_value.name][1:]
+            self.data_y[named_value.name][-1] = named_value.value
+
+        t1 = time.time()
+        for named_value, plot in self.plots.items():
             # Update the data
-            self.plots[named_value.name].setData(
-                self.data_x[named_value.name], self.data_y[named_value.name]
+            plot.setData(
+                self.data_x[named_value], self.data_y[named_value]
             )
 
-        self.win.setRange(
-            xRange=[
-                time.time() - self.time - TIME_WINDOW_TO_DISPLAY_S,
-                time.time() - self.time,
-            ],
-        )
+        t2 = time.time()
+        print("Plotting time: {}".format(t2 - t1))
+
+        t1 = time.time()
+        # self.win.autoRange()
+        # self.win.setRange(
+        #     xRange=[
+        #         time.time() - self.time - TIME_WINDOW_TO_DISPLAY_S,
+        #         time.time() - self.time,
+        #     ],
+        # )
+        t2 = time.time()
+        print("Setting range time: {}".format(t2 - t1))
+
+        end_time = time.time()
+        print("Refresh time: {}".format(end_time - start_time))
+        print("================")

--- a/src/software/thunderscope/arbitrary_plot/named_value_plotter.py
+++ b/src/software/thunderscope/arbitrary_plot/named_value_plotter.py
@@ -37,10 +37,8 @@ class NamedValuePlotter(object):
     def refresh(self):
         """Refreshes NamedValuePlotter and updates data in the respective
         plots.
-
         """
-        self.times_visualized += 1
-        start_time = time.time()
+
         # Dump the entire buffer into a deque. This operation is fast because
         # its just consuming data from the buffer and appending it to a deque.
         for _ in range(self.named_value_buffer.queue.qsize()):
@@ -71,9 +69,7 @@ class NamedValuePlotter(object):
 
         for named_value, plot in self.plots.items():
             # Update the data
-            plot.setData(
-                self.data_x[named_value], self.data_y[named_value]
-            )
+            plot.setData(self.data_x[named_value], self.data_y[named_value])
 
         self.win.setRange(
             xRange=[


### PR DESCRIPTION
### Description
Thundersccope runs very slowly on my laptop when running AI vs AI, and as the AI runs for a longer time the performance deteriorates. After some testing, it turned out that setting the range of the plot and updating the data per each value in the queue are relatively expensive operations which can result in the queue to grow and freeze Thunderscope on lower performant computers.

Note that the plot will not automatically set the range of the y-axis anymore, though auto-range can be manually triggered by clicking on the "A" icon in the bottom left of the widget:
![image](https://user-images.githubusercontent.com/28585597/166586420-a1ef1e3d-09f1-410b-8d58-08b44b073f06.png)


### Testing Done
Some manual testing done on two computers with Ubuntu 20 and compared the average time it took to run `refresh`.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
