### PR TITLE
HRVO Visualization Protobuf Message

### DIFF
--- a/src/extlibs/hrvo/BUILD
+++ b/src/extlibs/hrvo/BUILD
@@ -49,9 +49,20 @@ cc_library(
         "simulator.h",
     ],
     deps = [
+        "//extlibs/hrvo:velocity_obstacle",
         "//proto:visualization_cc_proto",
         "//proto/primitive:primitive_msg_factory",
         "//software/geom:vector",
         "//software/world",
+    ],
+)
+
+cc_library(
+    name = "velocity_obstacle",
+    hdrs = [
+        "velocity_obstacle.h",
+    ],
+    deps = [
+        "//software/geom:vector",
     ],
 )

--- a/src/extlibs/hrvo/agent.h
+++ b/src/extlibs/hrvo/agent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "extlibs/hrvo/path.h"
+#include "extlibs/hrvo/velocity_obstacle.h"
 #include "software/geom/vector.h"
 
 class HRVOSimulator;
@@ -28,24 +29,6 @@ class Agent
           float maxAccel, AgentPath &path);
 
     virtual ~Agent() = default;
-
-    /**
-     * A hybrid reciprocal velocity obstacle.
-     */
-    class VelocityObstacle
-    {
-       public:
-        VelocityObstacle() = default;
-
-        // The position of the apex of the hybrid reciprocal velocity obstacle.
-        Vector apex_;
-
-        // The direction of the first side of the hybrid reciprocal velocity obstacle.
-        Vector side1_;
-
-        // The direction of the second side of the hybrid reciprocal velocity obstacle.
-        Vector side2_;
-    };
 
     /**
      * Computes the new velocity of this agent.

--- a/src/extlibs/hrvo/hrvo_agent.cpp
+++ b/src/extlibs/hrvo/hrvo_agent.cpp
@@ -39,6 +39,7 @@
 
 #include "kd_tree.h"
 #include "path.h"
+#include "proto/message_translation/tbots_geometry.h"
 #include "software/geom/vector.h"
 
 
@@ -72,7 +73,7 @@ void HRVOAgent::computeNeighbors()
     simulator_->getKdTree()->query(this, new_neighbor_dist);
 }
 
-Agent::VelocityObstacle HRVOAgent::createVelocityObstacle(const Agent &other_agent)
+VelocityObstacle HRVOAgent::createVelocityObstacle(const Agent &other_agent)
 {
     VelocityObstacle velocityObstacle;
     if ((position_ - other_agent.getPosition()).lengthSquared() >
@@ -577,19 +578,12 @@ void HRVOAgent::insertNeighbor(std::size_t agentNo, float &rangeSq)
     }
 }
 
-std::vector<Polygon> HRVOAgent::getVelocityObstaclesAsPolygons() const
+std::vector<TbotsProto::VelocityObstacle> HRVOAgent::getVelocityObstaclesAsProto() const
 {
-    std::vector<Polygon> velocity_obstacles;
-    for (const Agent::VelocityObstacle &vo : velocityObstacles_)
+    std::vector<TbotsProto::VelocityObstacle> velocity_obstacles;
+    for (const VelocityObstacle &vo : velocityObstacles_)
     {
-        std::vector<Point> points;
-        Vector shifted_apex  = position_ + vo.apex_;
-        Vector shifted_side1 = position_ + vo.side1_;
-        Vector shifted_side2 = position_ + vo.side2_;
-        points.emplace_back(Point(shifted_apex.x(), shifted_apex.y()));
-        points.emplace_back(Point(shifted_side1.x(), shifted_side1.y()));
-        points.emplace_back(Point(shifted_side2.x(), shifted_side2.y()));
-        velocity_obstacles.emplace_back(Polygon(points));
+        velocity_obstacles.emplace_back(*createVelocityObstacleProto(vo));
     }
     return velocity_obstacles;
 }

--- a/src/extlibs/hrvo/hrvo_agent.h
+++ b/src/extlibs/hrvo/hrvo_agent.h
@@ -84,7 +84,7 @@ class HRVOAgent : public Agent
      * @return The hybrid reciprocal velocity obstacle which other_agent should see for
      * this Agent
      */
