### PR TITLE
Better Ball Update

### DIFF
--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -249,7 +249,7 @@ bool SensorFusion::shouldUseRobotBallPositionInsteadOfSSL(
     const std::vector<BallDetection> &ball_detection)
 {
     // as off current, this would always return true
-    constexpr float distance_threshold = 10.00f;
+    constexpr float distance_threshold = 0.5f;
 
     if (!friendly_robot_id_with_ball_in_dribbler.has_value())
     {
@@ -334,7 +334,7 @@ void SensorFusion::updateWorld(const SSLProto::SSL_DetectionFrame &ssl_detection
 
     if (shouldUseRobotBallPositionInsteadOfSSL(ssl_detection_frame, ball_detections))
     {
-        //LOG(INFO) << "Yay";
+        // LOG(INFO) << "Yay";
         updateBallPositionUsingSensorData(ssl_detection_frame);
     }
     else

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -180,21 +180,17 @@ void SensorFusion::updateWorld(
     }
 }
 
-static float computeDistanceBetweenBallAndRobot(const Robot &robot, const Ball &ball)
+static double computeDistanceBetweenBallAndRobot(const Robot &robot, const Ball &ball)
 {
-    Point robot_position = robot.position();
-    Point ball_position  = ball.position();
-
-    double x_difference = ball_position.x() - robot_position.x();
-    double y_difference = ball_position.y() - robot_position.y();
+    Vector robot_position = {robot.position().x(), robot.position().y()};
+    Vector ball_position  = {ball.position().x(), ball.position().y()};
 
     // using the classic distance formula
-    return static_cast<float>(
-        std::sqrt(x_difference * x_difference + y_difference * y_difference));
+    return (ball_position - robot_position).length();
 }
 
 
-bool SensorFusion::shouldUseRobotBallPositionInsteadOfSSL(
+bool SensorFusion::shouldUseRobotBallPositionInsteadOfVision(
     const SSLProto::SSL_DetectionFrame &ssl_detection_frame,
     const std::vector<BallDetection> &ball_detection)
 {
@@ -219,7 +215,7 @@ bool SensorFusion::shouldUseRobotBallPositionInsteadOfSSL(
         return false;
     }
 
-    float distance = computeDistanceBetweenBallAndRobot(
+    double distance = computeDistanceBetweenBallAndRobot(
         robot_with_ball_in_dribbler.value(), ball.value());
     if (distance > DISTANCE_THRESHOLD_FOR_BREAKBEAM_FAULT_DETECTION)
     {
@@ -284,7 +280,7 @@ void SensorFusion::updateWorld(const SSLProto::SSL_DetectionFrame &ssl_detection
         ball_in_dribbler_timeout                = 0;
     }
 
-    if (shouldUseRobotBallPositionInsteadOfSSL(ssl_detection_frame, ball_detections))
+    if (shouldUseRobotBallPositionInsteadOfVision(ssl_detection_frame, ball_detections))
     {
         std::optional<Robot> robot_with_ball_in_dribbler =
             friendly_team.getRobotById(friendly_robot_id_with_ball_in_dribbler.value());

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -198,7 +198,7 @@ bool SensorFusion::shouldUseRobotBallPositionInsteadOfSSL(
     const SSLProto::SSL_DetectionFrame &ssl_detection_frame,
     const std::vector<BallDetection> &ball_detection)
 {
-    // the following if statements essentially ensures that we could caculate the
+    // the following if statements essentially ensures that we could calculate the
     // distance. Essentially unwarpping all the std::optional<T> that are required to
     // calculate the distance
     if (!friendly_robot_id_with_ball_in_dribbler.has_value())

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -1,7 +1,5 @@
 #include "software/sensor_fusion/sensor_fusion.h"
 
-#include <cmath>
-
 #include "software/logger/logger.h"
 
 SensorFusion::SensorFusion(TbotsProto::SensorFusionConfig sensor_fusion_config)
@@ -182,58 +180,10 @@ void SensorFusion::updateWorld(
     }
 }
 
-void SensorFusion::updateBallPositionUsingSensorData(
-
-    const SSLProto::SSL_DetectionFrame &ssl_detection_frame)
-{
-    std::optional<Robot> robot_with_ball_in_dribbler =
-        friendly_team.getRobotById(friendly_robot_id_with_ball_in_dribbler.value());
-
-    std::vector<BallDetection> dribbler_in_ball_detection = {BallDetection{
-        .position = robot_with_ball_in_dribbler->position() +
-                    Vector::createFromAngle(robot_with_ball_in_dribbler->orientation())
-                        // MAX_FRACTION_OF_BALL_COVERED_BY_ROBOT of the ball should be
-                        // inside the robot
-                        .normalize(DIST_TO_FRONT_OF_ROBOT_METERS +
-                                   BALL_TO_FRONT_OF_ROBOT_DISTANCE_WHEN_DRIBBLING),
-        .distance_from_ground = 0,
-        .timestamp            = Timestamp::fromSeconds(ssl_detection_frame.t_capture()),
-        .confidence           = 1}};
-
-    std::optional<Ball> new_ball = createBall(dribbler_in_ball_detection);
-
-    if (new_ball)
-    {
-        updateBall(*new_ball);
-    }
-}
-
-// static std::optional<SSLProto::SSL_DetectionBall> findMaxConfidenceBall(
-//     const SSLProto::SSL_DetectionFrame &frame)
-//{
-//     if (frame.balls_size() <= 0)
-//     {
-//         return std::nullopt;
-//     }
-//
-//     SSLProto::SSL_DetectionBall max_confidence_ball = frame.balls(0);
-//     for (auto &current_ball : frame.balls())
-//     {
-//         if (current_ball.confidence() > max_confidence_ball.confidence())
-//         {
-//             max_confidence_ball = current_ball;
-//         }
-//     }
-//
-//     return max_confidence_ball;
-// }
-
-float computeDistanceBetweenBallAndRobot(const Robot &robot, const Ball &ball)
+static float computeDistanceBetweenBallAndRobot(const Robot &robot, const Ball &ball)
 {
     Point robot_position = robot.position();
     Point ball_position  = ball.position();
-    // LOG(INFO) << ball_position.x() << "," << ball_position.y() << "|"
-    //           << robot_position.x() << "," << robot_position.y();
 
     double x_difference = ball_position.x() - robot_position.x();
     double y_difference = ball_position.y() - robot_position.y();
@@ -334,8 +284,27 @@ void SensorFusion::updateWorld(const SSLProto::SSL_DetectionFrame &ssl_detection
 
     if (shouldUseRobotBallPositionInsteadOfSSL(ssl_detection_frame, ball_detections))
     {
-        // LOG(INFO) << "Yay";
-        updateBallPositionUsingSensorData(ssl_detection_frame);
+        std::optional<Robot> robot_with_ball_in_dribbler =
+            friendly_team.getRobotById(friendly_robot_id_with_ball_in_dribbler.value());
+
+        std::vector<BallDetection> dribbler_in_ball_detection = {BallDetection{
+            .position =
+                robot_with_ball_in_dribbler->position() +
+                Vector::createFromAngle(robot_with_ball_in_dribbler->orientation())
+                    // MAX_FRACTION_OF_BALL_COVERED_BY_ROBOT of the ball should be
+                    // inside the robot
+                    .normalize(DIST_TO_FRONT_OF_ROBOT_METERS +
+                               BALL_TO_FRONT_OF_ROBOT_DISTANCE_WHEN_DRIBBLING),
+            .distance_from_ground = 0,
+            .timestamp  = Timestamp::fromSeconds(ssl_detection_frame.t_capture()),
+            .confidence = 1}};
+
+        std::optional<Ball> new_ball = createBall(dribbler_in_ball_detection);
+
+        if (new_ball)
+        {
+            updateBall(*new_ball);
+        }
     }
     else
     {

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -198,9 +198,9 @@ bool SensorFusion::shouldUseRobotBallPositionInsteadOfSSL(
     const SSLProto::SSL_DetectionFrame &ssl_detection_frame,
     const std::vector<BallDetection> &ball_detection)
 {
-    // as off current, this would always return true
-    constexpr float distance_threshold = 0.5f;
-
+    // the following if statements essentially ensures that we could caculate the
+    // distance. Essentially unwarpping all the std::optional<T> that are required to
+    // calcualte the distance
     if (!friendly_robot_id_with_ball_in_dribbler.has_value())
     {
         return false;
@@ -221,13 +221,15 @@ bool SensorFusion::shouldUseRobotBallPositionInsteadOfSSL(
 
     float distance = computeDistanceBetweenBallAndRobot(
         robot_with_ball_in_dribbler.value(), ball.value());
-    // LOG(INFO) << "distance: " << distance;
-
-    if (distance > distance_threshold)
+    if (distance > DISTANCE_THRESHOLD_FOR_BREAKBEAM_FAULT_DETECTION)
     {
         return false;
     }
 
+    // In other words, this is only true if we have the position of the ball, breakbeam
+    // robot, and the distance between what the ssl says and where the robots are acutally
+    // at is less that a threshold distance set by
+    // DISTANCE_THRESHOLD_FOR_BREAKBEAM_FAULT_DETECTION
     return true;
 }
 

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -200,7 +200,7 @@ bool SensorFusion::shouldUseRobotBallPositionInsteadOfSSL(
 {
     // the following if statements essentially ensures that we could caculate the
     // distance. Essentially unwarpping all the std::optional<T> that are required to
-    // calcualte the distance
+    // calculate the distance
     if (!friendly_robot_id_with_ball_in_dribbler.has_value())
     {
         return false;
@@ -227,7 +227,7 @@ bool SensorFusion::shouldUseRobotBallPositionInsteadOfSSL(
     }
 
     // In other words, this is only true if we have the position of the ball, breakbeam
-    // robot, and the distance between what the ssl says and where the robots are acutally
+    // robot, and the distance between what the ssl says and where the robots are actually
     // at is less that a threshold distance set by
     // DISTANCE_THRESHOLD_FOR_BREAKBEAM_FAULT_DETECTION
     return true;

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -199,12 +199,6 @@ bool SensorFusion::shouldTrustRobotStatus(
         return false;
     }
 
-    std::optional<Ball> ball = createBall(ball_detection);
-    if (!ball.has_value())
-    {
-        return false;
-    }
-
     double distance =
         (robot_with_ball_in_dribbler.value().position() - ball.value().position())
             .length();
@@ -213,7 +207,7 @@ bool SensorFusion::shouldTrustRobotStatus(
         return false;
     }
 
-    // In other words, this is only true if we have the position of the ball, breakbeam
+    // In other words, this is only true if we have the position of the breakbeam
     // robot, and the distance between what the ssl says and where the robots are actually
     // at is less that a threshold distance set by
     // DISTANCE_THRESHOLD_FOR_BREAKBEAM_FAULT_DETECTION

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -309,6 +309,11 @@ void SensorFusion::updateWorld(const SSLProto::SSL_DetectionFrame &ssl_detection
                             Vector(0, 0), closest_enemy->timestamp());
             }
         }
+
+        // we shouldn't trust breakbeam so we reset the dribbler and its associated
+        // variables
+        friendly_robot_id_with_ball_in_dribbler = std::nullopt;
+        ball_in_dribbler_timeout                = 0;
     }
 
     if (ball && field)

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -202,8 +202,8 @@ bool SensorFusion::shouldTrustRobotStatus()
             .length();
 
     // In other words, this is only true if we have the position of the breakbeam
-    // robot, and the distance between what the ssl says and where the robots are actually
-    // at is less that a threshold distance set by
+    // robot, and the distance between what SSL says and where the robots are actually
+    // at is less than a threshold distance set by
     // DISTANCE_THRESHOLD_FOR_BREAKBEAM_FAULT_DETECTION
     return distance <= DISTANCE_THRESHOLD_FOR_BREAKBEAM_FAULT_DETECTION;
 }

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -280,8 +280,6 @@ void SensorFusion::updateWorld(const SSLProto::SSL_DetectionFrame &ssl_detection
             .position =
                 robot_with_ball_in_dribbler->position() +
                 Vector::createFromAngle(robot_with_ball_in_dribbler->orientation())
-                    // MAX_FRACTION_OF_BALL_COVERED_BY_ROBOT of the ball should be
-                    // inside the robot
                     .normalize(DIST_TO_FRONT_OF_ROBOT_METERS +
                                BALL_TO_FRONT_OF_ROBOT_DISTANCE_WHEN_DRIBBLING),
             .distance_from_ground = 0,

--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -56,7 +56,7 @@ class SensorFusion
      * @return True if we were to use the position of the robot instead of the ssl camera
      * system. False otherwise
      */
-    bool shouldUseRobotBallPositionInsteadOfSSL(
+    bool shouldUseRobotBallPositionInsteadOfVision(
         const SSLProto::SSL_DetectionFrame &frame,
         const std::vector<BallDetection> &ball_detection);
 
@@ -72,7 +72,7 @@ class SensorFusion
     // between the robot that has the ball is greater than the distance below, then we
     // know that the breakbeam has a problem see for more:
     // https://github.com/UBC-Thunderbots/Software/issues/3197
-    static constexpr float DISTANCE_THRESHOLD_FOR_BREAKBEAM_FAULT_DETECTION = 0.5f;
+    static constexpr double DISTANCE_THRESHOLD_FOR_BREAKBEAM_FAULT_DETECTION = 0.5;
 
    private:
     /**

--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -142,9 +142,6 @@ class SensorFusion
      */
     static bool teamHasBall(const Team &team, const Ball &ball);
 
-    void updateBallPositionUsingSensorData(
-        const SSLProto::SSL_DetectionFrame &ssl_detection_frame);
-
     TbotsProto::SensorFusionConfig sensor_fusion_config;
     std::optional<Field> field;
     std::optional<Ball> ball;

--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -55,6 +55,10 @@ class SensorFusion
     // started, determined experimentally with the simulator
     static constexpr double VISION_PACKET_RESET_TIME_THRESHOLD = 0.5;
 
+    bool shouldUseRobotBallPositionInsteadOfSSL(
+        const SSLProto::SSL_DetectionFrame &frame,
+        const std::vector<BallDetection> &ball_detection);
+
    private:
     /**
      * Updates relevant components of world based on a new data
@@ -137,9 +141,6 @@ class SensorFusion
      * @return whether the team has control over the ball
      */
     static bool teamHasBall(const Team &team, const Ball &ball);
-
-    bool shouldUseRobotBallPositionInsteadOfSSL(
-        const SSLProto::SSL_DetectionFrame &frame, const std::vector<BallDetection> &ball_detection);
 
     void updateBallPositionUsingSensorData(
         const SSLProto::SSL_DetectionFrame &ssl_detection_frame);

--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -138,6 +138,12 @@ class SensorFusion
      */
     static bool teamHasBall(const Team &team, const Ball &ball);
 
+    bool shouldUseRobotBallPositionInsteadOfSSL(
+        const SSLProto::SSL_DetectionFrame &frame, const std::vector<BallDetection> &ball_detection);
+
+    void updateBallPositionUsingSensorData(
+        const SSLProto::SSL_DetectionFrame &ssl_detection_frame);
+
     TbotsProto::SensorFusionConfig sensor_fusion_config;
     std::optional<Field> field;
     std::optional<Ball> ball;

--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -48,6 +48,19 @@ class SensorFusion
      */
     std::optional<World> getWorld() const;
 
+    /**
+     * This function controls the behavior of how the ball is being updated. If this
+     * returns True, we use the position of the robot that triggers the breakbeam instead
+     * of the one given by the ssl vision system.
+     *
+     * @return True if we were to use the position of the robot instead of the ssl camera
+     * system. False otherwise
+     */
+    bool shouldUseRobotBallPositionInsteadOfSSL(
+        const SSLProto::SSL_DetectionFrame &frame,
+        const std::vector<BallDetection> &ball_detection);
+
+
     // Number of vision packets to indicate that the vision client most likely reset,
     // determined experimentally with the simulator
     static constexpr unsigned int VISION_PACKET_RESET_COUNT_THRESHOLD = 5;
@@ -55,9 +68,11 @@ class SensorFusion
     // started, determined experimentally with the simulator
     static constexpr double VISION_PACKET_RESET_TIME_THRESHOLD = 0.5;
 
-    bool shouldUseRobotBallPositionInsteadOfSSL(
-        const SSLProto::SSL_DetectionFrame &frame,
-        const std::vector<BallDetection> &ball_detection);
+    // This is used for detecting if the breakbeam is at fault. The idea is that distance
+    // between the robot that has the ball is greater than the distance below, then we
+    // know that the breakbeam has a problem see for more:
+    // https://github.com/UBC-Thunderbots/Software/issues/3197
+    static constexpr float DISTANCE_THRESHOLD_FOR_BREAKBEAM_FAULT_DETECTION = 0.5f;
 
    private:
     /**

--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -48,19 +48,6 @@ class SensorFusion
      */
     std::optional<World> getWorld() const;
 
-    /**
-     * This function controls the behavior of how the ball is being updated. If this
-     * returns True, we use the position of the robot that triggers the breakbeam instead
-     * of the one given by the ssl vision system.
-     *
-     * @return True if we were to use the position of the robot instead of the ssl camera
-     * system. False otherwise
-     */
-    bool shouldUseRobotBallPositionInsteadOfVision(
-        const SSLProto::SSL_DetectionFrame &frame,
-        const std::vector<BallDetection> &ball_detection);
-
-
     // Number of vision packets to indicate that the vision client most likely reset,
     // determined experimentally with the simulator
     static constexpr unsigned int VISION_PACKET_RESET_COUNT_THRESHOLD = 5;
@@ -157,6 +144,16 @@ class SensorFusion
      */
     static bool teamHasBall(const Team &team, const Ball &ball);
 
+    /**
+     * This function controls the behavior of how the ball is being updated. If this
+     * returns True, we use the position of the robot that triggers the breakbeam instead
+     * of the one given by the ssl vision system.
+     *
+     * @return True if we were to use the position of the robot instead of the ssl camera
+     * system. False otherwise
+     */
+    bool shouldTrustRobotStatus(const SSLProto::SSL_DetectionFrame &frame,
+                                const std::vector<BallDetection> &ball_detection);
     TbotsProto::SensorFusionConfig sensor_fusion_config;
     std::optional<Field> field;
     std::optional<Ball> ball;

--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -152,8 +152,7 @@ class SensorFusion
      * @return True if we were to use the position of the robot instead of the ssl camera
      * system. False otherwise
      */
-    bool shouldTrustRobotStatus(const SSLProto::SSL_DetectionFrame &frame,
-                                const std::vector<BallDetection> &ball_detection);
+    bool shouldTrustRobotStatus();
     TbotsProto::SensorFusionConfig sensor_fusion_config;
     std::optional<Field> field;
     std::optional<Ball> ball;

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -2,8 +2,6 @@
 
 #include <gtest/gtest.h>
 
-#include <csignal>
-
 #include "proto/message_translation/ssl_detection.h"
 #include "proto/message_translation/ssl_geometry.h"
 #include "proto/message_translation/ssl_wrapper.h"

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -935,8 +935,8 @@ TEST_F(SensorFusionTest, breakbeam_not_fail_update_test)
 TEST_F(SensorFusionTest, breakbeam_fail_test_ssl)
 {
     // The following code test this thing: if the breakbeam is triggered and the position
-    // of the robot and the ball given by the ssl vision system is too far away to make sense
-    // , we expect shouldUseRobotBallPositionInsteadOfSSL to return False
+    // of the robot and the ball given by the ssl vision system is too far away to make
+    // sense , we expect shouldUseRobotBallPositionInsteadOfSSL to return False
     SensorProto sensor_msg;
 
     // creating ssl vision

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -926,7 +926,7 @@ TEST_F(SensorFusionTest, breakbeam_not_fail_update_test)
     std::vector<BallDetection> ball_detection =
         createBallDetections({*(ssl_wrapper_packet->mutable_detection())});
 
-    bool state = sensor_fusion.shouldUseRobotBallPositionInsteadOfSSL(
+    bool state = sensor_fusion.shouldUseRobotBallPositionInsteadOfVision(
         *(ssl_wrapper_packet->mutable_detection()), ball_detection);
 
     EXPECT_TRUE(state);
@@ -981,7 +981,7 @@ TEST_F(SensorFusionTest, breakbeam_fail_test_ssl)
     std::vector<BallDetection> ball_detection =
         createBallDetections({*(ssl_wrapper_packet->mutable_detection())});
 
-    bool state = sensor_fusion.shouldUseRobotBallPositionInsteadOfSSL(
+    bool state = sensor_fusion.shouldUseRobotBallPositionInsteadOfVision(
         *(ssl_wrapper_packet->mutable_detection()), ball_detection);
 
     EXPECT_FALSE(state);

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -876,15 +876,11 @@ TEST_F(SensorFusionTest, test_sensor_fusion_reset_behaviour_ignore_bad_packets)
     EXPECT_EQ(initWorld(), result);
 }
 
-TEST_F(SensorFusionTest, test_should_use_robot_position_instead_of_something_else)
+TEST_F(SensorFusionTest, breakbeam_not_fail_update_test)
 {
-    /* we essentially have to test the following. We first have to initialize the game
-     * state. At first the robot has the dribbler and the ssl reads that the ball is close
-     * to the robot. so we expect true. The second test would be like that expect that the
-     * ball from ssl deviates a lot from the robot so we expect that function to return
-     * false
-     */
-
+    // The following code test this thing: if the breakbeam is triggered and the position
+    // of the robot and the ball given by the ssl vision system is less than a certain
+    // threshold, we expect shouldUseRobotBallPositionInsteadOfSSL to return True
     SensorProto sensor_msg;
 
     // creating ssl vision
@@ -936,15 +932,11 @@ TEST_F(SensorFusionTest, test_should_use_robot_position_instead_of_something_els
     EXPECT_TRUE(state);
 }
 
-TEST_F(SensorFusionTest, another_test)
+TEST_F(SensorFusionTest, breakbeam_fail_test_ssl)
 {
-    /* we essentially have to test the following. We first have to initialize the game
-     * state. At first the robot has the dribbler and the ssl reads that the ball is close
-     * to the robot. so we expect true. The second test would be like that expect that the
-     * ball from ssl deviates a lot from the robot so we expect that function to return
-     * false
-     */
-
+    // The following code test this thing: if the breakbeam is triggered and the position
+    // of the robot and the ball given by the ssl vision system is too far away to make sense
+    // , we expect shouldUseRobotBallPositionInsteadOfSSL to return False
     SensorProto sensor_msg;
 
     // creating ssl vision
@@ -962,7 +954,6 @@ TEST_F(SensorFusionTest, another_test)
     RobotState robot_state(Point(0, 0), Vector(0, 0), Angle::fromRadians(2),
                            AngularVelocity::zero());
     RobotStateWithId robot_id = {2, robot_state};
-    // blue_robot_states.push_back(robot_id);
     yellow_robot_states.push_back(robot_id);
 
     std::unique_ptr<SSLProto::SSL_DetectionFrame> frame =

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -914,9 +914,9 @@ TEST_F(SensorFusionTest, breakbeam_pass_update_test)
     *(robot_msg->mutable_power_status()) = *power_status_msg;
 
     // create ssl wrapper packet
-    auto gemotry_data = initSSLDivBGeomData();
+    auto geometry_data = initSSLDivBGeomData();
     auto ssl_wrapper_packet =
-        createSSLWrapperPacket(std::move(gemotry_data), std::move(frame));
+        createSSLWrapperPacket(std::move(geometry_data), std::move(frame));
     *(sensor_msg.mutable_ssl_vision_msg()) = *ssl_wrapper_packet;
     *(sensor_msg.add_robot_status_msgs())  = *robot_msg;
 
@@ -936,9 +936,9 @@ TEST_F(SensorFusionTest, breakbeam_pass_update_test)
     std::unique_ptr<SSLProto::SSL_DetectionFrame> new_frame =
         createSSLDetectionFrame(camera_id, new_time, frame_number, {ball_state},
                                 yellow_robot_states, blue_robot_states);
-    auto gemotry_data_copy = initSSLDivBGeomData();
+    auto geomotry_data_copy = initSSLDivBGeomData();
     auto new_packet =
-        createSSLWrapperPacket(std::move(gemotry_data_copy), std::move(new_frame));
+        createSSLWrapperPacket(std::move(geomotry_data_copy), std::move(new_frame));
     *(sensor_msg.mutable_ssl_vision_msg()) = *new_packet;
     sensor_fusion.processSensorProto(sensor_msg);
 
@@ -994,9 +994,9 @@ TEST_F(SensorFusionTest, breakbeam_fail_test_ssl)
     *(robot_msg->mutable_power_status()) = *power_status_msg;
 
     // create ssl wrapper packet
-    auto gemotry_data = initSSLDivBGeomData();
+    auto geometry_data = initSSLDivBGeomData();
     auto ssl_wrapper_packet =
-        createSSLWrapperPacket(std::move(gemotry_data), std::move(frame));
+        createSSLWrapperPacket(std::move(geometry_data), std::move(frame));
     *(sensor_msg.mutable_ssl_vision_msg()) = *ssl_wrapper_packet;
     *(sensor_msg.add_robot_status_msgs())  = *robot_msg;
 

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -921,7 +921,7 @@ TEST_F(SensorFusionTest, breakbeam_pass_update_test)
 
     // we have to call update sensor fusion two times because of updating ball position
     // comes before updating breakbeam tripped. Thus, we have to call this function two
-    // times before the ball position is upated
+    // times before the ball position is updated
     sensor_fusion.processSensorProto(sensor_msg);
     sensor_fusion.processSensorProto(sensor_msg);
 

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -880,7 +880,8 @@ TEST_F(SensorFusionTest, breakbeam_pass_update_test)
 {
     // The following code test this thing: if the breakbeam is triggered and the position
     // of the robot and the ball given by the ssl vision system is less than a certain
-    // threshold, we expect shouldUseRobotBallPositionInsteadOfSSL to return True
+    // threshold, we should expcet the ball position to be updated as the position of the
+    // ssl vision packet!.
     SensorProto sensor_msg;
 
     // creating ssl vision
@@ -927,9 +928,9 @@ TEST_F(SensorFusionTest, breakbeam_pass_update_test)
 
     Point updated_ball_pos = sensor_fusion.getWorld().value().ball().position();
 
-    // is it using the robot state position
+    // is it not using the robot state position
     EXPECT_TRUE(updated_ball_pos != robot_state.position());
-    // is it not using the ssl vision?
+    // is it using the ssl vision?
     EXPECT_TRUE(updated_ball_pos == ssl_position);
 }
 

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -880,7 +880,7 @@ TEST_F(SensorFusionTest, breakbeam_pass_update_test)
 {
     // The following code test this thing: if the breakbeam is triggered and the position
     // of the robot and the ball given by the ssl vision system is less than a certain
-    // threshold, we should expcet the ball position to be updated as the position of the
+    // threshold, we should expect the ball position to be updated as the position of the
     // ssl robot_position packet!.
     SensorProto sensor_msg;
 


### PR DESCRIPTION
### Description

Implemented a feature so that the ball update is a bit better than before. The idea is the to calculate the distance between the robot that has a breakbeam trigger and the ball. If that distance is too big, we know for sure that the breakbeam is at fault and we ignore updating the ball using the position of the robot!

### Testing Done

Write some stuff in the `src/software/sensor_fusion/sensor_fusion_test.cpp` . Probably needs field testing. I am ran thunderscope and thunderscope seems to be stable. 

### Resolved Issues

resolves #3197

### Length Justification and Key Files to Review

N/A

### Review Checklist

- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue