### PR TITLE
Thunderloop Send Error when Battery is Unstable

### DIFF
--- a/src/proto/robot_status_msg.proto
+++ b/src/proto/robot_status_msg.proto
@@ -74,10 +74,10 @@ enum ErrorCode
     NO_ERROR = 0;
 
     // Level triggered events
-    HIGH_CAP           = 1;
-    LOW_BATTERY        = 2;
-    HIGH_BOARD_TEMP    = 3;
-    DRIBBLER_MOTOR_HOT = 4;
+    HIGH_CAP              = 1;
+    LOW_BATTERY           = 2;
+    HIGH_BOARD_TEMP       = 3;
+    DRIBBLER_MOTOR_HOT    = 4;
     UNSTABLE_POWER_SUPPLY = 5;
 }
 

--- a/src/proto/robot_status_msg.proto
+++ b/src/proto/robot_status_msg.proto
@@ -78,6 +78,7 @@ enum ErrorCode
     LOW_BATTERY        = 2;
     HIGH_BOARD_TEMP    = 3;
     DRIBBLER_MOTOR_HOT = 4;
+    UNSTABLE_POWER_SUPPLY = 5;
 }
 
 enum MotorFault

--- a/src/software/jetson_nano/BUILD
+++ b/src/software/jetson_nano/BUILD
@@ -65,12 +65,11 @@ sh_binary(
     srcs = ["setup_nano.sh"],
 )
 
-
 cc_test(
     name = "test_battery",
     srcs = ["battery_test.cpp"],
     deps = [
+        ":thunderloop",
         "//shared/test_util:tbots_gtest_main",
-        ":thunderloop"
     ],
 )

--- a/src/software/jetson_nano/BUILD
+++ b/src/software/jetson_nano/BUILD
@@ -64,3 +64,13 @@ sh_binary(
     name = "setup_nano",
     srcs = ["setup_nano.sh"],
 )
+
+
+cc_test(
+    name = "test_battery",
+    srcs = ["battery_test.cpp"],
+    deps = [
+        "//shared/test_util:tbots_gtest_main",
+        ":thunderloop"
+    ],
+)

--- a/src/software/jetson_nano/battery_test.cpp
+++ b/src/software/jetson_nano/battery_test.cpp
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+
+#include "thunderloop.h"
+
+TEST(TestBattery, is_power_stable)
+{
+    std::ifstream file("/var/log/dmesg");
+    EXPECT_TRUE(isPowerStable(file));
+}
+
+TEST(TestBattery, can_open_file)
+{
+    std::ifstream file("/var/log/dmesg");
+    EXPECT_TRUE(file.is_open());
+}

--- a/src/software/jetson_nano/battery_test.cpp
+++ b/src/software/jetson_nano/battery_test.cpp
@@ -1,11 +1,32 @@
 #include <gtest/gtest.h>
 
+#include <cstdio>
+#include <fstream>
+
 #include "thunderloop.h"
 
 TEST(TestBattery, is_power_stable)
 {
-    std::ifstream file("/var/log/dmesg");
-    EXPECT_TRUE(isPowerStable(file));
+    std::ofstream file("/tmp/battery_test_1.log");
+    file << "this is some placeholder text!";
+    file.close();
+
+    std::ifstream input_file("/tmp/battery_test_1.log");
+
+    EXPECT_TRUE(isPowerStable(input_file));
+    std::remove("/tmp/battery_test_1.log");
+}
+
+TEST(TestBattery, is_power_not_stable)
+{
+    std::ofstream output_file("/tmp/battery_test_2.log");
+    output_file << "soctherm: OC ALARM 0x00000001";
+    output_file.close();
+
+    std::ifstream input_file("/tmp/battery_test_2.log");
+
+    EXPECT_FALSE(isPowerStable(input_file));
+    std::remove("/tmp/battery_test_2.log");
 }
 
 TEST(TestBattery, can_open_file)

