### PR TITLE
Clamp dynamic radius in HRVO

### DIFF
--- a/src/software/ai/navigator/path_planner/hrvo/agent.cpp
+++ b/src/software/ai/navigator/path_planner/hrvo/agent.cpp
@@ -77,9 +77,11 @@ void Agent::updateRadiusFromVelocity()
     // is equal to min_radius, and at max_speed is equal to min_radius +
     // max_radius_inflation. A 4th degree polynomial was chosen because we want the radius
     // to increase quickly for smaller velocities.
-    double a = -max_radius_inflation / std::pow(max_speed, 4.0);
-    radius   = min_radius + max_radius_inflation +
-             a * std::pow(velocity.length() - max_speed, 4.0);
+    // Clamp velocity to avoid the possibility of negative radius
+    double clamped_velocity = std::min(velocity.length(), max_speed);
+    double a                = -max_radius_inflation / std::pow(max_speed, 4.0);
+    radius                  = min_radius + max_radius_inflation +
+             a * std::pow(clamped_velocity - max_speed, 4.0);
 }
 
 double Agent::getMaxAccel() const


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description
Clamping the velocity used by HRVO to dynamically change its radius. This is to avoid the possibility of a significantly high velocity causing the radius to be negative. Here's a [graph](https://www.desmos.com/calculator/fk7xnpcqqb) of the quartic function used.

#2941 provides more context behind this change.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Related to #2941
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
