### PR TITLE
Fix euclidean to wheel conversion bugs

### DIFF
--- a/src/shared/2021_robot_constants.cpp
+++ b/src/shared/2021_robot_constants.cpp
@@ -10,9 +10,8 @@ RobotConstants_t create2021RobotConstants(void)
         .robot_radius_m  = ROBOT_MAX_RADIUS_METERS,
         // TODO (#2112): update this
         .jerk_limit_kg_m_per_s_3 = 40.0f,
-        .front_wheel_angle_deg =
-            34.06f,  // The measured angle is 32 degrees, but it only works at 34
-        .back_wheel_angle_deg = 46.04f,
+        .front_wheel_angle_deg   = 32.06f,
+        .back_wheel_angle_deg    = 46.04f,
         // TODO (#2112): update this
         .front_of_robot_width_meters = 0.11f,
         // TODO (#2112): update this

--- a/src/software/jetson_nano/services/motor.cpp
+++ b/src/software/jetson_nano/services/motor.cpp
@@ -324,25 +324,29 @@ TbotsProto::MotorStatus MotorService::poll(const TbotsProto::MotorControl& motor
                                              back_left_velocity, back_right_velocity};
 
     // Run-away protection
-    if (std::abs(current_wheel_velocities[0] - prev_wheel_velocities[0]) >
+    if (std::abs(current_wheel_velocities[FRONT_RIGHT_WHEEL_SPACE_INDEX] -
+                 prev_wheel_velocities[FRONT_RIGHT_WHEEL_SPACE_INDEX]) >
         RUNAWAY_PROTECTION_THRESHOLD_MPS)
     {
         driver_control_enable_gpio.setValue(GpioState::LOW);
         LOG(FATAL) << "Front right motor runaway";
     }
-    else if (std::abs(current_wheel_velocities[1] - prev_wheel_velocities[1]) >
+    else if (std::abs(current_wheel_velocities[FRONT_LEFT_WHEEL_SPACE_INDEX] -
+                      prev_wheel_velocities[FRONT_LEFT_WHEEL_SPACE_INDEX]) >
              RUNAWAY_PROTECTION_THRESHOLD_MPS)
     {
         driver_control_enable_gpio.setValue(GpioState::LOW);
         LOG(FATAL) << "Front left motor runaway";
     }
-    else if (std::abs(current_wheel_velocities[2] - prev_wheel_velocities[2]) >
+    else if (std::abs(current_wheel_velocities[BACK_LEFT_WHEEL_SPACE_INDEX] -
+                      prev_wheel_velocities[BACK_LEFT_WHEEL_SPACE_INDEX]) >
              RUNAWAY_PROTECTION_THRESHOLD_MPS)
     {
         driver_control_enable_gpio.setValue(GpioState::LOW);
         LOG(FATAL) << "Back left motor runaway";
     }
-    else if (std::abs(current_wheel_velocities[3] - prev_wheel_velocities[3]) >
+    else if (std::abs(current_wheel_velocities[BACK_RIGHT_WHEEL_SPACE_INDEX] -
+                      prev_wheel_velocities[BACK_RIGHT_WHEEL_SPACE_INDEX]) >
              RUNAWAY_PROTECTION_THRESHOLD_MPS)
     {
         driver_control_enable_gpio.setValue(GpioState::LOW);
@@ -407,16 +411,20 @@ TbotsProto::MotorStatus MotorService::poll(const TbotsProto::MotorControl& motor
     // Set target speeds accounting for acceleration
     tmc4671_writeInt(
         FRONT_RIGHT_MOTOR_CHIP_SELECT, TMC4671_PID_VELOCITY_TARGET,
-        static_cast<int>(target_wheel_velocities[0] * ELECTRICAL_RPM_PER_MECHANICAL_MPS));
+        static_cast<int>(target_wheel_velocities[FRONT_RIGHT_WHEEL_SPACE_INDEX] *
+                         ELECTRICAL_RPM_PER_MECHANICAL_MPS));
     tmc4671_writeInt(
         FRONT_LEFT_MOTOR_CHIP_SELECT, TMC4671_PID_VELOCITY_TARGET,
-        static_cast<int>(target_wheel_velocities[1] * ELECTRICAL_RPM_PER_MECHANICAL_MPS));
+        static_cast<int>(target_wheel_velocities[FRONT_LEFT_WHEEL_SPACE_INDEX] *
+                         ELECTRICAL_RPM_PER_MECHANICAL_MPS));
     tmc4671_writeInt(
         BACK_LEFT_MOTOR_CHIP_SELECT, TMC4671_PID_VELOCITY_TARGET,
-        static_cast<int>(target_wheel_velocities[2] * ELECTRICAL_RPM_PER_MECHANICAL_MPS));
+        static_cast<int>(target_wheel_velocities[BACK_LEFT_WHEEL_SPACE_INDEX] *
+                         ELECTRICAL_RPM_PER_MECHANICAL_MPS));
     tmc4671_writeInt(
         BACK_RIGHT_MOTOR_CHIP_SELECT, TMC4671_PID_VELOCITY_TARGET,
-        static_cast<int>(target_wheel_velocities[3] * ELECTRICAL_RPM_PER_MECHANICAL_MPS));
+        static_cast<int>(target_wheel_velocities[BACK_RIGHT_WHEEL_SPACE_INDEX] *
+                         ELECTRICAL_RPM_PER_MECHANICAL_MPS));
 
     if (target_dribbler_rpm > test_ramp_rpm + 1500)
     {

--- a/src/software/physics/euclidean_to_wheel.cpp
+++ b/src/software/physics/euclidean_to_wheel.cpp
@@ -54,7 +54,7 @@ EuclideanToWheel::EuclideanToWheel(const RobotConstants_t &robot_constants)
 
 WheelSpace_t EuclideanToWheel::getWheelVelocity(EuclideanSpace_t euclidean_velocity) const
 {
-    // need to multiply the angular velocity by the wheel radius to
+    // need to multiply the angular velocity by the robot radius to
     // calculate the wheel velocity (robot tangential velocity)
     // ref: http://robocup.mi.fu-berlin.de/buch/omnidrive.pdf pg 8
     euclidean_velocity[2] = euclidean_velocity[2] * robot_radius_m_;

--- a/src/software/physics/euclidean_to_wheel.cpp
+++ b/src/software/physics/euclidean_to_wheel.cpp
@@ -5,52 +5,74 @@
 #include "shared/2021_robot_constants.h"
 
 EuclideanToWheel::EuclideanToWheel(const RobotConstants_t &robot_constants)
+    : robot_radius_m_(robot_constants.robot_radius_m)
 {
-    // import robot constants
-    front_wheel_angle_phi_rad_  = robot_constants.front_wheel_angle_deg * M_PI / 180.;
-    rear_wheel_angle_theta_rad_ = robot_constants.back_wheel_angle_deg * M_PI / 180.;
-    wheel_radius_m_             = robot_constants.wheel_radius_meters;
+    // Phi, the angle between the hemisphere line of the robot and the front wheel axles
+    // [rads]
+    auto p = robot_constants.front_wheel_angle_deg * M_PI / 180.;
+
+    // Theta, the angle between the hemisphere line of the robot and the rear wheel axles
+    // [rads]
+    auto t = robot_constants.back_wheel_angle_deg * M_PI / 180.;
+
+    // Caching repeated calculations
+    auto cos_p = std::cos(p);
+    auto cos_t = std::cos(t);
+    auto sin_p = std::sin(p);
+    auto sin_t = std::sin(t);
 
     // clang-format off
     euclidean_to_wheel_velocity_D_ <<
-        -sin(front_wheel_angle_phi_rad_), cos(front_wheel_angle_phi_rad_), 1,
-        -sin(front_wheel_angle_phi_rad_), -cos(front_wheel_angle_phi_rad_), 1,
-        sin(rear_wheel_angle_theta_rad_), -cos(rear_wheel_angle_theta_rad_), 1,
-        sin(rear_wheel_angle_theta_rad_), cos(rear_wheel_angle_theta_rad_), 1;
+        -sin_p,  cos_p, 1,
+        -sin_p, -cos_p, 1,
+         sin_t, -cos_t, 1,
+         sin_t,  cos_t, 1;
     // clang-format on
 
-    auto i =
-        1 / (2 * sin(front_wheel_angle_phi_rad_) + 2 * sin(rear_wheel_angle_theta_rad_));
-    auto j =
-        cos(rear_wheel_angle_theta_rad_) / (2 * pow(cos(front_wheel_angle_phi_rad_), 2) +
-                                            2 * pow(cos(rear_wheel_angle_theta_rad_), 2));
-    auto k = sin(rear_wheel_angle_theta_rad_) /
-             (2 * sin(front_wheel_angle_phi_rad_) + 2 * sin(rear_wheel_angle_theta_rad_));
+    // Inverse of euclidean to wheel matrix (D) for converting wheel velocity to euclidean
+    // velocity.
+    // NOTE: The pseudoinverse given in the paper
+    // (http://robocup.mi.fu-berlin.de/buch/omnidrive.pdf pg 17) is incorrect. The inverse
+    // was calculated using Wolfram Alpha: https://bit.ly/3A08BJX
+    auto i = 1 / (2 * sin_p + 2 * sin_t);
 
-    //clang-format off
-    wheel_to_euclidean_velocity_D_inverse_ << -i, -i, i, i, j, -j, -(1 - j), (1 - j), k,
-        k, (1 - k), (1 - k);
-    //clang-format on
+    auto j_denom = 2 * cos_p * cos_p + 2 * cos_t * cos_t;
+    auto j1      = cos_p / j_denom;
+    auto j2      = cos_t / j_denom;
+
+    auto k_denom = 2 * sin_p + 2 * sin_t;
+    auto k1      = sin_t / k_denom;
+    auto k2      = sin_p / k_denom;
+
+    // clang-format off
+    wheel_to_euclidean_velocity_D_inverse_ <<
+        -i,  -i,   i,  i,
+        j1, -j1, -j2, j2,
+        k1,  k1,  k2, k2;
+    // clang-format on
 }
 
-WheelSpace_t EuclideanToWheel::getWheelVelocity(EuclideanSpace_t euclidean_velocity)
+WheelSpace_t EuclideanToWheel::getWheelVelocity(EuclideanSpace_t euclidean_velocity) const
 {
-    // need to multiply the angular velocity by the wheel radius
+    // need to multiply the angular velocity by the wheel radius to
+    // calculate the wheel velocity (robot tangential velocity)
     // ref: http://robocup.mi.fu-berlin.de/buch/omnidrive.pdf pg 8
-    euclidean_velocity[2] = euclidean_velocity[2] * wheel_radius_m_;
+    euclidean_velocity[2] = euclidean_velocity[2] * robot_radius_m_;
 
     return euclidean_to_wheel_velocity_D_ * euclidean_velocity;
 }
 
 EuclideanSpace_t EuclideanToWheel::getEuclideanVelocity(
-    const WheelSpace_t &wheel_velocity)
+    const WheelSpace_t &wheel_velocity) const
 {
     EuclideanSpace_t euclidean_velocity =
         wheel_to_euclidean_velocity_D_inverse_ * wheel_velocity;
 
-    // need to divide the angular velocity by the wheel radius
+    // The above multiplication will calculate the tangential robot
+    // velocity. This can be divided by the robot radius to calculate
+    // the angular velocity
     // ref: http://robocup.mi.fu-berlin.de/buch/omnidrive.pdf pg 8
-    euclidean_velocity[2] = euclidean_velocity[2] / wheel_radius_m_;
+    euclidean_velocity[2] = euclidean_velocity[2] / robot_radius_m_;
 
     return euclidean_velocity;
 }

--- a/src/software/physics/euclidean_to_wheel.h
+++ b/src/software/physics/euclidean_to_wheel.h
@@ -41,7 +41,7 @@ class EuclideanToWheel
      * @param euclidean_velocity The Euclidean velocity.
      * @return The equivalent wheel speeds.
      */
-    WheelSpace_t getWheelVelocity(EuclideanSpace_t euclidean_velocity);
+    WheelSpace_t getWheelVelocity(EuclideanSpace_t euclidean_velocity) const;
 
     /**
      * Gets the Euclidean velocity from the wheel velocity.
@@ -49,24 +49,13 @@ class EuclideanToWheel
      * @param wheel_velocity The wheel velocity.
      * @return The equivalent Euclidean velocity.
      */
-    EuclideanSpace_t getEuclideanVelocity(const WheelSpace_t &wheel_velocity);
+    EuclideanSpace_t getEuclideanVelocity(const WheelSpace_t &wheel_velocity) const;
 
    private:
     /**
-     * The angle between the hemisphere line of the robot and the front wheel axles
-     * [rads].
+     * The radius of the robot in meters.
      */
-    double front_wheel_angle_phi_rad_{};
-
-    /**
-     * The angle between the hemisphere line of the robot and the rear wheel axles [rads]
-     */
-    double rear_wheel_angle_theta_rad_{};
-
-    /**
-     * The radius of the wheel in meters.
-     */
-    double wheel_radius_m_{};
+    const double robot_radius_m_{};
 
     /**
      * Euclidean velocity to wheel velocity coupling matrix.

--- a/src/software/physics/euclidean_to_wheel.h
+++ b/src/software/physics/euclidean_to_wheel.h
@@ -23,6 +23,11 @@ typedef Eigen::Vector3d EuclideanSpace_t;
  */
 typedef Eigen::Vector4d WheelSpace_t;
 
+static constexpr int FRONT_RIGHT_WHEEL_SPACE_INDEX = 0;
+static constexpr int FRONT_LEFT_WHEEL_SPACE_INDEX  = 1;
+static constexpr int BACK_LEFT_WHEEL_SPACE_INDEX   = 2;
+static constexpr int BACK_RIGHT_WHEEL_SPACE_INDEX  = 3;
+
 class EuclideanToWheel
 {
    public:

--- a/src/software/physics/euclidean_to_wheel_test.cpp
+++ b/src/software/physics/euclidean_to_wheel_test.cpp
@@ -10,6 +10,8 @@ class EuclideanToWheelTest : public ::testing::Test
     EuclideanToWheelTest() = default;
     EuclideanSpace_t target_euclidean_velocity{};
     WheelSpace_t expected_wheel_speeds{};
+    WheelSpace_t calculated_wheel_speeds{};
+    double robot_radius = create2021RobotConstants().robot_radius_m;
 
     EuclideanToWheel euclidean_to_four_wheel =
         EuclideanToWheel(create2021RobotConstants());
@@ -17,11 +19,136 @@ class EuclideanToWheelTest : public ::testing::Test
 
 TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_zero)
 {
-    // test +/right
     target_euclidean_velocity = {0, 0, 0};
     expected_wheel_speeds     = {0, 0, 0, 0};
 
     EXPECT_TRUE(TestUtil::equalWithinTolerance(
         expected_wheel_speeds,
         euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity), 0.001));
+}
+
+// Note: The tests below assume that counter-clockwise motor rotation is positive
+// velocity, and vise-versa.
+TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_positive_x)
+{
+    // Test +x/right
+    target_euclidean_velocity = {1, 0, 0};
+    calculated_wheel_speeds =
+        euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
+
+    // Front wheels must be - velocity, back wheels must be + velocity.
+    EXPECT_LT(calculated_wheel_speeds[0], 0);
+    EXPECT_LT(calculated_wheel_speeds[1], 0);
+    EXPECT_GT(calculated_wheel_speeds[2], 0);
+    EXPECT_GT(calculated_wheel_speeds[3], 0);
+}
+
+TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_negative_x)
+{
+    // Test -x/left
+    target_euclidean_velocity = {-1, 0, 0};
+    calculated_wheel_speeds =
+        euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
+
+    // Front wheels must be + velocity, back wheels must be - velocity.
+    EXPECT_GT(calculated_wheel_speeds[0], 0);
+    EXPECT_GT(calculated_wheel_speeds[1], 0);
+    EXPECT_LT(calculated_wheel_speeds[2], 0);
+    EXPECT_LT(calculated_wheel_speeds[3], 0);
+}
+
+TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_positive_y)
+{
+    // Test +y/forwards
+    target_euclidean_velocity = {0, 1, 0};
+    calculated_wheel_speeds =
+        euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
+
+    // Right wheels must be + velocity, Left wheels must be - velocity.
+    EXPECT_GT(calculated_wheel_speeds[0], 0);
+    EXPECT_LT(calculated_wheel_speeds[1], 0);
+    EXPECT_LT(calculated_wheel_speeds[2], 0);
+    EXPECT_GT(calculated_wheel_speeds[3], 0);
+
+    // Right wheels must have same velocity magnitude as left wheels, but opposite sign.
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[0], -calculated_wheel_speeds[1]);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[2], -calculated_wheel_speeds[3]);
+}
+
+TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_negative_y)
+{
+    // Test -y/backwards
+    target_euclidean_velocity = {0, -1, 0};
+    calculated_wheel_speeds =
+        euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
+
+    // Right wheels must be + velocity, Left wheels must be - velocity.
+    EXPECT_LT(calculated_wheel_speeds[0], 0);
+    EXPECT_GT(calculated_wheel_speeds[1], 0);
+    EXPECT_GT(calculated_wheel_speeds[2], 0);
+    EXPECT_LT(calculated_wheel_speeds[3], 0);
+
+    // Right wheels must have same velocity magnitude as left wheels, but opposite sign.
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[0], -calculated_wheel_speeds[1]);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[2], -calculated_wheel_speeds[3]);
+}
+
+TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_positive_w)
+{
+    // Test +w/counter-clockwise
+    target_euclidean_velocity = {0, 0, 1};
+    calculated_wheel_speeds =
+        euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
+
+    // Formula for the length of a segment: length = radius * angle
+    // Since angle = 1rad, the length of the segment is equal to the radius.
+    // Therefore, all wheel speeds must be equal to the robot radius.
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[0], robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[1], robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[2], robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[3], robot_radius);
+}
+
+TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_negative_w)
+{
+    // Test -w/clockwise
+    target_euclidean_velocity = {0, 0, -1};
+    calculated_wheel_speeds =
+        euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
+
+    // Formula for the length of a segment: length = radius * angle
+    // Since angle = -1rad, the length of the segment is equal to the -radius.
+    // Therefore, all wheel speeds (=length of segment/sec) must be equal to the robot
+    // radius.
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[0], -robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[1], -robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[2], -robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[3], -robot_radius);
+}
+
+TEST_F(EuclideanToWheelTest, test_conversion_is_linear)
+{
+    target_euclidean_velocity = {3, 1, 5};
+    auto result = euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
+
+    target_euclidean_velocity = {300, 100, 500};
+    auto scaled_result =
+        euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
+
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(result * 100, scaled_result, 0.001));
+}
+
+TEST_F(EuclideanToWheelTest, test_double_convertion)
+{
+    // Converting from euclidean to wheel velocity and back should result in the same
+    // value
+    target_euclidean_velocity = {3, 1, 5};
+
+    auto wheel_velocity =
+        euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
+    auto calculated_euclidean_velocity =
+        euclidean_to_four_wheel.getEuclideanVelocity(wheel_velocity);
+
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(target_euclidean_velocity,
+                                               calculated_euclidean_velocity, 0.001));
 }

