### PR TITLE
Improve tactic generation for enemy free kick

### DIFF
--- a/src/software/ai/hl/stp/play/enemy_free_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/enemy_free_kick_play.cpp
@@ -14,117 +14,70 @@ EnemyFreekickPlay::EnemyFreekickPlay(TbotsProto::AiConfig config) : Play(config,
 void EnemyFreekickPlay::getNextTactics(TacticCoroutine::push_type &yield,
                                        const World &world)
 {
-    // Init a Crease Defender Tactic
-    auto crease_defender_tactic = std::make_shared<CreaseDefenderTactic>(
-        ai_config.robot_navigation_obstacle_config());
+    // Free kicks are usually taken near the edge of the field. We assign one robot to
+    // shadow the enemy robot taking the free kick
+    auto shadow_free_kicker = std::make_shared<ShadowEnemyTactic>();
 
-    // These robots will both block the enemy robot taking a free kick
-    std::array<std::shared_ptr<ShadowEnemyTactic>, 2> shadow_free_kicker = {
-        std::make_shared<ShadowEnemyTactic>(), std::make_shared<ShadowEnemyTactic>()};
+    // Assign up to two crease defenders
+    std::vector<std::shared_ptr<CreaseDefenderTactic>> crease_defenders = {
+            std::make_shared<CreaseDefenderTactic>(
+                    ai_config.robot_navigation_obstacle_config()),
+            std::make_shared<CreaseDefenderTactic>(
+                    ai_config.robot_navigation_obstacle_config())};
 
-    // Init Shadow Enemy Tactics for extra robots
-    std::array<std::shared_ptr<ShadowEnemyTactic>, 2> shadow_potential_receivers = {
-        std::make_shared<ShadowEnemyTactic>(), std::make_shared<ShadowEnemyTactic>()};
-
-    // Init Move Tactics for extra robots (These will be used if there are no robots to
-    // shadow)
-    auto move_tactic_main      = std::make_shared<MoveTactic>();
-    auto move_tactic_secondary = std::make_shared<MoveTactic>();
+    // Try to shadow as many enemy robots as possible
+    std::vector<std::shared_ptr<ShadowEnemyTactic>> shadow_potential_receivers;
 
     do
     {
-        // Create tactic vector (starting with Goalie)
+        // Create tactic vector
         PriorityTacticVector tactics_to_run = {{}};
 
         // Get all enemy threats
         auto enemy_threats = getAllEnemyThreats(world.field(), world.friendlyTeam(),
                                                 world.enemyTeam(), world.ball(), false);
 
-        // shadow free kicker should shadow the robot with the ball and if no such enemy
-        // exists, then it will default to positioning between the ball and the friendly
-        // defense area
-        if (enemy_threats.size() >= 1)
+        if (enemy_threats.empty())
         {
-            std::get<0>(shadow_free_kicker)
-                ->updateControlParams(enemy_threats.at(0), ROBOT_MAX_RADIUS_METERS * 3);
-            std::get<1>(shadow_free_kicker)
-                ->updateControlParams(enemy_threats.at(0), ROBOT_MAX_RADIUS_METERS * 3);
+            return;
         }
 
-        // Add Freekick shadower tactics
-        tactics_to_run[0].emplace_back(std::get<0>(shadow_free_kicker));
-        tactics_to_run[0].emplace_back(std::get<1>(shadow_free_kicker));
-        // Add Crease defender tactic on side of open enemy threats
-        if (enemy_threats.size() >= 4)
+        // Assign crease defenders
+        auto num_crease_defenders = world.friendlyTeam().numRobots() > 3 ? 2 : 1;
+        if (num_crease_defenders == 2)
         {
-            if (enemy_threats.at(3).robot.position().y() > 0)
-            {
-                crease_defender_tactic->updateControlParams(
+            crease_defenders[0]->updateControlParams(
                     world.ball().position(), TbotsProto::CreaseDefenderAlignment::LEFT);
-            }
-            else
-            {
-                crease_defender_tactic->updateControlParams(
+            crease_defenders[1]->updateControlParams(
                     world.ball().position(), TbotsProto::CreaseDefenderAlignment::RIGHT);
-            }
+
+            tactics_to_run[0].emplace_back(crease_defenders[0]);
+            tactics_to_run[0].emplace_back(crease_defenders[1]);
         }
         else
         {
-            crease_defender_tactic->updateControlParams(
-                world.ball().position(), TbotsProto::CreaseDefenderAlignment::CENTRE);
+            crease_defenders[0]->updateControlParams(
+                    world.ball().position(), TbotsProto::CreaseDefenderAlignment::CENTRE);
+
+            tactics_to_run[0].emplace_back(crease_defenders[0]);
         }
 
-        tactics_to_run[0].emplace_back(crease_defender_tactic);
-
-        // Assign ShadowEnemy tactics until we have every enemy covered. If there are not
-        // enough threats to shadow, move our robots to block the friendly net
-        if (enemy_threats.size() <= 1)
+        auto num_unassigned_robots = 4 - num_crease_defenders;
+        for (int i = 0;
+             i < std::min(num_unassigned_robots, (int)enemy_threats.size() - 1); i++)
         {
-            // Since the first enemy threat is covered by the shadow_free_kicker, just
-            // move to block the net
-            move_tactic_main->updateControlParams(
-                world.field().friendlyGoalCenter() +
-                    Vector(0, 2 * ROBOT_MAX_RADIUS_METERS),
-                (world.ball().position() - world.field().friendlyGoalCenter())
-                    .orientation(),
-                0);
-            move_tactic_main->updateControlParams(
-                world.field().friendlyGoalCenter() +
-                    Vector(0, -2 * ROBOT_MAX_RADIUS_METERS),
-                (world.ball().position() - world.field().friendlyGoalCenter())
-                    .orientation(),
-                0);
+            shadow_potential_receivers.emplace_back(
+                    std::make_shared<ShadowEnemyTactic>());
+            shadow_potential_receivers[i]->updateControlParams(
+                    enemy_threats[i + 1], ROBOT_MAX_RADIUS_METERS * 3);
 
-            tactics_to_run[0].emplace_back(move_tactic_main);
-            tactics_to_run[0].emplace_back(move_tactic_secondary);
+            tactics_to_run[0].emplace_back(shadow_potential_receivers[i]);
         }
-        if (enemy_threats.size() == 2)
-        {
-            // Shadow the second most threatening enemy threat and move one robot to block
-            // the net
-            move_tactic_main->updateControlParams(
-                world.field().friendlyGoalCenter() +
-                    Vector(0, 2 * ROBOT_MAX_RADIUS_METERS),
-                (world.ball().position() - world.field().friendlyGoalCenter())
-                    .orientation(),
-                0);
-            std::get<0>(shadow_potential_receivers)
-                ->updateControlParams(enemy_threats.at(1), ROBOT_MAX_RADIUS_METERS * 3);
 
-            tactics_to_run[0].emplace_back(std::get<0>(shadow_potential_receivers));
-            tactics_to_run[0].emplace_back(move_tactic_main);
-        }
-        if (enemy_threats.size() >= 3)
-        {
-            // Shadow the second and third most threatening enemy threats
-            std::get<0>(shadow_potential_receivers)
-                ->updateControlParams(enemy_threats.at(1), ROBOT_MAX_RADIUS_METERS * 3);
-            std::get<1>(shadow_potential_receivers)
-                ->updateControlParams(enemy_threats.at(2), ROBOT_MAX_RADIUS_METERS * 3);
-
-            tactics_to_run[0].emplace_back(std::get<0>(shadow_potential_receivers));
-            tactics_to_run[0].emplace_back(std::get<1>(shadow_potential_receivers));
-        }
+        // Shadow free kicker should shadow the enemy robot with the ball
+        shadow_free_kicker->updateControlParams(enemy_threats[0],
+                                                ROBOT_MAX_RADIUS_METERS * 3);
+        tactics_to_run[0].emplace_back(shadow_free_kicker);
 
         // yield the Tactics this Play wants to run, in order of priority
         yield(tactics_to_run);

--- a/src/software/ai/hl/stp/play/enemy_free_kick_play.cpp
+++ b/src/software/ai/hl/stp/play/enemy_free_kick_play.cpp
@@ -62,7 +62,7 @@ void EnemyFreekickPlay::getNextTactics(TacticCoroutine::push_type &yield,
             tactics_to_run[0].emplace_back(crease_defenders[0]);
         }
 
-        auto num_unassigned_robots = 4 - num_crease_defenders;
+        auto num_unassigned_robots = 5 - num_crease_defenders;
         for (int i = 0;
              i < std::min(num_unassigned_robots, (int)enemy_threats.size() - 1); i++)
         {


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

* Change number of crease defenders based on number of robots we have
* Assign only one robot to shadow enemy free kicker
* Prioritize shadowing potential pass receivers

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
