### PR TITLE
Integrate single touch plays into OffensePlay

### DIFF
--- a/docs/fsm-diagrams.md
+++ b/docs/fsm-diagrams.md
@@ -61,7 +61,9 @@ stateDiagram-v2
 classDef terminate fill:white,color:black,font-weight:bold
 direction LR
 [*] --> StartState
-StartState --> AttemptShotState : <i>startLookingForPass</i>
+StartState --> AttemptShotState : [shouldSingleTouch]\n<i>singleTouchStartLookingForPass</i>
+StartState --> AttemptShotState : [!hasPassInProgress]\n<i>startLookingForPass</i>
+StartState --> TakePassState : [hasPassInProgress]\n<i>maintainPassInProgress</i>
 AttemptShotState --> TakePassState : [passFound]\n<i>takePass</i>
 AttemptShotState --> Terminate:::terminate : [tookShot]
 AttemptShotState --> AttemptShotState : [!passFound]\n<i>lookForPass</i>
@@ -79,7 +81,12 @@ Terminate:::terminate --> AttemptShotState : <i>startLookingForPass</i>
 stateDiagram-v2
 classDef terminate fill:white,color:black,font-weight:bold
 direction LR
-[*] --> DribbleFSM
+[*] --> MoveFSM
+MoveFSM --> DribbleFSM : [!shouldSingleTouch]\n<i>keepAway</i>
+MoveFSM --> KickFSM : [shouldKick]\n<i>singleTouchKick</i>
+MoveFSM --> MoveFSM : [!shouldKick]\n<i>alignToBall</i>
+KickFSM --> KickFSM : <i>singleTouchKick</i>
+KickFSM --> Terminate:::terminate
 DribbleFSM --> PivotKickFSM : [shouldKick]\n<i>pivotKick</i>
 DribbleFSM --> DribbleFSM : [!shouldKick]\n<i>keepAway</i>
 PivotKickFSM --> PivotKickFSM : <i>pivotKick</i>

--- a/src/software/ai/hl/stp/play/offense/offense_play.cpp
+++ b/src/software/ai/hl/stp/play/offense/offense_play.cpp
@@ -11,7 +11,6 @@ OffensePlay::OffensePlay(TbotsProto::AiConfig config)
     : Play(config, true),
       shoot_or_pass_play(std::make_shared<ShootOrPassPlay>(ai_config)),
       crease_defense_play(std::make_shared<CreaseDefensePlay>(ai_config))
-
 {
 }
 
@@ -34,12 +33,32 @@ void OffensePlay::updateTactics(const PlayUpdate &play_update)
     PriorityTacticVector tactics_to_return;
     unsigned int num_defenders = 2;
     unsigned int num_enemy_robots =
-        static_cast<int>(play_update.world.enemyTeam().numRobots());
+        static_cast<unsigned int>(play_update.world.enemyTeam().numRobots());
 
