### PR TITLE
HRVO: Remove velocity feedback

### DIFF
--- a/src/extlibs/hrvo/simulator.cpp
+++ b/src/extlibs/hrvo/simulator.cpp
@@ -51,7 +51,6 @@ HRVOSimulator::HRVOSimulator(float time_step, const RobotConstants_t &robot_cons
       robot_constants(robot_constants),
       global_time(0.0f),
       time_step(time_step),
-      last_time_velocity_updated(0.0f),
       reached_goals(false),
       kd_tree(std::make_unique<KdTree>(this)),
       agents(),

--- a/src/extlibs/hrvo/simulator.cpp
+++ b/src/extlibs/hrvo/simulator.cpp
@@ -118,17 +118,6 @@ void HRVOSimulator::updateWorld(const World &world)
             if (hrvo_agent.has_value())
             {
                 hrvo_agent.value()->setPosition(friendly_robot.position().toVector());
-
-                // Only update velocity if time has passed since the last time velocity
-                // was updated. This is to allow SensorFusion to update the actual robot
-                // velocity in World.
-                // TODO (#2531): Remove 4 multiplier and fix goal keeper moving slowly
-                if (global_time - last_time_velocity_updated >= 4 * time_step)
-                {
-                    Vector velocity = friendly_robot.velocity();
-                    hrvo_agent.value()->setVelocity(friendly_robot.velocity());
-                    last_time_velocity_updated = global_time;
-                }
             }
         }
 

--- a/src/extlibs/hrvo/simulator.cpp
+++ b/src/extlibs/hrvo/simulator.cpp
@@ -118,6 +118,8 @@ void HRVOSimulator::updateWorld(const World &world)
             if (hrvo_agent.has_value())
             {
                 hrvo_agent.value()->setPosition(friendly_robot.position().toVector());
+                // We do not use velocity feedback for friendly robots as it results
+                // in the robots not being able to accelerate properly.
             }
         }
 

--- a/src/extlibs/hrvo/simulator.h
+++ b/src/extlibs/hrvo/simulator.h
@@ -287,9 +287,6 @@ class HRVOSimulator
     // The amount of time which the simulator should advance by
     const float time_step;
 
-    // The last time which the velocity of the robot was updated
-    float last_time_velocity_updated;
-
     // True if all agents have reached their destination
     bool reached_goals;
 


### PR DESCRIPTION
### Description
HRVO's `Simulator::updateWorld` method had a bug where it will use velocity feedback from the vision (`World`) for only the first robot in the team (often robot 0), and ignore it for all other robots. From further testing, using velocity feedback from either the World or directly from the ErForce Simulator results in the robots not being able to accelerate properly and often moving slowly or not in the directly of the velocity output of HRVO. Furthermore, not using velocity feedback and solely relying on HRVO's internal velocity estimates resulted in the robot moving fairly accurately in simulation. As a result, all velocity feedback is being removed from HRVO. If we determine that velocity feedback is required from field testing, then we will look into adding proper working velocity feedback back into HRVO.

Given the bug explained above, these changes should only effect the movement of the goalie.

### Testing Done
Existing tests continue to pass
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Related to #2498
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
