### PR TITLE
Fix setup_nano.sh Script

### DIFF
--- a/src/software/jetson_nano/setup_nano.sh
+++ b/src/software/jetson_nano/setup_nano.sh
@@ -44,5 +44,5 @@ pip_libaries=(
 sudo /opt/tbotspython/bin/pip3.8 install "${pip_libaries[@]}"
 
 # Install platformio udev rules
-curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
+curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

The script ```src/software/jetson_nano/setup_nano.sh``` does not work as intended. By using [link-inspector](https://github.com/justindhillon/link-inspector), I found out that the platformio udev rules don't get installed due to I curling a broken link. 

So I have changed the link from https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules to https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules

### Testing Done

I ran the script before the changes and received errors. I then ran the script after the changes and everything ran smoothly.

### Review Checklist

- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

### Support my work

I used [link-inspector](https://github.com/justindhillon/link-inspector) to find and fix this issue. If you find this PR useful, give the repo a :star: