### PR TITLE
protobuf function name update

### DIFF
--- a/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
@@ -261,7 +261,7 @@ void Simulator::sendSSLSimErrorInternal(ErrorSource source)
     emit sendSSLSimError(errors, source);
 }
 
-static void createRobot(Simulator::RobotMap &list, float x, float y, uint32_t id,
+static void createProtobufRobot(Simulator::RobotMap &list, float x, float y, uint32_t id,
                         const ErrorAggregator *agg, SimulatorData *data,
                         const QMap<uint32_t, robot::Specs> &teamSpecs)
 {
@@ -637,7 +637,7 @@ void Simulator::setTeam(Simulator::RobotMap &list, float side, const robot::Team
         }
         teamSpecs[id].CopyFrom(specs);
 
-        createRobot(list, x, side * y, id, m_aggregator, m_data, teamSpecs);
+        createProtobufRobot(list, x, side * y, id, m_aggregator, m_data, teamSpecs);
         y -= 0.3;
     }
 }
@@ -727,7 +727,7 @@ void Simulator::moveRobot(const sslsim::TeleportRobot &robot)
                 ErForceVector targetPos;
                 coordinates::fromVision(robot, targetPos);
                 // TODO: check if the given position is fine
-                createRobot(list, targetPos.x, targetPos.y, robot.id().id(), m_aggregator,
+                createProtobufRobot(list, targetPos.x, targetPos.y, robot.id().id(), m_aggregator,
                             m_data, teamSpecs);
             }
         }

--- a/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
@@ -262,8 +262,8 @@ void Simulator::sendSSLSimErrorInternal(ErrorSource source)
 }
 
 static void createProtobufRobot(Simulator::RobotMap &list, float x, float y, uint32_t id,
-                        const ErrorAggregator *agg, SimulatorData *data,
-                        const QMap<uint32_t, robot::Specs> &teamSpecs)
+                                const ErrorAggregator *agg, SimulatorData *data,
+                                const QMap<uint32_t, robot::Specs> &teamSpecs)
 {
     SimRobot *robot = new SimRobot(&data->rng, teamSpecs[id], data->dynamicsWorld,
                                    btVector3(x, y, 0), 0.f);
@@ -727,8 +727,8 @@ void Simulator::moveRobot(const sslsim::TeleportRobot &robot)
                 ErForceVector targetPos;
                 coordinates::fromVision(robot, targetPos);
                 // TODO: check if the given position is fine
-                createProtobufRobot(list, targetPos.x, targetPos.y, robot.id().id(), m_aggregator,
-                            m_data, teamSpecs);
+                createProtobufRobot(list, targetPos.x, targetPos.y, robot.id().id(),
+                                    m_aggregator, m_data, teamSpecs);
             }
         }
         else if (!robot.present() && isPresent)

--- a/src/software/ai/passing/pass_generator.hpp
+++ b/src/software/ai/passing/pass_generator.hpp
@@ -163,7 +163,7 @@ PassEvaluation<ZoneEnum> PassGenerator<ZoneEnum>::generatePassEvaluation(
         passes.push_back(zone_and_pass.second);
     }
 
-    LOG(VISUALIZE) << *createPassVisualization(passes);
+    LOG(VISUALIZE) << *createProtobufPassVisualization(passes);
 
     return PassEvaluation<ZoneEnum>(pitch_division_, current_best_passes_,
                                     passing_config_, world.getMostRecentTimestamp());


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
     Make Protobuf conversion function names more consistent #2901 
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.

The naming of our protobuf conversion functions in tbots_protobuf.h is currently inconsistent. All functions create a C++ object and create a protobuf object that represents it, as such, all function names should have the word "protobuf" in their name to clearly identify that the conversion is from C++ to protobuf, and not viseversa.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

 Make Protobuf conversion function names more consistent #2901 

https://github.com/UBC-Thunderbots/Software/issues/2901
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
