### PR TITLE
Hide Proto Plotter widget to improve Thunderscope frame rate

### DIFF
--- a/src/software/thunderscope/play/playinfo_widget.py
+++ b/src/software/thunderscope/play/playinfo_widget.py
@@ -21,10 +21,9 @@ class PlayInfoWidget(QWidget):
     HEADER_SIZE_HINT_WIDTH_EXPANSION = 12
     ITEM_SIZE_HINT_WIDTH_EXPANSION = 10
 
-    def __init__(self, minimum_column_width: int = 200, buffer_size: int = 5) -> None:
+    def __init__(self, buffer_size: int = 1) -> None:
         """Shows the current play information including tactic and FSM state
 
-        :param minimum_column_width: minimum width of columns
         :param buffer_size: The buffer size, set higher for smoother plots.
                             Set lower for more realtime plots. Default is arbitrary
 
@@ -35,6 +34,7 @@ class PlayInfoWidget(QWidget):
 
         self.playinfo_buffer = ThreadSafeBuffer(buffer_size, PlayInfo, False)
         self.play_table.verticalHeader().setVisible(False)
+        self.last_playinfo = None
 
         self.vertical_layout = QVBoxLayout()
         self.vertical_layout.addWidget(self.play_table)
@@ -43,7 +43,13 @@ class PlayInfoWidget(QWidget):
     def refresh(self) -> None:
         """Update the play info widget with new play information
         """
-        playinfo = self.playinfo_buffer.get(block=False)
+        playinfo = self.playinfo_buffer.get(block=False, return_cached=False)
+
+        # Updating QTableWidget could be expensive, so we only update if there is new data
+        if playinfo is None or playinfo == self.last_playinfo:
+            return
+
+        self.last_playinfo = playinfo
 
         play_info_dict = MessageToDict(playinfo)
 

--- a/src/software/thunderscope/play/refereeinfo_widget.py
+++ b/src/software/thunderscope/play/refereeinfo_widget.py
@@ -18,7 +18,7 @@ class RefereeInfoWidget(QWidget):
     HEADER_SIZE_HINT_WIDTH_EXPANSION = 12
     ITEM_SIZE_HINT_WIDTH_EXPANSION = 11
 
-    def __init__(self, buffer_size: int = 5) -> None:
+    def __init__(self, buffer_size: int = 1) -> None:
         """Shows the referee information 
 
         :param buffer_size: The buffer size, set higher for smoother plots.
@@ -42,7 +42,12 @@ class RefereeInfoWidget(QWidget):
     def refresh(self) -> None:
         """Update the referee info widget with new referee information
         """
-        referee = self.referee_buffer.get(block=False)
+        referee = self.referee_buffer.get(block=False, return_cached=False)
+
+        # Updating QTableWidget could be expensive, so we only update if there is new data
+        if referee is None:
+            return
+
         referee_msg_dict = MessageToDict(referee)
 
         if not referee_msg_dict:

--- a/src/software/thunderscope/thunderscope_config.py
+++ b/src/software/thunderscope/thunderscope_config.py
@@ -197,13 +197,13 @@ def configure_base_fullsystem(
             anchor="Parameters",
             position="above",
         ),
-           TScopeWidget(
-               name="Logs",
-               widget=setup_log_widget(**{"proto_unix_io": full_system_proto_unix_io}),
-               anchor="Parameters",
-               position="above",
-               stretch=WidgetStretchData(x=3),
-           ),
+        TScopeWidget(
+            name="Logs",
+            widget=setup_log_widget(**{"proto_unix_io": full_system_proto_unix_io}),
+            anchor="Parameters",
+            position="above",
+            stretch=WidgetStretchData(x=3),
+        ),
         TScopeWidget(
             name="Referee Info",
             widget=setup_referee_info(**{"proto_unix_io": full_system_proto_unix_io}),
@@ -234,12 +234,12 @@ def configure_base_fullsystem(
             anchor="Performance",
             position="below",
         ),
-       TScopeWidget(
-           name="Play Info",
-           widget=setup_play_info(**{"proto_unix_io": full_system_proto_unix_io}),
-           anchor="Referee Info",
-           position="above",
-       ),
+        TScopeWidget(
+            name="Play Info",
+            widget=setup_play_info(**{"proto_unix_io": full_system_proto_unix_io}),
+            anchor="Referee Info",
+            position="above",
+        ),
     ] + extra_widgets
 
 

