### PR TITLE
Remove duplicated pass generator call & improve rank zone runtime

### DIFF
--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.cpp
@@ -3,7 +3,7 @@
 #include <Tracy.hpp>
 #include <algorithm>
 
-ShootOrPassPlayFSM::ShootOrPassPlayFSM(TbotsProto::AiConfig ai_config)
+ShootOrPassPlayFSM::ShootOrPassPlayFSM(const TbotsProto::AiConfig& ai_config)
     : ai_config(ai_config),
       attacker_tactic(std::make_shared<AttackerTactic>(ai_config)),
       receiver_tactic(std::make_shared<ReceiverTactic>()),
@@ -21,8 +21,8 @@ ShootOrPassPlayFSM::ShootOrPassPlayFSM(TbotsProto::AiConfig ai_config)
 }
 
 void ShootOrPassPlayFSM::updateOffensivePositioningTactics(
-    std::vector<EighteenZoneId> ranked_zones, PassEvaluation<EighteenZoneId> pass_eval,
-    unsigned int num_tactics)
+    const std::vector<EighteenZoneId>& ranked_zones,
+    const PassEvaluation<EighteenZoneId>& pass_eval, unsigned int num_tactics)
 {
     // These two tactics will set robots to roam around the field, trying to put
     // themselves into a good position to receive a pass
@@ -53,30 +53,21 @@ void ShootOrPassPlayFSM::lookForPass(const Update& event)
     if (event.common.num_tactics > 1)
     {
         ZoneNamedN(_tracy_look_for_pass, "ShootOrPassPlayFSM: Look for pass", true);
-
-        auto pass_eval    = pass_generator.generatePassEvaluation(event.common.world_ptr);
-        auto ranked_zones = pass_eval.rankZonesForReceiving(
+        PassEvaluation<EighteenZoneId> pass_eval =
+            pass_generator.generatePassEvaluation(event.common.world_ptr);
+        best_pass_and_score_so_far = pass_eval.getBestPassOnField();
+        auto ranked_zones          = pass_eval.rankZonesForReceiving(
             event.common.world_ptr, event.common.world_ptr->ball().position());
-
-        best_pass_and_score_so_far = pass_eval.getBestPassOnField();
-
-
-        // Wait for a good pass by starting out only looking for "perfect" passes
-        // (with a score of 1) and decreasing this threshold over time
-        // This boolean indicates if we're ready to perform a pass
-        double abs_min_pass_score =
-            ai_config.shoot_or_pass_play_config().abs_min_pass_score();
-        double pass_score_ramp_down_duration =
-            ai_config.shoot_or_pass_play_config().pass_score_ramp_down_duration();
-        pass_eval = pass_generator.generatePassEvaluation(event.common.world_ptr);
-        best_pass_and_score_so_far = pass_eval.getBestPassOnField();
 
         // update the best pass in the attacker tactic
         attacker_tactic->updateControlParams(best_pass_and_score_so_far.pass, false);
 
-        // If we've assigned a robot as the passer in the PassGenerator, we
-        // lower our threshold based on how long the PassGenerator has been
-        // running since we set it
+        // Wait for a good pass by starting out only looking for "perfect" passes
+        // (with a score of 1) and decreasing this threshold over time
+        double abs_min_pass_score =
+            ai_config.shoot_or_pass_play_config().abs_min_pass_score();
+        double pass_score_ramp_down_duration =
+            ai_config.shoot_or_pass_play_config().pass_score_ramp_down_duration();
         time_since_commit_stage_start = event.common.world_ptr->getMostRecentTimestamp() -
                                         pass_optimization_start_time;
         min_pass_score_threshold =

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
@@ -32,7 +32,7 @@ struct ShootOrPassPlayFSM
      *
      * @param ai_config the play config for this play FSM
      */
-    explicit ShootOrPassPlayFSM(TbotsProto::AiConfig ai_config);
+    explicit ShootOrPassPlayFSM(const TbotsProto::AiConfig& ai_config);
 
     /**
      * Updates the offensive positioning tactics
@@ -42,9 +42,9 @@ struct ShootOrPassPlayFSM
      * @param pass_eval The pass evaluation to help find best passes
      * @param num_tactics the number of tactics to return
      */
-    void updateOffensivePositioningTactics(std::vector<EighteenZoneId> ranked_zones,
-                                           PassEvaluation<EighteenZoneId> pass_eval,
-                                           unsigned int num_tactics);
+    void updateOffensivePositioningTactics(
+        const std::vector<EighteenZoneId>& ranked_zones,
+        const PassEvaluation<EighteenZoneId>& pass_eval, unsigned int num_tactics);
 
     /**
      * Action that looks for a pass

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm_test.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm_test.cpp
@@ -61,11 +61,17 @@ TEST(ShootOrPassPlayFSMTest, test_abort_pass_guard)
             world, 2, [](PriorityTacticVector new_tactics) {}, InterPlayCommunication{},
             [](InterPlayCommunication comm) {})));
 
-    // 2 process events needed so that fsm finds a pass between the 2 robots on the field.
+    // 3 process events needed so that fsm finds a pass between the 2 robots on the field.
     fsm.process_event(ShootOrPassPlayFSM::Update(
         ShootOrPassPlayFSM::ControlParams{},
         PlayUpdate(
-            world, 3, [](PriorityTacticVector new_tactics) {}, InterPlayCommunication{},
+            world, 2, [](PriorityTacticVector new_tactics) {}, InterPlayCommunication{},
+            [](InterPlayCommunication comm) {})));
+
+    fsm.process_event(ShootOrPassPlayFSM::Update(
+        ShootOrPassPlayFSM::ControlParams{},
+        PlayUpdate(
+            world, 2, [](PriorityTacticVector new_tactics) {}, InterPlayCommunication{},
             [](InterPlayCommunication comm) {})));
 
     EXPECT_TRUE(fsm.is(boost::sml::state<ShootOrPassPlayFSM::TakePassState>));

--- a/src/software/ai/passing/pass_evaluation.hpp
+++ b/src/software/ai/passing/pass_evaluation.hpp
@@ -159,14 +159,21 @@ std::vector<ZoneEnum> PassEvaluation<ZoneEnum>::rankZonesForReceiving(
 {
     std::vector<ZoneEnum> cherry_pick_zones = pitch_division_->getAllZoneIds();
 
+    // We cache the ratings of each zone to avoid rateZone being called multiple times
+    // by the std::sort comparator function. This is very important as rateZone is
+    // an expensive function to call.
+    std::map<ZoneEnum, double> cached_ratings;
+    for (const auto& zone : cherry_pick_zones)
+    {
+        cached_ratings[zone] =
+            rateZone(world_ptr->field(), world_ptr->enemyTeam(),
+                     pitch_division_->getZone(zone), pass_position, passing_config_);
+    }
+
     std::sort(cherry_pick_zones.begin(), cherry_pick_zones.end(),
-              [this, &world_ptr, &pass_position](const ZoneEnum& z1, const ZoneEnum& z2) {
-                  return rateZone(world_ptr->field(), world_ptr->enemyTeam(),
-                                  pitch_division_->getZone(z1), pass_position,
-                                  passing_config_) >
-                         rateZone(world_ptr->field(), world_ptr->enemyTeam(),
-                                  pitch_division_->getZone(z2), pass_position,
-                                  passing_config_);
+              [&](const ZoneEnum& z1, const ZoneEnum& z2) {
+                  return cached_ratings[z1] > cached_ratings[z2];
               });
+
     return cherry_pick_zones;
 }


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->
### Description
Fixing a bug in `ShootOrPassPlayFSM::lookForPass` where we had duplicated calls to `generatePassEvaluation` which searches the entire field for passes. A second bug was actually found after opening this PR in `rankZonesForReceiving` function which called `rateZone` (fairly expensive function) inside an `std::sort` comparator function. Since each zone is compared with multiple other zones to sort the array, it meant that we rated each zone ~10 times.

On my computer running with `-o` optimization flag, the first bug fix reduced the average runtime of `lookForPass` from 8.07ms to 6.45ms. ~~which is a nice improvement for minimal effort. Hopefully we could find more bugs like this around our code :sweat_smile:~~ The second bug fix reduced the average runtime further to 3ms. 

Given that `lookForPass` was the most expensive function in our AI, these two improvements stabalized the AI runtime per tick much further (avg 2.77ms)
![image](https://github.com/UBC-Thunderbots/Software/assets/28585597/7bf922ed-a1c2-4fe3-b29f-5e2b40b7226b)

<details>
  <summary> Additional Tracy Profiling Plots for those interested </summary>
  Note the plot name at the top left of each image. 

**Tracy profiling results on master:**
![image](https://github.com/UBC-Thunderbots/Software/assets/28585597/88ae682d-7597-4e8e-aee9-2fac142c76b0)
![image](https://github.com/UBC-Thunderbots/Software/assets/28585597/91b90658-a869-44d9-b876-8600baba03f0)

**After removing duplicated call:**
![image](https://github.com/UBC-Thunderbots/Software/assets/28585597/ddd8c26a-8966-4c28-9de1-22ff9ab93360)

**After caching `rankZone` calls:**
![image](https://github.com/UBC-Thunderbots/Software/assets/28585597/47cb3848-a107-4db4-9027-4c9b5f94dee1)
![image](https://github.com/UBC-Thunderbots/Software/assets/28585597/1a80dcba-2fc2-4038-a318-a39611535824)

</details>

~~:exclamation: Surprisingly, roughly 2/3 of the runtime of `lookForPass` after this fix is spent in `rankZonesForReceiving`. This should be investigated as this function should not be so expensive!~~

I've also made some additional formatting/refactoring changes to the rest of the file to make it a bit more clear (these changes should not have any effects on the gameplay behaviour :tm:)
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Ran AI vs AI and it looked fine.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
