### PR TITLE
Implement recent primitive loss

### DIFF
--- a/src/software/jetson_nano/services/network.cpp
+++ b/src/software/jetson_nano/services/network.cpp
@@ -33,43 +33,48 @@ std::tuple<TbotsProto::PrimitiveSet, TbotsProto::World> NetworkService::poll(
 void NetworkService::primitiveSetCallback(TbotsProto::PrimitiveSet input)
 {
     std::scoped_lock<std::mutex> lock(primitive_set_mutex);
-    primitive_set_msg   = input;
-    const auto& seq_num = input.sequence_number();
+    const uint64_t& seq_num = input.sequence_number();
 
-    // Ignore the primitive and consider it as lost if it is received out of order
-    if (!recent_primitive_seq_nums.empty() && seq_num <= recent_primitive_seq_nums.back())
+    // If the primitive set seems very out of date, then this is likely due to an AI reset. Clear the queue
+    if (!recent_primitive_set_seq_nums.empty() && seq_num <= recent_primitive_set_seq_nums.back() - RECENT_PACKET_LOSS_PERIOD)
     {
+        recent_primitive_set_seq_nums = std::queue<uint64_t>();
+        LOG(WARNING) << "Old primitive set received. Resetting primitive set sequence number tracking";
+    }
+    else if (!recent_primitive_set_seq_nums.empty() && seq_num <= recent_primitive_set_seq_nums.back())
+    {
+        // If the primitive set is older than the last received primitive set, then ignore it
         return;
     }
+    primitive_set_msg       = input;
+    recent_primitive_set_seq_nums.push(seq_num);
 
-    recent_primitive_seq_nums.push(seq_num);
-
-    // Pop sequence numbers of primitives that are no longer recent
-    while (seq_num - recent_primitive_seq_nums.front() >= RECENT_PACKET_LOSS_PERIOD)
+    // Pop sequence numbers of primitive sets that are no longer recent
+    while (seq_num - recent_primitive_set_seq_nums.front() >= RECENT_PACKET_LOSS_PERIOD)
     {
-        recent_primitive_seq_nums.pop();
+        recent_primitive_set_seq_nums.pop();
     }
 
-    auto expected_primitives_count =
+    uint64_t expected_primitive_set_count =
         std::min(seq_num, static_cast<uint64_t>(RECENT_PACKET_LOSS_PERIOD));
-    auto lost_primitives_count =
-        expected_primitives_count - recent_primitive_seq_nums.size();
-    auto packet_loss_rate = static_cast<float>(lost_primitives_count) /
-                            static_cast<float>(expected_primitives_count);
+    uint64_t lost_primitive_set_count =
+            expected_primitive_set_count - recent_primitive_set_seq_nums.size();
+    float packet_loss_rate = static_cast<float>(lost_primitive_set_count) /
+                             static_cast<float>(expected_primitive_set_count);
 
+    LOG(INFO) << "Primitive lost rate: " << packet_loss_rate << " "
+              << recent_primitive_set_seq_nums.size();
     if (packet_loss_rate > PACKET_LOSS_WARNING_THRESHOLD)
     {
-        LOG(WARNING) << "Primitive packet loss in the past " << expected_primitives_count
-                     << " packets more than " << PACKET_LOSS_WARNING_THRESHOLD * 100
+        LOG(WARNING) << "Primitive set packet loss in the past " << expected_primitive_set_count
+                     << " packets is more than " << PACKET_LOSS_WARNING_THRESHOLD * 100
                      << "% ";
     }
 }
 
 void NetworkService::worldCallback(TbotsProto::World input)
 {
+    // TODO(#2728): Implement a recent world loss count and warning
     std::scoped_lock<std::mutex> lock(world_mutex);
     world_msg = input;
-    // TODO(#2728): Implement a recent world loss count and warning
-
-    last_world_time = input.time_sent().epoch_timestamp_seconds();
 }

--- a/src/software/jetson_nano/services/network.cpp
+++ b/src/software/jetson_nano/services/network.cpp
@@ -35,18 +35,23 @@ void NetworkService::primitiveSetCallback(TbotsProto::PrimitiveSet input)
     std::scoped_lock<std::mutex> lock(primitive_set_mutex);
     const uint64_t& seq_num = input.sequence_number();
 
-    // If the primitive set seems very out of date, then this is likely due to an AI reset. Clear the queue
-    if (!recent_primitive_set_seq_nums.empty() && seq_num <= recent_primitive_set_seq_nums.back() - RECENT_PACKET_LOSS_PERIOD)
+    // If the primitive set seems very out of date, then this is likely due to an AI
+    // reset. Clear the queue
+    if (!recent_primitive_set_seq_nums.empty() &&
+        seq_num <= recent_primitive_set_seq_nums.back() - RECENT_PACKET_LOSS_PERIOD)
     {
         recent_primitive_set_seq_nums = std::queue<uint64_t>();
-        LOG(WARNING) << "Old primitive set received. Resetting primitive set sequence number tracking";
+        LOG(WARNING)
+            << "Old primitive set received. Resetting primitive set sequence number tracking";
     }
-    else if (!recent_primitive_set_seq_nums.empty() && seq_num <= recent_primitive_set_seq_nums.back())
+    else if (!recent_primitive_set_seq_nums.empty() &&
+             seq_num <= recent_primitive_set_seq_nums.back())
     {
-        // If the primitive set is older than the last received primitive set, then ignore it
+        // If the primitive set is older than the last received primitive set, then ignore
+        // it
         return;
     }
-    primitive_set_msg       = input;
+    primitive_set_msg = input;
     recent_primitive_set_seq_nums.push(seq_num);
 
     // Pop sequence numbers of primitive sets that are no longer recent
@@ -58,7 +63,7 @@ void NetworkService::primitiveSetCallback(TbotsProto::PrimitiveSet input)
     uint64_t expected_primitive_set_count =
         std::min(seq_num, static_cast<uint64_t>(RECENT_PACKET_LOSS_PERIOD));
     uint64_t lost_primitive_set_count =
-            expected_primitive_set_count - recent_primitive_set_seq_nums.size();
+        expected_primitive_set_count - recent_primitive_set_seq_nums.size();
     float packet_loss_rate = static_cast<float>(lost_primitive_set_count) /
                              static_cast<float>(expected_primitive_set_count);
 
@@ -66,9 +71,9 @@ void NetworkService::primitiveSetCallback(TbotsProto::PrimitiveSet input)
               << recent_primitive_set_seq_nums.size();
     if (packet_loss_rate > PACKET_LOSS_WARNING_THRESHOLD)
     {
-        LOG(WARNING) << "Primitive set packet loss in the past " << expected_primitive_set_count
-                     << " packets is more than " << PACKET_LOSS_WARNING_THRESHOLD * 100
-                     << "% ";
+        LOG(WARNING) << "Primitive set packet loss in the past "
+                     << expected_primitive_set_count << " packets is more than "
+                     << PACKET_LOSS_WARNING_THRESHOLD * 100 << "% ";
     }
 }
 