-    Agent::VelocityObstacle createVelocityObstacle(const Agent &other_agent) override;
+    VelocityObstacle createVelocityObstacle(const Agent &other_agent) override;
 
     /**
      * Computes the maxNeighbors nearest neighbors of this agent.
@@ -117,7 +117,7 @@ class HRVOAgent : public Agent
      * which this HRVO Agent currently sees.
      * @return A list of polygons which represent velocity obstacles
      */
-    std::vector<Polygon> getVelocityObstaclesAsPolygons() const;
+    std::vector<TbotsProto::VelocityObstacle> getVelocityObstaclesAsProto() const;
 
     /**
      * Update preferred speed of Agent. The preferred speed represents the speed which we

--- a/src/extlibs/hrvo/linear_velocity_agent.cpp
+++ b/src/extlibs/hrvo/linear_velocity_agent.cpp
@@ -42,8 +42,7 @@ void LinearVelocityAgent::computeNewVelocity()
     }
 }
 
-Agent::VelocityObstacle LinearVelocityAgent::createVelocityObstacle(
-    const Agent &other_agent)
+VelocityObstacle LinearVelocityAgent::createVelocityObstacle(const Agent &other_agent)
 {
     VelocityObstacle velocityObstacle;
     if ((position_ - other_agent.getPosition()).lengthSquared() >

--- a/src/extlibs/hrvo/linear_velocity_agent.h
+++ b/src/extlibs/hrvo/linear_velocity_agent.h
@@ -36,5 +36,5 @@ class LinearVelocityAgent : public Agent
      * @param other_agent The Agent which this velocity obstacle is being generated for
      * @return The velocity obstacle which other_agent should see for this Agent
      */
-    Agent::VelocityObstacle createVelocityObstacle(const Agent &other_agent) override;
+    VelocityObstacle createVelocityObstacle(const Agent &other_agent) override;
 };

