### PR TITLE
Adjust Kickoff Boundaries

### DIFF
--- a/src/proto/primitive.proto
+++ b/src/proto/primitive.proto
@@ -43,6 +43,8 @@ enum MotionConstraint
     HALF_METER_AROUND_BALL = 7 [(dynamic) = true];
     // Path between ball and placement point in ball placement
     AVOID_BALL_PLACEMENT_INTERFERENCE = 8 [(dynamic) = true];
+    // The enemy half of the field without the centre circle
+    ENEMY_HALF_WITHOUT_CENTRE_CIRCLE = 9;
 }
 
 message MotionControl

--- a/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
+++ b/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
@@ -106,8 +106,8 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield,
 
         PriorityTacticVector result = {{}};
 
-        // TODO This needs to be adjusted post field testing, ball needs to land exactly
-        // in the middle of the enemy field
+        // TODO (#2612): This needs to be adjusted post field testing, ball needs to land
+        // exactly in the middle of the enemy field
         kickoff_chip_tactic->updateControlParams(
             world.ball().position(),
             world.field().centerPoint() + Vector(world.field().xLength() / 6, 0));

--- a/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
+++ b/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
@@ -67,7 +67,7 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield,
 
     // move tactics to use to move to positions defined above
     std::vector<std::shared_ptr<MoveTactic>> move_tactics = {
-        std::make_shared<MoveTactic>(), std::make_shared<MoveTactic>(),
+        std::make_shared<PrepareKickoffMoveTactic>(), std::make_shared<MoveTactic>(),
         std::make_shared<MoveTactic>(), std::make_shared<MoveTactic>(),
         std::make_shared<MoveTactic>()};
 

--- a/src/software/ai/hl/stp/tactic/move/move_tactic.h
+++ b/src/software/ai/hl/stp/tactic/move/move_tactic.h
@@ -67,3 +67,4 @@ class MoveTactic : public Tactic
 // Creates a new tactic called PenaltySetupTactic that is a duplicate of MoveTactic
 COPY_TACTIC(PenaltySetupTactic, MoveTactic)
 COPY_TACTIC(MoveGoalieToGoalLineTactic, MoveTactic)
+COPY_TACTIC(PrepareKickoffMoveTactic, MoveTactic)

--- a/src/software/ai/hl/stp/tactic/tactic_visitor.h
+++ b/src/software/ai/hl/stp/tactic/tactic_visitor.h
@@ -62,5 +62,5 @@ class TacticVisitor
     virtual void visit(const StopTactic &tactic)                 = 0;
     virtual void visit(const StopTestTactic &tactic)             = 0;
     virtual void visit(const MoveGoalieToGoalLineTactic &tactic) = 0;
-    virtual void visit(const PrepareKickoffMoveTactic &tactic) = 0;
+    virtual void visit(const PrepareKickoffMoveTactic &tactic)   = 0;
 };

--- a/src/software/ai/hl/stp/tactic/tactic_visitor.h
+++ b/src/software/ai/hl/stp/tactic/tactic_visitor.h
@@ -25,6 +25,7 @@ class ShadowEnemyTactic;
 class StopTactic;
 class StopTestTactic;
 class MoveGoalieToGoalLineTactic;