-    // enemy team has at most half a full team, so we need at most half the number of
-    // defenders
-    if (num_enemy_robots <= 3)
+    if (play_update.world.gameState().isSetupState() &&
+        (play_update.world.gameState().isOurDirectFree() ||
+         play_update.world.gameState().isOurIndirectFree()))
     {
+        // if we're in free kick on the enemy side, then we can commit more robots in
+        // forward positions
+        if (play_update.world.ball().position().x() > 0)
+        {
+            num_defenders = static_cast<unsigned int>(std::max(
+                0, static_cast<int>(
+                       2 - 2 * play_update.world.ball().position().x() /
+                               (play_update.world.field().fieldLines().xMax() / 3.0))));
+        }
+        shoot_or_pass_play->updateControlParams(true);
+    }
+    else if (play_update.world.gameState().isReadyState() &&
+             play_update.world.gameState().isOurKickoff())
+    {
+        shoot_or_pass_play->updateControlParams(true);
+    }
+    else if (num_enemy_robots <= 3)
+    {
+        // enemy team has at most half a full team, so we need at most half the number of
+        // defenders
         num_defenders = 1;
         if (num_enemy_robots < 2)
         {
@@ -50,6 +69,13 @@ void OffensePlay::updateTactics(const PlayUpdate &play_update)
     {
         // play_update.num_tactics == 0 is handled above
         num_defenders = play_update.num_tactics - 1;
+    }
+    else if (play_update.world.ball().position().x() <
+             play_update.world.field().fieldLines().xMin() / 4.0)
+    {
+        // if we have more than 3 robots and the ball is on our side of the field, then we
+        // should dedicate an additional robot to defense
+        num_defenders = 3;
     }
 
     unsigned int num_shoot_or_pass = play_update.num_tactics - num_defenders;

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play.cpp
@@ -6,7 +6,9 @@
 #include "software/util/generic_factory/generic_factory.h"
 
 ShootOrPassPlay::ShootOrPassPlay(TbotsProto::AiConfig config)
-    : Play(config, true), fsm{ShootOrPassPlayFSM{config}}, control_params{}
+    : Play(config, true),
+      fsm{ShootOrPassPlayFSM{config}},
+      control_params{.should_one_touch = false}
 {
 }
 
@@ -18,6 +20,11 @@ void ShootOrPassPlay::getNextTactics(TacticCoroutine::push_type &yield,
     {
         yield({{}});
     }
+}
+
+void ShootOrPassPlay::updateControlParams(bool should_one_touch)
+{
+    control_params.should_one_touch = should_one_touch;
 }
 
 void ShootOrPassPlay::updateTactics(const PlayUpdate &play_update)

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play.cpp
@@ -8,7 +8,7 @@
 ShootOrPassPlay::ShootOrPassPlay(TbotsProto::AiConfig config)
     : Play(config, true),
       fsm{ShootOrPassPlayFSM{config}},
-      control_params{.should_one_touch = false}
+      control_params{.should_single_touch = false}
 {
 }
 
@@ -22,9 +22,9 @@ void ShootOrPassPlay::getNextTactics(TacticCoroutine::push_type &yield,
     }
 }
 
-void ShootOrPassPlay::updateControlParams(bool should_one_touch)
+void ShootOrPassPlay::updateControlParams(bool should_single_touch)
 {
-    control_params.should_one_touch = should_one_touch;
+    control_params.should_single_touch = should_single_touch;
 }
 
 void ShootOrPassPlay::updateTactics(const PlayUpdate &play_update)

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play.h
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play.h
@@ -16,7 +16,7 @@ class ShootOrPassPlay : public Play
     void updateTactics(const PlayUpdate &play_update) override;
     std::vector<std::string> getState() override;
 
-    void updateControlParams(bool should_one_touch);
+    void updateControlParams(bool should_single_touch);
 
    private:
     FSM<ShootOrPassPlayFSM> fsm;

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play.h
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play.h
@@ -16,6 +16,8 @@ class ShootOrPassPlay : public Play
     void updateTactics(const PlayUpdate &play_update) override;
     std::vector<std::string> getState() override;
 
+    void updateControlParams(bool should_one_touch);
+
    private:
     FSM<ShootOrPassPlayFSM> fsm;
     ShootOrPassPlayFSM::ControlParams control_params;

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.cpp
@@ -100,7 +100,7 @@ void ShootOrPassPlayFSM::startLookingForPass(const Update& event)
     lookForPass(event);
 }
 
-void ShootOrPassPlayFSM::freeKickStartLookingForPass(const Update& event)
+void ShootOrPassPlayFSM::singleTouchStartLookingForPass(const Update& event)
 {
     attacker_tactic = std::make_shared<AttackerTactic>(ai_config);
     attacker_tactic->updateShouldSingleTouch(true);
@@ -227,9 +227,9 @@ bool ShootOrPassPlayFSM::tookShot(const Update& event)
     return ball_oriented_towards_goal && (ball_velocity > ball_shot_threshold);
 }
 