--- a/src/software/jetson_nano/services/network.cpp
+++ b/src/software/jetson_nano/services/network.cpp
@@ -60,13 +60,14 @@ void NetworkService::primitiveSetCallback(TbotsProto::PrimitiveSet input)
         recent_primitive_set_seq_nums.pop();
     }
 
+    // seq_num + 1 is to account for the sequence numbers starting from 0
     uint64_t expected_primitive_set_count =
         std::min(seq_num + 1, static_cast<uint64_t>(RECENT_PACKET_LOSS_PERIOD));
     uint64_t lost_primitive_set_count =
         expected_primitive_set_count - recent_primitive_set_seq_nums.size();
     float packet_loss_rate = static_cast<float>(lost_primitive_set_count) /
                              static_cast<float>(expected_primitive_set_count);
-    
+
     if (packet_loss_rate > PACKET_LOSS_WARNING_THRESHOLD)
     {
         LOG(WARNING) << "Primitive set packet loss in the past "

--- a/src/software/jetson_nano/services/network.h
+++ b/src/software/jetson_nano/services/network.h
@@ -58,6 +58,7 @@ class NetworkService
     void primitiveSetCallback(TbotsProto::PrimitiveSet input);
     void worldCallback(TbotsProto::World input);
 
-    // Queue of the sequence numbers of received primitive sets in the past RECENT_PACKET_LOSS_PERIOD primitive sets
+    // Queue of the sequence numbers of received primitive sets in the past
+    // RECENT_PACKET_LOSS_PERIOD primitive sets
     std::queue<uint64_t> recent_primitive_set_seq_nums;
 };

--- a/src/software/jetson_nano/services/network.h
+++ b/src/software/jetson_nano/services/network.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mutex>
+#include <queue>
 
 #include "proto/robot_status_msg.pb.h"
 #include "proto/tbots_software_msgs.pb.h"
@@ -8,6 +9,9 @@
 #include "shared/robot_constants.h"
 #include "software/networking/threaded_proto_udp_listener.hpp"
 #include "software/networking/threaded_proto_udp_sender.hpp"
+
+constexpr float PACKET_LOSS_WARNING_THRESHOLD = 0.1f;
+constexpr uint8_t RECENT_PACKET_LOSS_PERIOD   = 100;
 
 class NetworkService
 {
@@ -57,6 +61,5 @@ class NetworkService
     double last_primitive_time = 0.0;
     double last_world_time     = 0.0;
 
-    uint64_t last_primitive_sequence_number = 0;
-    uint64_t total_primitives_lost          = 0;
+    std::queue<uint64_t> recent_primitive_seq_nums;
 };

--- a/src/software/jetson_nano/services/network.h
+++ b/src/software/jetson_nano/services/network.h
@@ -58,8 +58,6 @@ class NetworkService
     void primitiveSetCallback(TbotsProto::PrimitiveSet input);
     void worldCallback(TbotsProto::World input);
 
-    double last_primitive_time = 0.0;
-    double last_world_time     = 0.0;
-
-    std::queue<uint64_t> recent_primitive_seq_nums;
+    // Queue of the sequence numbers of received primitive sets in the past RECENT_PACKET_LOSS_PERIOD primitive sets
+    std::queue<uint64_t> recent_primitive_set_seq_nums;
 };


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Implemented recent primitive loss detection using an internal queue to store sequence numbers of recent received primitives. 

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Successfully builds and passes all tests. Will do testing with the physical robots on 10/18/2022. 

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
Resolves #2727 

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
