### PR TITLE
Add Timeout to Robot Diagnostics (Auto) Kick and Chip buttons

### DIFF
--- a/src/software/thunderscope/proto_unix_io.py
+++ b/src/software/thunderscope/proto_unix_io.py
@@ -101,20 +101,23 @@ class ProtoUnixIO:
         """
         self.all_proto_observers.append(buffer)
 
-    def send_proto(self, proto_class, data):
+    def send_proto(self, proto_class, data, block=False, timeout=None):
         """Send the data to all register_observers
 
         :param proto_class: The class to send
         :param data: The data to send
+        :param block: If block is True, then block until a free space opens up
+                      to put the proto. Otherwise, proto will be dropped if queue is full.
+        :param timeout: If block is True, then wait for this many seconds
 
         """
         if proto_class.DESCRIPTOR.full_name in self.proto_observers:
             for buffer in self.proto_observers[proto_class.DESCRIPTOR.full_name]:
-                buffer.put(data)
+                buffer.put(data, block, timeout)
 
         for buffer in self.all_proto_observers:
             try:
-                buffer.put(data, block=False)
+                buffer.put(data, block, timeout)
             except queue.Full:
                 print("Buffer registered to receive everything dropped data")
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -58,19 +58,20 @@ class RobotCommunication(object):
         self.send_estop_state_thread = threading.Thread(target=self.__send_estop_state)
         self.run_thread = threading.Thread(target=self.run)
 
-        try:
-            self.estop_reader = ThreadedEstopReader(
-                self.estop_path, self.estop_buadrate
-            )
-        except Exception:
-            raise Exception("Could not find estop, make sure its plugged in")
+        # try:
+        #     self.estop_reader = ThreadedEstopReader(
+        #         self.estop_path, self.estop_buadrate
+        #     )
+        # except Exception:
+        #     raise Exception("Could not find estop, make sure its plugged in")
 
     def __send_estop_state(self):
-        while True:
-            self.full_system_proto_unix_io.send_proto(
-                EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
-            )
-            time.sleep(0.1)
+        print('ytes')
+        # while True:
+        #     self.full_system_proto_unix_io.send_proto(
+        #         EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
+        #     )
+        #     time.sleep(0.1)
 
     def run(self):
         """Forward World and PrimitiveSet protos from fullsystem to the robots.

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -58,20 +58,19 @@ class RobotCommunication(object):
         self.send_estop_state_thread = threading.Thread(target=self.__send_estop_state)
         self.run_thread = threading.Thread(target=self.run)
 
-        # try:
-        #     self.estop_reader = ThreadedEstopReader(
-        #         self.estop_path, self.estop_buadrate
-        #     )
-        # except Exception:
-        #     raise Exception("Could not find estop, make sure its plugged in")
+        try:
+            self.estop_reader = ThreadedEstopReader(
+                self.estop_path, self.estop_buadrate
+            )
+        except Exception:
+            raise Exception("Could not find estop, make sure its plugged in")
 
     def __send_estop_state(self):
-        print("test")
-        # while True:
-        #     self.full_system_proto_unix_io.send_proto(
-        #         EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
-        #     )
-        #     time.sleep(0.1)
+        while True:
+            self.full_system_proto_unix_io.send_proto(
+                EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
+            )
+            time.sleep(0.1)
 
     def run(self):
         """Forward World and PrimitiveSet protos from fullsystem to the robots.

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -58,20 +58,19 @@ class RobotCommunication(object):
         self.send_estop_state_thread = threading.Thread(target=self.__send_estop_state)
         self.run_thread = threading.Thread(target=self.run)
 
-        # try:
-        #     self.estop_reader = ThreadedEstopReader(
-        #         self.estop_path, self.estop_buadrate
-        #     )
-        # except Exception:
-        #     raise Exception("Could not find estop, make sure its plugged in")
+        try:
+            self.estop_reader = ThreadedEstopReader(
+                self.estop_path, self.estop_buadrate
+            )
+        except Exception:
+            raise Exception("Could not find estop, make sure its plugged in")
 
     def __send_estop_state(self):
-        print("yea")
-        # while True:
-        #     self.full_system_proto_unix_io.send_proto(
-        #         EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
-        #     )
-        #     time.sleep(0.1)
+        while True:
+            self.full_system_proto_unix_io.send_proto(
+                EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
+            )
+            time.sleep(0.1)
 
     def run(self):
         """Forward World and PrimitiveSet protos from fullsystem to the robots.
@@ -122,8 +121,9 @@ class RobotCommunication(object):
 
                 self.sequence_number += 1
 
-                self.last_time = primitive_set.time_sent.epoch_timestamp_seconds
-                self.send_primitive_set.send_proto(primitive_set)
+                if self.estop_reader.isEstopPlay():
+                    self.last_time = primitive_set.time_sent.epoch_timestamp_seconds
+                    self.send_primitive_set.send_proto(primitive_set)
 
                 time.sleep(0.001)
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -95,8 +95,7 @@ class RobotCommunication(object):
                 # Send the primitive set
                 primitive_set = self.primitive_buffer.get(block=False)
 
-                if True:
-                    self.send_primitive_set.send_proto(primitive_set)
+                self.send_primitive_set.send_proto(primitive_set)
 
             else:
 