-bool ShootOrPassPlayFSM::shouldFreeKick(const Update& event)
+bool ShootOrPassPlayFSM::shouldSingleTouch(const Update& event)
 {
-    return event.control_params.should_one_touch;
+    return event.control_params.should_single_touch;
 }
 
 bool ShootOrPassPlayFSM::hasPassInProgress(const Update& event)

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.cpp
@@ -103,7 +103,7 @@ void ShootOrPassPlayFSM::startLookingForPass(const Update& event)
 void ShootOrPassPlayFSM::singleTouchStartLookingForPass(const Update& event)
 {
     attacker_tactic = std::make_shared<AttackerTactic>(ai_config);
-    attacker_tactic->updateShouldSingleTouch(true);
+    attacker_tactic->updateControlParams(true);
     receiver_tactic              = std::make_shared<ReceiverTactic>();
     pass_optimization_start_time = event.common.world.getMostRecentTimestamp();
     lookForPass(event);

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
@@ -22,7 +22,7 @@ struct ShootOrPassPlayFSM
 
     struct ControlParams
     {
-        bool should_one_touch;
+        bool should_single_touch;
     };
 
     DEFINE_PLAY_UPDATE_STRUCT_WITH_CONTROL_AND_COMMON_PARAMS
@@ -55,11 +55,11 @@ struct ShootOrPassPlayFSM
     void lookForPass(const Update& event);
 
     /**
-     * Action to restart looking for a pass for a free kicker
+     * Action to restart looking for a pass in single touch mode
      *
      * @param event the ShootOrPassPlayFSM Update event
      */
-    void freeKickStartLookingForPass(const Update& event);
+    void singleTouchStartLookingForPass(const Update& event);
 
     /**
      * Action to restart looking for a pass
@@ -74,6 +74,13 @@ struct ShootOrPassPlayFSM
      * @param event the ShootOrPassPlayFSM Update event
      */
     void takePass(const Update& event);
+
+    /**
+     * Action to maintain a pass in progress
+     *
+     * @param event the ShootOrPassPlayFSM Update event
+     */
+    void maintainPassInProgress(const Update& event);
 
     /**
      * Guard to check if a pass has been found
@@ -111,9 +118,23 @@ struct ShootOrPassPlayFSM
      */
     bool tookShot(const Update& event);
 
-    bool shouldFreeKick(const Update& event);
+    /**
+     * Guard on whether we should use single touch mode
+     *
+     * @param event the ShootOrPassPlayFSM Update event
+     *
+     * @return whether we should use single touch mode
+     */
+    bool shouldSingleTouch(const Update& event);
+
+    /**
+     * Guard on whether there is a pass in progress
+     *
+     * @param event the ShootOrPassPlayFSM Update event
+     *
+     * @return whether there is a pass in progress
+     */
     bool hasPassInProgress(const Update& event);
-    void maintainPassInProgress(const Update& event);
 
     auto operator()()
     {
@@ -126,11 +147,11 @@ struct ShootOrPassPlayFSM
 
         DEFINE_SML_ACTION(lookForPass)
         DEFINE_SML_ACTION(startLookingForPass)
-        DEFINE_SML_ACTION(freeKickStartLookingForPass)
+        DEFINE_SML_ACTION(singleTouchStartLookingForPass)
         DEFINE_SML_ACTION(takePass)
         DEFINE_SML_ACTION(maintainPassInProgress)
 
-        DEFINE_SML_GUARD(shouldFreeKick)
+        DEFINE_SML_GUARD(shouldSingleTouch)
         DEFINE_SML_GUARD(passFound)
         DEFINE_SML_GUARD(shouldAbortPass)
         DEFINE_SML_GUARD(passCompleted)
@@ -139,7 +160,7 @@ struct ShootOrPassPlayFSM
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state
-            *StartState_S + Update_E[shouldFreeKick_G] / freeKickStartLookingForPass_A =
+            *StartState_S + Update_E[shouldSingleTouch_G] / singleTouchStartLookingForPass_A =
                 AttemptShotState_S,
             StartState_S + Update_E[!hasPassInProgress_G] / startLookingForPass_A =
                 AttemptShotState_S,

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
@@ -160,8 +160,8 @@ struct ShootOrPassPlayFSM
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state
-            *StartState_S + Update_E[shouldSingleTouch_G] / singleTouchStartLookingForPass_A =
-                AttemptShotState_S,
+            *StartState_S + Update_E[shouldSingleTouch_G] /
+                                singleTouchStartLookingForPass_A = AttemptShotState_S,
             StartState_S + Update_E[!hasPassInProgress_G] / startLookingForPass_A =
                 AttemptShotState_S,
             StartState_S + Update_E[hasPassInProgress_G] / maintainPassInProgress_A =

--- a/src/software/ai/hl/stp/tactic/attacker/BUILD
+++ b/src/software/ai/hl/stp/tactic/attacker/BUILD
@@ -15,6 +15,8 @@ cc_library(
         "//software/ai/evaluation:keep_away",
         "//software/ai/hl/stp/tactic",
         "//software/ai/hl/stp/tactic/chip:chip_tactic",
+        "//software/ai/hl/stp/tactic/kick:kick_tactic",
+        "//software/ai/hl/stp/tactic/move:move_tactic",
         "//software/ai/hl/stp/tactic/pivot_kick:pivot_kick_tactic",
         "//software/ai/passing:pass",
         "//software/logger",

--- a/src/software/ai/hl/stp/tactic/attacker/attacker_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/attacker/attacker_fsm.cpp
@@ -103,3 +103,70 @@ bool AttackerFSM::shouldKick(const Update& event)
     // otherwise check for shot or pass committed
     return event.control_params.pass_committed || event.control_params.shot;
 }
+
+
+void AttackerFSM::alignToBall(const Update& event,
+                              boost::sml::back::process<MoveFSM::Update> processEvent)
+{
+    Vector ball_to_center_vec =
+        Vector(0, 0) - event.common.world.ball().position().toVector();
+    // We want the kicker to get into position behind the ball facing the center
+    // of the field
+    MoveFSM::ControlParams control_params{
+        .destination = event.common.world.ball().position() -
+                       ball_to_center_vec.normalize(ROBOT_MAX_RADIUS_METERS * 2),
+        .final_orientation      = ball_to_center_vec.orientation(),
+        .final_speed            = 0.0,
+        .dribbler_mode          = TbotsProto::DribblerMode::OFF,
+        .ball_collision_type    = TbotsProto::BallCollisionType::AVOID,
+        .auto_chip_or_kick      = AutoChipOrKick{AutoChipOrKickMode::OFF, 0},
+        .max_allowed_speed_mode = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
+        .target_spin_rev_per_s  = 0.0};
+
+    processEvent(MoveFSM::Update(control_params, event.common));
+}
+
+void AttackerFSM::singleTouchKick(const Update& event,
+                                  boost::sml::back::process<KickFSM::Update> processEvent)
+{
+    auto ball_position = event.common.world.ball().position();
+    Point chip_target  = event.common.world.field().enemyGoalCenter();
+    if (event.control_params.chip_target)
+    {
+        chip_target = event.control_params.chip_target.value();
+    }
+    // default to chipping the ball away
+    KickFSM::ControlParams control_params{
+        .kick_origin       = ball_position,
+        .kick_direction    = (chip_target - ball_position).orientation(),
+        .auto_chip_or_kick = AutoChipOrKick{AutoChipOrKickMode::AUTOCHIP,
+                                            (chip_target - ball_position).length()}};
+
+    if (event.control_params.shot)
+    {
+        // shoot on net
+        control_params = KickFSM::ControlParams{
+            .kick_origin = ball_position,
+            .kick_direction =
+                (event.control_params.shot->getPointToShootAt() - ball_position)
+                    .orientation(),
+            .auto_chip_or_kick = AutoChipOrKick{AutoChipOrKickMode::AUTOKICK,
+                                                BALL_MAX_SPEED_METERS_PER_SECOND - 0.5}};
+    }
+    else if (event.control_params.pass_committed)
+    {
+        // we have committed to passing, execute the pass
+        control_params = KickFSM::ControlParams{
+            .kick_origin    = event.control_params.best_pass_so_far->passerPoint(),
+            .kick_direction = event.control_params.best_pass_so_far->passerOrientation(),
+            .auto_chip_or_kick =
+                AutoChipOrKick{AutoChipOrKickMode::AUTOKICK,
+                               event.control_params.best_pass_so_far->speed()}};
+    }
+    processEvent(KickFSM::Update(control_params, event.common));
+}
+
+bool AttackerFSM::shouldSingleTouch(const Update& event)
+{
+    return event.control_params.should_single_touch;
+}

--- a/src/software/ai/hl/stp/tactic/attacker/attacker_fsm.h
+++ b/src/software/ai/hl/stp/tactic/attacker/attacker_fsm.h
@@ -4,6 +4,8 @@
 #include "software/ai/evaluation/keep_away.h"
 #include "software/ai/evaluation/shot.h"
 #include "software/ai/hl/stp/tactic/chip/chip_fsm.h"
+#include "software/ai/hl/stp/tactic/kick/kick_fsm.h"
+#include "software/ai/hl/stp/tactic/move/move_fsm.h"
 #include "software/ai/hl/stp/tactic/pivot_kick/pivot_kick_fsm.h"
 #include "software/ai/hl/stp/tactic/tactic.h"
 #include "software/ai/passing/pass.h"
@@ -31,6 +33,8 @@ struct AttackerFSM
         // The point the robot will chip towards if it is unable to shoot and is in danger
         // of losing the ball to an enemy
         std::optional<Point> chip_target;
+        // Whether we should one touch the ball
+        bool should_single_touch = false;
     };
 
     DEFINE_TACTIC_UPDATE_STRUCT_WITH_CONTROL_AND_COMMON_PARAMS
@@ -54,15 +58,39 @@ struct AttackerFSM
                   boost::sml::back::process<DribbleFSM::Update> processEvent);
 
     /**
+     * Action that executes a single touch kick
+     *
+     * @param event AttackerFSM::Update event
+     * @param processEvent processes the KickFSM::Update
+     */
+    void singleTouchKick(const Update& event,
+                         boost::sml::back::process<KickFSM::Update> processEvent);
+
+    /**
+     * Action that gets the robot into position to kick the ball
+     *
+     * @param event AttackerFSM::Update event
+     * @param processEvent processes the MoveFSM::Update
+     */
+    void alignToBall(const Update& event,
+                     boost::sml::back::process<MoveFSM::Update> processEvent);
+
+    /**
      * Guard that checks if the ball should be kicked, which is when there's a nearby
      * enemy or a good pass/shot
      *
      * @param event AttackerFSM::Update event
-     *
      * @return if the ball should be kicked
      */
     bool shouldKick(const Update& event);
 
