### PR TITLE
Make defense more aggressive in stealing balls from enemy robots

### DIFF
--- a/docs/fsm-diagrams.md
+++ b/docs/fsm-diagrams.md
@@ -45,7 +45,10 @@ stateDiagram-v2
 classDef terminate fill:white,color:black,font-weight:bold
 direction LR
 [*] --> DefenseState
-DefenseState --> DefenseState : <i>defendAgainstThreats</i>
+DefenseState --> AggressiveDefenseState : [shouldDefendAggressively]\n<i>shadowAndBlockShots</i>
+DefenseState --> DefenseState : <i>blockShots</i>
+AggressiveDefenseState --> DefenseState : [!shouldDefendAggressively]\n<i>blockShots</i>
+AggressiveDefenseState --> AggressiveDefenseState : <i>shadowAndBlockShots</i>
 Terminate:::terminate --> Terminate:::terminate
 
 ```

--- a/src/proto/parameters.proto
+++ b/src/proto/parameters.proto
@@ -401,4 +401,17 @@ message PossessionTrackerConfig
         (bounds).min_double_value = 0.0,
         (bounds).max_double_value = 30.0
     ];
+
+    // Min distance in meters that ball must move between two timestamps
+    // for the ball to be considered moved
+    required double ball_moved_threshold_meters = 6
+        [default = 0.05, (bounds).min_double_value = 0.0, (bounds).max_double_value = 5.0];
+
+    // Min time that the ball must stay still in order for possession 
+    // to be considered stagnant
+    required double time_ball_stagnant_threshold_s = 7 [
+        default                   = 3.5,
+        (bounds).min_double_value = 0.0,
+        (bounds).max_double_value = 30.0
+    ];
 }

--- a/src/proto/parameters.proto
+++ b/src/proto/parameters.proto
@@ -338,10 +338,7 @@ message DefensePlayConfig
         ];
     }
 
-    // The distance at which a threat is considered "immediate" if there is only 1
-    // "immediate" threat the defense play will swarm that robot with shadowers
-    required double immediate_threat_distance = 1
-        [default = 6.0, (bounds).min_double_value = 0.0, (bounds).max_double_value = 9.5];
+    reserved 1;
 
     // The DefenderAssignmentConfig for tuning defender assignments
     required DefenderAssignmentConfig defender_assignment_config = 2;
@@ -374,7 +371,7 @@ message PossessionTrackerConfig
     // Max distance in meters between robot and ball for robot
     // to be considered near the ball
     required double distance_near_tolerance_meters = 1
-        [default = 0.1, (bounds).min_double_value = 0.0, (bounds).max_double_value = 5.0];
+        [default = 0.2, (bounds).min_double_value = 0.0, (bounds).max_double_value = 5.0];
 
     // Min distance in meters between robot and ball for robot
     // to be considered far away from the ball
@@ -395,5 +392,13 @@ message PossessionTrackerConfig
         default                   = 1.5,
         (bounds).min_double_value = 0.0,
         (bounds).max_double_value = 10.0
+    ];
+
+    // Min time that team must hold possession for in order to be
+    // considered stagnant
+    required double time_stagnant_threshold_s = 5 [
+        default                   = 2.5,
+        (bounds).min_double_value = 0.0,
+        (bounds).max_double_value = 30.0
     ];
 }

--- a/src/proto/parameters.proto
+++ b/src/proto/parameters.proto
@@ -404,10 +404,13 @@ message PossessionTrackerConfig
 
     // Min distance in meters that ball must move between two timestamps
     // for the ball to be considered moved
-    required double ball_moved_threshold_meters = 6
-        [default = 0.05, (bounds).min_double_value = 0.0, (bounds).max_double_value = 5.0];
+    required double ball_moved_threshold_meters = 6 [
+        default                   = 0.05,
+        (bounds).min_double_value = 0.0,
+        (bounds).max_double_value = 5.0
+    ];
 
-    // Min time that the ball must stay still in order for possession 
+    // Min time that the ball must stay still in order for possession
     // to be considered stagnant
     required double time_ball_stagnant_threshold_s = 7 [
         default                   = 3.5,

--- a/src/software/ai/hl/stp/play/defense/BUILD
+++ b/src/software/ai/hl/stp/play/defense/BUILD
@@ -22,6 +22,7 @@ cc_library(
         "//software/ai/hl/stp/play",
         "//software/ai/hl/stp/tactic/crease_defender:crease_defender_tactic",
         "//software/ai/hl/stp/tactic/pass_defender:pass_defender_tactic",
+        "//software/ai/hl/stp/tactic/shadow_enemy:shadow_enemy_tactic",
         "//software/logger",
         "//software/util/generic_factory",
         "@sml",

--- a/src/software/ai/hl/stp/play/defense/defense_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/defense/defense_play_fsm.cpp
@@ -4,16 +4,48 @@
 #include "software/ai/evaluation/enemy_threat.h"
 
 DefensePlayFSM::DefensePlayFSM(TbotsProto::AiConfig ai_config)
-    : ai_config(ai_config), crease_defenders({}), pass_defenders({})
+    : ai_config(ai_config), crease_defenders({}), pass_defenders({}), shadowers({})
 {
 }
 
-void DefensePlayFSM::defendAgainstThreats(const Update& event)
+bool DefensePlayFSM::shouldDefendAggressively(const Update& event)
+{
+    TeamPossession possession = event.common.world.getTeamWithPossession();
+    return (possession == TeamPossession::STAGNANT_ENEMY_TEAM);
+}
+
+void DefensePlayFSM::blockShots(const Update& event)
 {
     auto enemy_threats = getAllEnemyThreats(
         event.common.world.field(), event.common.world.friendlyTeam(),
         event.common.world.enemyTeam(), event.common.world.ball(), false);
 
+    updateCreaseAndPassDefenders(event, enemy_threats);
+    updateShadowers(event, {});
+
+    setTactics(event);
+}
+
+void DefensePlayFSM::shadowAndBlockShots(const Update& event)
+{
+    auto enemy_threats = getAllEnemyThreats(
+        event.common.world.field(), event.common.world.friendlyTeam(),
+        event.common.world.enemyTeam(), event.common.world.ball(), false);
+
+    updateCreaseAndPassDefenders(event, enemy_threats);
+
+    if (pass_defenders.size() > 0)
+    {
+        pass_defenders.erase(pass_defenders.begin());
+        updateShadowers(event, {enemy_threats.front()});
+    }
+
+    setTactics(event);
+}
+
+void DefensePlayFSM::updateCreaseAndPassDefenders(
+    const Update& event, const std::vector<EnemyThreat>& enemy_threats)
+{
     auto assignments = getAllDefenderAssignments(
         enemy_threats, event.common.world.field(), event.common.world.ball(),
         ai_config.defense_play_config().defender_assignment_config());
@@ -109,13 +141,19 @@ void DefensePlayFSM::defendAgainstThreats(const Update& event)
     {
         pass_defenders.at(i)->updateControlParams(pass_defender_assignments.at(i).target);
     }
+}
 
-    PriorityTacticVector tactics_to_return = {{}, {}};
-    tactics_to_return[0].insert(tactics_to_return[0].end(), crease_defenders.begin(),
-                                crease_defenders.end());
-    tactics_to_return[1].insert(tactics_to_return[1].end(), pass_defenders.begin(),
-                                pass_defenders.end());
-    event.common.set_tactics(tactics_to_return);
+void DefensePlayFSM::updateShadowers(const Update& event,
+                                     const std::vector<EnemyThreat>& threats_to_shadow)
+{
+    setUpShadowers(static_cast<unsigned int>(threats_to_shadow.size()));
+
+    const double ROBOT_SHADOWING_DISTANCE_METERS = ROBOT_MAX_RADIUS_METERS * 3;
+    for (unsigned int i = 0; i < shadowers.size(); i++)
+    {
+        shadowers.at(i)->updateControlParams(threats_to_shadow.at(i),
+                                             ROBOT_SHADOWING_DISTANCE_METERS);
+    }
 }
 
 void DefensePlayFSM::setUpCreaseDefenders(unsigned int num_crease_defenders)
@@ -143,4 +181,30 @@ void DefensePlayFSM::setUpPassDefenders(unsigned int num_pass_defenders)
     pass_defenders = std::vector<std::shared_ptr<PassDefenderTactic>>(num_pass_defenders);
     std::generate(pass_defenders.begin(), pass_defenders.end(),
                   [this]() { return std::make_shared<PassDefenderTactic>(); });
+}
+
+void DefensePlayFSM::setUpShadowers(unsigned int num_shadowers)
+{
+    if (num_shadowers == shadowers.size())
+    {
+        return;
+    }
+
+    shadowers = std::vector<std::shared_ptr<ShadowEnemyTactic>>(num_shadowers);
+    std::generate(shadowers.begin(), shadowers.end(),
+                  [this]() { return std::make_shared<ShadowEnemyTactic>(); });
+}
+
+void DefensePlayFSM::setTactics(const Update& event)
+{
+    PriorityTacticVector tactics_to_return = {{}, {}, {}};
+
+    tactics_to_return[0].insert(tactics_to_return[0].end(), crease_defenders.begin(),
+                                crease_defenders.end());
+    tactics_to_return[1].insert(tactics_to_return[1].end(), pass_defenders.begin(),
+                                pass_defenders.end());
+    tactics_to_return[2].insert(tactics_to_return[2].end(), shadowers.begin(),
+                                shadowers.end());
+
+    event.common.set_tactics(tactics_to_return);
 }

--- a/src/software/ai/hl/stp/play/defense/defense_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/defense/defense_play_fsm.cpp
@@ -1,7 +1,6 @@
 #include "software/ai/hl/stp/play/defense/defense_play_fsm.h"
 
 #include "software/ai/evaluation/defender_assignment.h"
-#include "software/ai/evaluation/enemy_threat.h"
 
 DefensePlayFSM::DefensePlayFSM(TbotsProto::AiConfig ai_config)
     : ai_config(ai_config), crease_defenders({}), pass_defenders({}), shadowers({})
@@ -148,7 +147,6 @@ void DefensePlayFSM::updateShadowers(const Update& event,
 {
     setUpShadowers(static_cast<unsigned int>(threats_to_shadow.size()));
 
-    const double ROBOT_SHADOWING_DISTANCE_METERS = ROBOT_MAX_RADIUS_METERS * 3;
     for (unsigned int i = 0; i < shadowers.size(); i++)
     {
         shadowers.at(i)->updateControlParams(threats_to_shadow.at(i),

--- a/src/software/ai/hl/stp/play/defense/defense_play_fsm.h
+++ b/src/software/ai/hl/stp/play/defense/defense_play_fsm.h
@@ -21,6 +21,9 @@ struct DefensePlayFSM
 
     DEFINE_PLAY_UPDATE_STRUCT_WITH_CONTROL_AND_COMMON_PARAMS
 
+    // Distance away from an enemy that shadowers will position themselves to shadow
+    const double ROBOT_SHADOWING_DISTANCE_METERS = ROBOT_MAX_RADIUS_METERS * 3;
+
     /**
      * Creates a defense play FSM
      *

--- a/src/software/ai/hl/stp/play/defense/defense_play_fsm.h
+++ b/src/software/ai/hl/stp/play/defense/defense_play_fsm.h
@@ -5,11 +5,13 @@
 #include "software/ai/hl/stp/play/play_fsm.h"
 #include "software/ai/hl/stp/tactic/crease_defender/crease_defender_tactic.h"
 #include "software/ai/hl/stp/tactic/pass_defender/pass_defender_tactic.h"
+#include "software/ai/hl/stp/tactic/shadow_enemy/shadow_enemy_tactic.h"
 #include "software/logger/logger.h"
 
 struct DefensePlayFSM
 {
     class DefenseState;
+    class AggressiveDefenseState;
 
     struct ControlParams
     {
@@ -27,12 +29,48 @@ struct DefensePlayFSM
     explicit DefensePlayFSM(TbotsProto::AiConfig ai_config);
 
     /**
+     * Guard to check whether we should be defending more aggressively
+     *
+     * @param event the FSM event
+     *
+     * @return whether we should be defending more aggressively
+     */
+    bool shouldDefendAggressively(const Update& event);
+
+    /**
      * Action to identify all immediate enemy threats and assign
      * defenders to block enemy shots and passes
      *
      * @param event the FSM event
      */
-    void defendAgainstThreats(const Update& event);
+    void blockShots(const Update& event);
+
+    /**
+     * Action to shadow the primary enemy threat and assign
+     * extra defenders to block enemy shots and passes
+     *
+     * @param event the FSM event
+     */
+    void shadowAndBlockShots(const Update& event);
+
+    /**
+     * Helper function to update crease and pass defenders to defend
+     * against specified threats
+     *
+     * @param event the FSM event
+     * @param enemy_threats the enemy threats to defend against
+     */
+    void updateCreaseAndPassDefenders(const Update& event,
+                                      const std::vector<EnemyThreat>& enemy_threats);
+
+    /**
+     * Helper function to update shadowers to shadow specified threats
+     *
+     * @param event the FSM event
+     * @param threats_to_shadow the enemy threats to shadow
+     */
+    void updateShadowers(const Update& event,
+                         const std::vector<EnemyThreat>& threats_to_shadow);
 
     /**
      * Helper function to set up crease defender tactic vector members
@@ -48,24 +86,49 @@ struct DefensePlayFSM
      */
     void setUpPassDefenders(unsigned int num_pass_defenders);
 
+    /**
+     * Helper function to set up shadow enemy tactic vector members
+     *
+     * @param num_shadowers the number of shadow enemy tactics to set
+     */
+    void setUpShadowers(unsigned int num_shadowers);
+
+    /**
+     * Helper function to return the next tactics
+     *
+     * @param event the FSM event
+     */
+    void setTactics(const Update& event);
+
     auto operator()()
     {
         using namespace boost::sml;
 
         DEFINE_SML_STATE(DefenseState)
+        DEFINE_SML_STATE(AggressiveDefenseState)
 
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_ACTION(defendAgainstThreats)
+        DEFINE_SML_GUARD(shouldDefendAggressively)
+
+        DEFINE_SML_ACTION(blockShots)
+        DEFINE_SML_ACTION(shadowAndBlockShots)
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state
-            *DefenseState_S + Update_E / defendAgainstThreats_A = DefenseState_S,
-            X + Update_E                                        = X);
+            *DefenseState_S + Update_E[shouldDefendAggressively_G] /
+                                  shadowAndBlockShots_A = AggressiveDefenseState_S,
+            DefenseState_S + Update_E / blockShots_A    = DefenseState_S,
+            AggressiveDefenseState_S +
+                Update_E[!shouldDefendAggressively_G] / blockShots_A = DefenseState_S,
+            AggressiveDefenseState_S + Update_E / shadowAndBlockShots_A =
+                AggressiveDefenseState_S,
+            X + Update_E = X);
     }
 
    private:
     TbotsProto::AiConfig ai_config;
     std::vector<std::shared_ptr<CreaseDefenderTactic>> crease_defenders;
     std::vector<std::shared_ptr<PassDefenderTactic>> pass_defenders;
+    std::vector<std::shared_ptr<ShadowEnemyTactic>> shadowers;
 };

--- a/src/software/ai/hl/stp/play/defense/defense_play_fsm_test.cpp
+++ b/src/software/ai/hl/stp/play/defense/defense_play_fsm_test.cpp
@@ -15,6 +15,7 @@ TEST(DefensePlayFSMTest, test_transitions)
     FSM<DefensePlayFSM> fsm(DefensePlayFSM{ai_config});
     EXPECT_TRUE(fsm.is(boost::sml::state<DefensePlayFSM::DefenseState>));
 
+    world.setTeamWithPossession(TeamPossession::ENEMY_TEAM);
     fsm.process_event(DefensePlayFSM::Update(
         DefensePlayFSM::ControlParams{
             .max_allowed_speed_mode = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT},
@@ -22,6 +23,25 @@ TEST(DefensePlayFSMTest, test_transitions)
             world, 3, [](PriorityTacticVector new_tactics) {}, InterPlayCommunication{},
             [](InterPlayCommunication comm) {})));
 
-    // DefensePlayFSM always stays in the DefenseState
+    EXPECT_TRUE(fsm.is(boost::sml::state<DefensePlayFSM::DefenseState>));
+
+    world.setTeamWithPossession(TeamPossession::STAGNANT_ENEMY_TEAM);
+    fsm.process_event(DefensePlayFSM::Update(
+        DefensePlayFSM::ControlParams{
+            .max_allowed_speed_mode = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT},
+        PlayUpdate(
+            world, 3, [](PriorityTacticVector new_tactics) {}, InterPlayCommunication{},
+            [](InterPlayCommunication comm) {})));
+
+    EXPECT_TRUE(fsm.is(boost::sml::state<DefensePlayFSM::AggressiveDefenseState>));
+
+    world.setTeamWithPossession(TeamPossession::ENEMY_TEAM);
+    fsm.process_event(DefensePlayFSM::Update(
+        DefensePlayFSM::ControlParams{
+            .max_allowed_speed_mode = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT},
+        PlayUpdate(
+            world, 3, [](PriorityTacticVector new_tactics) {}, InterPlayCommunication{},
+            [](InterPlayCommunication comm) {})));
+
     EXPECT_TRUE(fsm.is(boost::sml::state<DefensePlayFSM::DefenseState>));
 }

--- a/src/software/ai/hl/stp/play/defense/defense_play_test.py
+++ b/src/software/ai/hl/stp/play/defense/defense_play_test.py
@@ -83,7 +83,7 @@ def test_defense_play(simulated_test_runner, blue_bots, yellow_bots):
             ]
         ],
         ag_eventually_validation_sequence_set=[[]],
-        test_timeout_s=30,
+        test_timeout_s=60,
     )
 
 

--- a/src/software/ai/hl/stp/play/offense/offense_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/offense/offense_play_fsm.cpp
@@ -10,7 +10,8 @@ OffensePlayFSM::OffensePlayFSM(TbotsProto::AiConfig ai_config)
 bool OffensePlayFSM::enemyHasPossession(const Update& event)
 {
     TeamPossession possession = event.common.world.getTeamWithPossession();
-    return (possession == TeamPossession::ENEMY_TEAM);
+    return (possession == TeamPossession::ENEMY_TEAM) ||
+           (possession == TeamPossession::STAGNANT_ENEMY_TEAM);
 }
 
 void OffensePlayFSM::setupOffensiveStrategy(const Update& event)

--- a/src/software/sensor_fusion/possession/possession_tracker.cpp
+++ b/src/software/sensor_fusion/possession/possession_tracker.cpp
@@ -63,6 +63,9 @@ TeamPossession PossessionTracker::getTeamWithPossession(const Team &friendly_tea
         if (field.pointInFriendlyHalf(ball.position()) ||
             num_enemies_in_friendly_half > 0)
         {
+            // Possession is considered stagnant since the ball is being
+            // actively over fought over (both teams are near ball), but
+            // enemy possession remains unchanged 
             possession = TeamPossession::STAGNANT_ENEMY_TEAM;
         }
         else

--- a/src/software/sensor_fusion/possession/possession_tracker.cpp
+++ b/src/software/sensor_fusion/possession/possession_tracker.cpp
@@ -7,14 +7,18 @@
 PossessionTracker::PossessionTracker(const TbotsProto::PossessionTrackerConfig &config)
     : distance_near_tolerance_meters(config.distance_near_tolerance_meters()),
       distance_far_tolerance_meters(config.distance_far_tolerance_meters()),
+      ball_moved_threshold_meters(config.ball_moved_threshold_meters()),
       time_near_threshold(Duration::fromSeconds(config.time_near_threshold_s())),
       time_far_threshold(Duration::fromSeconds(config.time_far_threshold_s())),
       time_stagnant_threshold(Duration::fromSeconds(config.time_stagnant_threshold_s())),
+      time_ball_stagnant_threshold(Duration::fromSeconds(config.time_ball_stagnant_threshold_s())),
       last_timestamp(Timestamp::fromSeconds(0)),
       time_near_friendly(Duration::fromSeconds(0)),
       time_near_enemy(Duration::fromSeconds(0)),
       time_far_friendly(Duration::fromSeconds(0)),
       time_far_enemy(Duration::fromSeconds(0)),
+      time_since_ball_moved(Duration::fromSeconds(0)),
+      last_ball_position(Point()),
       possession(TeamPossession::FRIENDLY_TEAM)
 {
 }
@@ -37,7 +41,8 @@ TeamPossession PossessionTracker::getTeamWithPossession(const Team &friendly_tea
     else if ((time_near_friendly < time_near_threshold) &&
              (time_near_enemy > time_near_threshold))
     {
-        if (time_near_enemy < time_stagnant_threshold)
+        if (time_near_enemy < time_stagnant_threshold &&
+            time_since_ball_moved < time_ball_stagnant_threshold)
         {
             possession = TeamPossession::ENEMY_TEAM;
         }
@@ -91,11 +96,37 @@ void PossessionTracker::updateTimes(const Team &friendly_team, const Team &enemy
     Duration delta_time = ball.timestamp() - last_timestamp;
     last_timestamp      = ball.timestamp();
 
+    // Check whether the ball moved and update the amount of time 
+    // since the ball last moved
+    if (distance(ball.position(), last_ball_position) > ball_moved_threshold_meters)
+    {
+        time_since_ball_moved = Duration::fromSeconds(0);
+    }
+    else
+    {
+        time_since_ball_moved = time_since_ball_moved + delta_time;
+    }
+    last_ball_position = ball.position();
+
     auto nearest_friendly =
         getRobotWithEffectiveBallPossession(friendly_team, ball, field);
     auto nearest_enemy = getRobotWithEffectiveBallPossession(enemy_team, ball, field);
-    if (!nearest_friendly || !nearest_enemy)
+
+    if (!nearest_enemy)
     {
+        // No enemy threats, so zero time spent near and away from enemy.
+        // This will ensure that the friendly team has possession.
+        time_near_enemy = Duration::fromSeconds(0);
+        time_far_enemy = Duration::fromSeconds(0);
+        return;
+    }
+
+    if (!nearest_friendly)
+    {
+        // No friendly robots, so zero time spent near and away from friendly team.
+        // This will ensure that the enemy team has possession.
+        time_near_friendly = Duration::fromSeconds(0);
+        time_far_friendly = Duration::fromSeconds(0);
         return;
     }
 

--- a/src/software/sensor_fusion/possession/possession_tracker.cpp
+++ b/src/software/sensor_fusion/possession/possession_tracker.cpp
@@ -9,6 +9,7 @@ PossessionTracker::PossessionTracker(const TbotsProto::PossessionTrackerConfig &
       distance_far_tolerance_meters(config.distance_far_tolerance_meters()),
       time_near_threshold(Duration::fromSeconds(config.time_near_threshold_s())),
       time_far_threshold(Duration::fromSeconds(config.time_far_threshold_s())),
+      time_stagnant_threshold(Duration::fromSeconds(config.time_stagnant_threshold_s())),
       last_timestamp(Timestamp::fromSeconds(0)),
       time_near_friendly(Duration::fromSeconds(0)),
       time_near_enemy(Duration::fromSeconds(0)),
@@ -36,7 +37,14 @@ TeamPossession PossessionTracker::getTeamWithPossession(const Team &friendly_tea
     else if ((time_near_friendly < time_near_threshold) &&
              (time_near_enemy > time_near_threshold))
     {
-        possession = TeamPossession::ENEMY_TEAM;
+        if (time_near_enemy < time_stagnant_threshold)
+        {
+            possession = TeamPossession::ENEMY_TEAM;
+        }
+        else
+        {
+            possession = TeamPossession::STAGNANT_ENEMY_TEAM;
+        }
     }
     else if ((time_near_friendly > time_near_threshold) &&
              (time_near_enemy > time_near_threshold))
@@ -55,7 +63,7 @@ TeamPossession PossessionTracker::getTeamWithPossession(const Team &friendly_tea
         if (field.pointInFriendlyHalf(ball.position()) ||
             num_enemies_in_friendly_half > 0)
         {
-            possession = TeamPossession::ENEMY_TEAM;
+            possession = TeamPossession::STAGNANT_ENEMY_TEAM;
         }
         else
         {

--- a/src/software/sensor_fusion/possession/possession_tracker.cpp
+++ b/src/software/sensor_fusion/possession/possession_tracker.cpp
@@ -11,7 +11,8 @@ PossessionTracker::PossessionTracker(const TbotsProto::PossessionTrackerConfig &
       time_near_threshold(Duration::fromSeconds(config.time_near_threshold_s())),
       time_far_threshold(Duration::fromSeconds(config.time_far_threshold_s())),
       time_stagnant_threshold(Duration::fromSeconds(config.time_stagnant_threshold_s())),
-      time_ball_stagnant_threshold(Duration::fromSeconds(config.time_ball_stagnant_threshold_s())),
+      time_ball_stagnant_threshold(
+          Duration::fromSeconds(config.time_ball_stagnant_threshold_s())),
       last_timestamp(Timestamp::fromSeconds(0)),
       time_near_friendly(Duration::fromSeconds(0)),
       time_near_enemy(Duration::fromSeconds(0)),
@@ -96,7 +97,7 @@ void PossessionTracker::updateTimes(const Team &friendly_team, const Team &enemy
     Duration delta_time = ball.timestamp() - last_timestamp;
     last_timestamp      = ball.timestamp();
 
-    // Check whether the ball moved and update the amount of time 
+    // Check whether the ball moved and update the amount of time
     // since the ball last moved
     if (distance(ball.position(), last_ball_position) > ball_moved_threshold_meters)
     {
@@ -117,7 +118,7 @@ void PossessionTracker::updateTimes(const Team &friendly_team, const Team &enemy
         // No enemy threats, so zero time spent near and away from enemy.
         // This will ensure that the friendly team has possession.
         time_near_enemy = Duration::fromSeconds(0);
-        time_far_enemy = Duration::fromSeconds(0);
+        time_far_enemy  = Duration::fromSeconds(0);
         return;
     }
 
@@ -126,7 +127,7 @@ void PossessionTracker::updateTimes(const Team &friendly_team, const Team &enemy
         // No friendly robots, so zero time spent near and away from friendly team.
         // This will ensure that the enemy team has possession.
         time_near_friendly = Duration::fromSeconds(0);
-        time_far_friendly = Duration::fromSeconds(0);
+        time_far_friendly  = Duration::fromSeconds(0);
         return;
     }
 

--- a/src/software/sensor_fusion/possession/possession_tracker.cpp
+++ b/src/software/sensor_fusion/possession/possession_tracker.cpp
@@ -65,7 +65,7 @@ TeamPossession PossessionTracker::getTeamWithPossession(const Team &friendly_tea
         {
             // Possession is considered stagnant since the ball is being
             // actively over fought over (both teams are near ball), but
-            // enemy possession remains unchanged 
+            // enemy possession remains unchanged
             possession = TeamPossession::STAGNANT_ENEMY_TEAM;
         }
         else

--- a/src/software/sensor_fusion/possession/possession_tracker.h
+++ b/src/software/sensor_fusion/possession/possession_tracker.h
@@ -48,6 +48,9 @@ class PossessionTracker
     // Min time that robot must stay away from ball for it to be considered far away
     Duration time_far_threshold;
 
+    // Min time that team must hold possession for in order to be considered stagnant
+    Duration time_stagnant_threshold;
+
     // The timestamp of last game snapshot the PossessionTracker was updated with
     Timestamp last_timestamp;
 

--- a/src/software/sensor_fusion/possession/possession_tracker.h
+++ b/src/software/sensor_fusion/possession/possession_tracker.h
@@ -42,6 +42,10 @@ class PossessionTracker
     // to be considered far away from the ball
     double distance_far_tolerance_meters;
 
+    // Min distance in meters that ball must move between two timestamps
+    // for the ball to be considered moved
+    double ball_moved_threshold_meters;
+
     // Min time that robot must stay close to ball for it to be considered near
     Duration time_near_threshold;
 
@@ -50,6 +54,9 @@ class PossessionTracker
 
     // Min time that team must hold possession for in order to be considered stagnant
     Duration time_stagnant_threshold;
+
+    // Min time that the ball must stay still in order for possession to be considered stagnant
+    Duration time_ball_stagnant_threshold;
 
     // The timestamp of last game snapshot the PossessionTracker was updated with
     Timestamp last_timestamp;
@@ -66,11 +73,18 @@ class PossessionTracker
     // The amount of time that the enemy team has spent far away from the ball
     Duration time_far_enemy;
 
+    // The amount of time since the ball last moved
+    Duration time_since_ball_moved;
+
+    // The position of the ball at the last timestamp
+    Point last_ball_position;
+
     // The team currently with possession of the ball
     TeamPossession possession;
 
     /**
      * Updates the amounts of time that each team has spent near or away from the ball
+     * and the amount of time since the ball last moved
      *
      * @param friendly_team the friendly team
      * @param enemy_team the enemy team

--- a/src/software/sensor_fusion/possession/possession_tracker.h
+++ b/src/software/sensor_fusion/possession/possession_tracker.h
@@ -55,7 +55,8 @@ class PossessionTracker
     // Min time that team must hold possession for in order to be considered stagnant
     Duration time_stagnant_threshold;
 
-    // Min time that the ball must stay still in order for possession to be considered stagnant
+    // Min time that the ball must stay still in order for possession to be considered
+    // stagnant
     Duration time_ball_stagnant_threshold;
 
     // The timestamp of last game snapshot the PossessionTracker was updated with

--- a/src/software/sensor_fusion/possession/possession_tracker_test.cpp
+++ b/src/software/sensor_fusion/possession/possession_tracker_test.cpp
@@ -40,12 +40,19 @@ TEST(PossessionTrackerTest, get_possession_with_ball_near_team)
         world.friendlyTeam(), world.enemyTeam(), world.ball(), world.field());
     EXPECT_EQ(possession, TeamPossession::ENEMY_TEAM);
 
-    // Move ball near friendly bot for a period of time.
-    // Friendly team should have clear possession.
-    world.updateBall(Ball({0.55, 0}, {0, 0}, Timestamp::fromSeconds(0.5)));
+    // Keep ball near enemy bot for a prolonged period of time.
+    // Enemy possession should be considered stagnant.
+    world.updateBall(Ball({1.45, 0}, {0, 0}, Timestamp::fromSeconds(5)));
     possession = possession_tracker.getTeamWithPossession(
         world.friendlyTeam(), world.enemyTeam(), world.ball(), world.field());
-    world.updateBall(Ball({0.55, 0}, {0, 0}, Timestamp::fromSeconds(1)));
+    EXPECT_EQ(possession, TeamPossession::STAGNANT_ENEMY_TEAM);
+
+    // Move ball near friendly bot for a period of time.
+    // Friendly team should have clear possession.
+    world.updateBall(Ball({0.55, 0}, {0, 0}, Timestamp::fromSeconds(5.5)));
+    possession = possession_tracker.getTeamWithPossession(
+        world.friendlyTeam(), world.enemyTeam(), world.ball(), world.field());
+    world.updateBall(Ball({0.55, 0}, {0, 0}, Timestamp::fromSeconds(6)));
     possession = possession_tracker.getTeamWithPossession(
         world.friendlyTeam(), world.enemyTeam(), world.ball(), world.field());
     EXPECT_EQ(possession, TeamPossession::FRIENDLY_TEAM);

--- a/src/software/sensor_fusion/possession/possession_tracker_test.cpp
+++ b/src/software/sensor_fusion/possession/possession_tracker_test.cpp
@@ -69,15 +69,15 @@ TEST(PossessionTrackerTest, get_possession_with_ball_near_both_teams)
 
     // Ball equally near both friendly and enemy bots for a period of time
     // (i.e both teams have presence over the ball).
-    // Enemy team should have possession since the ball is being fought
-    // over in the friendly half.
+    // Enemy team should have stagnant possession since the ball is being fought
+    // over in the friendly half, but enemy possession remains unchanged.
     world.updateBall(Ball({-0.5, 0}, {0, 0}, Timestamp::fromSeconds(0)));
     possession = possession_tracker.getTeamWithPossession(
         world.friendlyTeam(), world.enemyTeam(), world.ball(), world.field());
     world.updateBall(Ball({-0.5, 0}, {0, 0}, Timestamp::fromSeconds(1)));
     possession = possession_tracker.getTeamWithPossession(
         world.friendlyTeam(), world.enemyTeam(), world.ball(), world.field());
-    EXPECT_EQ(possession, TeamPossession::ENEMY_TEAM);
+    EXPECT_EQ(possession, TeamPossession::STAGNANT_ENEMY_TEAM);
 
     // Position all bots in the enemy half.
     friendly_team = TestUtil::setRobotPositionsHelper(

--- a/src/software/world/team_types.h
+++ b/src/software/world/team_types.h
@@ -15,4 +15,10 @@ MAKE_ENUM(TeamColour, YELLOW, BLUE)
 /**
  * Indicates which team has possession of the ball
  */
-MAKE_ENUM(TeamPossession, FRIENDLY_TEAM, ENEMY_TEAM)
+MAKE_ENUM(TeamPossession,
+          // Friendly team has possession over ball
+          FRIENDLY_TEAM,
+          // Enemy team has possession over ball
+          ENEMY_TEAM,
+          // Enemy possession is stagnant (undisturbed for some time)
+          STAGNANT_ENEMY_TEAM)


### PR DESCRIPTION
## Please fill out the following before requesting review on this PR

### Description

Makes defense play more aggressive by adding shadowers that can steal balls from enemies. 

The defense play will switch to `AggressiveDefenseState` when the possession tracker sees that the enemy team has had possession for a while (possession is stagnant). The time threshold which determines stagnancy is a configurable param that we can adjust (shorter time -> more aggressive). In `AggressiveDefenseState`, the pass defender targeting the primary enemy is replaced with a shadower so that we can attempt to steal the ball.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
