### PR TITLE
Command Line Arg to Disable Estop for Testing

### DIFF
--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -28,6 +28,7 @@ class RobotCommunication(object):
         current_mode,
         multicast_channel,
         interface,
+        disable_estop,
         estop_path="/dev/ttyACM0",
         estop_buadrate=115200,
     ):
@@ -37,6 +38,7 @@ class RobotCommunication(object):
         :param current_mode: one of RobotCommunicationMode, indicates which mode is currently running
         :param multicast_channel: The multicast channel to use
         :param interface: The interface to use
+        :param disable_estop: whether to disable estop checks (ONLY FOR TESTING LOCALLY)
         :param estop_path: The path to the estop
         :param estop_baudrate: The baudrate of the estop
 
@@ -44,11 +46,12 @@ class RobotCommunication(object):
         self.sequence_number = 0
         self.last_time = time.time()
         self.current_proto_unix_io = current_proto_unix_io
+        self.current_mode = current_mode
         self.multicast_channel = str(multicast_channel)
         self.interface = interface
+        self.disable_estop = disable_estop
         self.estop_path = estop_path
         self.estop_buadrate = estop_buadrate
-        self.current_mode = current_mode
 
         self.world_buffer = ThreadSafeBuffer(1, World)
         self.primitive_buffer = ThreadSafeBuffer(1, PrimitiveSet)
@@ -87,18 +90,22 @@ class RobotCommunication(object):
         self.send_estop_state_thread = threading.Thread(target=self.__send_estop_state)
         self.run_thread = threading.Thread(target=self.run)
 
-        try:
-            self.estop_reader = ThreadedEstopReader(
-                self.estop_path, self.estop_buadrate
-            )
-        except Exception:
-            raise Exception("Could not find estop, make sure its plugged in")
+        if not self.disable_estop:
+            try:
+                self.estop_reader = ThreadedEstopReader(
+                    self.estop_path, self.estop_buadrate
+                )
+            except Exception:
+                raise Exception("Could not find estop, make sure its plugged in")
 
     def __send_estop_state(self):
-        while True:
-            self.current_proto_unix_io.send_proto(
-                EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
-            )
+        if self.disable_estop:
+            pass
+        else:
+            while True:
+                self.current_proto_unix_io.send_proto(
+                    EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())
+                )
             time.sleep(0.1)
 
     def run(self):
@@ -173,7 +180,7 @@ class RobotCommunication(object):
 
             self.sequence_number += 1
 
-            if self.estop_reader.isEstopPlay():
+            if not self.disable_estop and self.estop_reader.isEstopPlay():
                 self.last_time = primitive_set.time_sent.epoch_timestamp_seconds
                 self.send_primitive_set.send_proto(primitive_set)
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -90,6 +90,7 @@ class RobotCommunication(object):
         self.send_estop_state_thread = threading.Thread(target=self.__send_estop_state)
         self.run_thread = threading.Thread(target=self.run)
 
+        # only checks for estop if checking is not disabled
         if not self.disable_estop:
             try:
                 self.estop_reader = ThreadedEstopReader(
@@ -99,9 +100,7 @@ class RobotCommunication(object):
                 raise Exception("Could not find estop, make sure its plugged in")
 
     def __send_estop_state(self):
-        if self.disable_estop:
-            pass
-        else:
+        if not self.disable_estop:
             while True:
                 self.current_proto_unix_io.send_proto(
                     EstopState, EstopState(is_playing=self.estop_reader.isEstopPlay())

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
         "--disable_estop",
         action="store_true",
         default=False,
-        help="Disables checking for estop plugged in (ONLY USE FOR LOCAL TESTING)"
+        help="Disables checking for estop plugged in (ONLY USE FOR LOCAL TESTING)",
     )
 
     # Sanity check that an interface was provided
@@ -268,7 +268,7 @@ if __name__ == "__main__":
             current_mode,
             getRobotMulticastChannel(0),
             args.interface,
-            args.disable_estop
+            args.disable_estop,
         ) as robot_communication:
             if args.run_diagnostics:
                 tscope.toggle_robot_connection_signal.connect(

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -153,6 +153,12 @@ if __name__ == "__main__":
         default=115200,
         help="Estop Baudrate",
     )
+    parser.add_argument(
+        "--disable_estop",
+        action="store_true",
+        default=False,
+        help="Disables checking for estop plugged in (ONLY USE FOR LOCAL TESTING)"
+    )
 
     # Sanity check that an interface was provided
     args = parser.parse_args()
@@ -262,6 +268,7 @@ if __name__ == "__main__":
             current_mode,
             getRobotMulticastChannel(0),
             args.interface,
+            args.disable_estop
         ) as robot_communication:
             if args.run_diagnostics:
                 tscope.toggle_robot_connection_signal.connect(


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Added a Command Line argument to disable all estop checks for testing

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Thunderscope builds and runs normally

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