+class PrepareKickoffMoveTactic;
 
 /**
  * Refer to the docs about why we use the Visitor Design Pattern
@@ -61,4 +62,5 @@ class TacticVisitor
     virtual void visit(const StopTactic &tactic)                 = 0;
     virtual void visit(const StopTestTactic &tactic)             = 0;
     virtual void visit(const MoveGoalieToGoalLineTactic &tactic) = 0;
+    virtual void visit(const PrepareKickoffMoveTactic &tactic) = 0;
 };

--- a/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
@@ -13,7 +13,7 @@ std::set<TbotsProto::MotionConstraint> buildMotionConstraintSet(
 
     // updates current_allowed_constraints
     current_motion_constraints = motion_constraint_visitor.getUpdatedMotionConstraints(
-            tactic, current_motion_constraints);
+        tactic, current_motion_constraints);
 
     return current_motion_constraints;
 }

--- a/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
@@ -6,26 +6,18 @@
 std::set<TbotsProto::MotionConstraint> buildMotionConstraintSet(
     const GameState &game_state, const Tactic &tactic)
 {
-    std::set<TbotsProto::MotionConstraint> current_allowed_constraints;
     MotionConstraintVisitor motion_constraint_visitor;
 
     std::set<TbotsProto::MotionConstraint> current_motion_constraints =
         buildMotionConstraintSetFromGameState(game_state);
-    try
-    {
-        // updates current_allowed_constraints
-        current_allowed_constraints =
-            motion_constraint_visitor.getCurrentAllowedConstraints(tactic);
-    }
-    catch (std::invalid_argument &)
-    {
-        // Tactic didn't implement accept so don't add any more motion constraints
-    }
 
-    for (const auto &constraint : current_allowed_constraints)
-    {
-        current_motion_constraints.erase(constraint);
-    }
+    // updates current_allowed_constraints
+    current_motion_constraints = motion_constraint_visitor.getUpdatedMotionConstraints(
+            tactic, current_motion_constraints);
+
+    //TODO: testing
+    //current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
+    //current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
 
     return current_motion_constraints;
 }

--- a/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
@@ -15,10 +15,6 @@ std::set<TbotsProto::MotionConstraint> buildMotionConstraintSet(
     current_motion_constraints = motion_constraint_visitor.getUpdatedMotionConstraints(
             tactic, current_motion_constraints);
 
-    //TODO: testing
-    //current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
-    //current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
-
     return current_motion_constraints;
 }
 

--- a/src/software/ai/motion_constraint/motion_constraint_set_builder_test.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_set_builder_test.cpp
@@ -38,12 +38,14 @@ namespace
             std::make_tuple(std::make_shared<ChipTactic>(),
                             std::set<TbotsProto::MotionConstraint>(),
                             std::set<TbotsProto::MotionConstraint>()),
-            std::make_tuple(std::make_shared<KickoffChipTactic>(),
-                            std::set<TbotsProto::MotionConstraint>(
-                                {TbotsProto::MotionConstraint::CENTER_CIRCLE,
-                                 TbotsProto::MotionConstraint::ENEMY_HALF,
-                                 TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL}),
-                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(
+                std::make_shared<KickoffChipTactic>(),
+                std::set<TbotsProto::MotionConstraint>(
+                    {TbotsProto::MotionConstraint::CENTER_CIRCLE,
+                     TbotsProto::MotionConstraint::ENEMY_HALF,
+                     TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL}),
+                std::set<TbotsProto::MotionConstraint>(
+                    {TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE})),
             std::make_tuple(std::make_shared<PenaltyKickTactic>(ai_config),
                             std::set<TbotsProto::MotionConstraint>(
                                 {TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,

--- a/src/software/ai/motion_constraint/motion_constraint_set_builder_test.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_set_builder_test.cpp
@@ -15,52 +15,68 @@ namespace
     Pass pass({1, 1}, {0.5, 0}, 2.29);
     TbotsProto::AiConfig ai_config;
 
-    // vector of pairs of Tactic and allowed MotionConstraints
+    // vector of tuples of Tactic, MotionConstraints that should be removed,
+    // MotionConstraints that should be added
     std::vector<
-        std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>>
+        std::tuple<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>,
+                   std::set<TbotsProto::MotionConstraint>>>
         test_vector = {
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new MoveTactic(), std::set<TbotsProto::MotionConstraint>({})),
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new CreaseDefenderTactic(ai_config.robot_navigation_obstacle_config()),
-                std::set<TbotsProto::MotionConstraint>(
-                    {TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL})),
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new GoalieTactic(ai_config),
-                std::set<TbotsProto::MotionConstraint>(
-                    {TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA,
-                     TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
-                     TbotsProto::MotionConstraint::FRIENDLY_HALF})),
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new ChipTactic(), std::set<TbotsProto::MotionConstraint>({})),
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new KickoffChipTactic(),
+            std::make_tuple(std::make_shared<MoveTactic>(),
+                            std::set<TbotsProto::MotionConstraint>(),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(std::make_shared<CreaseDefenderTactic>(
+                                ai_config.robot_navigation_obstacle_config()),
+                            std::set<TbotsProto::MotionConstraint>(
+                                {TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL}),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(std::make_shared<GoalieTactic>(ai_config),
+                            std::set<TbotsProto::MotionConstraint>(
+                                {TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA,
+                                 TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
+                                 TbotsProto::MotionConstraint::FRIENDLY_HALF}),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(std::make_shared<ChipTactic>(),
+                            std::set<TbotsProto::MotionConstraint>(),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(std::make_shared<KickoffChipTactic>(),
+                            std::set<TbotsProto::MotionConstraint>(
+                                {TbotsProto::MotionConstraint::CENTER_CIRCLE,
+                                 TbotsProto::MotionConstraint::ENEMY_HALF,
+                                 TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL}),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(std::make_shared<PenaltyKickTactic>(ai_config),
+                            std::set<TbotsProto::MotionConstraint>(
+                                {TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
+                                 TbotsProto::MotionConstraint::ENEMY_DEFENSE_AREA,
+                                 TbotsProto::MotionConstraint::ENEMY_HALF}),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(std::make_shared<PenaltySetupTactic>(),
+                            std::set<TbotsProto::MotionConstraint>(
+                                {TbotsProto::MotionConstraint::ENEMY_HALF,
+                                 TbotsProto::MotionConstraint::ENEMY_DEFENSE_AREA,
+                                 TbotsProto::MotionConstraint::FRIENDLY_HALF,
+                                 TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL}),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(std::make_shared<ReceiverTactic>(),
+                            std::set<TbotsProto::MotionConstraint>(),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(std::make_shared<ShadowEnemyTactic>(),
+                            std::set<TbotsProto::MotionConstraint>(),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(std::make_shared<AttackerTactic>(ai_config),
+                            std::set<TbotsProto::MotionConstraint>(),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(std::make_shared<StopTactic>(),
+                            std::set<TbotsProto::MotionConstraint>(),
+                            std::set<TbotsProto::MotionConstraint>()),
+            std::make_tuple(
+                std::make_shared<PrepareKickoffMoveTactic>(),
                 std::set<TbotsProto::MotionConstraint>(
                     {TbotsProto::MotionConstraint::CENTER_CIRCLE,
-                     TbotsProto::MotionConstraint::ENEMY_HALF,
-                     TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL})),
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new PenaltyKickTactic(ai_config),
+                     TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
+                     TbotsProto::MotionConstraint::ENEMY_HALF}),
                 std::set<TbotsProto::MotionConstraint>(
-                    {TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
-                     TbotsProto::MotionConstraint::ENEMY_DEFENSE_AREA,
-                     TbotsProto::MotionConstraint::ENEMY_HALF})),
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new PenaltySetupTactic(),
-                std::set<TbotsProto::MotionConstraint>(
-                    {TbotsProto::MotionConstraint::ENEMY_HALF,
-                     TbotsProto::MotionConstraint::ENEMY_DEFENSE_AREA,
-                     TbotsProto::MotionConstraint::FRIENDLY_HALF,
-                     TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL})),
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new ReceiverTactic(), std::set<TbotsProto::MotionConstraint>({})),
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new ShadowEnemyTactic(), std::set<TbotsProto::MotionConstraint>({})),
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new AttackerTactic(ai_config),
-                std::set<TbotsProto::MotionConstraint>({})),
-            std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
-                new StopTactic(), std::set<TbotsProto::MotionConstraint>({}))};
+                    {TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE}))};
 
     // sets of motion constraints for each type of game state
     auto stoppage_or_them_motion_constraints = std::set<TbotsProto::MotionConstraint>(
@@ -95,7 +111,8 @@ namespace
 
 class CheckMotionConstraints
     : public ::testing::TestWithParam<
-          std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>>
+          std::tuple<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>,
+                     std::set<TbotsProto::MotionConstraint>>>
 {
    public:
     std::set<TbotsProto::MotionConstraint> correct_motion_constraints;
@@ -106,133 +123,151 @@ class CheckMotionConstraints
 TEST_P(CheckMotionConstraints, CycleStoppageOrThemGameStatesTest)
 {
     correct_motion_constraints = stoppage_or_them_motion_constraints;
+    auto &[tactic, remove_motion_constraints, insert_motion_constraints] = GetParam();
 
-    for (TbotsProto::MotionConstraint c : GetParam().second)
+    for (TbotsProto::MotionConstraint c : remove_motion_constraints)
     {
         correct_motion_constraints.erase(c);
     }
 
+    for (TbotsProto::MotionConstraint c : insert_motion_constraints)
+    {
+        correct_motion_constraints.insert(c);
+    }
+
     game_state.updateRefereeCommand(RefereeCommand::HALT);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::STOP);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::NORMAL_START);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::DIRECT_FREE_THEM);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::INDIRECT_FREE_THEM);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::TIMEOUT_US);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::TIMEOUT_THEM);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::GOAL_US);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::GOAL_THEM);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 }
 
 TEST_P(CheckMotionConstraints, CycleGameStartOrUsGameStatesTest)
 {
     correct_motion_constraints = gamestart_or_us_motion_constraints;
+    auto &[tactic, remove_motion_constraints, insert_motion_constraints] = GetParam();
 
-    for (TbotsProto::MotionConstraint c : GetParam().second)
+    for (TbotsProto::MotionConstraint c : remove_motion_constraints)
     {
         correct_motion_constraints.erase(c);
     }
 
+    for (TbotsProto::MotionConstraint c : insert_motion_constraints)
+    {
+        correct_motion_constraints.insert(c);
+    }
+
     game_state.updateRefereeCommand(RefereeCommand::FORCE_START);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::DIRECT_FREE_US);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::INDIRECT_FREE_US);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::BALL_PLACEMENT_US);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 }
 
 TEST_P(CheckMotionConstraints, CycleKickoffGameStatesTest)
 {
     correct_motion_constraints = kickoff_motion_constraints;
+    auto &[tactic, remove_motion_constraints, insert_motion_constraints] = GetParam();
 
-    for (TbotsProto::MotionConstraint c : GetParam().second)
+    for (TbotsProto::MotionConstraint c : remove_motion_constraints)
     {
         correct_motion_constraints.erase(c);
     }
 
+    for (TbotsProto::MotionConstraint c : insert_motion_constraints)
+    {
+        correct_motion_constraints.insert(c);
+    }
+
     game_state.updateRefereeCommand(RefereeCommand::PREPARE_KICKOFF_US);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 
     game_state.updateRefereeCommand(RefereeCommand::PREPARE_KICKOFF_THEM);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 }
 
 TEST_P(CheckMotionConstraints, CycleOurPenaltyGameStatesTest)
 {
     correct_motion_constraints = our_penalty_motion_constraints;
+    auto &[tactic, remove_motion_constraints, insert_motion_constraints] = GetParam();
 
-    for (TbotsProto::MotionConstraint c : GetParam().second)
+    for (TbotsProto::MotionConstraint c : remove_motion_constraints)
     {
         correct_motion_constraints.erase(c);
     }
 
+    for (TbotsProto::MotionConstraint c : insert_motion_constraints)
+    {
+        correct_motion_constraints.insert(c);
+    }
+
     game_state.updateRefereeCommand(RefereeCommand::PREPARE_PENALTY_US);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 }
 
 TEST_P(CheckMotionConstraints, CycleThemPenaltyGameStatesTest)
 {
     correct_motion_constraints = them_penalty_motion_constraints;
+    auto &[tactic, remove_motion_constraints, insert_motion_constraints] = GetParam();
 
-    for (TbotsProto::MotionConstraint c : GetParam().second)
+    for (TbotsProto::MotionConstraint c : remove_motion_constraints)
     {
         correct_motion_constraints.erase(c);
     }
 
+    for (TbotsProto::MotionConstraint c : insert_motion_constraints)
+    {
+        correct_motion_constraints.insert(c);
+    }
+
     game_state.updateRefereeCommand(RefereeCommand::PREPARE_PENALTY_THEM);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 }
 
 TEST_P(CheckMotionConstraints, CycleThemBallPlacementTest)
 {
     correct_motion_constraints = them_ball_placement;
+    auto &[tactic, remove_motion_constraints, insert_motion_constraints] = GetParam();
 
-    for (TbotsProto::MotionConstraint c : GetParam().second)
+    for (TbotsProto::MotionConstraint c : remove_motion_constraints)
     {
         correct_motion_constraints.erase(c);
     }
 
+    for (TbotsProto::MotionConstraint c : insert_motion_constraints)
+    {
+        correct_motion_constraints.insert(c);
+    }
+
     game_state.updateRefereeCommand(RefereeCommand::BALL_PLACEMENT_THEM);
-    EXPECT_EQ(correct_motion_constraints,
-              buildMotionConstraintSet(game_state, *GetParam().first));
+    EXPECT_EQ(correct_motion_constraints, buildMotionConstraintSet(game_state, *tactic));
 }
 
 

--- a/src/software/ai/motion_constraint/motion_constraint_set_builder_test.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_set_builder_test.cpp
@@ -29,7 +29,6 @@ namespace
                 new GoalieTactic(ai_config),
                 std::set<TbotsProto::MotionConstraint>(
                     {TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA,
-                     TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA,
                      TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
                      TbotsProto::MotionConstraint::FRIENDLY_HALF})),
             std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
@@ -38,6 +37,7 @@ namespace
                 new KickoffChipTactic(),
                 std::set<TbotsProto::MotionConstraint>(
                     {TbotsProto::MotionConstraint::CENTER_CIRCLE,
+                     TbotsProto::MotionConstraint::ENEMY_HALF,
                      TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL})),
             std::pair<std::shared_ptr<Tactic>, std::set<TbotsProto::MotionConstraint>>(
                 new PenaltyKickTactic(ai_config),

--- a/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
@@ -32,6 +32,8 @@ void MotionConstraintVisitor::visit(const KickoffChipTactic &tactic)
     current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
     current_motion_constraints.erase(
         TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+    current_motion_constraints.insert(
+        TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
 }
 
 void MotionConstraintVisitor::visit(const PrepareKickoffMoveTactic &tactic)

--- a/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
@@ -6,14 +6,14 @@ void MotionConstraintVisitor::visit(const GoalieTactic &tactic)
 {
     current_motion_constraints.erase(TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA);
     current_motion_constraints.erase(
-            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
     current_motion_constraints.erase(TbotsProto::MotionConstraint::FRIENDLY_HALF);
 }
 
 void MotionConstraintVisitor::visit(const CreaseDefenderTactic &tactic)
 {
     current_motion_constraints.erase(
-            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
 }
 
 void MotionConstraintVisitor::visit(const ShadowEnemyTactic &tactic) {}
@@ -31,15 +31,17 @@ void MotionConstraintVisitor::visit(const KickoffChipTactic &tactic)
     current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
     current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
     current_motion_constraints.erase(
-            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
 }
 
-void MotionConstraintVisitor::visit(const PrepareKickoffMoveTactic &tactic) {
+void MotionConstraintVisitor::visit(const PrepareKickoffMoveTactic &tactic)
+{
     current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
     current_motion_constraints.erase(
-            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
     current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
-    current_motion_constraints.insert(TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
+    current_motion_constraints.insert(
+        TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
 }
 
 void MotionConstraintVisitor::visit(const StopTactic &tactic) {}
@@ -47,7 +49,7 @@ void MotionConstraintVisitor::visit(const StopTactic &tactic) {}
 void MotionConstraintVisitor::visit(const PenaltyKickTactic &tactic)
 {
     current_motion_constraints.erase(
-            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
     current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_DEFENSE_AREA);
     current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
 }
@@ -58,12 +60,12 @@ void MotionConstraintVisitor::visit(const PenaltySetupTactic &tactic)
     current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_DEFENSE_AREA);
     current_motion_constraints.erase(TbotsProto::MotionConstraint::FRIENDLY_HALF);
     current_motion_constraints.erase(
-            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
 }
 
 void MotionConstraintVisitor::visit(const ReceiverTactic &tactic) {}
 
-void MotionConstraintVisitor::visit(const AttackerTactic &tactic) { }
+void MotionConstraintVisitor::visit(const AttackerTactic &tactic) {}
 
 void MotionConstraintVisitor::visit(const DefenseShadowEnemyTactic &tactic) {}
 

--- a/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
@@ -63,7 +63,17 @@ void MotionConstraintVisitor::visit(const PenaltySetupTactic &tactic)
 
 void MotionConstraintVisitor::visit(const ReceiverTactic &tactic) {}
 
-void MotionConstraintVisitor::visit(const AttackerTactic &tactic) { }
+void MotionConstraintVisitor::visit(const AttackerTactic &tactic) {
+
+    if (current_motion_constraints.contains(TbotsProto::MotionConstraint::ENEMY_HALF))
+    {
+        current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
+        current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
+        current_motion_constraints.insert(
+                TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
+    }
+
+}
 
 void MotionConstraintVisitor::visit(const DefenseShadowEnemyTactic &tactic) {}
 
@@ -78,7 +88,7 @@ void MotionConstraintVisitor::visit(const DribbleTactic &tactic) {}
 void MotionConstraintVisitor::visit(const GetBehindBallTactic &tactic) {}
 
 void MotionConstraintVisitor::visit(const MoveGoalieToGoalLineTactic &tactic)
-{
+{{
     current_allowed_constraints = std::set<TbotsProto::MotionConstraint>({
         TbotsProto::MotionConstraint::FRIENDLY_HALF,
         TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA

--- a/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
@@ -2,29 +2,31 @@
 
 #include "software/ai/hl/stp/tactic/all_tactics.h"
 
-
-
-// We disable clang-format here because it makes these lists borderline unreadable,
-// and certainly way more difficult to edit
-// clang-format off
 void MotionConstraintVisitor::visit(const GoalieTactic &tactic)
 {
-    current_allowed_constraints = std::set<TbotsProto::MotionConstraint>({
-        TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA,
-        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
-        TbotsProto::MotionConstraint::FRIENDLY_HALF
-    });
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA);
+    current_motion_constraints.erase(
+            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::FRIENDLY_HALF);
 }
 
-void MotionConstraintVisitor::visit(const CreaseDefenderTactic &tactic) {
-    current_allowed_constraints = std::set<TbotsProto::MotionConstraint>({
-        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
-    });
+void MotionConstraintVisitor::visit(const CreaseDefenderTactic &tactic)
+{
+    current_motion_constraints.erase(
+            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
 }
 
 void MotionConstraintVisitor::visit(const ShadowEnemyTactic &tactic) {}
 
-void MotionConstraintVisitor::visit(const MoveTactic &tactic) {}
+void MotionConstraintVisitor::visit(const MoveTactic &tactic) {
+
+    if (current_motion_constraints.contains(TbotsProto::MotionConstraint::ENEMY_HALF)) {
+        current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
+        current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
+        current_motion_constraints.insert(TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
+    }
+
+}
 
 void MotionConstraintVisitor::visit(const ChipTactic &tactic) {}
 
@@ -34,45 +36,41 @@ void MotionConstraintVisitor::visit(const PivotKickTactic &tactic) {}
 
 void MotionConstraintVisitor::visit(const KickoffChipTactic &tactic)
 {
-    current_allowed_constraints = std::set<TbotsProto::MotionConstraint>({
-        TbotsProto::MotionConstraint::CENTER_CIRCLE,
-        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL
-    });
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
+    current_motion_constraints.erase(
+            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
 }
 
 void MotionConstraintVisitor::visit(const StopTactic &tactic) {}
 
 void MotionConstraintVisitor::visit(const PenaltyKickTactic &tactic)
 {
-    current_allowed_constraints = std::set<TbotsProto::MotionConstraint>({
-        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
-        TbotsProto::MotionConstraint::ENEMY_DEFENSE_AREA,
-        TbotsProto::MotionConstraint::ENEMY_HALF
-    });
+    current_motion_constraints.erase(
+            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_DEFENSE_AREA);
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
 }
 
 void MotionConstraintVisitor::visit(const PenaltySetupTactic &tactic)
 {
-    current_allowed_constraints = std::set<TbotsProto::MotionConstraint>({
-        TbotsProto::MotionConstraint::ENEMY_HALF,
-        TbotsProto::MotionConstraint::ENEMY_DEFENSE_AREA,
-        TbotsProto::MotionConstraint::FRIENDLY_HALF,
-        TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL
-    });
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_DEFENSE_AREA);
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::FRIENDLY_HALF);
+    current_motion_constraints.erase(
+            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
 }
 
 void MotionConstraintVisitor::visit(const ReceiverTactic &tactic) {}
 
-void MotionConstraintVisitor::visit(const AttackerTactic &tactic) {
-
+void MotionConstraintVisitor::visit(const AttackerTactic &tactic)
+{
     if (current_motion_constraints.contains(TbotsProto::MotionConstraint::ENEMY_HALF))
     {
         current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
         current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
         current_motion_constraints.insert(
-                TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
+            TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
     }
-
 }
 
 void MotionConstraintVisitor::visit(const DefenseShadowEnemyTactic &tactic) {}
@@ -88,18 +86,17 @@ void MotionConstraintVisitor::visit(const DribbleTactic &tactic) {}
 void MotionConstraintVisitor::visit(const GetBehindBallTactic &tactic) {}
 
 void MotionConstraintVisitor::visit(const MoveGoalieToGoalLineTactic &tactic)
-{{
-    current_allowed_constraints = std::set<TbotsProto::MotionConstraint>({
-        TbotsProto::MotionConstraint::FRIENDLY_HALF,
-        TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA
-    });
+{
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::FRIENDLY_HALF);
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA);
 }
 
-// clang-format on
-
 std::set<TbotsProto::MotionConstraint>
-MotionConstraintVisitor::getCurrentAllowedConstraints(const Tactic &tactic)
+MotionConstraintVisitor::getUpdatedMotionConstraints(
+    const Tactic &tactic,
+    const std::set<TbotsProto::MotionConstraint> &existing_motion_constraints)
 {
+    current_motion_constraints = existing_motion_constraints;
     tactic.accept(*this);
-    return current_allowed_constraints;
+    return current_motion_constraints;
 }

--- a/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
@@ -18,15 +18,7 @@ void MotionConstraintVisitor::visit(const CreaseDefenderTactic &tactic)
 
 void MotionConstraintVisitor::visit(const ShadowEnemyTactic &tactic) {}
 
-void MotionConstraintVisitor::visit(const MoveTactic &tactic) {
-
-    if (current_motion_constraints.contains(TbotsProto::MotionConstraint::ENEMY_HALF)) {
-        current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
-        current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
-        current_motion_constraints.insert(TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
-    }
-
-}
+void MotionConstraintVisitor::visit(const MoveTactic &tactic) {}
 
 void MotionConstraintVisitor::visit(const ChipTactic &tactic) {}
 
@@ -39,6 +31,20 @@ void MotionConstraintVisitor::visit(const KickoffChipTactic &tactic)
     current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
     current_motion_constraints.erase(
             TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+    //TODO: edit
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
+    current_motion_constraints.insert(TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
+}
+
+//TODO: Create a visitor for a new prepare kickoff move tactic
+void MotionConstraintVisitor::visit(const PrepareKickoffMoveTactic &tactic) {
+
+    //TODO: When we are in the prepare kickoff state, we still want to be as close to the ball as possible
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
+    current_motion_constraints.erase(
+            TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
+    current_motion_constraints.insert(TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
 }
 
 void MotionConstraintVisitor::visit(const StopTactic &tactic) {}
@@ -62,16 +68,7 @@ void MotionConstraintVisitor::visit(const PenaltySetupTactic &tactic)
 
 void MotionConstraintVisitor::visit(const ReceiverTactic &tactic) {}
 
-void MotionConstraintVisitor::visit(const AttackerTactic &tactic)
-{
-    if (current_motion_constraints.contains(TbotsProto::MotionConstraint::ENEMY_HALF))
-    {
-        current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
-        current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
-        current_motion_constraints.insert(
-            TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
-    }
-}
+void MotionConstraintVisitor::visit(const AttackerTactic &tactic) { }
 
 void MotionConstraintVisitor::visit(const DefenseShadowEnemyTactic &tactic) {}
 

--- a/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_visitor.cpp
@@ -29,17 +29,12 @@ void MotionConstraintVisitor::visit(const PivotKickTactic &tactic) {}
 void MotionConstraintVisitor::visit(const KickoffChipTactic &tactic)
 {
     current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
+    current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
     current_motion_constraints.erase(
             TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);
-    //TODO: edit
-    current_motion_constraints.erase(TbotsProto::MotionConstraint::ENEMY_HALF);
-    current_motion_constraints.insert(TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE);
 }
 
-//TODO: Create a visitor for a new prepare kickoff move tactic
 void MotionConstraintVisitor::visit(const PrepareKickoffMoveTactic &tactic) {
-
-    //TODO: When we are in the prepare kickoff state, we still want to be as close to the ball as possible
     current_motion_constraints.erase(TbotsProto::MotionConstraint::CENTER_CIRCLE);
     current_motion_constraints.erase(
             TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL);

--- a/src/software/ai/motion_constraint/motion_constraint_visitor.h
+++ b/src/software/ai/motion_constraint/motion_constraint_visitor.h
@@ -51,7 +51,7 @@ class MotionConstraintVisitor : public TacticVisitor
      */
     std::set<TbotsProto::MotionConstraint> getUpdatedMotionConstraints(
         const Tactic &tactic,
-        std::set<TbotsProto::MotionConstraint> existing_motion_constraints);
+        const std::set<TbotsProto::MotionConstraint> &existing_motion_constraints);
 
    private:
     std::set<TbotsProto::MotionConstraint> current_motion_constraints;

