### PR TITLE
Reduce the size of the PrimitiveSet sent to the robots

### DIFF
--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -151,7 +151,10 @@ class RobotCommunication(object):
                 fullsystem_primitives = dict(primitive_set.robot_primitives)
                 for robot_id in fullsystem_primitives.keys():
                     if robot_id in self.robots_connected_to_fullsystem:
-                        robot_primitives[robot_id] = fullsystem_primitives[robot_id]
+                        primitive = self.__reduce_primitive_size(
+                            fullsystem_primitives[robot_id]
+                        )
+                        robot_primitives[robot_id] = primitive
 
             # get the manual control primitive
             diagnostics_primitive = DirectControlPrimitive(
@@ -224,6 +227,21 @@ class RobotCommunication(object):
         """
         if self.running:
             self.current_proto_unix_io.send_proto(type, data)
+
+    def __reduce_primitive_size(self, primitive):
+        """
+        Reduces the size of the primitive by removing the static obstacles
+        :param primitive: the primitive to be reduced
+        :return: The reduced primitive
+        """
+
+        # The static_obstacles array is the largest part of the Primitive proto.
+        # Since it is not used by the robots, we will remove all values from its
+        # array.
+        if primitive.HasField("move"):
+            del primitive.move.motion_control.static_obstacles[:]
+
+        return primitive
 
     def setup_for_fullsystem(self):
         """

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -151,10 +151,9 @@ class RobotCommunication(object):
                 fullsystem_primitives = dict(primitive_set.robot_primitives)
                 for robot_id in fullsystem_primitives.keys():
                     if robot_id in self.robots_connected_to_fullsystem:
-                        primitive = self.__reduce_primitive_size(
+                        robot_primitives[robot_id] = self.__reduce_primitive_size(
                             fullsystem_primitives[robot_id]
                         )
-                        robot_primitives[robot_id] = primitive
 
             # get the manual control primitive
             diagnostics_primitive = DirectControlPrimitive(


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description
[Maximum transmission unit](https://en.wikipedia.org/wiki/Maximum_transmission_unit) (MTU) of ethernet is ~1500 bytes. With the headers that get added to a message, ~1400bytes is around the largest payload you can send in a single UDP packet, over the network. Currently, our PrimitiveSet packet sizes are around **1670-1700 bytes** long when we're commanding 6 robots with AI. This means that the network has to split our packet into 2 fragments and send them separately, then concatenate them back together once they both arrive at the destination (in this case, the Jetson on the robots). This fragmentation can increase the chance of packet loss, since if either of the fragments are lost or corrupted in the way, the entire packet will be dropped by the receiver. Additionally, the larger the size of the packet we send, the higher the risk of there being interference with one of the bytes, causing corruption of the message. To reduce the chance of overall packet loss, one approach we can take is to avoid [fragmentation](https://en.wikipedia.org/wiki/IP_fragmentation) by reducing our packet size.

Looking through the fields we send as part of the `PrimitiveSet` proto, it is easily noticeable that `static_obstacles` array takes the largest space. This field is used for drawing static obstacles (orange rectangles) in Thunderscope. Additionally, this field is not used by the robots since they dynamically recreate the set of static obstacles. As such, I have added a function to empty out the `static_obstacles` list before sending the packet over the network. With this update, the `PrimitiveSet` packet size has reduced significantly to around **720-780 bytes**. 

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Locally I tried to recreate sending the packet over wifi and it seem to still work, but someone should actually test this with actual robots to make sure that this does not mess up the primitive sets the AI sends.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