@@ -121,9 +120,8 @@ class RobotCommunication(object):
 
                 self.sequence_number += 1
 
-                if True:
-                    self.last_time = primitive_set.time_sent.epoch_timestamp_seconds
-                    self.send_primitive_set.send_proto(primitive_set)
+                self.last_time = primitive_set.time_sent.epoch_timestamp_seconds
+                self.send_primitive_set.send_proto(primitive_set)
 
                 time.sleep(0.001)
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -58,19 +58,20 @@ class RobotCommunication(object):
         self.send_estop_state_thread = threading.Thread(target=self.__send_estop_state)
         self.run_thread = threading.Thread(target=self.run)
 
-        try:
-            self.estop_reader = ThreadedEstopReader(
-                self.estop_path, self.estop_buadrate
-            )
-        except Exception:
-            raise Exception("Could not find estop, make sure its plugged in")
+        # try:
+        #     self.estop_reader = ThreadedEstopReader(
+        #         self.estop_path, self.estop_buadrate
+        #     )
+        # except Exception:
+        #     raise Exception("Could not find estop, make sure its plugged in")
 
     def __send_estop_state(self):
-        while True:
-            self.full_system_proto_unix_io.send_proto(
-                EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
-            )
-            time.sleep(0.1)
+        print("yea")
+        # while True:
+        #     self.full_system_proto_unix_io.send_proto(
+        #         EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
+        #     )
+        #     time.sleep(0.1)
 
     def run(self):
         """Forward World and PrimitiveSet protos from fullsystem to the robots.
@@ -121,9 +122,8 @@ class RobotCommunication(object):
 
                 self.sequence_number += 1
 
-                if self.estop_reader.isEstopPlay():
-                    self.last_time = primitive_set.time_sent.epoch_timestamp_seconds
-                    self.send_primitive_set.send_proto(primitive_set)
+                self.last_time = primitive_set.time_sent.epoch_timestamp_seconds
+                self.send_primitive_set.send_proto(primitive_set)
 
                 time.sleep(0.001)
 
@@ -188,8 +188,8 @@ class RobotCommunication(object):
         # TODO (#2741): we might not want to support robot diagnostics in tscope
         # make a ticket here to create a widget to call these functions to detach
         # from AI and connect to robots/or remove
-        # self.disconnect_fullsystem_from_robots()
-        # self.connect_robot_to_diagnostics(0)
+        self.disconnect_fullsystem_from_robots()
+        self.connect_robot_to_diagnostics(0)
 
         self.send_estop_state_thread.start()
         self.run_thread.start()

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -58,20 +58,19 @@ class RobotCommunication(object):
         self.send_estop_state_thread = threading.Thread(target=self.__send_estop_state)
         self.run_thread = threading.Thread(target=self.run)
 
-        # try:
-        #     self.estop_reader = ThreadedEstopReader(
-        #         self.estop_path, self.estop_buadrate
-        #     )
-        # except Exception:
-        #     raise Exception("Could not find estop, make sure its plugged in")
+        try:
+            self.estop_reader = ThreadedEstopReader(
+                self.estop_path, self.estop_buadrate
+            )
+        except Exception:
+            raise Exception("Could not find estop, make sure its plugged in")
 
     def __send_estop_state(self):
-        print("ytes")
-        # while True:
-        #     self.full_system_proto_unix_io.send_proto(
-        #         EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
-        #     )
-        #     time.sleep(0.1)
+        while True:
+            self.full_system_proto_unix_io.send_proto(
+                EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
+            )
+            time.sleep(0.1)
 
     def run(self):
         """Forward World and PrimitiveSet protos from fullsystem to the robots.

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -58,19 +58,20 @@ class RobotCommunication(object):
         self.send_estop_state_thread = threading.Thread(target=self.__send_estop_state)
         self.run_thread = threading.Thread(target=self.run)
 
-        try:
-            self.estop_reader = ThreadedEstopReader(
-                self.estop_path, self.estop_buadrate
-            )
-        except Exception:
-            raise Exception("Could not find estop, make sure its plugged in")
+        # try:
+        #     self.estop_reader = ThreadedEstopReader(
+        #         self.estop_path, self.estop_buadrate
+        #     )
+        # except Exception:
+        #     raise Exception("Could not find estop, make sure its plugged in")
 
     def __send_estop_state(self):