+    /**
+     * Guard on whether we should single touch
+     *
+     * @param event AttackerFSM::Update event
+     * @return whether we should single touch
+     */
+    bool shouldSingleTouch(const Update& event);
 
     auto operator()()
     {
@@ -70,15 +98,26 @@ struct AttackerFSM
 
         DEFINE_SML_STATE(PivotKickFSM)
         DEFINE_SML_STATE(DribbleFSM)
+        DEFINE_SML_STATE(KickFSM)
+        DEFINE_SML_STATE(MoveFSM)
         DEFINE_SML_EVENT(Update)
 
         DEFINE_SML_GUARD(shouldKick)
+        DEFINE_SML_GUARD(shouldSingleTouch)
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(pivotKick, PivotKickFSM)
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(keepAway, DribbleFSM)
+        DEFINE_SML_SUB_FSM_UPDATE_ACTION(singleTouchKick, KickFSM)
+        DEFINE_SML_SUB_FSM_UPDATE_ACTION(alignToBall, MoveFSM)
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state
-            *DribbleFSM_S + Update_E[shouldKick_G] / pivotKick_A = PivotKickFSM_S,
+            *MoveFSM_S + Update_E[!shouldSingleTouch_G] / keepAway_A = DribbleFSM_S,
+            // single touch attacking
+            MoveFSM_S + Update_E[shouldKick_G] / singleTouchKick_A = KickFSM_S,
+            MoveFSM_S + Update_E[!shouldKick_G] / alignToBall_A,
+            KickFSM_S + Update_E / singleTouchKick_A, KickFSM_S = X,
+            // dribble allowed attacking
+            DribbleFSM_S + Update_E[shouldKick_G] / pivotKick_A = PivotKickFSM_S,
             DribbleFSM_S + Update_E[!shouldKick_G] / keepAway_A,
             PivotKickFSM_S + Update_E / pivotKick_A, PivotKickFSM_S = X,
             X + Update_E / SET_STOP_PRIMITIVE_ACTION = X);