--- a/src/software/ai/motion_constraint/motion_constraint_visitor.h
+++ b/src/software/ai/motion_constraint/motion_constraint_visitor.h
@@ -39,6 +39,7 @@ class MotionConstraintVisitor : public TacticVisitor
     void visit(const GetBehindBallTactic &tactic) override;
     void visit(const PivotKickTactic &tactic) override;
     void visit(const MoveGoalieToGoalLineTactic &tactic) override;
+    void visit(const PrepareKickoffMoveTactic &tactic) override;
 
     /**
      * Gets the motion constraints updated with the requirements of the tactics

--- a/src/software/ai/motion_constraint/motion_constraint_visitor.h
+++ b/src/software/ai/motion_constraint/motion_constraint_visitor.h
@@ -17,7 +17,7 @@ class MotionConstraintVisitor : public TacticVisitor
      *
      * @param The tactic to register
      *
-     * @modifies current_allowed_constraints
+     * @modifies current_motion_constraints
      */
     void visit(const GoalieTactic &tactic) override;
     void visit(const CreaseDefenderTactic &tactic) override;
@@ -41,16 +41,18 @@ class MotionConstraintVisitor : public TacticVisitor
     void visit(const MoveGoalieToGoalLineTactic &tactic) override;
 
     /**
-     * Gets the current allowed constraints from a tactic
+     * Gets the motion constraints updated with the requirements of the tactics
      *
-     * @param The tactic to register
+     * @param The tactic to use to update the motion constraints
+     * @param The existing motion constraints from other sources
      *
-     * @modifies current_allowed_constraints
+     * @modifies current_motion_constraints
      * @return set of MotionConstraints
      */