-        while True:
-            self.full_system_proto_unix_io.send_proto(
-                EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
-            )
-            time.sleep(0.1)
+        print("test")
+        # while True:
+        #     self.full_system_proto_unix_io.send_proto(
+        #         EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
+        #     )
+        #     time.sleep(0.1)
 
     def run(self):
         """Forward World and PrimitiveSet protos from fullsystem to the robots.

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -95,7 +95,8 @@ class RobotCommunication(object):
                 # Send the primitive set
                 primitive_set = self.primitive_buffer.get(block=False)
 
-                self.send_primitive_set.send_proto(primitive_set)
+                if self.estop_reader.isEstopPlay():
+                    self.send_primitive_set.send_proto(primitive_set)
 
             else:
 
@@ -120,8 +121,9 @@ class RobotCommunication(object):
 
                 self.sequence_number += 1
 
-                self.last_time = primitive_set.time_sent.epoch_timestamp_seconds
-                self.send_primitive_set.send_proto(primitive_set)
+                if self.estop_reader.isEstopPlay():
+                    self.last_time = primitive_set.time_sent.epoch_timestamp_seconds
+                    self.send_primitive_set.send_proto(primitive_set)
 
                 time.sleep(0.001)
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -183,13 +183,13 @@ class RobotCommunication(object):
             self.multicast_channel + "%" + self.interface, VISION_PORT, True
         )
 
-        self.connect_fullsystem_to_robots()
+        # self.connect_fullsystem_to_robots()
 
         # TODO (#2741): we might not want to support robot diagnostics in tscope
         # make a ticket here to create a widget to call these functions to detach
         # from AI and connect to robots/or remove
-        self.disconnect_fullsystem_from_robots()
-        self.connect_robot_to_diagnostics(0)
+        # self.disconnect_fullsystem_from_robots()
+        # self.connect_robot_to_diagnostics(0)
 
         self.send_estop_state_thread.start()
         self.run_thread.start()

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -66,7 +66,7 @@ class RobotCommunication(object):
         #     raise Exception("Could not find estop, make sure its plugged in")
 
     def __send_estop_state(self):
-        print('ytes')
+        print("ytes")
         # while True:
         #     self.full_system_proto_unix_io.send_proto(
         #         EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -58,6 +58,8 @@ class RobotCommunication(object):
         self.send_estop_state_thread = threading.Thread(target=self.__send_estop_state)
         self.run_thread = threading.Thread(target=self.run)
 
+        self.fullsystem_connected_to_robots = True
+
         try:
             self.estop_reader = ThreadedEstopReader(
                 self.estop_path, self.estop_buadrate
@@ -183,7 +185,7 @@ class RobotCommunication(object):
             self.multicast_channel + "%" + self.interface, VISION_PORT, True
         )
 
-        # self.connect_fullsystem_to_robots()
+        self.connect_fullsystem_to_robots()
 
         # TODO (#2741): we might not want to support robot diagnostics in tscope
         # make a ticket here to create a widget to call these functions to detach

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -5,11 +5,9 @@ from software.py_constants import *
 from proto.import_all_protos import *
 from enum import Enum
 import software.thunderscope.common.common_widgets as common_widgets
+from software.py_constants import MILLISECONDS_PER_SECOND
 
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
-
-MILLISECONDS_PER_SECOND = 1000
-
 
 class ChickerCommandMode(Enum):
     KICK = 1

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -14,6 +14,7 @@ class ChickerCommandMode(Enum):
     AUTOKICK = 3
     AUTOCHIP = 4
 
+
 class ChickerWidget(QWidget):
     def __init__(self, proto_unix_io):
         """Handles the robot diagnostics input to create a PowerControl message

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -185,13 +185,14 @@ class ChickerWidget(QWidget):
         # sends proto
         self.proto_unix_io.send_proto(PowerControl, power_control)
 
-        # send empty proto
+        # send empty proto for kick or chip commands
         # this is due to a bug in robot_communication where if a new PowerControl message is not sent,
-        # the previous, cached message is resent to the robot repeatedly
+        # the previous, cached message is resent to the robot repeatedly which we don't want for kick/chip
         # so sending an empty message overwrites the cache and prevents spamming commands
         # if buffer is full, blocks execution until buffer has space
-        power_control = PowerControl()
-        self.proto_unix_io.send_proto(PowerControl, power_control, True)
+        if command == ChickerCommandMode.KICK or command == ChickerCommandMode.CHIP:
+            power_control = PowerControl()
+            self.proto_unix_io.send_proto(PowerControl, power_control, True)
 
     def change_button_state(self, button, enable):
         """Change button color and clickable state.

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -140,6 +140,8 @@ class ChickerWidget(QWidget):
         """
         if self.no_auto_selected:
             self.kick_chip_buttons_enable = True
+            power_control = PowerControl()
+            self.proto_unix_io.send_proto(PowerControl, power_control, True)
 
     def set_should_enable_buttons(self, enable):
         """

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -225,5 +225,3 @@ class ChickerWidget(QWidget):
             self.send_command(ChickerCommandMode.AUTOKICK)
         elif self.auto_chip_button.isChecked():
             self.send_command(ChickerCommandMode.AUTOCHIP)
-        elif self.no_auto_button.isChecked():
-            pass

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -37,11 +37,6 @@ class ChickerWidget(QWidget):
         self.kick_button = self.push_buttons[0]
         self.chip_button = self.push_buttons[1]
 
-        # QObject.connect(self.kick_button, SIGNAL ('clicked()'), self.kick_clicked())
-
-        self.kick_button.clicked.connect(self.kick_clicked)
-        self.chip_button.clicked.connect(self.chip_clicked)
-
         vbox_layout.addWidget(self.push_button_box)
 
         # radio button group box
@@ -52,6 +47,13 @@ class ChickerWidget(QWidget):
         self.auto_kick_button = self.radio_buttons[1]
         self.auto_chip_button = self.radio_buttons[2]
 
+        # adding onclick functions for buttons
+
+        # kick button and chip button connected to respective functions
+        self.kick_button.clicked.connect(self.kick_clicked)
+        self.chip_button.clicked.connect(self.chip_clicked)
+
+        # no auto button enables both buttons, while auto kick and auto chip disable both buttons
         self.no_auto_button.toggled.connect(self.buttons_enable)
         self.auto_kick_button.toggled.connect(self.buttons_disable)
         self.auto_chip_button.toggled.connect(self.buttons_disable)
@@ -59,6 +61,7 @@ class ChickerWidget(QWidget):
         vbox_layout.addWidget(self.radio_button_box)
         self.no_auto_button.setChecked(True)
 
+        # set buttons to be initially enabled
         self.kick_button_enable = True
         self.chip_button_enable = True
 
@@ -87,16 +90,24 @@ class ChickerWidget(QWidget):
         self.power_value = 1
 
     def kick_clicked(self):
+        # if button is enabled
         if self.kick_button_enable:
+            # send kick primitive
             self.send_kick_or_chip(True)
             self.toggle_kick_button()
+
+            # set and start timer to re-enable kick button after 3 seconds
             t = Timer(3, lambda s: s.toggle_kick_button(), [self])
             t.start()
 
     def chip_clicked(self):
+        # if button is enabled
         if self.chip_button_enable:
+            # send chip primitive
             self.send_kick_or_chip(False)
             self.toggle_chip_button()
+
+            # set and start timer to re-enable chip button after 3 seconds
             t = Timer(3, lambda s: s.toggle_chip_button(), [self])
             t.start()
 
@@ -115,6 +126,14 @@ class ChickerWidget(QWidget):
         self.chip_button_enable = True
 
     def send_kick_or_chip(self, kick):
+        """Sends a kick or chip primitive dependant on boolean parameter
+
+        :param kick: boolean to indicate whether to send Kick (True) or Chip (False) primitive
+        :returns: None
+
+        """
+        
+        # gets slider values and sets label to that value
         geneva_value = self.geneva_slider.value()
         self.geneva_label.setText(Slot.Name(geneva_value))
 
@@ -124,6 +143,7 @@ class ChickerWidget(QWidget):
         power_control = PowerControl()
         power_control.geneva_slot = geneva_value
 
+        # sends kick or chip primitive
         if kick:
             power_control.chicker.auto_chip_or_kick.autokick_speed_m_per_s = power_value
         else:
@@ -131,6 +151,7 @@ class ChickerWidget(QWidget):
                 power_value
             )
 
+        # sends proto
         self.proto_unix_io.send_proto(PowerControl, power_control)
 
     def change_button_state(self, button, enable):
@@ -150,7 +171,7 @@ class ChickerWidget(QWidget):
 
     def refresh(self):
 
-        # slider values
+        # refreshes button state based on enable boolean
         self.change_button_state(self.kick_button, self.kick_button_enable)
         self.change_button_state(self.chip_button, self.chip_button_enable)
 

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -6,7 +6,6 @@ from proto.import_all_protos import *
 from enum import Enum
 import software.thunderscope.common.common_widgets as common_widgets
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
-import time
 
 
 class ChickerCommandMode(Enum):
@@ -186,14 +185,13 @@ class ChickerWidget(QWidget):
         # sends proto
         self.proto_unix_io.send_proto(PowerControl, power_control)
 
-        time.sleep(0.001)
-
         # send empty proto
         # this is due to a bug in robot_communication where if a new PowerControl message is not sent,
         # the previous, cached message is resent to the robot repeatedly
         # so sending an empty message overwrites the cache and prevents spamming commands
+        # if buffer is full, blocks execution until buffer has space
         power_control = PowerControl()
-        self.proto_unix_io.send_proto(PowerControl, power_control)
+        self.proto_unix_io.send_proto(PowerControl, power_control, True)
 
     def change_button_state(self, button, enable):
         """Change button color and clickable state.

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -9,6 +9,7 @@ from software.py_constants import MILLISECONDS_PER_SECOND
 
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
 
+
 class ChickerCommandMode(Enum):
     KICK = 1
     CHIP = 2

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -6,6 +6,7 @@ from proto.import_all_protos import *
 from enum import Enum
 import software.thunderscope.common.common_widgets as common_widgets
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
+import time
 
 
 class ChickerCommandMode(Enum):
@@ -184,6 +185,8 @@ class ChickerWidget(QWidget):
 
         # sends proto
         self.proto_unix_io.send_proto(PowerControl, power_control)
+
+        time.sleep(0.001)
 
         # send empty proto
         # this is due to a bug in robot_communication where if a new PowerControl message is not sent,

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -5,8 +5,6 @@ from software.py_constants import *
 from proto.import_all_protos import *
 from enum import Enum
 import software.thunderscope.common.common_widgets as common_widgets
-from software.py_constants import MILLISECONDS_PER_SECOND
-
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
 
 

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -36,6 +36,8 @@ class ChickerWidget(QWidget):
         self.radio_buttons_group = QButtonGroup()
         self.proto_unix_io = proto_unix_io
 
