### PR TITLE
Fix bug for replaying Robocup 2022 matches in Thunderscope + Styling changes

### DIFF
--- a/src/proto/BUILD
+++ b/src/proto/BUILD
@@ -44,6 +44,7 @@ py_proto_library(
     srcs = [
         "ball.proto",
         "game_state.proto",
+        "estop_state.proto",
         "geometry.proto",
         "parameters.proto",
         "play.proto",

--- a/src/proto/BUILD
+++ b/src/proto/BUILD
@@ -43,8 +43,8 @@ py_proto_library(
     name = "tbots_py_proto",
     srcs = [
         "ball.proto",
-        "game_state.proto",
         "estop_state.proto",
+        "game_state.proto",
         "geometry.proto",
         "parameters.proto",
         "play.proto",

--- a/src/proto/estop_state.proto
+++ b/src/proto/estop_state.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message EstopState
+{
+    bool is_playing = 1;
+}

--- a/src/proto/estop_state.proto
+++ b/src/proto/estop_state.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package TbotsProto;
+
 message EstopState
 {
     bool is_playing = 1;

--- a/src/software/thunderscope/colors.py
+++ b/src/software/thunderscope/colors.py
@@ -11,6 +11,8 @@ class Colors(object):
     SIM_BALL_COLOR = QtGui.QColor(255, 100, 0, 150)
     YELLOW_ROBOT_COLOR = QtGui.QColor(255, 255, 0, 255)
     BLUE_ROBOT_COLOR = QtGui.QColor(0, 75, 255, 255)
+    TRANSPARENT = QtGui.QColor(0, 0, 0, 0)
+    DESIRED_ROBOT_LOCATION_OUTLINE = QtGui.QColor(255, 0, 0, 150)
 
     ROBOT_SPEED_SLOW_COLOR = "black"
     NAVIGATOR_PATH_COLOR = "green"

--- a/src/software/thunderscope/field/field_layer.py
+++ b/src/software/thunderscope/field/field_layer.py
@@ -1,5 +1,8 @@
+import math
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
+from proto.geometry_pb2 import Point, Angle
+from software.py_constants import *
 
 
 class FieldLayer(pg.GraphicsObject):
@@ -33,16 +36,35 @@ class FieldLayer(pg.GraphicsObject):
         # Instead it is bottom left x, bottom left y, width height.
         return QtCore.QRectF(-9000, -6000, 18000, 12000)
 
-    def createCircle(self, x, y, radius):
+    def createCircle(self, origin: Point, radius):
         """Creates a Rectangle that bounds the circle
 
-        :param x: The x position
-        :param y: The y position
-        :param radius: The radius of the circle
+        :param origin: Proto Point representing the origin of the circle
+        :param radius: The radius of the circle in meters
         :returns: bounding rectangle
 
         """
         # TODO (#2398) fix this to be top left coordinates, width, height
+        x_mm = int(MILLIMETERS_PER_METER * origin.x_meters)
+        y_mm = int(MILLIMETERS_PER_METER * origin.y_meters)
+        radius_mm = int(MILLIMETERS_PER_METER * radius)
         return QtCore.QRectF(
-            int(x - radius), int(y - radius), int(radius * 2), int(radius * 2)
+            int(x_mm - radius_mm),
+            int(y_mm - radius_mm),
+            int(radius_mm * 2),
+            int(radius_mm * 2),
+        )
+
+    def drawRobot(self, position: Point, orientation: Angle, painter):
+        """
+        Draw a robot at the given position and orientation
+        :param position: Proto Point representing the position of robot
+        :param orientation: Proto Angle representing the orientation of robot
+        :param painter: The painter object to draw robot with
+        """
+        convert_degree = -16
+        painter.drawChord(
+            self.createCircle(position, ROBOT_MAX_RADIUS_METERS),
+            int((math.degrees(orientation.radians) + 45)) * convert_degree,
+            270 * convert_degree,
         )

--- a/src/software/thunderscope/field/hrvo_layer.py
+++ b/src/software/thunderscope/field/hrvo_layer.py
@@ -94,9 +94,5 @@ class HRVOLayer(FieldLayer):
 
         for robot_circle in velocity_obstacle_msg.robots:
             painter.drawEllipse(
-                self.createCircle(
-                    int(MILLIMETERS_PER_METER * robot_circle.origin.x_meters),
-                    int(MILLIMETERS_PER_METER * robot_circle.origin.y_meters),
-                    int(MILLIMETERS_PER_METER * robot_circle.radius),
-                )
+                self.createCircle(robot_circle.origin, robot_circle.radius)
             )

--- a/src/software/thunderscope/field/obstacle_layer.py
+++ b/src/software/thunderscope/field/obstacle_layer.py
@@ -57,11 +57,9 @@ class ObstacleLayer(FieldLayer):
                     poly = QtGui.QPolygon(polygon_points)
                     painter.drawPolygon(poly)
 
-                for circleobstacle in obstacle.circle:
+                for circle_obstacle in obstacle.circle:
                     painter.drawEllipse(
                         self.createCircle(
-                            int(MILLIMETERS_PER_METER * circleobstacle.origin.x_meters),
-                            int(MILLIMETERS_PER_METER * circleobstacle.origin.y_meters),
-                            int(MILLIMETERS_PER_METER * circleobstacle.radius),
+                            circle_obstacle.origin, circle_obstacle.radius
                         )
                     )

--- a/src/software/thunderscope/field/path_layer.py
+++ b/src/software/thunderscope/field/path_layer.py
@@ -5,7 +5,6 @@ from pyqtgraph.Qt import QtCore, QtGui
 import software.thunderscope.constants as constants
 from software.py_constants import *
 from software.thunderscope.colors import Colors
-from software.networking.threaded_unix_listener import ThreadedUnixListener
 from software.thunderscope.field.field_layer import FieldLayer
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
 
@@ -20,6 +19,21 @@ class PathLayer(FieldLayer):
         """
         FieldLayer.__init__(self)
         self.primitive_set_buffer = ThreadSafeBuffer(buffer_size, PrimitiveSet)
+
+        # Cached painter pens and brush
+        self.path_pen = pg.mkPen(
+            Colors.NAVIGATOR_PATH_COLOR,
+            width=constants.LINE_WIDTH,
+            style=QtCore.Qt.PenStyle.CustomDashLine,
+            dash=[1, 2],
+        )
+        self.desired_position_pen = pg.mkPen(
+            Colors.DESIRED_ROBOT_LOCATION_OUTLINE,
+            width=constants.LINE_WIDTH,
+            style=QtCore.Qt.PenStyle.CustomDashLine,
+            dash=[1, 2],
+        )
+        self.transparent_brush = pg.mkBrush(Colors.TRANSPARENT)
 
     def paint(self, painter, option, widget):
         """Paint this layer
@@ -39,15 +53,16 @@ class PathLayer(FieldLayer):
         ]
 
         requested_destinations = [
-            primitive.move.motion_control.requested_destination
+            (
+                primitive.move.motion_control.requested_destination,
+                primitive.move.final_angle,
+            )
             for primitive in primitive_set
             if primitive.HasField("move")
         ]
 
-        painter.setPen(
-            pg.mkPen(Colors.NAVIGATOR_PATH_COLOR, width=constants.LINE_WIDTH)
-        )
-
+        # Draw lines representing all paths
+        painter.setPen(self.path_pen)
         for path in paths:
             polygon_points = [
                 QtCore.QPoint(
@@ -59,27 +74,8 @@ class PathLayer(FieldLayer):
             poly = QtGui.QPolygon(polygon_points)
             painter.drawPolyline(poly)
 
-        offset_1 = 30
-        offset_2 = 60
-        for dest in requested_destinations:
-            x_mm = int(MILLIMETERS_PER_METER * dest.x_meters)
-            y_mm = int(MILLIMETERS_PER_METER * dest.y_meters)
-            # polygon represents an X to mark the requested destination
-            polygon_points = [
-                QtCore.QPoint(x_mm, y_mm + offset_1),
-                QtCore.QPoint(x_mm + offset_1, y_mm + offset_2),
-                QtCore.QPoint(x_mm + offset_2, y_mm + offset_1),
-                QtCore.QPoint(x_mm + offset_1, y_mm),
-                QtCore.QPoint(x_mm - offset_1, y_mm + offset_2),
-                QtCore.QPoint(x_mm - offset_2, y_mm + offset_1),
-                QtCore.QPoint(x_mm, y_mm - offset_1),
-                QtCore.QPoint(x_mm - offset_1, y_mm - offset_2),
-                QtCore.QPoint(x_mm - offset_2, y_mm - offset_1),
-                QtCore.QPoint(x_mm - offset_1, y_mm),
-                QtCore.QPoint(x_mm + offset_1, y_mm - offset_2),
-                QtCore.QPoint(x_mm + offset_2, y_mm - offset_1),
-            ]
-
-            poly = QtGui.QPolygon(polygon_points)
-            painter.setBrush(pg.mkBrush(Colors.NAVIGATOR_PATH_COLOR))
-            painter.drawPolygon(poly)
+        # Draw outlines of robots representing the desired final position and orientation
+        painter.setBrush(self.transparent_brush)
+        painter.setPen(self.desired_position_pen)
+        for dest, final_angle in requested_destinations:
+            self.drawRobot(dest, final_angle, painter)

--- a/src/software/thunderscope/field/simulator_layer.py
+++ b/src/software/thunderscope/field/simulator_layer.py
@@ -4,6 +4,7 @@ from proto.import_all_protos import *
 from pyqtgraph.Qt import QtCore, QtGui
 from pyqtgraph.Qt.QtCore import Qt
 
+from proto.geometry_pb2 import Point
 from software.thunderscope.colors import Colors
 from software.networking.threaded_unix_listener import ThreadedUnixListener
 from software.py_constants import *
@@ -45,10 +46,7 @@ class SimulatorLayer(FieldLayer):
         painter.setBrush(pg.mkBrush(Colors.SIM_BALL_COLOR))
 
         # Draw the ball from the simulator state
-        painter.drawEllipse(
-            self.createCircle(
-                sim_world_state.ball.p_y * MILLIMETERS_PER_METER,
-                -sim_world_state.ball.p_x * MILLIMETERS_PER_METER,
-                BALL_MAX_RADIUS_MILLIMETERS,
-            )
+        origin = Point(
+            x_meters=sim_world_state.ball.p_y, y_meters=-sim_world_state.ball.p_x
         )
+        painter.drawEllipse(self.createCircle(origin, BALL_MAX_RADIUS_METERS))

--- a/src/software/thunderscope/field/validation_layer.py
+++ b/src/software/thunderscope/field/validation_layer.py
@@ -51,13 +51,7 @@ class ValidationLayer(FieldLayer):
             painter.setPen(pg.mkPen(Colors.VALIDATION_FAILED_COLOR, width=3))
 
         for circle in validation.geometry.circles:
-            painter.drawEllipse(
-                self.createCircle(
-                    int(MILLIMETERS_PER_METER * circle.origin.x_meters),
-                    int(MILLIMETERS_PER_METER * circle.origin.y_meters),
-                    int(MILLIMETERS_PER_METER * circle.radius),
-                )
-            )
+            painter.drawEllipse(self.createCircle(circle.origin, circle.radius))
 
         for polygon in validation.geometry.polygons:
             polygon_points = [

--- a/src/software/thunderscope/field/world_layer.py
+++ b/src/software/thunderscope/field/world_layer.py
@@ -7,6 +7,7 @@ from pyqtgraph.Qt import QtCore, QtGui
 from pyqtgraph.Qt.QtCore import Qt
 from pyqtgraph.Qt.QtWidgets import *
 
+from proto.geometry_pb2 import Point
 from software.py_constants import *
 from software.thunderscope.constants import LINE_WIDTH
 from software.thunderscope.colors import Colors
@@ -330,7 +331,7 @@ class WorldLayer(FieldLayer):
 
         # Draw Centre Circle
         painter.drawEllipse(
-            self.createCircle(0, 0, field.center_circle_radius * MILLIMETERS_PER_METER)
+            self.createCircle(Point(x_meters=0, y_meters=0), field.center_circle_radius)
         )
 
     def draw_team(self, painter, color, team, robot_id_map):
@@ -343,10 +344,9 @@ class WorldLayer(FieldLayer):
         :param robot_id_map: map of robot_id -> text_item for the team being drawn
 
         """
-        convert_degree = -16
-
         for robot in team.team_robots:
 
+            # Draw robot ID
             if robot.id not in robot_id_map:
                 robot_id_font = painter.font()
                 robot_id_font.setPointSize(int(ROBOT_MAX_RADIUS_MILLIMETERS / 4))
@@ -365,20 +365,13 @@ class WorldLayer(FieldLayer):
             )
             robot_id_map[robot.id].setVisible(self.display_robot_id)
 
+            # Draw robot
             painter.setPen(pg.mkPen(color))
             painter.setBrush(pg.mkBrush(color))
-
-            painter.drawChord(
-                self.createCircle(
-                    robot.current_state.global_position.x_meters
-                    * MILLIMETERS_PER_METER,
-                    robot.current_state.global_position.y_meters
-                    * MILLIMETERS_PER_METER,
-                    ROBOT_MAX_RADIUS_MILLIMETERS,
-                ),
-                int((math.degrees(robot.current_state.global_orientation.radians) + 45))
-                * convert_degree,
-                270 * convert_degree,
+            self.drawRobot(
+                robot.current_state.global_position,
+                robot.current_state.global_orientation,
+                painter,
             )
 
     def draw_ball_state(self, painter, ball_state: BallState):
@@ -393,11 +386,7 @@ class WorldLayer(FieldLayer):
         painter.setBrush(pg.mkBrush(Colors.BALL_COLOR))
 
         painter.drawEllipse(
-            self.createCircle(
-                ball_state.global_position.x_meters * MILLIMETERS_PER_METER,
-                ball_state.global_position.y_meters * MILLIMETERS_PER_METER,
-                BALL_MAX_RADIUS_MILLIMETERS,
-            )
+            self.createCircle(ball_state.global_position, BALL_MAX_RADIUS_METERS)
         )
 
         # If the mouse is being dragged on the screen, visualize
@@ -444,11 +433,7 @@ class WorldLayer(FieldLayer):
             ):
                 painter.drawEllipse(
                     self.createCircle(
-                        robot.current_state.global_position.x_meters
-                        * MILLIMETERS_PER_METER,
-                        robot.current_state.global_position.y_meters
-                        * MILLIMETERS_PER_METER,
-                        ROBOT_MAX_RADIUS_MILLIMETERS / 2,
+                        robot.current_state.global_position, ROBOT_MAX_RADIUS_METERS / 2
                     )
                 )
 

--- a/src/software/thunderscope/proto_unix_io.py
+++ b/src/software/thunderscope/proto_unix_io.py
@@ -34,7 +34,7 @@ class ProtoUnixIO:
 
     Sending Protobuf:
 
-    - Clases can also call send_proto to send data to any registered observers
+    - Classes can also call send_proto to send data to any registered observers
 
     Unix IO:
 

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -136,15 +136,10 @@ class ProtoPlayer(object):
         # Convert string to type. eval is an order of magnitude
         # faster than iterating over the protobuf library to find
         # the type from the string.
-        protobuf_class_str = protobuf_type.split(b".")
         try:
-            if len(protobuf_class_str) == 2:
-                # The format of the protobuf type is:
-                # package.proto_class (e.g. TbotsProto.Primitive)
-                proto_class = eval(str(protobuf_class_str[1], encoding="utf-8"))
-            elif len(protobuf_class_str) == 1:
-                # The protobuf type does not follow our TbotsProto convention
-                proto_class = eval(str(protobuf_class_str[0], encoding="utf-8"))
+            # The format of the protobuf type is:
+            # package.proto_class (e.g. TbotsProto.Primitive)
+            proto_class = eval(str(protobuf_type.split(b".")[-1], encoding="utf-8"))
         except NameError:
             raise TypeError(f"Unknown proto type in replay: '{protobuf_type}'")
 

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -131,8 +131,11 @@ class ProtoPlayer(object):
         # faster than iterating over the protobuf library to find
         # the type from the string.
         try:
+            # The format of the protobuf type is:
+            # package.proto_class (e.g. TbotsProto.Primitive)
             proto_class = eval(str(protobuf_type.split(b".")[1], encoding="utf-8"))
         except Exception:
+            # The protobuf type does not follow our convention
             proto_class = eval(str(protobuf_type, encoding="utf-8"))
 
         # Deserialize protobuf

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -130,7 +130,10 @@ class ProtoPlayer(object):
         # Convert string to type. eval is an order of magnitude
         # faster than iterating over the protobuf library to find
         # the type from the string.
-        proto_class = eval(str(protobuf_type.split(b".")[1], encoding="utf-8"))
+        try:
+            proto_class = eval(str(protobuf_type.split(b".")[1], encoding="utf-8"))
+        except Exception:
+            proto_class = eval(str(protobuf_type, encoding="utf-8"))
 
         # Deserialize protobuf
         proto = proto_class.FromString(base64.b64decode(data[len("b") : -len("\n")]))

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -70,6 +70,12 @@ class ProtoPlayer(object):
         # Load up all replay files in the log folder
         replay_files = glob.glob(self.log_folder_path + f"/*.{REPLAY_FILE_EXTENSION}")
 
+        if len(replay_files) == 0:
+            raise ValueError(
+                f'No replay files found in "{self.log_folder_path}", make sure that an absolute path '
+                f"to the folder containing the replay files is provided."
+            )
+
         # Sort the files by their chunk index
         def __sort_replay_chunks(file_path):
             head, tail = os.path.split(file_path)
@@ -130,13 +136,17 @@ class ProtoPlayer(object):
         # Convert string to type. eval is an order of magnitude
         # faster than iterating over the protobuf library to find
         # the type from the string.
+        protobuf_class_str = protobuf_type.split(b".")
         try:
-            # The format of the protobuf type is:
-            # package.proto_class (e.g. TbotsProto.Primitive)
-            proto_class = eval(str(protobuf_type.split(b".")[1], encoding="utf-8"))
-        except Exception:
-            # The protobuf type does not follow our convention
-            proto_class = eval(str(protobuf_type, encoding="utf-8"))
+            if len(protobuf_class_str) == 2:
+                # The format of the protobuf type is:
+                # package.proto_class (e.g. TbotsProto.Primitive)
+                proto_class = eval(str(protobuf_class_str[1], encoding="utf-8"))
+            elif len(protobuf_class_str) == 1:
+                # The protobuf type does not follow our TbotsProto convention
+                proto_class = eval(str(protobuf_class_str[0], encoding="utf-8"))
+        except NameError:
+            raise TypeError(f"Unknown proto type in replay: '{protobuf_type}'")
 
         # Deserialize protobuf
         proto = proto_class.FromString(base64.b64decode(data[len("b") : -len("\n")]))

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -83,6 +83,7 @@ if __name__ == "__main__":
         action="store",
         help="Replay folder for the blue full_system",
         default=None,
+        type=os.path.abspath,
     )
     parser.add_argument(
         "--yellow_log",


### PR DESCRIPTION
### Description
`EStopState` is a protobuf message type which was added in [this](https://github.com/akhilveeraghanta/Software/tree/akhil/robot-diagnostics-2) branch which was used at Robocup 2022. Given that the type does not exist on the Master branch, Thunderscope is unable to replay the Robocup matches. This PR will add just this proto type to unblock people from replaying the matches. 

This PR also draws the final desired robot position and **orientation** in Thunderscope. There are also some minor styling changes. Let me know if you prefer the older stylings, or something different!
New drawings:
![robot_final_dest](https://user-images.githubusercontent.com/28585597/187017482-050ff08c-ea14-4ef8-beb0-99253172d376.jpg)

### Testing Done
Was able to replay our last match against RoboFEI
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