--- a/src/software/physics/euclidean_to_wheel_test.cpp
+++ b/src/software/physics/euclidean_to_wheel_test.cpp
@@ -37,10 +37,10 @@ TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_positive_x)
         euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
 
     // Front wheels must be - velocity, back wheels must be + velocity.
-    EXPECT_LT(calculated_wheel_speeds[0], 0);
-    EXPECT_LT(calculated_wheel_speeds[1], 0);
-    EXPECT_GT(calculated_wheel_speeds[2], 0);
-    EXPECT_GT(calculated_wheel_speeds[3], 0);
+    EXPECT_LT(calculated_wheel_speeds[FRONT_RIGHT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_LT(calculated_wheel_speeds[FRONT_LEFT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_GT(calculated_wheel_speeds[BACK_LEFT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_GT(calculated_wheel_speeds[BACK_RIGHT_WHEEL_SPACE_INDEX], 0);
 }
 
 TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_negative_x)
@@ -51,10 +51,10 @@ TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_negative_x)
         euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
 
     // Front wheels must be + velocity, back wheels must be - velocity.
-    EXPECT_GT(calculated_wheel_speeds[0], 0);
-    EXPECT_GT(calculated_wheel_speeds[1], 0);
-    EXPECT_LT(calculated_wheel_speeds[2], 0);
-    EXPECT_LT(calculated_wheel_speeds[3], 0);
+    EXPECT_GT(calculated_wheel_speeds[FRONT_RIGHT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_GT(calculated_wheel_speeds[FRONT_LEFT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_LT(calculated_wheel_speeds[BACK_LEFT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_LT(calculated_wheel_speeds[BACK_RIGHT_WHEEL_SPACE_INDEX], 0);
 }
 
 TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_positive_y)
@@ -65,14 +65,16 @@ TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_positive_y)
         euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
 
     // Right wheels must be + velocity, Left wheels must be - velocity.
-    EXPECT_GT(calculated_wheel_speeds[0], 0);
-    EXPECT_LT(calculated_wheel_speeds[1], 0);
-    EXPECT_LT(calculated_wheel_speeds[2], 0);
-    EXPECT_GT(calculated_wheel_speeds[3], 0);
+    EXPECT_GT(calculated_wheel_speeds[FRONT_RIGHT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_LT(calculated_wheel_speeds[FRONT_LEFT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_LT(calculated_wheel_speeds[BACK_LEFT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_GT(calculated_wheel_speeds[BACK_RIGHT_WHEEL_SPACE_INDEX], 0);
 
     // Right wheels must have same velocity magnitude as left wheels, but opposite sign.
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[0], -calculated_wheel_speeds[1]);
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[2], -calculated_wheel_speeds[3]);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[FRONT_RIGHT_WHEEL_SPACE_INDEX],
+                     -calculated_wheel_speeds[FRONT_LEFT_WHEEL_SPACE_INDEX]);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[BACK_LEFT_WHEEL_SPACE_INDEX],
+                     -calculated_wheel_speeds[BACK_RIGHT_WHEEL_SPACE_INDEX]);
 }
 
 TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_negative_y)
@@ -83,14 +85,16 @@ TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_negative_y)
         euclidean_to_four_wheel.getWheelVelocity(target_euclidean_velocity);
 
     // Right wheels must be + velocity, Left wheels must be - velocity.
-    EXPECT_LT(calculated_wheel_speeds[0], 0);
-    EXPECT_GT(calculated_wheel_speeds[1], 0);
-    EXPECT_GT(calculated_wheel_speeds[2], 0);
-    EXPECT_LT(calculated_wheel_speeds[3], 0);
+    EXPECT_LT(calculated_wheel_speeds[FRONT_RIGHT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_GT(calculated_wheel_speeds[FRONT_LEFT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_GT(calculated_wheel_speeds[BACK_LEFT_WHEEL_SPACE_INDEX], 0);
+    EXPECT_LT(calculated_wheel_speeds[BACK_RIGHT_WHEEL_SPACE_INDEX], 0);
 
     // Right wheels must have same velocity magnitude as left wheels, but opposite sign.
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[0], -calculated_wheel_speeds[1]);
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[2], -calculated_wheel_speeds[3]);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[FRONT_RIGHT_WHEEL_SPACE_INDEX],
+                     -calculated_wheel_speeds[FRONT_LEFT_WHEEL_SPACE_INDEX]);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[BACK_LEFT_WHEEL_SPACE_INDEX],
+                     -calculated_wheel_speeds[BACK_RIGHT_WHEEL_SPACE_INDEX]);
 }
 
 TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_positive_w)
@@ -103,10 +107,11 @@ TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_positive_w)
     // Formula for the length of a segment: length = radius * angle
     // Since angle = 1rad, the length of the segment is equal to the radius.
     // Therefore, all wheel speeds must be equal to the robot radius.
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[0], robot_radius);
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[1], robot_radius);
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[2], robot_radius);
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[3], robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[FRONT_RIGHT_WHEEL_SPACE_INDEX],
+                     robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[FRONT_LEFT_WHEEL_SPACE_INDEX], robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[BACK_LEFT_WHEEL_SPACE_INDEX], robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[BACK_RIGHT_WHEEL_SPACE_INDEX], robot_radius);
 }
 
 TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_negative_w)
@@ -120,10 +125,13 @@ TEST_F(EuclideanToWheelTest, test_target_wheel_speeds_negative_w)
     // Since angle = -1rad, the length of the segment is equal to the -radius.
     // Therefore, all wheel speeds (=length of segment/sec) must be equal to the robot
     // radius.
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[0], -robot_radius);
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[1], -robot_radius);
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[2], -robot_radius);
-    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[3], -robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[FRONT_RIGHT_WHEEL_SPACE_INDEX],
+                     -robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[FRONT_LEFT_WHEEL_SPACE_INDEX],
+                     -robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[BACK_LEFT_WHEEL_SPACE_INDEX], -robot_radius);
+    EXPECT_DOUBLE_EQ(calculated_wheel_speeds[BACK_RIGHT_WHEEL_SPACE_INDEX],
+                     -robot_radius);
 }
 
 TEST_F(EuclideanToWheelTest, test_conversion_is_linear)


### PR DESCRIPTION
### Description
Fixed two bugs in the wheel conversion code.
Euclidean velocity is a vector of x, y, theta velocities (i.e. linear movement in the x, y direction, and the angular velocity of the robot). This is the output of the primitive executor (which gets the values from HRVO). The conversion math below takes the euclidean velocity and converts it to the velocities which the 4 wheels should be turning at.

### Testing Done
Added a set of new unit tests which pass. Tested the code on the robots as well and the robots are able to move to their destination, and rotate to the desired orientation (though they still can't do both at the same time, but that is likely related to motor ramping instead of the wheel conversion code).
Wheel angles were also updated again to be what they are in the CAD, and what I've been testing with in real-life. 
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Related to #2406
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist
Feel free to look into the paper linked in the code and double check that the math checks out (though the inverse in the paper seems to be incorrect). Personally, I recommend that you double check that the tests make sense. They are written to be generalised and not tied to a specific set of wheel angles, as a result, they don't test that values are exact. 
<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