-    std::set<TbotsProto::MotionConstraint> getCurrentAllowedConstraints(
-        const Tactic &tactic);
+    std::set<TbotsProto::MotionConstraint> getUpdatedMotionConstraints(
+        const Tactic &tactic,
+        std::set<TbotsProto::MotionConstraint> existing_motion_constraints);
 
    private:
-    std::set<TbotsProto::MotionConstraint> current_allowed_constraints;
+    std::set<TbotsProto::MotionConstraint> current_motion_constraints;
 };

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -64,12 +64,14 @@ RobotNavigationObstacleFactory::createStaticObstaclesFromMotionConstraint(
             break;
         case TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE:
         {
-            double radius = field.centerCircleRadius() + 0.2;
+            double radius                        = field.centerCircleRadius() + 0.2;
             Polygon centre_circle_and_enemy_half = Polygon(
                 {Point(0, field.fieldBoundary().yLength() / 2), Point(0, radius),
-                 Point(radius * std::cos(M_PI / 4), radius * std::sin(M_PI / 4)), Point(radius, 0),
-                 Point(radius * std::cos(M_PI / 4), -radius * std::sin(M_PI / 4)), Point(0, -radius),
-                 Point(0, -field.fieldBoundary().yLength() / 2), field.fieldBoundary().posXNegYCorner(),
+                 Point(radius * std::cos(M_PI / 4), radius * std::sin(M_PI / 4)),
+                 Point(radius, 0),
+                 Point(radius * std::cos(M_PI / 4), -radius * std::sin(M_PI / 4)),
+                 Point(0, -radius), Point(0, -field.fieldBoundary().yLength() / 2),
+                 field.fieldBoundary().posXNegYCorner(),
                  field.fieldBoundary().posXPosYCorner()});
             obstacles.push_back(createFromShape(centre_circle_and_enemy_half));
             break;

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -64,16 +64,26 @@ RobotNavigationObstacleFactory::createStaticObstaclesFromMotionConstraint(
             break;
         case TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE:
         {
-            double radius                        = field.centerCircleRadius() + 0.2;
-            Polygon centre_circle_and_enemy_half = Polygon(
-                {Point(0, field.fieldBoundary().yLength() / 2), Point(0, radius),
-                 Point(radius * std::cos(M_PI / 4), radius * std::sin(M_PI / 4)),
-                 Point(radius, 0),
-                 Point(radius * std::cos(M_PI / 4), -radius * std::sin(M_PI / 4)),
-                 Point(0, -radius), Point(0, -field.fieldBoundary().yLength() / 2),
-                 field.fieldBoundary().posXNegYCorner(),
-                 field.fieldBoundary().posXPosYCorner()});
-            obstacles.push_back(createFromShape(centre_circle_and_enemy_half));
+            double smaller_radius =
+                field.centerCircleRadius() - robot_radius_expansion_amount;
+            Polygon centre_circle_and_enemy_half =
+                Polygon({Point(-robot_radius_expansion_amount,
+                               field.fieldBoundary().yLength() / 2),
+                         Point(-robot_radius_expansion_amount, smaller_radius),
+                         Point(0, smaller_radius),
+                         Point(smaller_radius * std::cos(M_PI / 4),
+                               smaller_radius * std::sin(M_PI / 4)),
+                         Point(smaller_radius, 0),
+                         Point(smaller_radius * std::cos(M_PI / 4),
+                               -smaller_radius * std::sin(M_PI / 4)),
+                         Point(0, -smaller_radius),
+                         Point(-robot_radius_expansion_amount, -smaller_radius),
+                         Point(-robot_radius_expansion_amount,
+                               -field.fieldBoundary().yLength() / 2),
+                         field.fieldBoundary().posXNegYCorner(),
+                         field.fieldBoundary().posXPosYCorner()});
+            obstacles.push_back(
+                std::make_shared<GeomObstacle<Polygon>>(centre_circle_and_enemy_half));
             break;
         }
         case TbotsProto::MotionConstraint::AVOID_FIELD_BOUNDARY_ZONE:

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -64,12 +64,12 @@ RobotNavigationObstacleFactory::createStaticObstaclesFromMotionConstraint(
             break;
         case TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE:
         {
-            double larger_radius                 = field.centerCircleRadius() + 0.2;
+            double radius = field.centerCircleRadius() + 0.2;
             Polygon centre_circle_and_enemy_half = Polygon(
-                {Point(0, field.yLength() / 2), Point(0, larger_radius),
-                 Point(larger_radius, larger_radius), Point(larger_radius + 0.2, 0),
-                 Point(larger_radius, -larger_radius), Point(0, -larger_radius),
-                 Point(0, -field.yLength() / 2), field.fieldBoundary().posXNegYCorner(),
+                {Point(0, field.fieldBoundary().yLength() / 2), Point(0, radius),
+                 Point(radius * std::cos(M_PI / 4), radius * std::sin(M_PI / 4)), Point(radius, 0),
+                 Point(radius * std::cos(M_PI / 4), -radius * std::sin(M_PI / 4)), Point(0, -radius),
+                 Point(0, -field.fieldBoundary().yLength() / 2), field.fieldBoundary().posXNegYCorner(),
                  field.fieldBoundary().posXPosYCorner()});
             obstacles.push_back(createFromShape(centre_circle_and_enemy_half));
             break;

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -66,11 +66,11 @@ RobotNavigationObstacleFactory::createStaticObstaclesFromMotionConstraint(
         {
             double larger_radius                 = field.centerCircleRadius() + 0.2;
             Polygon centre_circle_and_enemy_half = Polygon(
-                    {Point(0, field.yLength() / 2), Point(0, larger_radius),
-                     Point(larger_radius, larger_radius), Point(larger_radius + 0.2, 0),
-                     Point(larger_radius, -larger_radius), Point(0, -larger_radius),
-                     Point(0, -field.yLength() / 2), field.fieldBoundary().posXNegYCorner(),
-                     field.fieldBoundary().posXPosYCorner()});
+                {Point(0, field.yLength() / 2), Point(0, larger_radius),
+                 Point(larger_radius, larger_radius), Point(larger_radius + 0.2, 0),
+                 Point(larger_radius, -larger_radius), Point(0, -larger_radius),
+                 Point(0, -field.yLength() / 2), field.fieldBoundary().posXNegYCorner(),
+                 field.fieldBoundary().posXPosYCorner()});
             obstacles.push_back(createFromShape(centre_circle_and_enemy_half));
             break;
         }

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -62,6 +62,18 @@ RobotNavigationObstacleFactory::createStaticObstaclesFromMotionConstraint(
             obstacles.push_back(createFromFieldRectangle(
                 field.enemyHalf(), field.fieldLines(), field.fieldBoundary()));
             break;
+        case TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE:
+        {
+            double larger_radius                 = field.centerCircleRadius() + 0.2;
+            Polygon centre_circle_and_enemy_half = Polygon(
+                    {Point(0, field.yLength() / 2), Point(0, larger_radius),
+                     Point(larger_radius, larger_radius), Point(larger_radius + 0.2, 0),
+                     Point(larger_radius, -larger_radius), Point(0, -larger_radius),
+                     Point(0, -field.yLength() / 2), field.fieldBoundary().posXNegYCorner(),
+                     field.fieldBoundary().posXPosYCorner()});
+            obstacles.push_back(createFromShape(centre_circle_and_enemy_half));
+            break;
+        }
         case TbotsProto::MotionConstraint::AVOID_FIELD_BOUNDARY_ZONE:
         {
             Rectangle field_walls    = field.fieldBoundary();
@@ -126,6 +138,9 @@ RobotNavigationObstacleFactory::createDynamicObstaclesFromMotionConstraint(
             // not handled by this obstacle factory since it's a static obstacle
             break;
         case TbotsProto::MotionConstraint::ENEMY_HALF:
+            // not handled by this obstacle factory since it's a static obstacle
+            break;
+        case TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE:
             // not handled by this obstacle factory since it's a static obstacle
             break;
         case TbotsProto::MotionConstraint::AVOID_FIELD_BOUNDARY_ZONE:

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -64,24 +64,19 @@ RobotNavigationObstacleFactory::createStaticObstaclesFromMotionConstraint(
             break;
         case TbotsProto::MotionConstraint::ENEMY_HALF_WITHOUT_CENTRE_CIRCLE:
         {
-            double smaller_radius =
-                field.centerCircleRadius() - robot_radius_expansion_amount;
-            Polygon centre_circle_and_enemy_half =
-                Polygon({Point(-robot_radius_expansion_amount,
-                               field.fieldBoundary().yLength() / 2),
-                         Point(-robot_radius_expansion_amount, smaller_radius),
-                         Point(0, smaller_radius),
-                         Point(smaller_radius * std::cos(M_PI / 4),
-                               smaller_radius * std::sin(M_PI / 4)),
-                         Point(smaller_radius, 0),
-                         Point(smaller_radius * std::cos(M_PI / 4),
-                               -smaller_radius * std::sin(M_PI / 4)),
-                         Point(0, -smaller_radius),
-                         Point(-robot_radius_expansion_amount, -smaller_radius),
-                         Point(-robot_radius_expansion_amount,
-                               -field.fieldBoundary().yLength() / 2),
-                         field.fieldBoundary().posXNegYCorner(),
-                         field.fieldBoundary().posXPosYCorner()});
+            double radius                        = field.centerCircleRadius();
+            Polygon centre_circle_and_enemy_half = Polygon(
+                {Point(-robot_radius_expansion_amount,
+                       field.fieldBoundary().yLength() / 2),
+                 Point(-robot_radius_expansion_amount, radius), Point(0, radius),
+                 Point(radius * std::cos(M_PI / 4), radius * std::sin(M_PI / 4)),
+                 Point(radius, 0),
+                 Point(radius * std::cos(M_PI / 4), -radius * std::sin(M_PI / 4)),
+                 Point(0, -radius), Point(-robot_radius_expansion_amount, -radius),
+                 Point(-robot_radius_expansion_amount,
+                       -field.fieldBoundary().yLength() / 2),
+                 field.fieldBoundary().posXNegYCorner(),
+                 field.fieldBoundary().posXPosYCorner()});
             obstacles.push_back(
                 std::make_shared<GeomObstacle<Polygon>>(centre_circle_and_enemy_half));
             break;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Allows a friendly robot to enter center circle during kickoff preparation by creating a new motion constraint for `PrepareKickoffMoveTactic`
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
* Ran AI vs AI on Thunderscope for kickoff friendly play
* Added new test parameter for `PrepareKickoffMoveTactic`
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
resolves #2800 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