--- a/src/software/ai/hl/stp/tactic/attacker/attacker_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/attacker/attacker_fsm_test.cpp
@@ -16,11 +16,18 @@ TEST(AttackerFSMTest, test_transitions)
                                               .chip_target      = std::nullopt};
 
     TbotsProto::AiConfig ai_config;
-    FSM<AttackerFSM> fsm{DribbleFSM(ai_config.dribble_tactic_config()),
+    FSM<AttackerFSM> fsm{GetBehindBallFSM(),
+                         DribbleFSM(ai_config.dribble_tactic_config()),
                          AttackerFSM(ai_config.attacker_tactic_config())};
-    EXPECT_TRUE(fsm.is(boost::sml::state<DribbleFSM>));
+    EXPECT_TRUE(fsm.is(boost::sml::state<MoveFSM>));
 
     // robot far from attacker point
+    fsm.process_event(AttackerFSM::Update(
+        control_params, TacticUpdate(
+                robot, world, [](std::unique_ptr<TbotsProto::Primitive>) {},
+                TEST_UTIL_CREATE_MOTION_CONTROL_NO_DEST)));
+    EXPECT_TRUE(fsm.is(boost::sml::state<DribbleFSM>));
+
     fsm.process_event(AttackerFSM::Update(
         control_params, TacticUpdate(
                             robot, world, [](std::unique_ptr<TbotsProto::Primitive>) {},

--- a/src/software/ai/hl/stp/tactic/attacker/attacker_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/attacker/attacker_fsm_test.cpp
@@ -24,8 +24,8 @@ TEST(AttackerFSMTest, test_transitions)
     // robot far from attacker point
     fsm.process_event(AttackerFSM::Update(
         control_params, TacticUpdate(
-                robot, world, [](std::unique_ptr<TbotsProto::Primitive>) {},
-                TEST_UTIL_CREATE_MOTION_CONTROL_NO_DEST)));
+                            robot, world, [](std::unique_ptr<TbotsProto::Primitive>) {},
+                            TEST_UTIL_CREATE_MOTION_CONTROL_NO_DEST)));
     EXPECT_TRUE(fsm.is(boost::sml::state<DribbleFSM>));
 
     fsm.process_event(AttackerFSM::Update(

--- a/src/software/ai/hl/stp/tactic/attacker/attacker_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/attacker/attacker_tactic.cpp
@@ -35,7 +35,8 @@ void AttackerTactic::updateControlParams(std::optional<Point> chip_target)
     this->chip_target = chip_target;
 }
 
-void AttackerTactic::updateControlParams(bool should_single_touch) {
+void AttackerTactic::updateControlParams(bool should_single_touch)
+{
     this->should_single_touch = should_single_touch;
 }
 
@@ -66,11 +67,11 @@ void AttackerTactic::updatePrimitive(const TacticUpdate& tactic_update, bool res
     }
 
     AttackerFSM::ControlParams control_params{
-            .best_pass_so_far    = best_pass_so_far,
-            .pass_committed      = pass_committed,
-            .shot                = shot,
-            .chip_target         = chip_target,
-            .should_single_touch = should_single_touch,
+        .best_pass_so_far    = best_pass_so_far,
+        .pass_committed      = pass_committed,
+        .shot                = shot,
+        .chip_target         = chip_target,
+        .should_single_touch = should_single_touch,
     };
 
     fsm_map.at(tactic_update.robot.id())

--- a/src/software/ai/hl/stp/tactic/attacker/attacker_tactic.h
+++ b/src/software/ai/hl/stp/tactic/attacker/attacker_tactic.h
@@ -24,7 +24,7 @@ class AttackerTactic : public Tactic
     AttackerTactic() = delete;
 
     /**
-     * Updates the control parameters for this AttackerTactic.
+     * Updates the control parameters for this AttackerTactic
      *
      * @param updated_pass The pass to perform
      */
@@ -38,6 +38,13 @@ class AttackerTactic : public Tactic
      * not provided, the point defaults to the enemy goal
      */
     void updateControlParams(std::optional<Point> chip_target);
+
+    /**
+     * Updates the control parameters for this AttackerTactic
+     *
+     * @param should_single_touch Whether we should single touch
+     */
+    void updateControlParams(bool should_single_touch);
 
     void accept(TacticVisitor& visitor) const override;
 
@@ -55,6 +62,9 @@ class AttackerTactic : public Tactic
     // The point the robot will chip towards if it is unable to shoot and is in danger
     // of losing the ball to an enemy
     std::optional<Point> chip_target;
+
+    // Whether we should single touch
+    bool should_single_touch;
 
     // AI config
     TbotsProto::AiConfig ai_config;

--- a/src/software/ai/hl/stp/tactic/fsm_state_test.cpp
+++ b/src/software/ai/hl/stp/tactic/fsm_state_test.cpp
@@ -14,7 +14,7 @@ TEST(FsmStateTest, test_get_fsm_state)
     Pass pass = Pass(Point(0, 0), Point(2, 0), 5);
     tactic.setLastExecutionRobot(robot.id());
 
-    EXPECT_EQ("DribbleFSM.GetPossession", tactic.getFSMState());
+    EXPECT_EQ("MoveFSM.MoveState", tactic.getFSMState());
     tactic.updateControlParams(pass, true);
     tactic.get(world, TEST_UTIL_CREATE_MOTION_CONTROL_NO_DEST);
 

--- a/src/software/ai/hl/stp/tactic/kick/kick_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/kick/kick_fsm.cpp
@@ -5,9 +5,7 @@ void KickFSM::updateKick(const Update &event)
     event.common.set_primitive(createMovePrimitive(
         CREATE_MOTION_CONTROL(event.control_params.kick_origin),
         event.control_params.kick_direction, 0.1, TbotsProto::DribblerMode::OFF,
-        TbotsProto::BallCollisionType::ALLOW,
-        AutoChipOrKick{AutoChipOrKickMode::AUTOKICK,
-                       event.control_params.kick_speed_meters_per_second},
+        TbotsProto::BallCollisionType::ALLOW, event.control_params.auto_chip_or_kick,
         TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT, 0.0,
         event.common.robot.robotConstants()));
 }

--- a/src/software/ai/hl/stp/tactic/kick/kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/kick/kick_fsm.h
@@ -12,10 +12,10 @@ struct KickFSM
     {
         // The location where the kick will be taken from
         Point kick_origin;
-        // The direction the Robot will kick in
+        // The direction the robot will kick in
         Angle kick_direction;
-        // How fast the Robot will kick the ball in meters per second
-        double kick_speed_meters_per_second;
+        // How the robot will chip or kick the ball
+        AutoChipOrKick auto_chip_or_kick;
     };
 
     DEFINE_TACTIC_UPDATE_STRUCT_WITH_CONTROL_AND_COMMON_PARAMS

--- a/src/software/ai/hl/stp/tactic/kick/kick_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/kick/kick_fsm_test.cpp
@@ -8,9 +8,10 @@ TEST(KickFSMTest, test_transitions)
 {
     World world = ::TestUtil::createBlankTestingWorld();
     Robot robot = ::TestUtil::createRobotAtPos(Point(-2, -3));
-    KickFSM::ControlParams control_params{.kick_origin    = Point(-2, 1.5),
-                                          .kick_direction = Angle::threeQuarter(),
-                                          .kick_speed_meters_per_second = 1.2};
+    KickFSM::ControlParams control_params{
+        .kick_origin       = Point(-2, 1.5),
+        .kick_direction    = Angle::threeQuarter(),
+        .auto_chip_or_kick = {AutoChipOrKickMode::AUTOKICK, 1.2}};
 
     FSM<KickFSM> fsm{GetBehindBallFSM()};
 

--- a/src/software/ai/hl/stp/tactic/kick/kick_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/kick/kick_tactic.cpp
@@ -13,18 +13,18 @@ KickTactic::KickTactic()
 
 void KickTactic::updateControlParams(const Point &kick_origin,
                                      const Angle &kick_direction,
-                                     double kick_speed_meters_per_second)
+                                     AutoChipOrKick auto_chip_or_kick)
 {
-    control_params.kick_origin                  = kick_origin;
-    control_params.kick_direction               = kick_direction;
-    control_params.kick_speed_meters_per_second = kick_speed_meters_per_second;
+    control_params.kick_origin       = kick_origin;
+    control_params.kick_direction    = kick_direction;
+    control_params.auto_chip_or_kick = auto_chip_or_kick;
 }
 
 void KickTactic::updateControlParams(const Point &kick_origin, const Point &kick_target,
-                                     double kick_speed_meters_per_second)
+                                     AutoChipOrKick auto_chip_or_kick)
 {
     updateControlParams(kick_origin, (kick_target - kick_origin).orientation(),
-                        kick_speed_meters_per_second);
+                        auto_chip_or_kick);
 }
 
 void KickTactic::accept(TacticVisitor &visitor) const

