### PR TITLE
fix breakbeam logic in sensor fusion + re enable some tests

### DIFF
--- a/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_test.cpp
@@ -22,7 +22,8 @@ class PenaltyKickPlayTest : public SimulatedErForceSimPlayTestFixture
     Field field                      = Field::createField(field_type);
 };
 
-TEST_F(PenaltyKickPlayTest, test_penalty_kick_setup)
+// TODO (#2602): test failing since a robot isn't avoiding the ball
+TEST_F(PenaltyKickPlayTest, DISABLED_test_penalty_kick_setup)
 {
     BallState ball_state(field.friendlyPenaltyMark(), Vector(0, 0));
     auto friendly_robots = TestUtil::createStationaryRobotStatesWithId(

--- a/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_test.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_test.cpp
@@ -22,8 +22,7 @@ class PenaltyKickPlayTest : public SimulatedErForceSimPlayTestFixture
     Field field                      = Field::createField(field_type);
 };
 
-// TODO (#2602): test failing since a robot isn't avoiding the ball
-TEST_F(PenaltyKickPlayTest, DISABLED_test_penalty_kick_setup)
+TEST_F(PenaltyKickPlayTest, test_penalty_kick_setup)
 {
     BallState ball_state(field.friendlyPenaltyMark(), Vector(0, 0));
     auto friendly_robots = TestUtil::createStationaryRobotStatesWithId(
@@ -66,8 +65,7 @@ TEST_F(PenaltyKickPlayTest, DISABLED_test_penalty_kick_setup)
             Duration::fromSeconds(9.5));
 }
 
-// TODO (#2167): disabled due to physics simulator bug causing failure
-TEST_F(PenaltyKickPlayTest, DISABLED_test_penalty_kick_take)
+TEST_F(PenaltyKickPlayTest, test_penalty_kick_take)
 {
     Vector behind_ball_direction =
         (field.friendlyPenaltyMark() - field.enemyGoalCenter()).normalize();

--- a/src/software/ai/hl/stp/play/stop_play_test.cpp
+++ b/src/software/ai/hl/stp/play/stop_play_test.cpp
@@ -96,8 +96,7 @@ TEST_F(StopPlayTest, test_stop_play_friendly_half_corner_robots_close_together)
             Duration::fromSeconds(10));
 }
 
-// TODO (#2602): test failing since a robot isn't avoiding the ball
-TEST_F(StopPlayTest, DISABLED_test_stop_play_enemy_half_robots_spread_out)
+TEST_F(StopPlayTest, test_stop_play_enemy_half_robots_spread_out)
 {
     BallState ball_state(Point(2, 0), Vector(0, 0));
     auto friendly_robots = TestUtil::createStationaryRobotStatesWithId(

--- a/src/software/ai/hl/stp/tactic/chip/chip_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/chip/chip_tactic_test.cpp
@@ -65,8 +65,7 @@ INSTANTIATE_TEST_CASE_P(
         // place the ball directly infront of the robot
         std::make_tuple(Vector(0.5, 0), Angle::zero()),
         // place the ball directly behind the robot
-        // TODO(#2602): re-enable once fixed
-        // std::make_tuple(Vector(-0.5, 0), Angle::zero()),
+        std::make_tuple(Vector(-0.5, 0), Angle::zero()),
         // place the ball in the robots dribbler
         std::make_tuple(Vector(ROBOT_MAX_RADIUS_METERS, 0), Angle::zero()),
         // Repeat the same tests but kick in the opposite direction
@@ -75,8 +74,7 @@ INSTANTIATE_TEST_CASE_P(
         // place the ball directly to the right of the robot
         std::make_tuple(Vector(0, -0.5), Angle::half()),
         // place the ball directly infront of the robot
-        // TODO(#2602): re-enable once fixed
-        // std::make_tuple(Vector(0.5, 0), Angle::half()),
+        std::make_tuple(Vector(0.5, 0), Angle::half()),
         // place the ball directly behind the robot
         std::make_tuple(Vector(-0.5, 0), Angle::half()),
         // place the ball in the robots dribbler

--- a/src/software/ai/hl/stp/tactic/kick/kick_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/kick/kick_tactic_test.cpp
@@ -65,8 +65,7 @@ INSTANTIATE_TEST_CASE_P(
         // place the ball directly infront of the robot
         std::make_tuple(Vector(0.5, 0), Angle::zero()),
         // place the ball directly behind the robot
-        // TODO(#2602): re-enable once fixed
-        // std::make_tuple(Vector(-0.5, 0), Angle::zero()),
+        std::make_tuple(Vector(-0.5, 0), Angle::zero()),
         // place the ball in the robots dribbler
         std::make_tuple(Vector(ROBOT_MAX_RADIUS_METERS, 0), Angle::zero()),
         // Repeat the same tests but kick in the opposite direction
@@ -75,8 +74,7 @@ INSTANTIATE_TEST_CASE_P(
         // place the ball directly to the right of the robot
         std::make_tuple(Vector(0, -0.5), Angle::half()),
         // place the ball directly infront of the robot
-        // TODO(#2602): re-enable once fixed
-        // std::make_tuple(Vector(0.5, 0), Angle::half()),
+        std::make_tuple(Vector(0.5, 0), Angle::half()),
         // place the ball directly behind the robot
         std::make_tuple(Vector(-0.5, 0), Angle::half()),
         // place the ball in the robots dribbler

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -177,12 +177,6 @@ void SensorFusion::updateWorld(
             ball_in_dribbler_timeout =
                 sensor_fusion_config.num_dropped_detections_before_ball_not_in_dribbler();
         }
-        else if (friendly_robot_id_with_ball_in_dribbler.has_value() &&
-                 friendly_robot_id_with_ball_in_dribbler.value() == robot_id)
-        {
-            friendly_robot_id_with_ball_in_dribbler = std::nullopt;
-            ball_in_dribbler_timeout                = 0;
-        }
     }
 }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
- ball_in_dribbler_timeout is being decremented in a different updateWorld but it also being reset if the ball isnt in the breakbeam
- re enable some tests in a closed issue
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