--- a/src/software/jetson_nano/thunderloop.cpp
+++ b/src/software/jetson_nano/thunderloop.cpp
@@ -425,7 +425,7 @@ static bool isPowerStable()
     if (!dmesg_log_file.is_open())
     {
         LOG(WARNING) << "Cannot dmesg log file. Do you have permission?";
-        return false;
+        return true;
     }
 
     std::string line;
@@ -433,11 +433,11 @@ static bool isPowerStable()
     {
         if (line.find("soctherm: OC ALARM 0x00000001") != std::string::npos)
         {
-            return true;
+            return false;
         }
     }
 
-    return false;
+    return true;
 }
 
 void Thunderloop::updateErrorCodes()

--- a/src/software/jetson_nano/thunderloop.cpp
+++ b/src/software/jetson_nano/thunderloop.cpp
@@ -437,6 +437,11 @@ bool isPowerStable(std::ifstream& log_file)
         }
     }
 
+    // https://pastebin.com/ebsATa2h we need to clear the error state bit because we have
+    // reached the end of the file. After being clearing the bit, std::getline would return
+    // the changes in the file. See the pastebin for example.
+    log_file.clear();
+
     return true;
 }
 
@@ -459,7 +464,10 @@ void Thunderloop::updateErrorCodes()
         robot_status_.mutable_error_code()->Add(TbotsProto::ErrorCode::HIGH_BOARD_TEMP);
     }
 
-    std::ifstream log_file(PATH_TO_RINGBUFFER_LOG);
+    // this is declared as static since we really only want to open this file once and
+    // pull from a buffer. clear would be called to ensure that std::getline would return
+    // the latest changes!
+    static std::ifstream log_file(PATH_TO_RINGBUFFER_LOG);
     if (!isPowerStable(log_file))
     {
         robot_status_.mutable_error_code()->Add(

--- a/src/software/jetson_nano/thunderloop.cpp
+++ b/src/software/jetson_nano/thunderloop.cpp
@@ -438,8 +438,8 @@ bool isPowerStable(std::ifstream& log_file)
     }
 
     // https://pastebin.com/ebsATa2h we need to clear the error state bit because we have
-    // reached the end of the file. After being clearing the bit, std::getline would return
-    // the changes in the file. See the pastebin for example.
+    // reached the end of the file. After being clearing the bit, std::getline would
+    // return the changes in the file. See the pastebin for example.
     log_file.clear();
 
     return true;

--- a/src/software/jetson_nano/thunderloop.cpp
+++ b/src/software/jetson_nano/thunderloop.cpp
@@ -437,9 +437,9 @@ bool isPowerStable(std::ifstream& log_file)
         }
     }
 
-    // https://pastebin.com/ebsATa2h we need to clear the error state bit because we have
-    // reached the end of the file. After being clearing the bit, std::getline would
-    // return the changes in the file. See the pastebin for example.
+    // We have reached the end of the line with the while loop from above. Therefore, we
+    // need to run std::ifstream::clear so that std::getline would return the new lines in
+    // the file stream.
     log_file.clear();
 
     return true;
@@ -464,10 +464,6 @@ void Thunderloop::updateErrorCodes()
         robot_status_.mutable_error_code()->Add(TbotsProto::ErrorCode::HIGH_BOARD_TEMP);
     }
 