--- a/src/software/thunderscope/thunderscope_config.py
+++ b/src/software/thunderscope/thunderscope_config.py
@@ -211,12 +211,6 @@ def configure_base_fullsystem(
             position="bottom",
         ),
         TScopeWidget(
-            name="Play Info",
-            widget=setup_play_info(**{"proto_unix_io": full_system_proto_unix_io}),
-            anchor="Referee Info",
-            position="above",
-        ),
-        TScopeWidget(
             name="Performance",
             widget=setup_performance_plot(
                 **{"proto_unix_io": full_system_proto_unix_io}
@@ -226,8 +220,8 @@ def configure_base_fullsystem(
             # otherwise, it opens in a new window
             # the setup functions returns the widget.win and the refresh function separately
             in_window=True,
-            anchor="Play Info",
-            position="right",
+            anchor="Referee Info",
+            position="below",
         ),
         TScopeWidget(
             name="FPS Widget",
@@ -238,8 +232,14 @@ def configure_base_fullsystem(
                 }
             ),
             anchor="Performance",
-            position="above",
+            position="below",
         ),
+       TScopeWidget(
+           name="Play Info",
+           widget=setup_play_info(**{"proto_unix_io": full_system_proto_unix_io}),
+           anchor="Referee Info",
+           position="above",
+       ),
     ] + extra_widgets
 
 

--- a/src/software/thunderscope/thunderscope_config.py
+++ b/src/software/thunderscope/thunderscope_config.py
@@ -190,36 +190,25 @@ def configure_base_fullsystem(
             stretch=WidgetStretchData(x=3),
         ),
         TScopeWidget(
-            name="Logs",
-            widget=setup_log_widget(**{"proto_unix_io": full_system_proto_unix_io}),
-            anchor="Parameters",
-            position="above",
-            stretch=WidgetStretchData(x=3),
-        ),
-        TScopeWidget(
             name="Error Log",
             widget=setup_robot_error_log_view_widget(
                 **{"proto_unix_io": full_system_proto_unix_io}
             ),
-            position="below",
-            anchor="Logs",
+            anchor="Parameters",
+            position="above",
         ),
+           TScopeWidget(
+               name="Logs",
+               widget=setup_log_widget(**{"proto_unix_io": full_system_proto_unix_io}),
+               anchor="Parameters",
+               position="above",
+               stretch=WidgetStretchData(x=3),
+           ),
         TScopeWidget(
             name="Referee Info",
             widget=setup_referee_info(**{"proto_unix_io": full_system_proto_unix_io}),
             anchor="Field",
             position="bottom",
-        ),
-        TScopeWidget(
-            name="FPS Widget",
-            widget=setup_fps_widget(
-                **{
-                    "bufferswap_counter": buffer_func_counter,
-                    "refresh_func_counter": refresh_func_counter,
-                }
-            ),
-            anchor="Referee Info",
-            position="above",
         ),
         TScopeWidget(
             name="Play Info",
@@ -239,6 +228,17 @@ def configure_base_fullsystem(
             in_window=True,
             anchor="Play Info",
             position="right",
+        ),
+        TScopeWidget(
+            name="FPS Widget",
+            widget=setup_fps_widget(
+                **{
+                    "bufferswap_counter": buffer_func_counter,
+                    "refresh_func_counter": refresh_func_counter,
+                }
+            ),
+            anchor="Performance",
+            position="above",
         ),
     ] + extra_widgets
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->
### Description
Shifted some of the widgets around such that they are not visible by default, and as a result, are not `refresh`ed. Primarily, the proto plotter is very slow in its current implementation (#2980 should help with its performance). Furthermore, updating Qt tables regularly can be slow, thus the code for the play info widget has been changed to update the table only if there's a new play protobuf.    

Hopefully with the recent AI performance improvements, we shouldn't need to look at the proto plotter as often. Though, in scenarios like Robocup it would be a good idea to have the widget visible to make sure AI is running and vision is being received (or we could add more performant widgets for this).

### Testing Done
Here are various percentile times for the frame-time (time between consecutive calls) of `refresh` function. All data is collected over 600 data points and is in seconds.

**On Master**
50p: 0.097
80p: 0.103
90p: 0.106
95p: 0.107

**After Changes**
50p: 0.027
80p: 0.057
90p: 0.068
95p: 0.078

### Resolved Issues
Additional Thunderscope performance improvements to #3125
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
