### PR TITLE
Fix Flaky Simulated Tests

### DIFF
--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -170,7 +170,9 @@ class SimulatedTestRunner(TbotsTestRunner):
                     world = self.world_buffer.get(
                         block=True, timeout=WORLD_BUFFER_TIMEOUT, return_cached=False
                     )
-                    # We need this blocking get call to synchronize the running speed of world and primitives
+                    # Get the primitive set if the buffer has one. Only elapse the time if a primitive set is gotten
+                    # We do this to synchronize the running speed of world and primitives
+                    # Since AI is usually slower than getting worlds, so that's the limiting factor
                     # Otherwise, we end up with behaviour that doesn't simulate what would happen in the real world
                     primitive_set = self.primitive_set_buffer.get(
                         block=False, timeout=WORLD_BUFFER_TIMEOUT, return_cached=False

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -147,6 +147,8 @@ class SimulatedTestRunner(TbotsTestRunner):
         eventually_validation_failure_msg = "Test Timed Out"
 
         while time_elapsed_s < test_timeout_s:
+            # get time before we execute the loop
+            primitive_block_time = time.time()
 
             # Check for new CI commands at this time step
             for (delay, cmd, team) in ci_cmd_with_delay:
@@ -166,28 +168,20 @@ class SimulatedTestRunner(TbotsTestRunner):
             self.simulator_proto_unix_io.send_proto(SimulatorTick, tick)
             time_elapsed_s += tick_duration_s
 
-            if self.thunderscope:
-                time.sleep(
-                    tick_duration_s - primitive_block_time
-                    if primitive_block_time >= 0
-                    else 0
-                )
-
             while True:
                 try:
                     world = self.world_buffer.get(
                         block=True, timeout=WORLD_BUFFER_TIMEOUT, return_cached=False
                     )
 
-                    # get time before we try to get the primitive
-                    primitive_block_time = time.time()
-                    # We need this blocking get call to synchronize the running speed of world and primitives
-                    # Otherwise, we end up with behaviour that doesn't simulate what would happen in the real world
+                    # We block until the timeout for the new primitives from AI. if not found still,
+                    # the SSL Wrapper packet is resent in a loop until we actually get a primitive set from AI
+                    # Otherwise, if the AI misses the first SSL Wrapper packet and doesn't start
+                    # the simulated test will continue to tick forward, causes syncing issues with the AI
                     self.primitive_set_buffer.get(
                         block=True, timeout=WORLD_BUFFER_TIMEOUT, return_cached=False
                     )
-                    # get the time difference after we get the primitive (after any blocking that happened)
-                    primitive_block_time = primitive_block_time - time.time()
+
                     break
                 except queue.Empty as empty:
                     # If we timeout, that means full_system missed the last
@@ -203,6 +197,13 @@ class SimulatedTestRunner(TbotsTestRunner):
                     self.blue_full_system_proto_unix_io.send_proto(
                         RobotStatus, robot_status
                     )
+
+            # get the time difference after we get the primitive (after any blocking that happened)
+            primitive_block_time = primitive_block_time - time.time()
+
+            # if the time we have blocked is less than a tick, sleep for the remaining time (for Thunderscope only)
+            if self.thunderscope and tick_duration_s > primitive_block_time:
+                time.sleep(tick_duration_s - primitive_block_time)
 
             # Validate
             (

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -186,7 +186,7 @@ class SimulatedTestRunner(TbotsTestRunner):
                     self.primitive_set_buffer.get(
                         block=True, timeout=WORLD_BUFFER_TIMEOUT, return_cached=False
                     )
-                    # get the time after we get the primitive (after any blocking that happened)
+                    # get the time difference after we get the primitive (after any blocking that happened)
                     primitive_block_time = primitive_block_time - time.time()
                     break
                 except queue.Empty as empty:

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -170,14 +170,13 @@ class SimulatedTestRunner(TbotsTestRunner):
                     world = self.world_buffer.get(
                         block=True, timeout=WORLD_BUFFER_TIMEOUT, return_cached=False
                     )
-                    # Get the primitive set if the buffer has one. Only elapse the time if a primitive set is gotten
-                    # We do this to synchronize the running speed of world and primitives
-                    # Since AI is usually slower than getting worlds, so that's the limiting factor
+                    # AI is usually slower than getting worlds, so that's the limiting factor
+                    # We get a new primitive set and only update the time if one exists to make time dependant on AI
                     # Otherwise, we end up with behaviour that doesn't simulate what would happen in the real world
                     primitive_set = self.primitive_set_buffer.get(
                         block=False, timeout=WORLD_BUFFER_TIMEOUT, return_cached=False
                     )
-                    if primitive_set:
+                    if primitive_set is not None:
                         time_elapsed_s += tick_duration_s
                     break
                 except queue.Empty as empty:
@@ -193,11 +192,6 @@ class SimulatedTestRunner(TbotsTestRunner):
                     )
                     self.blue_full_system_proto_unix_io.send_proto(
                         RobotStatus, robot_status
-                    )
-                    # We need this blocking get call to synchronize the running speed of world and primitives
-                    # Otherwise, we end up with behaviour that doesn't simulate what would happen in the real world
-                    self.primitive_set_buffer.get(
-                        block=True, timeout=WORLD_BUFFER_TIMEOUT, return_cached=False
                     )
 
             # Validate

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -141,14 +141,11 @@ class SimulatedTestRunner(TbotsTestRunner):
 
         time_elapsed_s = 0
 
-        # initialize the primitive block time to 0
-        primitive_block_time = 0
-
         eventually_validation_failure_msg = "Test Timed Out"
 
         while time_elapsed_s < test_timeout_s:
             # get time before we execute the loop
-            primitive_block_time = time.time()
+            processing_start_time = time.time()
 
             # Check for new CI commands at this time step
             for (delay, cmd, team) in ci_cmd_with_delay:
@@ -199,11 +196,11 @@ class SimulatedTestRunner(TbotsTestRunner):
                     )
 
             # get the time difference after we get the primitive (after any blocking that happened)
-            primitive_block_time = primitive_block_time - time.time()
+            processing_time = time.time() - processing_start_time
 
             # if the time we have blocked is less than a tick, sleep for the remaining time (for Thunderscope only)
-            if self.thunderscope and tick_duration_s > primitive_block_time:
-                time.sleep(tick_duration_s - primitive_block_time)
+            if self.thunderscope and tick_duration_s > processing_time:
+                time.sleep(tick_duration_s - processing_time)
 
             # Validate
             (

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -171,7 +171,7 @@ class SimulatedTestRunner(TbotsTestRunner):
                         block=True, timeout=WORLD_BUFFER_TIMEOUT, return_cached=False
                     )
                     # AI is usually slower than getting worlds, so that's the limiting factor
-                    # We get a new primitive set and only update the time if one exists to make time dependant on AI
+                    # We get a new primitive set and only update the time if one exists to make time dependent on AI
                     # Otherwise, we end up with behaviour that doesn't simulate what would happen in the real world
                     primitive_set = self.primitive_set_buffer.get(
                         block=False, timeout=WORLD_BUFFER_TIMEOUT, return_cached=False


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->
ball_placement_play_test was flaky. Looking at the logs, we see that the AI does nothing for the first few seconds while the time is still elapsing. It only starts a few seconds in, but the time runs out before the test does what it's supposed to. 

We elapse the time in the simulated test fixture whenever we get a new world, but we may not have a new primitive by this point. So the time keep elapsing with no new primitives, and the test times out. So we want to elapse the time when we get a new primitive instead

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Existing tests pass. CI passes (in progress)

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