--- a/src/extlibs/hrvo/simulator.cpp
+++ b/src/extlibs/hrvo/simulator.cpp
@@ -375,8 +375,6 @@ Vector HRVOSimulator::getRobotVelocity(unsigned int robot_id) const
 
 void HRVOSimulator::visualize(unsigned int robot_id) const
 {
-    // TODO (#2499): Create a new HRVO visualization proto and uncomment/update
-    // LOG(VISUALIZE)
     auto friendly_agent_opt = getFriendlyAgentFromRobotId(robot_id);
     if (!friendly_agent_opt.has_value())
     {
@@ -398,7 +396,7 @@ void HRVOSimulator::visualize(unsigned int robot_id) const
         *(hrvo_visualization.add_robots()) =
             *createCircleProto(Circle(position, agent->getRadius()));
     }
-    // LOG(VISUALIZE) << obstacle_proto;
+    LOG(VISUALIZE) << hrvo_visualization;
 }
 
 std::optional<std::shared_ptr<HRVOAgent>> HRVOSimulator::getFriendlyAgentFromRobotId(

--- a/src/extlibs/hrvo/simulator.cpp
+++ b/src/extlibs/hrvo/simulator.cpp
@@ -377,29 +377,25 @@ void HRVOSimulator::visualize(unsigned int robot_id) const
 {
     // TODO (#2499): Create a new HRVO visualization proto and uncomment/update
     // LOG(VISUALIZE)
-    TbotsProto::Obstacles obstacle_proto;
-
-    // Add velocity obstacles and candidate new velocities to be visualized
     auto friendly_agent_opt = getFriendlyAgentFromRobotId(robot_id);
-    if (friendly_agent_opt.has_value())
+    if (!friendly_agent_opt.has_value())
     {
-        auto friendly_agent = friendly_agent_opt.value();
-        for (auto &obstacle : friendly_agent->getVelocityObstaclesAsPolygons())
-        {
-            *(obstacle_proto.add_polygon()) = *createPolygonProto(obstacle);
-        }
-
-        for (auto &candidate_circle : friendly_agent->getCandidateVelocitiesAsCircles())
-        {
-            *(obstacle_proto.add_circle()) = *createCircleProto(candidate_circle);
-        }
+        LOG(WARNING) << "HRVO friendly agent with robot id " << robot_id
+                     << " can not be visualized." << std::endl;
+        return;
     }
 
-    // Add circles representing agents
+    TbotsProto::HRVOVisualization hrvo_visualization;
+    hrvo_visualization.set_robot_id(robot_id);
+
+    auto vo_protos = friendly_agent_opt.value()->getVelocityObstaclesAsProto();
+    *(hrvo_visualization.mutable_velocity_obstacles()) = {vo_protos.begin(),
+                                                          vo_protos.end()};
+
     for (auto &agent : agents)
     {
         Point position(agent->getPosition());
-        *(obstacle_proto.add_circle()) =
+        *(hrvo_visualization.add_robots()) =
             *createCircleProto(Circle(position, agent->getRadius()));
     }
     // LOG(VISUALIZE) << obstacle_proto;

--- a/src/extlibs/hrvo/velocity_obstacle.h
+++ b/src/extlibs/hrvo/velocity_obstacle.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "software/geom/vector.h"
+
+/**
+ * A hybrid reciprocal velocity obstacle.
+ */
+class VelocityObstacle
+{
+   public:
+    VelocityObstacle() = default;
+
+    // The position of the apex of the hybrid reciprocal velocity obstacle.
+    Vector apex_;
+
+    // The direction of the first side of the hybrid reciprocal velocity obstacle.
+    Vector side1_;
+
+    // The direction of the second side of the hybrid reciprocal velocity obstacle.
+    Vector side2_;
+};

--- a/src/proto/geometry.proto
+++ b/src/proto/geometry.proto
@@ -50,3 +50,10 @@ message Circle
     required Point origin  = 1;
     required double radius = 2;
 }
+
+message VelocityObstacle
+{
+    required Vector apex       = 1;
+    required Vector left_side  = 2;
+    required Vector right_side = 3;
+}

--- a/src/proto/message_translation/BUILD
+++ b/src/proto/message_translation/BUILD
@@ -37,6 +37,7 @@ cc_library(
     hdrs = ["tbots_geometry.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "//extlibs/hrvo:velocity_obstacle",
         "//proto:tbots_cc_proto",
         "//software/geom:angle",
         "//software/geom:angular_velocity",

--- a/src/proto/message_translation/tbots_geometry.cpp
+++ b/src/proto/message_translation/tbots_geometry.cpp
@@ -52,6 +52,16 @@ std::unique_ptr<TbotsProto::Circle> createCircleProto(const Circle& circle)
     return circle_proto;
 }
 
+std::unique_ptr<TbotsProto::VelocityObstacle> createVelocityObstacleProto(
+    const VelocityObstacle& vo)
+{
+    auto vo_proto                     = std::make_unique<TbotsProto::VelocityObstacle>();
+    *(vo_proto->mutable_apex())       = *createVectorProto(vo.apex_);
+    *(vo_proto->mutable_left_side())  = *createVectorProto(vo.side1_);
+    *(vo_proto->mutable_right_side()) = *createVectorProto(vo.side2_);
+    return vo_proto;
+}
+
 Point createPoint(const TbotsProto::Point& point)
 {
     return Point(point.x_meters(), point.y_meters());
@@ -87,4 +97,14 @@ Polygon createPolygon(const TbotsProto::Polygon& polygon)
 Circle createCircle(const TbotsProto::Circle& circle)
 {
     return Circle(createPoint(circle.origin()), circle.radius());
+}
+
+VelocityObstacle createVelocityObstacle(
+    const TbotsProto::VelocityObstacle& velocity_obstacle_msg)
+{
+    VelocityObstacle velocity_obstacle;
+    velocity_obstacle.apex_  = createVector(velocity_obstacle_msg.apex());
+    velocity_obstacle.side1_ = createVector(velocity_obstacle_msg.left_side());
+    velocity_obstacle.side2_ = createVector(velocity_obstacle_msg.right_side());
+    return velocity_obstacle;
 }

--- a/src/proto/message_translation/tbots_geometry.h
+++ b/src/proto/message_translation/tbots_geometry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "extlibs/hrvo/velocity_obstacle.h"
 #include "proto/geometry.pb.h"
 #include "software/geom/angle.h"
 #include "software/geom/angular_velocity.h"
@@ -21,6 +22,8 @@ std::unique_ptr<TbotsProto::AngularVelocity> createAngularVelocityProto(
 std::unique_ptr<TbotsProto::Vector> createVectorProto(const Vector& vector);
 std::unique_ptr<TbotsProto::Polygon> createPolygonProto(const Polygon& polygon);
 std::unique_ptr<TbotsProto::Circle> createCircleProto(const Circle& polygon);
+std::unique_ptr<TbotsProto::VelocityObstacle> createVelocityObstacleProto(
+    const VelocityObstacle& vo);
 
 /**
  * Protobuf msg types to internal geometry types conversions
@@ -36,3 +39,5 @@ AngularVelocity createAngularVelocity(
 Vector createVector(const TbotsProto::Vector& vector);
 Polygon createPolygon(const TbotsProto::Polygon& polygon);
 Circle createCircle(const TbotsProto::Circle& circle);
+VelocityObstacle createVelocityObstacle(
+    const TbotsProto::VelocityObstacle& velocity_obstacle_msg);

--- a/src/proto/message_translation/tbots_geometry_test.cpp
+++ b/src/proto/message_translation/tbots_geometry_test.cpp
@@ -66,3 +66,17 @@ TEST(TbotsProtobufTest, circle_msg_test)
     EXPECT_TRUE(
         google::protobuf::util::MessageDifferencer::Equals(*circle_msg_1, *circle_msg_2));
 }
+
+TEST(TbotsProtobufTest, velocity_obstacle_msg_test)
+{
+    VelocityObstacle velocity_obstacle;
+    velocity_obstacle.apex_      = Vector(3, 3);
+    velocity_obstacle.side1_     = Vector(-1, -2);
+    velocity_obstacle.side2_     = Vector(1, 2);
+    auto velocity_obstacle_msg_1 = createVelocityObstacleProto(velocity_obstacle);
+    auto velocity_obstacle_2     = createVelocityObstacle(*velocity_obstacle_msg_1);
+    auto velocity_obstacle_msg_2 = createVelocityObstacleProto(velocity_obstacle_2);
+
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
+        *velocity_obstacle_msg_1, *velocity_obstacle_msg_2));
+}

--- a/src/proto/visualization.proto
+++ b/src/proto/visualization.proto
@@ -27,3 +27,10 @@ message PassVisualization
 {
     repeated PassWithRating best_passes = 1;
 }
+
+message HRVOVisualization
+{
+    uint32 robot_id                              = 1;
+    repeated VelocityObstacle velocity_obstacles = 2;
+    repeated Circle robots                       = 3;
+}

--- a/src/software/jetson_nano/primitive_executor.cpp
+++ b/src/software/jetson_nano/primitive_executor.cpp
@@ -69,13 +69,9 @@ std::unique_ptr<TbotsProto::DirectControlPrimitive> PrimitiveExecutor::stepPrimi
     const unsigned int robot_id, const Angle& curr_orientation)
 {
     hrvo_simulator_.doStep();
-    // TODO (#2499): Remove if and visualize the HRVO Simulator of all robots
-    if (robot_id == 1)
-    {
-        // All robots should have identical HRVO simulations. To avoid spam, only
-        // the HRVO simulation for robot 0 will be sent to Thunderscope.
-        hrvo_simulator_.visualize(robot_id);
-    }
+
+    // Visualize the HRVO Simulator for the current robot
+    hrvo_simulator_.visualize(robot_id);
 
     switch (current_primitive_.primitive_case())
     {

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -137,6 +137,10 @@ if __name__ == "__main__":
         except OSError:
             pass
 
+        tscope = Thunderscope(
+            layout_path=args.layout,
+            visualization_buffer_size=args.visualization_buffer_size,
+        )
         proto_unix_io = tscope.blue_full_system_proto_unix_io
 
         # Setup LOG(VISUALIZE) handling from full system. We set from_log_visualize
@@ -153,11 +157,6 @@ if __name__ == "__main__":
 
         proto_unix_io.attach_unix_receiver(runtime_dir + "/log", RobotLog)
 
-        tscope = Thunderscope(
-            layout_path=args.layout,
-            load_yellow=load_yellow,
-            visualization_buffer_size=args.visualization_buffer_size,
-        )
         tscope.show()
 
     ###########################################################################


### PR DESCRIPTION

### Description
Added a new protobuf message for HRVO Simulator visualization. Each simulator will send its own state (robot positions and radii as circles, and velocity obstacles of the robot which owns the simulator) to thunderscope for visualization.
This is the first of two PRs working towards #2499 with mostly the C++ and proto part of the visualization.

Also fixes bug with thunderscope when running with `--visualize_cpp_test` flag.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Added a new test for the conversion of velocity obstacle to proto and back.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
