### PR TITLE
Fix AngularVelocity calculation bug in Sensor Fusion

### DIFF
--- a/src/software/sensor_fusion/filter/BUILD
+++ b/src/software/sensor_fusion/filter/BUILD
@@ -54,6 +54,7 @@ cc_test(
     deps = [
         ":robot_filter",
         "//shared/test_util:tbots_gtest_main",
+        "//software/test_util",
     ],
 )
 

--- a/src/software/sensor_fusion/filter/robot_filter.cpp
+++ b/src/software/sensor_fusion/filter/robot_filter.cpp
@@ -84,7 +84,7 @@ std::optional<Robot> RobotFilter::getFilteredData(
 
         // angular_velocity = orientation difference / time difference
         filtered_data.angular_velocity =
-            (filtered_data.orientation.minDiff(current_robot_state.orientation())) /
+            (filtered_data.orientation - current_robot_state.orientation()).clamp() /
             (filtered_data.timestamp.toSeconds() -
              current_robot_state.timestamp().toSeconds());
 

--- a/src/software/sensor_fusion/filter/robot_filter.cpp
+++ b/src/software/sensor_fusion/filter/robot_filter.cpp
@@ -84,7 +84,7 @@ std::optional<Robot> RobotFilter::getFilteredData(
 
         // angular_velocity = orientation difference / time difference
         filtered_data.angular_velocity =
-            (filtered_data.orientation - current_robot_state.orientation()) /
+            (filtered_data.orientation.minDiff(current_robot_state.orientation())) /
             (filtered_data.timestamp.toSeconds() -
              current_robot_state.timestamp().toSeconds());
 

--- a/src/software/sensor_fusion/filter/robot_filter_test.cpp
+++ b/src/software/sensor_fusion/filter/robot_filter_test.cpp
@@ -54,17 +54,19 @@ TEST(RobotFilterTest, two_match_robot_data_robot_state_not_expired_test)
     EXPECT_EQ(op_robot.value(), robot_filter.getFilteredData(new_robot_data).value());
 }
 
-TEST(RobotFilterTest, negative_orientation_test)
+TEST(RobotFilterTest, large_positive_orientation_test)
 {
-    Robot robot(1, Point(0, 0), Vector(0, 0), Angle::fromRadians(-2),
+    Robot robot(1, Point(0, 0), Vector(0, 0), Angle::fromDegrees(1.0),
                 AngularVelocity::fromRadians(0), Timestamp::fromSeconds(0));
     RobotFilter robot_filter(robot, Duration::fromSeconds(10));
     std::vector<RobotDetection> new_robot_data = {
-        {1, Point(0, 0), Angle::fromRadians(-3), 0.5, Timestamp::fromSeconds(1)}};
-    std::optional<Robot> op_robot;
-    op_robot.emplace(Robot(1, Point(0, 0), Vector(0, 0), Angle::fromRadians(-3),
-                           AngularVelocity::fromRadians(-1),
-                           Timestamp::fromSeconds(1)));
-    auto filtered = robot_filter.getFilteredData(new_robot_data).value();
-    EXPECT_EQ(op_robot.value(), robot_filter.getFilteredData(new_robot_data).value());
+        {1, Point(0, 0), Angle::fromDegrees(359), 0.5, Timestamp::fromSeconds(1)}};
+
+    Robot expected_robot(1, Point(0, 0), Vector(0, 0), Angle::fromDegrees(359.0),
+                           AngularVelocity::fromDegrees(-2.0),
+                           Timestamp::fromSeconds(1));
+    Robot filtered_robot = robot_filter.getFilteredData(new_robot_data).value();
+
+    EXPECT_DOUBLE_EQ(expected_robot.angularVelocity().toDegrees(), filtered_robot.angularVelocity().toDegrees());
+    EXPECT_EQ(expected_robot, filtered_robot);
 }

--- a/src/software/sensor_fusion/filter/robot_filter_test.cpp
+++ b/src/software/sensor_fusion/filter/robot_filter_test.cpp
@@ -53,3 +53,18 @@ TEST(RobotFilterTest, two_match_robot_data_robot_state_not_expired_test)
                            Timestamp::fromSeconds(9)));
     EXPECT_EQ(op_robot.value(), robot_filter.getFilteredData(new_robot_data).value());
 }