+        # Initialising the buttons
+
         # push button group box
         self.push_button_box, self.push_buttons = common_widgets.create_button(
             ["Kick", "Chip"]
@@ -53,29 +55,35 @@ class ChickerWidget(QWidget):
         self.auto_kick_button = self.radio_buttons[1]
         self.auto_chip_button = self.radio_buttons[2]
 
+        # set buttons to be initially enabled
+        self.kick_chip_buttons_enable = True
+
+        # indicating that no auto button is selected by default
+        self.no_auto_button.setChecked(True)
+        self.no_auto_selected = True
+
         # adding onclick functions for buttons
 
-        # kick button and chip button connected to respective functions
-        self.kick_button.clicked.connect(self.kick_clicked)
-        self.chip_button.clicked.connect(self.chip_clicked)
+        # kick button and chip button connected to send_command_and_timeout with their respective commands
+        self.kick_button.clicked.connect(
+            lambda: self.send_command_and_timeout(ChickerCommandMode.KICK)
+        )
+        self.chip_button.clicked.connect(
+            lambda: self.send_command_and_timeout(ChickerCommandMode.CHIP)
+        )
 
         # no auto button enables both buttons, while auto kick and auto chip disable both buttons
         self.no_auto_button.toggled.connect(
-            lambda: self.toggle_should_enable_buttons(True)
+            lambda: self.set_should_enable_buttons(True)
         )
         self.auto_kick_button.toggled.connect(
-            lambda: self.toggle_should_enable_buttons(False)
+            lambda: self.set_should_enable_buttons(False)
         )
         self.auto_chip_button.toggled.connect(
-            lambda: self.toggle_should_enable_buttons(False)
+            lambda: self.set_should_enable_buttons(False)
         )
 
         vbox_layout.addWidget(self.radio_button_box)
-        self.no_auto_button.setChecked(True)
-
-        # set buttons to be initially enabled
-        self.buttons_enable = True
-        self.buttons_should_enable = True
 
         # sliders
         (
@@ -101,82 +109,50 @@ class ChickerWidget(QWidget):
         self.geneva_value = 3
         self.power_value = 1
 
-    def kick_clicked(self):
+    def send_command_and_timeout(self, command):
         """
         If buttons are enabled, sends a Kick command and disables buttons
 
         Attaches a callback to re-enable buttons after 3 seconds
+
+        :param command: Command to send. One of ChickerCommandMode.KICK or ChickerCommandMode.CHIP
         """
         # if button is enabled
-        if self.buttons_enable:
+        if self.kick_chip_buttons_enable:
             # send kick primitive
-            self.send_command(ChickerCommandMode.KICK)
-            self.disable_kick_chip_button()
+            self.send_command(command)
+            self.disable_kick_chip_buttons()
 
-            # set and start timer to re-enable kick button after 3 seconds
-            self.start_timer_once(
-                self.enable_kick_chip_button, 3 * MILLISECONDS_PER_SECOND
+            # set and start timer to re-enable buttons after 3 seconds
+            QTimer.singleShot(
+                3 * MILLISECONDS_PER_SECOND, self.enable_kick_chip_buttons
             )
 
-    def chip_clicked(self):
+    def disable_kick_chip_buttons(self):
         """
-        If buttons are enabled, sends a Chip command and disables buttons
-
-        Attaches a callback to re-enable buttons after 3 seconds
+        Disables the buttons
         """
+        self.kick_chip_buttons_enable = False
 
-        # if button is enabled
-        if self.buttons_enable:
-            # send chip primitive
-            self.send_command(ChickerCommandMode.CHIP)
-            self.disable_kick_chip_button()
-
-            # set and start timer to re-enable chip button after 3 seconds
-            self.start_timer_once(
-                self.enable_kick_chip_button, 3 * MILLISECONDS_PER_SECOND
-            )
-
-    def start_timer_once(self, function, duration):
-        """Starts a QTimer to call the given function once after the given duration
-
-        :param function: function to call after duration
-        :param duration: duration to call function after
-        :returns: None
-
+    def enable_kick_chip_buttons(self):
         """
+        If buttons should be enabled, enables them
+        """
+        if self.no_auto_selected:
+            self.kick_chip_buttons_enable = True
 
-        timer = QTimer(self)
-        timer.setTimerType(Qt.TimerType.PreciseTimer)
-        timer.timeout.connect(function)
-        timer.setSingleShot(True)
-        timer.start(duration)
-
-    def disable_kick_chip_button(self):
+    def set_should_enable_buttons(self, enable):
         """
-        If buttons are enabled, disables them
-        """
-        if self.buttons_enable:
-            self.buttons_enable = False
-
-    def enable_kick_chip_button(self):
-        """
-        If buttons are disabled and buttons should be enabled, enables them
-        """
-        if not self.buttons_enable and self.buttons_should_enable:
-            self.buttons_enable = True
-
-    def toggle_should_enable_buttons(self, enable):
-        """
-        Toggles if buttons are clickable or not based on boolean parameter
+        Changes if buttons are clickable or not based on boolean parameter
 
         :param enable: boolean to indicate whether buttons should be made clickable or not
         """
-        self.buttons_should_enable = enable
+        self.no_auto_selected = enable
 
         if enable:
-            self.enable_kick_chip_button()
+            self.enable_kick_chip_buttons()
         else:
-            self.disable_kick_chip_button()
+            self.disable_kick_chip_buttons()
 
     def send_command(self, command):
         """Sends a [auto]kick or [auto]chip primitive
@@ -234,15 +210,13 @@ class ChickerWidget(QWidget):
         self.power_label.setText(str(power_value))
 
         # refreshes button state based on enable boolean
-        self.change_button_state(self.kick_button, self.buttons_enable)
-        self.change_button_state(self.chip_button, self.buttons_enable)
+        self.change_button_state(self.kick_button, self.kick_chip_buttons_enable)
+        self.change_button_state(self.chip_button, self.kick_chip_buttons_enable)
 
         # If auto is enabled, we want to populate the autochip or kick message
         if self.auto_kick_button.isChecked():
             self.send_command(ChickerCommandMode.AUTOKICK)
-            self.buttons_should_enable = False
         elif self.auto_chip_button.isChecked():
             self.send_command(ChickerCommandMode.AUTOCHIP)
-            self.buttons_should_enable = False
         elif self.no_auto_button.isChecked():
-            self.buttons_should_enable = True
+            pass

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -1,7 +1,8 @@
 import pyqtgraph as pg
-from pyqtgraph.Qt.QtCore import Qt
+from pyqtgraph.Qt.QtCore import *
 from pyqtgraph.Qt.QtWidgets import *
 from software.py_constants import *
+from threading import Timer
 from proto.import_all_protos import *
 import software.thunderscope.common.common_widgets as common_widgets
 
@@ -36,6 +37,11 @@ class ChickerWidget(QWidget):
         self.kick_button = self.push_buttons[0]
         self.chip_button = self.push_buttons[1]
 
+        # QObject.connect(self.kick_button, SIGNAL ('clicked()'), self.kick_clicked())
+
+        self.kick_button.clicked.connect(self.kick_clicked)
+        self.chip_button.clicked.connect(self.chip_clicked)
+
         vbox_layout.addWidget(self.push_button_box)
 
         # radio button group box
@@ -46,8 +52,15 @@ class ChickerWidget(QWidget):
         self.auto_kick_button = self.radio_buttons[1]
         self.auto_chip_button = self.radio_buttons[2]
 
+        self.no_auto_button.toggled.connect(self.buttons_enable)
+        self.auto_kick_button.toggled.connect(self.buttons_disable)
+        self.auto_chip_button.toggled.connect(self.buttons_disable)
+
         vbox_layout.addWidget(self.radio_button_box)
         self.no_auto_button.setChecked(True)
+
+        self.kick_button_enable = True
+        self.chip_button_enable = True
 
         # sliders
         (
@@ -73,6 +86,53 @@ class ChickerWidget(QWidget):
         self.geneva_value = 3
         self.power_value = 1
 
+    def kick_clicked(self):
+        if self.kick_button_enable:
+            self.send_kick_or_chip(True)
+            self.toggle_kick_button()
+            t = Timer(3, lambda s: s.toggle_kick_button(), [self])
+            t.start()
+
+    def chip_clicked(self):
+        if self.chip_button_enable:
+            self.send_kick_or_chip(False)
+            self.toggle_chip_button()
+            t = Timer(3, lambda s: s.toggle_chip_button(), [self])
+            t.start()
+
+    def toggle_kick_button(self):
+        self.kick_button_enable = not self.kick_button_enable
+
+    def toggle_chip_button(self):
+        self.chip_button_enable = not self.chip_button_enable
+
+    def buttons_disable(self):
+        self.kick_button_enable = False
+        self.chip_button_enable = False
+
+    def buttons_enable(self):
+        self.kick_button_enable = True
+        self.chip_button_enable = True
+
+    def send_kick_or_chip(self, kick):
+        geneva_value = self.geneva_slider.value()
+        self.geneva_label.setText(Slot.Name(geneva_value))
+
+        power_value = self.power_slider.value()
+        self.power_label.setText(str(power_value))
+
+        power_control = PowerControl()
+        power_control.geneva_slot = geneva_value
+
+        if kick:
+            power_control.chicker.auto_chip_or_kick.autokick_speed_m_per_s = power_value
+        else:
+            power_control.chicker.auto_chip_or_kick.autochip_distance_meters = (
+                power_value
+            )
+
+        self.proto_unix_io.send_proto(PowerControl, power_control)
+
     def change_button_state(self, button, enable):
         """Change button color and clickable state.
 
@@ -91,31 +151,13 @@ class ChickerWidget(QWidget):
     def refresh(self):
 
         # slider values
-        geneva_value = self.geneva_slider.value()
-        self.geneva_label.setText(Slot.Name(geneva_value))
-
-        power_value = self.power_slider.value()
-        self.power_label.setText(str(power_value))
-
-        # if autokick is enabled, we don't want to allow kick/chip
-        auto_kick_enabled = (
-            self.auto_kick_button.isChecked() or self.auto_chip_button.isChecked()
-        )
-        self.change_button_state(self.kick_button, not auto_kick_enabled)
-        self.change_button_state(self.chip_button, not auto_kick_enabled)
-
-        power_control = PowerControl()
-        power_control.geneva_slot = geneva_value
+        self.change_button_state(self.kick_button, self.kick_button_enable)
+        self.change_button_state(self.chip_button, self.chip_button_enable)
 
         # If auto is enabled, we want to populate the autochip or kick message
         if self.auto_kick_button.isChecked():
-            power_control.chicker.auto_chip_or_kick.autokick_speed_m_per_s = power_value
+            self.send_kick_or_chip(True)
         elif self.auto_chip_button.isChecked():
-            power_control.chicker.auto_chip_or_kick.autochip_distance_meters = (
-                power_value
-            )
+            self.send_kick_or_chip(False)
         elif self.no_auto_button.isChecked():
             pass
-            # TODO (#2715): ATTACH A CALLBACK AND SENDPROTO/KICK IMMEDIATELY
-
-        self.proto_unix_io.send_proto(PowerControl, power_control)

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -60,9 +60,15 @@ class ChickerWidget(QWidget):
         self.chip_button.clicked.connect(self.chip_clicked)
 
         # no auto button enables both buttons, while auto kick and auto chip disable both buttons
-        self.no_auto_button.toggled.connect(lambda: self.toggle_should_enable_buttons(True))
-        self.auto_kick_button.toggled.connect(lambda: self.toggle_should_enable_buttons(False))
-        self.auto_chip_button.toggled.connect(lambda: self.toggle_should_enable_buttons(False))
+        self.no_auto_button.toggled.connect(
+            lambda: self.toggle_should_enable_buttons(True)
+        )
+        self.auto_kick_button.toggled.connect(
+            lambda: self.toggle_should_enable_buttons(False)
+        )
+        self.auto_chip_button.toggled.connect(
+            lambda: self.toggle_should_enable_buttons(False)
+        )
 
         vbox_layout.addWidget(self.radio_button_box)
         self.no_auto_button.setChecked(True)
@@ -108,7 +114,9 @@ class ChickerWidget(QWidget):
             self.disable_kick_chip_button()
 
             # set and start timer to re-enable kick button after 3 seconds
-            self.start_timer_once(self.enable_kick_chip_button, 3 * MILLISECONDS_PER_SECOND)
+            self.start_timer_once(
+                self.enable_kick_chip_button, 3 * MILLISECONDS_PER_SECOND
+            )
 
     def chip_clicked(self):
         """
@@ -124,7 +132,9 @@ class ChickerWidget(QWidget):
             self.disable_kick_chip_button()
 
             # set and start timer to re-enable chip button after 3 seconds
-            self.start_timer_once(self.enable_kick_chip_button, 3 * MILLISECONDS_PER_SECOND)
+            self.start_timer_once(
+                self.enable_kick_chip_button, 3 * MILLISECONDS_PER_SECOND
+            )
 
     def start_timer_once(self, function, duration):
         """Starts a QTimer to call the given function once after the given duration
@@ -236,4 +246,3 @@ class ChickerWidget(QWidget):
             self.buttons_should_enable = False
         elif self.no_auto_button.isChecked():
             self.buttons_should_enable = True
-            pass

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -173,8 +173,12 @@ class ChickerWidget(QWidget):
         # sends kick, chip, autokick, or autchip primitive
         if command == ChickerCommandMode.KICK:
             power_control.chicker.kick_speed_m_per_s = power_value
+            self.proto_unix_io.send_proto(PowerControl, power_control)
+            power_control.chicker.kick_speed_m_per_s = 0
         elif command == ChickerCommandMode.CHIP:
             power_control.chicker.chip_distance_meters = power_value
+            self.proto_unix_io.send_proto(PowerControl, power_control)
+            power_control.chicker.chip_distance_meters = 0
         elif command == ChickerCommandMode.AUTOKICK:
             power_control.chicker.auto_chip_or_kick.autokick_speed_m_per_s = power_value
         elif command == ChickerCommandMode.AUTOCHIP:

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -14,7 +14,6 @@ class ChickerCommandMode(Enum):
     AUTOKICK = 3
     AUTOCHIP = 4
 
-
 class ChickerWidget(QWidget):
     def __init__(self, proto_unix_io):
         """Handles the robot diagnostics input to create a PowerControl message
@@ -173,12 +172,8 @@ class ChickerWidget(QWidget):
         # sends kick, chip, autokick, or autchip primitive
         if command == ChickerCommandMode.KICK:
             power_control.chicker.kick_speed_m_per_s = power_value
-            self.proto_unix_io.send_proto(PowerControl, power_control)
-            power_control.chicker.kick_speed_m_per_s = 0
         elif command == ChickerCommandMode.CHIP:
             power_control.chicker.chip_distance_meters = power_value
-            self.proto_unix_io.send_proto(PowerControl, power_control)
-            power_control.chicker.chip_distance_meters = 0
         elif command == ChickerCommandMode.AUTOKICK:
             power_control.chicker.auto_chip_or_kick.autokick_speed_m_per_s = power_value
         elif command == ChickerCommandMode.AUTOCHIP:
@@ -187,6 +182,13 @@ class ChickerWidget(QWidget):
             )
 
         # sends proto
+        self.proto_unix_io.send_proto(PowerControl, power_control)
+
+        # send empty proto
+        # this is due to a bug in robot_communication where if a new PowerControl message is not sent,
+        # the previous, cached message is resent to the robot repeatedly
+        # so sending an empty message overwrites the cache and prevents spamming commands
+        power_control = PowerControl()
         self.proto_unix_io.send_proto(PowerControl, power_control)
 
     def change_button_state(self, button, enable):

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -8,6 +8,8 @@ import software.thunderscope.common.common_widgets as common_widgets
 
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
 
+MILLISECONDS_PER_SECOND = 1000
+
 
 class ChickerCommandMode(Enum):
     KICK = 1
@@ -61,9 +63,9 @@ class ChickerWidget(QWidget):
         self.chip_button.clicked.connect(self.chip_clicked)
 
         # no auto button enables both buttons, while auto kick and auto chip disable both buttons
-        self.no_auto_button.toggled.connect(self.buttons_enable)
-        self.auto_kick_button.toggled.connect(self.buttons_disable)
-        self.auto_chip_button.toggled.connect(self.buttons_disable)
+        self.no_auto_button.toggled.connect(self.enable_kick_chip_button)
+        self.auto_kick_button.toggled.connect(self.disable_kick_chip_button)
+        self.auto_chip_button.toggled.connect(self.disable_kick_chip_button)
 
         vbox_layout.addWidget(self.radio_button_box)
         self.no_auto_button.setChecked(True)
@@ -104,7 +106,7 @@ class ChickerWidget(QWidget):
             self.toggle_kick_button()
 
             # set and start timer to re-enable kick button after 3 seconds
-            self.start_timer_once(self.toggle_kick_button, 3000)
+            self.start_timer_once(self.toggle_kick_button, 3 * MILLISECONDS_PER_SECOND)
 
     def chip_clicked(self):
         # if button is enabled
@@ -114,7 +116,7 @@ class ChickerWidget(QWidget):
             self.toggle_chip_button()
 
             # set and start timer to re-enable chip button after 3 seconds
-            self.start_timer_once(self.toggle_chip_button, 3000)
+            self.start_timer_once(self.toggle_chip_button, 3 * MILLISECONDS_PER_SECOND)
 
     def start_timer_once(self, function, duration):
         """Starts a QTimer to call the given function once after the given duration
@@ -125,11 +127,11 @@ class ChickerWidget(QWidget):
 
         """
 
-        t = QTimer(self)
-        t.setTimerType(Qt.TimerType.PreciseTimer)
-        t.timeout.connect(function)
-        t.setSingleShot(True)
-        t.start(duration)
+        timer = QTimer(self)
+        timer.setTimerType(Qt.TimerType.PreciseTimer)
+        timer.timeout.connect(function)
+        timer.setSingleShot(True)
+        timer.start(duration)
 
     def toggle_kick_button(self):
         self.kick_button_enable = not self.kick_button_enable
@@ -137,16 +139,16 @@ class ChickerWidget(QWidget):
     def toggle_chip_button(self):
         self.chip_button_enable = not self.chip_button_enable
 
-    def buttons_disable(self):
+    def disable_kick_chip_button(self):
         self.kick_button_enable = False
         self.chip_button_enable = False
 
-    def buttons_enable(self):
+    def enable_kick_chip_button(self):
         self.kick_button_enable = True
         self.chip_button_enable = True
 
     def send_command(self, command):
-        """Sends a kick or chip primitive dependent on boolean parameter
+        """Sends a [auto]kick or [auto]chip primitive
 
         :param command: enum int value to indicate what primitive to send
         :returns: None

--- a/src/software/thunderscope/robot_diagnostics/chicker.py
+++ b/src/software/thunderscope/robot_diagnostics/chicker.py
@@ -126,13 +126,13 @@ class ChickerWidget(QWidget):
         self.chip_button_enable = True
 
     def send_kick_or_chip(self, kick):
-        """Sends a kick or chip primitive dependant on boolean parameter
+        """Sends a kick or chip primitive dependent on boolean parameter
 
         :param kick: boolean to indicate whether to send Kick (True) or Chip (False) primitive
         :returns: None
 
         """
-        
+
         # gets slider values and sets label to that value
         geneva_value = self.geneva_slider.value()
         self.geneva_label.setText(Slot.Name(geneva_value))

--- a/src/software/thunderscope/thread_safe_buffer.py
+++ b/src/software/thunderscope/thread_safe_buffer.py
@@ -73,16 +73,17 @@ class ThreadSafeBuffer(object):
 
         return self.cached_msg
 
-    def put(self, proto, block=False):
+    def put(self, proto, block=False, timeout=None):
         """Put data into the buffer. If the buffer is full, then
         the proto will be logged.
 
         :param proto: The proto to place in the buffer
         :param block: Should block until there is space in the buffer
+        :param timeout: If block is True, then wait for this many seconds
 
         """
         if block:
-            self.queue.put(proto)
+            self.queue.put(proto, block, timeout)
             return
 
         try:


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Added functionality to kick and chip buttons in robot diagnostics in Thunderscope to be able to send one kick or chip primitive upon button click.

Added callback to buttons which is called upon click. Added a 3 second cooldown after each button click where button is temporarily disabled to prevent primitives being sent too close to each other.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Thunderscope builds successfully

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

Resolves #2715 

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
