### PR TITLE
Add support for new estops + up the min voltage for battery warnings

### DIFF
--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -114,7 +114,7 @@ static const unsigned int MAX_ROBOT_IDS = MAX_ROBOT_IDS_PER_SIDE * 2;
 static const unsigned NUM_CELLS_IN_BATTERY    = 3;
 static const unsigned NUM_BATTERIES_IN_SERIES = 2;
 static const double MAX_SINGLE_CELL_VOLTAGE   = 4.2;
-static const double MIN_SINGLE_CELL_VOLTAGE   = 3.2 + 0.1;  // +0.1v headroom
+static const double MIN_SINGLE_CELL_VOLTAGE   = 3.7 + 0.1;  // +0.1v headroom
 
 static const double MIN_BATTERY_VOLTAGE =
     MIN_SINGLE_CELL_VOLTAGE * NUM_CELLS_IN_BATTERY * NUM_BATTERIES_IN_SERIES;

--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -114,7 +114,7 @@ static const unsigned int MAX_ROBOT_IDS = MAX_ROBOT_IDS_PER_SIDE * 2;
 static const unsigned NUM_CELLS_IN_BATTERY    = 3;
 static const unsigned NUM_BATTERIES_IN_SERIES = 2;
 static const double MAX_SINGLE_CELL_VOLTAGE   = 4.2;
-static const double MIN_SINGLE_CELL_VOLTAGE   = 3.7 + 0.1;  // +0.1v headroom
+static const double MIN_SINGLE_CELL_VOLTAGE   = 3.5 + 0.1;  // +0.1v headroom
 
 static const double MIN_BATTERY_VOLTAGE =
     MIN_SINGLE_CELL_VOLTAGE * NUM_CELLS_IN_BATTERY * NUM_BATTERIES_IN_SERIES;

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -19,7 +19,7 @@ class RobotCommunication(object):
         multicast_channel,
         interface,
         disable_estop,
-        estop_path="/dev/ttyACM0",
+        estop_path,
         estop_buadrate=115200,
     ):
         """Initialize the communication with the robots

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -257,11 +257,17 @@ if __name__ == "__main__":
         # else, it will be the diagnostics proto
         current_proto_unix_io = tscope.proto_unix_io_map[ProtoUnixIOTypes.CURRENT]
 
+        # different estops use different ports this detects which one to use based on what is plugged in
+        estop_path = (
+            "/dev/ttyACM0" if os.path.isfile("/dev/ttyACM0") else "/dev/ttyUSB0"
+        )
+
         with RobotCommunication(
             current_proto_unix_io,
             getRobotMulticastChannel(0),
             args.interface,
             args.disable_estop,
+            estop_path,
         ) as robot_communication:
             if args.run_diagnostics:
                 for tab in tscope_config.tabs:


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

new estops use arduino nanos instead of micros. For some reason these use /dev/ttyUSB0 instead of /dev/ttyACM0. 

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

used a new and old estop with diagnostics
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