+
+TEST(RobotFilterTest, negative_orientation_test)
+{
+    Robot robot(1, Point(0, 0), Vector(0, 0), Angle::fromRadians(-2),
+                AngularVelocity::fromRadians(0), Timestamp::fromSeconds(0));
+    RobotFilter robot_filter(robot, Duration::fromSeconds(10));
+    std::vector<RobotDetection> new_robot_data = {
+        {1, Point(0, 0), Angle::fromRadians(-3), 0.5, Timestamp::fromSeconds(1)}};
+    std::optional<Robot> op_robot;
+    op_robot.emplace(Robot(1, Point(0, 0), Vector(0, 0), Angle::fromRadians(-3),
+                           AngularVelocity::fromRadians(-1),
+                           Timestamp::fromSeconds(1)));
+    auto filtered = robot_filter.getFilteredData(new_robot_data).value();
+    EXPECT_EQ(op_robot.value(), robot_filter.getFilteredData(new_robot_data).value());
+}

--- a/src/software/sensor_fusion/filter/robot_filter_test.cpp
+++ b/src/software/sensor_fusion/filter/robot_filter_test.cpp
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 #include <string.h>
 
+#include "software/test_util/equal_within_tolerance.h"
+
 TEST(RobotFilterTest, no_match_robot_data_robot_state_expired_test)
 {
     Robot robot(1, Point(0, 0), Vector(0, 0), Angle::fromRadians(0),
@@ -63,10 +65,11 @@ TEST(RobotFilterTest, large_positive_orientation_test)
         {1, Point(0, 0), Angle::fromDegrees(359), 0.5, Timestamp::fromSeconds(1)}};
 
     Robot expected_robot(1, Point(0, 0), Vector(0, 0), Angle::fromDegrees(359.0),
-                           AngularVelocity::fromDegrees(-2.0),
-                           Timestamp::fromSeconds(1));
+                         AngularVelocity::fromDegrees(-2.0), Timestamp::fromSeconds(1));
     Robot filtered_robot = robot_filter.getFilteredData(new_robot_data).value();
 
-    EXPECT_DOUBLE_EQ(expected_robot.angularVelocity().toDegrees(), filtered_robot.angularVelocity().toDegrees());
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(
+        expected_robot.angularVelocity().toDegrees(),
+        filtered_robot.angularVelocity().toDegrees(), 1e-6));
     EXPECT_EQ(expected_robot, filtered_robot);
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->
### Description
Fixing a bug in Sensor Fusion (specifically robot filter) where to calculate the angular velocity we computed the difference between the current and previous robot orientation. To find this difference `-` was used without `Angle::clamp`. Just using `-` can be problematic since it subtracts the two angles and does not bother two keep the result between -180degrees to 180degrees. For example, finding the difference between 359degrees and 1degree using `-` would output 358degrees, where as the more likely answer is 2degrees (which is what `clamp` would return as it tries to keep the angle between -180 and 180 degrees). This could also happen with something like 179degrees and -179degrees.
Due to the edge cases like above, the filtered robot angular velocity sometimes spiked to very large numbers when in reality the velocity was fairly small.  

**Possible future improvements:** Currently `AngularVelocity` is a typedef (basically an alias) for the `Angle` class. This is the case since the two classes share most of the same implementation. However, there does exist some differences between the two classes which are decently important to differentiate, which are currently treated as the same. For example, comparing an 360 degree `Angle` and a 0 degree `Angle` will return true (i.e. they're the same):
https://github.com/UBC-Thunderbots/Software/blob/a8b4ca10b36a294c3c2031b8d101a5e26cd22ede/src/software/geom/angle.h#L576-L580
However, an angular velocity of 360 dps is _not_ the same as an angular velocity of 0 dps. This initially turned out to be an issue with the new test I added, as it treated  358deg and 2deg (359deg - 1deg with and without being clamped) as the same value, eventhough they are two different angular velocities.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Added a new test for a scenario which would have failed previously, and which passes with the updated implementation.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