--- a/src/software/ai/hl/stp/tactic/kick/kick_tactic.h
+++ b/src/software/ai/hl/stp/tactic/kick/kick_tactic.h
@@ -22,23 +22,21 @@ class KickTactic : public Tactic
      * Updates the params for this tactic that cannot be derived from the world
      *
      * @param kick_origin The location where the kick will be taken
-     * @param kick_direction The direction the Robot will kick in
-     * @param kick_speed_meters_per_second The distance between the starting location
-     * of the kick and the location of the first bounce
+     * @param kick_direction The direction the robot will kick in
+     * @param auto_chip_or_kick The auto kick or chip settings
      */
     void updateControlParams(const Point& kick_origin, const Angle& kick_direction,
-                             double kick_speed_meters_per_second);
+                             AutoChipOrKick auto_chip_or_kick);
 
     /**
-     * Updates the control parameters for this KickTactic.
+     * Updates the control parameters for this KickTactic
      *
      * @param kick_origin The location where the kick will be taken
-     * @param kick_direction The direction the Robot will kick in
-     * @param kick_speed_meters_per_second The speed of how fast the Robot
-     * will kick the ball in meters per second
+     * @param kick_target The location where the robot will kick towards
+     * @param auto_chip_or_kick The auto kick or chip settings
      */
     void updateControlParams(const Point& kick_origin, const Point& kick_target,
-                             double kick_speed_meters_per_second);
+                             AutoChipOrKick auto_chip_or_kick);
 
     void accept(TacticVisitor& visitor) const override;
 

--- a/src/software/ai/hl/stp/tactic/kick/kick_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/kick/kick_tactic_test.cpp
@@ -35,7 +35,7 @@ TEST_P(KickTacticTest, kick_test)
 
     auto tactic = std::make_shared<KickTactic>();
     tactic->updateControlParams(robot_position + ball_offset_from_robot, angle_to_kick_at,
-                                5);
+                                AutoChipOrKick{AutoChipOrKickMode::AUTOKICK, 5});
     setTactic(1, tactic);
 
     std::vector<ValidationFunction> terminating_validation_functions = {

--- a/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.cpp
@@ -120,9 +120,9 @@ void PenaltyKickFSM::shoot(const Update &event,
                            boost::sml::back::process<KickFSM::Update> processEvent)
 {
     KickFSM::ControlParams control_params{
-        .kick_origin                  = event.common.world.ball().position(),
-        .kick_direction               = shot_angle,
-        .kick_speed_meters_per_second = PENALTY_KICK_SHOT_SPEED};
+        .kick_origin       = event.common.world.ball().position(),
+        .kick_direction    = shot_angle,
+        .auto_chip_or_kick = {AutoChipOrKickMode::AUTOKICK, PENALTY_KICK_SHOT_SPEED}};
     processEvent(KickFSM::Update(control_params, event.common));
 }
 

--- a/src/software/ai/hl/stp/tactic/tactic_factory.cpp
+++ b/src/software/ai/hl/stp/tactic/tactic_factory.cpp
@@ -122,9 +122,11 @@ std::shared_ptr<Tactic> createTactic(const TbotsProto::KickTactic &tactic_proto,
                                      TbotsProto::AiConfig ai_config)
 {
     auto tactic = std::make_shared<KickTactic>();
-    tactic->updateControlParams(createPoint(tactic_proto.kick_origin()),
-                                createAngle(tactic_proto.kick_direction()),
-                                tactic_proto.kick_speed_meters_per_second());
+    tactic->updateControlParams(
+        createPoint(tactic_proto.kick_origin()),
+        createAngle(tactic_proto.kick_direction()),
+        AutoChipOrKick{AutoChipOrKickMode::AUTOKICK,
+                       tactic_proto.kick_speed_meters_per_second()});
     return tactic;
 }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Single-touch plays are plays where dribbling is not allowed, which are KickoffPlay and FreeKickPlay. This PR integrates these single-touch plays into offense play. 

### Testing Done

Runs in simulation. 

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

Resolves #2798 

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
