### PR TITLE
[Thunderscope] Replace sliders with text/number boxes in parameter tree

### DIFF
--- a/src/software/thunderscope/common/proto_parameter_tree_util.py
+++ b/src/software/thunderscope/common/proto_parameter_tree_util.py
@@ -5,7 +5,7 @@ from thefuzz import fuzz
 
 
 def __create_int_parameter_writable(key, value, descriptor):
-    """Converts an int field of a proto to a SliderParameter with
+    """Converts an int field of a proto to a NumericParameterItem with
     the min/max bounds set according to the provided ParameterRangeOptions
 
     min/vax options.
@@ -27,7 +27,7 @@ def __create_int_parameter_writable(key, value, descriptor):
 
     return {
         "name": key,
-        "type": "slider",
+        "type": "int",
         "value": value,
         "default": value,
         "limits": (int(min_max["min_int_value"]), int(min_max["max_int_value"])),
@@ -36,7 +36,7 @@ def __create_int_parameter_writable(key, value, descriptor):
 
 
 def __create_double_parameter_writable(key, value, descriptor):
-    """Converts a double field of a proto to a SliderParameter with
+    """Converts a double field of a proto to a NumericParameterItem with
     the min/max bounds set according to the provided ParameterRangeOptions
     min/vax options.
 
@@ -57,7 +57,7 @@ def __create_double_parameter_writable(key, value, descriptor):
 
     return {
         "name": key,
-        "type": "slider",
+        "type": "float",
         "value": value,
         "default": value,
         "limits": (min_max["min_double_value"], min_max["max_double_value"],),


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

Changed the sliders within Thunderscope into text boxes. Allows for exact int or float inputs.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

Ran Thunderscope, works without issue and changes appear.

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

Resolves #2987

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