-    // this is declared as static since we really only want to open this file once and
-    // pull from a buffer. clear would be called to ensure that std::getline would return
-    // the latest changes!
-    static std::ifstream log_file(PATH_TO_RINGBUFFER_LOG);
     if (!isPowerStable(log_file))
     {
         robot_status_.mutable_error_code()->Add(

--- a/src/software/jetson_nano/thunderloop.h
+++ b/src/software/jetson_nano/thunderloop.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <chrono>
 #include <csignal>
 #include <iostream>
@@ -97,6 +98,7 @@ class Thunderloop
      */
     void updateErrorCodes();
 
+
     // Input Msg Buffers
     TbotsProto::PrimitiveSet primitive_set_;
     TbotsProto::World world_;
@@ -134,5 +136,17 @@ class Thunderloop
     const double PACKET_TIMEOUT_NS = 500.0 * NANOSECONDS_PER_MILLISECOND;
 
     // Path to the CPU thermal zone temperature file
-    const std::string CPU_TEMP_FILE_PATH = "/sys/class/thermal/thermal_zone1/temp";
+    const std::string CPU_TEMP_FILE_PATH     = "/sys/class/thermal/thermal_zone1/temp";
+    const std::string PATH_TO_RINGBUFFER_LOG = "/var/log/dmesg";
 };
+
+/*
+ * reads from the kernel ring buffer, likely, /var/log/dmesg file to see if the power
+ * is stable
+ *
+ * This is not defined in Thunderscope because I want to test this function without
+ * injecting gtest into the private class in Thunderloop
+ *
+ * @return True if the power is stable, false otherwise
+ */
+bool isPowerStable(std::ifstream &log_file);

--- a/src/software/jetson_nano/thunderloop.h
+++ b/src/software/jetson_nano/thunderloop.h
@@ -143,7 +143,7 @@ class Thunderloop
 /*
  * reads from the kernel ring buffer, likely /var/log/dmesg file, to see if the power
  * is stable
-*
+ *
  * This is not defined in Thunderloop to allow it to be unit tested easily
  *
  * @return True if the power is stable, false otherwise

--- a/src/software/jetson_nano/thunderloop.h
+++ b/src/software/jetson_nano/thunderloop.h
@@ -141,11 +141,10 @@ class Thunderloop
 };
 
 /*
- * reads from the kernel ring buffer, likely, /var/log/dmesg file to see if the power
+ * reads from the kernel ring buffer, likely /var/log/dmesg file, to see if the power
  * is stable
- *
- * This is not defined in Thunderscope because I want to test this function without
- * injecting gtest into the private class in Thunderloop
+*
+ * This is not defined in Thunderloop to allow it to be unit tested easily
  *
  * @return True if the power is stable, false otherwise
  */

--- a/src/software/jetson_nano/thunderloop.h
+++ b/src/software/jetson_nano/thunderloop.h
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <csignal>
+#include <fstream>
 #include <iostream>
 #include <thread>
 
@@ -138,6 +139,8 @@ class Thunderloop
     // Path to the CPU thermal zone temperature file
     const std::string CPU_TEMP_FILE_PATH     = "/sys/class/thermal/thermal_zone1/temp";
     const std::string PATH_TO_RINGBUFFER_LOG = "/var/log/dmesg";
+
+    std::ifstream log_file = std::ifstream(PATH_TO_RINGBUFFER_LOG);
 };
 
 /*


### PR DESCRIPTION
### Description

resolve #3181. This essentially sends a message when the battery isn't stable. 

### Testing Done

ran the following code to make sure I can actually read the file! 

```
#include <fstream>
#include <iostream>

static bool isPowerStable()
{
    std::ifstream dmesg_log_file("/var/log/dmesg");
    // if the log file cannot be open, we would return false. Chances are, the battery
    // power supply is indeed stable
    if (!dmesg_log_file.is_open())
    {
        //LOG(WARNING) << "Cannot dmesg log file. Do you have permission?";
        std::cout << "Cannot dmesg log file. Do you have permission?" << std::endl;
        return true;
    }

    std::string line;
    while (getline(dmesg_log_file, line))
    {
        if (line.find("kernel") != std::string::npos)
        {
            return false;
        }
    }

    return true;
}

int main(){
    if(isPowerStable()){
        std::cout << "Yay" << std::endl; 
    }else{
        std::cout << "this is expected as the log message is likely to contain the word 'kernel' " << std::endl; 
    }
}

```



### Resolved Issues

resolves #3181

### Review Checklist

- [X]  **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
