### PR TITLE
Gamecontroller can Bind to a Different Port Based on Command Line Argument

### DIFF
--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -313,6 +313,8 @@ def load_command_line_arguments():
         help="Estop Baudrate",
     )
 
+    parser.add_argument('--gamecontroller_port', type=int, default=None, help='The port number for the game controller.')
+
     parser.add_argument(
         "--run_yellow",
         action="store_true",
@@ -348,6 +350,7 @@ def field_test_runner():
     blue_full_system_proto_unix_io = ProtoUnixIO()
     args = load_command_line_arguments()
 
+
     # Grab the current test name to store the proto log for the test case
     current_test = os.environ.get("PYTEST_CURRENT_TEST").split(":")[-1].split(" ")[0]
     current_test = current_test.replace("]", "")
@@ -382,7 +385,8 @@ def field_test_runner():
         enable_radio=args.enable_radio,
     ) as rc_friendly:
         with Gamecontroller(
-            supress_logs=(not args.show_gamecontroller_logs)
+            supress_logs=(not args.show_gamecontroller_logs),
+            gamecontroller_port=args.gamecontroller_port
         ) as gamecontroller:
             friendly_fs.setup_proto_unix_io(friendly_proto_unix_io)
             rc_friendly.setup_for_fullsystem()

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -327,9 +327,19 @@ def load_command_line_arguments():
         help="Run the test with friendly robots in yellow mode",
     )
 
-    parser.add_argument("--sslvision_multicast_address", type=str, default=None, help="the multicast address for ssl vision")
+    parser.add_argument(
+        "--sslvision_multicast_address",
+        type=str,
+        default=None,
+        help="the multicast address for ssl vision",
+    )
 
-    parser.add_argument("--sslreferee_multicast_address", type=str, default=None, help="the multicast address for referee (game controller likely)")
+    parser.add_argument(
+        "--sslreferee_multicast_address",
+        type=str,
+        default=None,
+        help="the multicast address for referee (game controller likely)",
+    )
 
     estop_group = parser.add_mutually_exclusive_group()
     estop_group.add_argument(
@@ -392,7 +402,7 @@ def field_test_runner():
         estop_path=estop_path,
         enable_radio=args.enable_radio,
         referee_address=args.sslreferee_multicast_address,
-        sslvision_address=args.sslvision_multicast_address
+        sslvision_address=args.sslvision_multicast_address,
     ) as rc_friendly:
         with Gamecontroller(
             supress_logs=(not args.show_gamecontroller_logs),

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -327,6 +327,10 @@ def load_command_line_arguments():
         help="Run the test with friendly robots in yellow mode",
     )
 
+    parser.add_argument("--sslvision_multicast_address", type=str, default=None, help="the multicast address for ssl vision")
+
+    parser.add_argument("--sslreferee_multicast_address", type=str, default=None, help="the multicast address for referee (game controller likely)")
+
     estop_group = parser.add_mutually_exclusive_group()
     estop_group.add_argument(
         "--keyboard_estop",
@@ -387,6 +391,8 @@ def field_test_runner():
         estop_mode=estop_mode,
         estop_path=estop_path,
         enable_radio=args.enable_radio,
+        referee_address=args.sslreferee_multicast_address,
+        sslvision_address=args.sslvision_multicast_address
     ) as rc_friendly:
         with Gamecontroller(
             supress_logs=(not args.show_gamecontroller_logs),

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -313,7 +313,12 @@ def load_command_line_arguments():
         help="Estop Baudrate",
     )
 
-    parser.add_argument('--gamecontroller_port', type=int, default=None, help='The port number for the game controller.')
+    parser.add_argument(
+        "--gamecontroller_port",
+        type=int,
+        default=None,
+        help="The port number for the game controller.",
+    )
 
     parser.add_argument(
         "--run_yellow",
@@ -350,7 +355,6 @@ def field_test_runner():
     blue_full_system_proto_unix_io = ProtoUnixIO()
     args = load_command_line_arguments()
 
-
     # Grab the current test name to store the proto log for the test case
     current_test = os.environ.get("PYTEST_CURRENT_TEST").split(":")[-1].split(" ")[0]
     current_test = current_test.replace("]", "")
@@ -386,7 +390,7 @@ def field_test_runner():
     ) as rc_friendly:
         with Gamecontroller(
             supress_logs=(not args.show_gamecontroller_logs),
-            gamecontroller_port=args.gamecontroller_port
+            gamecontroller_port=args.gamecontroller_port,
         ) as gamecontroller:
             friendly_fs.setup_proto_unix_io(friendly_proto_unix_io)
             rc_friendly.setup_for_fullsystem()

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -388,7 +388,7 @@ def field_test_runner():
     ) as friendly_fs, Gamecontroller(
         # we would be using conventional port if and only if we are playing in robocup.
         supress_logs=(not args.show_gamecontroller_logs),
-        use_conventional_port=False
+        use_conventional_port=False,
     ) as gamecontroller, RobotCommunication(
         current_proto_unix_io=friendly_proto_unix_io,
         multicast_channel=getRobotMulticastChannel(args.channel),
@@ -403,8 +403,7 @@ def field_test_runner():
         rc_friendly.setup_for_fullsystem()
 
         gamecontroller.setup_proto_unix_io(
-            blue_full_system_proto_unix_io,
-            yellow_full_system_proto_unix_io,
+            blue_full_system_proto_unix_io, yellow_full_system_proto_unix_io,
         )
         # Inject the proto unix ios into thunderscope and start the test
         tscope = Thunderscope(

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -320,27 +320,6 @@ def load_command_line_arguments():
         help="Run the test with friendly robots in yellow mode",
     )
 
-    parser.add_argument(
-        "--sslvision_multicast_address",
-        type=str,
-        default=SSL_VISION_ADDRESS,
-        help="the multicast address for ssl vision",
-    )
-
-    parser.add_argument(
-        "--use_unconventional_port",
-        action="store_true",
-        default=False,
-        help="setting this option would cause gamecontroller to bind on an unconventional port, likely 12393",
-    )
-
-    parser.add_argument(
-        "--not_launch_gc",
-        action="store_true",
-        default=False,
-        help="whether we are launching gamecontroller or not",
-    )
-
     estop_group = parser.add_mutually_exclusive_group()
     estop_group.add_argument(
         "--keyboard_estop",

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -358,6 +358,14 @@ def load_command_line_arguments():
     return parser.parse_args()
 
 
+def get_referee_port(gamecontroller: Gamecontroller):
+    if gamecontroller is not None:
+        print("Using a weird gamecontroller port")
+        return gamecontroller.get_referee_port()
+    print("Using default port")
+    return 40000
+
+
 @pytest.fixture
 def field_test_runner():
     """
@@ -395,9 +403,9 @@ def field_test_runner():
         friendly_colour_yellow=args.run_yellow,
         should_restart_on_crash=False,
     ) as friendly_fs, Gamecontroller(
-        use_unconventional_port=args.use_unconventional_port,
-        not_launch_gc=args.not_launch_gc,
+        # we would be using conventional port if and only if we are playing in robocup.
         supress_logs=(not args.show_gamecontroller_logs),
+        use_conventional_port=False
     ) as gamecontroller, RobotCommunication(
         current_proto_unix_io=friendly_proto_unix_io,
         multicast_channel=getRobotMulticastChannel(args.channel),
@@ -408,12 +416,12 @@ def field_test_runner():
         sslvision_address=args.sslvision_multicast_address,
         referee_port=gamecontroller.get_referee_port(),
     ) as rc_friendly:
-
         friendly_fs.setup_proto_unix_io(friendly_proto_unix_io)
         rc_friendly.setup_for_fullsystem()
 
         gamecontroller.setup_proto_unix_io(
-            blue_full_system_proto_unix_io, yellow_full_system_proto_unix_io,
+            blue_full_system_proto_unix_io,
+            yellow_full_system_proto_unix_io,
         )
         # Inject the proto unix ios into thunderscope and start the test
         tscope = Thunderscope(

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -396,7 +396,6 @@ def field_test_runner():
         estop_mode=estop_mode,
         estop_path=estop_path,
         enable_radio=args.enable_radio,
-        sslvision_address=args.sslvision_multicast_address,
         referee_port=gamecontroller.get_referee_port(),
     ) as rc_friendly:
         friendly_fs.setup_proto_unix_io(friendly_proto_unix_io)

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -413,8 +413,7 @@ def field_test_runner():
         rc_friendly.setup_for_fullsystem()
 
         gamecontroller.setup_proto_unix_io(
-            blue_full_system_proto_unix_io,
-            yellow_full_system_proto_unix_io,
+            blue_full_system_proto_unix_io, yellow_full_system_proto_unix_io,
         )
         # Inject the proto unix ios into thunderscope and start the test
         tscope = Thunderscope(

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -336,19 +336,6 @@ def load_command_line_arguments():
 
     return parser.parse_args()
 
-
-def get_referee_port(gamecontroller: Gamecontroller):
-    """
-    return the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
-
-    :param gamecontroller: the gamecontroller we are using
-    :return: the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
-    """
-    if gamecontroller is not None:
-        return gamecontroller.get_referee_port()
-    return 40000
-
-
 @pytest.fixture
 def field_test_runner():
     """
@@ -396,7 +383,7 @@ def field_test_runner():
         estop_mode=estop_mode,
         estop_path=estop_path,
         enable_radio=args.enable_radio,
-        referee_port=gamecontroller.get_referee_port(),
+        referee_port=Gamecontroller.get_referee_port_staticmethod(gamecontroller),
     ) as rc_friendly:
         friendly_fs.setup_proto_unix_io(friendly_proto_unix_io)
         rc_friendly.setup_for_fullsystem()

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -384,7 +384,7 @@ def field_test_runner():
         estop_mode=estop_mode,
         estop_path=estop_path,
         enable_radio=args.enable_radio,
-        referee_port=Gamecontroller.get_referee_port_staticmethod(gamecontroller),
+        referee_port=Gamecontroller.get_referee_port_static(gamecontroller),
     ) as rc_friendly:
         friendly_fs.setup_proto_unix_io(friendly_proto_unix_io)
         rc_friendly.setup_for_fullsystem()

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -336,6 +336,7 @@ def load_command_line_arguments():
 
     return parser.parse_args()
 
+
 @pytest.fixture
 def field_test_runner():
     """

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -359,10 +359,14 @@ def load_command_line_arguments():
 
 
 def get_referee_port(gamecontroller: Gamecontroller):
+    """
+    return the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
+
+    :param gamecontroller: the gamecontroller we are using
+    :return: the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
+    """
     if gamecontroller is not None:
-        print("Using a weird gamecontroller port")
         return gamecontroller.get_referee_port()
-    print("Using default port")
     return 40000
 
 

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -330,14 +330,14 @@ def load_command_line_arguments():
     parser.add_argument(
         "--sslvision_multicast_address",
         type=str,
-        default=None,
+        default=SSL_VISION_ADDRESS,
         help="the multicast address for ssl vision",
     )
 
     parser.add_argument(
         "--sslreferee_multicast_address",
         type=str,
-        default=None,
+        default=SSL_REFEREE_ADDRESS,
         help="the multicast address for referee (game controller likely)",
     )
 

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -51,7 +51,7 @@ class FieldTestRunner(TbotsTestRunner):
         :param test_name: The name of the test to run
         :param blue_full_system_proto_unix_io: The blue full system proto unix io to use
         :param yellow_full_system_proto_unix_io: The yellow full system proto unix io to use
-        :param gamecontroller: The gamecontroller context managed instance 
+        :param gamecontroller: The gamecontroller context managed instance
         :param publish_validation_protos: whether to publish validation protos
         :param: is_yellow_friendly: if yellow is the friendly team
         """
@@ -314,13 +314,6 @@ def load_command_line_arguments():
     )
 
     parser.add_argument(
-        "--gamecontroller_port",
-        type=int,
-        default=None,
-        help="The port number for the game controller.",
-    )
-
-    parser.add_argument(
         "--run_yellow",
         action="store_true",
         default=False,
@@ -335,10 +328,17 @@ def load_command_line_arguments():
     )
 
     parser.add_argument(
-        "--sslreferee_multicast_address",
-        type=str,
-        default=SSL_REFEREE_ADDRESS,
-        help="the multicast address for referee (game controller likely)",
+        "--use_unconventional_port",
+        action="store_true",
+        default=False,
+        help="setting this option would cause gamecontroller to bind on an unconventional port, likely 12393",
+    )
+
+    parser.add_argument(
+        "--not_launch_gc",
+        action="store_true",
+        default=False,
+        help="whether we are launching gamecontroller or not",
     )
 
     estop_group = parser.add_mutually_exclusive_group()
@@ -394,87 +394,89 @@ def field_test_runner():
         debug_full_system=debug_full_sys,
         friendly_colour_yellow=args.run_yellow,
         should_restart_on_crash=False,
-    ) as friendly_fs, RobotCommunication(
+    ) as friendly_fs, Gamecontroller(
+        use_unconventional_port=args.use_unconventional_port,
+        not_launch_gc=args.not_launch_gc,
+        supress_logs=(not args.show_gamecontroller_logs),
+    ) as gamecontroller, RobotCommunication(
         current_proto_unix_io=friendly_proto_unix_io,
         multicast_channel=getRobotMulticastChannel(args.channel),
         interface=args.interface,
         estop_mode=estop_mode,
         estop_path=estop_path,
         enable_radio=args.enable_radio,
-        referee_address=args.sslreferee_multicast_address,
         sslvision_address=args.sslvision_multicast_address,
+        referee_port=gamecontroller.get_referee_port(),
     ) as rc_friendly:
-        with Gamecontroller(
-            supress_logs=(not args.show_gamecontroller_logs),
-            gamecontroller_port=args.gamecontroller_port,
-        ) as gamecontroller:
-            friendly_fs.setup_proto_unix_io(friendly_proto_unix_io)
-            rc_friendly.setup_for_fullsystem()
 
-            gamecontroller.setup_proto_unix_io(
-                blue_full_system_proto_unix_io, yellow_full_system_proto_unix_io,
-            )
-            # Inject the proto unix ios into thunderscope and start the test
-            tscope = Thunderscope(
-                configure_field_test_view(
-                    simulator_proto_unix_io=simulator_proto_unix_io,
-                    blue_full_system_proto_unix_io=blue_full_system_proto_unix_io,
-                    yellow_full_system_proto_unix_io=yellow_full_system_proto_unix_io,
-                    yellow_is_friendly=args.run_yellow,
-                ),
-                layout_path=None,
-            )
+        friendly_fs.setup_proto_unix_io(friendly_proto_unix_io)
+        rc_friendly.setup_for_fullsystem()
 
-            # connect the keyboard estop toggle to the key event if needed
-            if estop_mode == EstopMode.KEYBOARD_ESTOP:
-                tscope.keyboard_estop_shortcut.activated.connect(
-                    rc_friendly.toggle_keyboard_estop
-                )
-                # we call this method to enable estop automatically when a field test starts
-                rc_friendly.toggle_keyboard_estop()
-                logger.warning(
-                    "\x1b[31;20m"
-                    + "Keyboard Estop Enabled, robots will start moving automatically when test starts!"
-                    + "\x1b[0m"
-                )
-
-            time.sleep(LAUNCH_DELAY_S)
-            runner = FieldTestRunner(
-                test_name=current_test,
+        gamecontroller.setup_proto_unix_io(
+            blue_full_system_proto_unix_io,
+            yellow_full_system_proto_unix_io,
+        )
+        # Inject the proto unix ios into thunderscope and start the test
+        tscope = Thunderscope(
+            configure_field_test_view(
+                simulator_proto_unix_io=simulator_proto_unix_io,
                 blue_full_system_proto_unix_io=blue_full_system_proto_unix_io,
                 yellow_full_system_proto_unix_io=yellow_full_system_proto_unix_io,
-                gamecontroller=gamecontroller,
-                thunderscope=tscope,
-                is_yellow_friendly=args.run_yellow,
+                yellow_is_friendly=args.run_yellow,
+            ),
+            layout_path=None,
+        )
+
+        # connect the keyboard estop toggle to the key event if needed
+        if estop_mode == EstopMode.KEYBOARD_ESTOP:
+            tscope.keyboard_estop_shortcut.activated.connect(
+                rc_friendly.toggle_keyboard_estop
+            )
+            # we call this method to enable estop automatically when a field test starts
+            rc_friendly.toggle_keyboard_estop()
+            logger.warning(
+                "\x1b[31;20m"
+                + "Keyboard Estop Enabled, robots will start moving automatically when test starts!"
+                + "\x1b[0m"
             )
 
-            friendly_proto_unix_io.register_observer(World, runner.world_buffer)
+        time.sleep(LAUNCH_DELAY_S)
+        runner = FieldTestRunner(
+            test_name=current_test,
+            blue_full_system_proto_unix_io=blue_full_system_proto_unix_io,
+            yellow_full_system_proto_unix_io=yellow_full_system_proto_unix_io,
+            gamecontroller=gamecontroller,
+            thunderscope=tscope,
+            is_yellow_friendly=args.run_yellow,
+        )
 
-            # Setup proto loggers.
-            #
-            # NOTE: Its important we use the test runners time provider because
-            # test will run as fast as possible with a varying tick rate. The
-            # SimulatorTestRunner time provider is tied to the simulators
-            # t_capture coming out of the wrapper packet (rather than time.time).
-            with ProtoLogger(
-                f"{args.blue_full_system_runtime_dir}/logs/{current_test}",
-                time_provider=runner.time_provider,
-            ) as blue_logger, ProtoLogger(
-                f"{args.yellow_full_system_runtime_dir}/logs/{current_test}",
-                time_provider=runner.time_provider,
-            ) as yellow_logger:
-                blue_full_system_proto_unix_io.register_to_observe_everything(
-                    blue_logger.buffer
-                )
-                yellow_full_system_proto_unix_io.register_to_observe_everything(
-                    yellow_logger.buffer
-                )
-                yield runner
-                print(
-                    f"\n\nTo replay this test for the blue team, go to the `src` folder and run \n./tbots.py run thunderscope --blue_log {blue_logger.log_folder}",
-                    flush=True,
-                )
-                print(
-                    f"\n\nTo replay this test for the yellow team, go to the `src` folder and run \n./tbots.py run thunderscope --yellow_log {yellow_logger.log_folder}",
-                    flush=True,
-                )
+        friendly_proto_unix_io.register_observer(World, runner.world_buffer)
+
+        # Setup proto loggers.
+        #
+        # NOTE: Its important we use the test runners time provider because
+        # test will run as fast as possible with a varying tick rate. The
+        # SimulatorTestRunner time provider is tied to the simulators
+        # t_capture coming out of the wrapper packet (rather than time.time).
+        with ProtoLogger(
+            f"{args.blue_full_system_runtime_dir}/logs/{current_test}",
+            time_provider=runner.time_provider,
+        ) as blue_logger, ProtoLogger(
+            f"{args.yellow_full_system_runtime_dir}/logs/{current_test}",
+            time_provider=runner.time_provider,
+        ) as yellow_logger:
+            blue_full_system_proto_unix_io.register_to_observe_everything(
+                blue_logger.buffer
+            )
+            yellow_full_system_proto_unix_io.register_to_observe_everything(
+                yellow_logger.buffer
+            )
+            yield runner
+            print(
+                f"\n\nTo replay this test for the blue team, go to the `src` folder and run \n./tbots.py run thunderscope --blue_log {blue_logger.log_folder}",
+                flush=True,
+            )
+            print(
+                f"\n\nTo replay this test for the yellow team, go to the `src` folder and run \n./tbots.py run thunderscope --yellow_log {yellow_logger.log_folder}",
+                flush=True,
+            )

--- a/src/software/networking/ssl_proto_communication.py
+++ b/src/software/networking/ssl_proto_communication.py
@@ -34,9 +34,15 @@ class SslSocket(object):
 
         :param port the port to bind to
         """
-        # bind to all local interfaces, TCP
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.socket.connect(("", port))
+        try:
+            # bind to all local interfaces, TCP
+            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.socket.connect(("", port))
+        except ConnectionRefusedError:
+            raise ConnectionRefusedError(
+                f"SSL Socket connection refused on port {port}. Is binary already running in a separate process?"
+            )
+
 
     def send(self, proto: protobuf_message.Message) -> None:
         """

--- a/src/software/networking/ssl_proto_communication.py
+++ b/src/software/networking/ssl_proto_communication.py
@@ -43,7 +43,6 @@ class SslSocket(object):
                 f"SSL Socket connection refused on port {port}. Is binary already running in a separate process?"
             )
 
-
     def send(self, proto: protobuf_message.Message) -> None:
         """
         Send the proto through the socket.

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -493,6 +493,8 @@ def load_command_line_arguments():
         default=False,
         help="Use realism in the simulator",
     )
+
+    parser.add_argument('--gamecontroller_port', type=int, default=None, help='The port number for the game controller.')
     return parser.parse_args()
 
 
@@ -542,7 +544,8 @@ def simulated_test_runner():
         should_restart_on_crash=False,
     ) as yellow_fs:
         with Gamecontroller(
-            supress_logs=(not args.show_gamecontroller_logs)
+            supress_logs=(not args.show_gamecontroller_logs),
+            gamecontroller_port=args.gamecontroller_port
         ) as gamecontroller:
 
             blue_fs.setup_proto_unix_io(blue_full_system_proto_unix_io)

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -494,7 +494,12 @@ def load_command_line_arguments():
         help="Use realism in the simulator",
     )
 
-    parser.add_argument('--gamecontroller_port', type=int, default=None, help='The port number for the game controller.')
+    parser.add_argument(
+        "--gamecontroller_port",
+        type=int,
+        default=None,
+        help="The port number for the game controller.",
+    )
     return parser.parse_args()
 
 
@@ -545,7 +550,7 @@ def simulated_test_runner():
     ) as yellow_fs:
         with Gamecontroller(
             supress_logs=(not args.show_gamecontroller_logs),
-            gamecontroller_port=args.gamecontroller_port
+            gamecontroller_port=args.gamecontroller_port,
         ) as gamecontroller:
 
             blue_fs.setup_proto_unix_io(blue_full_system_proto_unix_io)

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -493,7 +493,6 @@ def load_command_line_arguments():
         default=False,
         help="Use realism in the simulator",
     )
-
     return parser.parse_args()
 
 
@@ -543,7 +542,7 @@ def simulated_test_runner():
         should_restart_on_crash=False,
     ) as yellow_fs:
         with Gamecontroller(
-            supress_logs=(not args.show_gamecontroller_logs),
+            supress_logs=(not args.show_gamecontroller_logs)
         ) as gamecontroller:
 
             blue_fs.setup_proto_unix_io(blue_full_system_proto_unix_io)

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -494,12 +494,6 @@ def load_command_line_arguments():
         help="Use realism in the simulator",
     )
 
-    parser.add_argument(
-        "--gamecontroller_port",
-        type=int,
-        default=None,
-        help="The port number for the game controller.",
-    )
     return parser.parse_args()
 
 
@@ -550,7 +544,6 @@ def simulated_test_runner():
     ) as yellow_fs:
         with Gamecontroller(
             supress_logs=(not args.show_gamecontroller_logs),
-            gamecontroller_port=args.gamecontroller_port,
         ) as gamecontroller:
 
             blue_fs.setup_proto_unix_io(blue_full_system_proto_unix_io)

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -61,7 +61,6 @@ class Gamecontroller(object):
         command += ["-publishAddress", f"{self.REFEREE_IP}:{self.referee_port}"]
         command += ["-ciAddress", f"localhost:{self.ci_port}"]
 
-        print(f"command: {command}")
         if self.supress_logs:
             with open(os.devnull, "w") as fp:
                 self.gamecontroller_proc = Popen(command, stdout=fp, stderr=fp)

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -27,16 +27,23 @@ class Gamecontroller(object):
     REFEREE_IP = "224.5.23.1"
     CI_MODE_OUTPUT_RECEIVE_BUFFER_SIZE = 9000
 
-    def __init__(self, supress_logs: bool = False, gamecontroller_port=None) -> None:
+    def __init__(self, supress_logs: bool = False, gamecontroller_port:int =None, referee_addresse:int= None) -> None:
         """Run Gamecontroller
 
         :param supress_logs: Whether to suppress the logs
+        :param gamecontroller_port: the port that the gamecontroller would bind to 
+        :param referee_address: the address the referee binds to
         """
         self.supress_logs = supress_logs
 
         # We need to find 2 free ports to use for the gamecontroller
         # so that we can run multiple gamecontroller instances in parallel
         self.referee_port = self.next_free_port()
+
+        self.REFEREE_IP = referee_addresse
+        if referee_addresse is None: 
+            self.REFEREE_IP = "224.5.23.1"
+        print(self.REFEREE_IP)
 
         self.ci_port = gamecontroller_port
         if self.ci_port is None:
@@ -60,6 +67,7 @@ class Gamecontroller(object):
         command += ["-publishAddress", f"{self.REFEREE_IP}:{self.referee_port}"]
         command += ["-ciAddress", f"localhost:{self.ci_port}"]
 
+        print(command)
         if self.supress_logs:
             with open(os.devnull, "w") as fp:
                 self.gamecontroller_proc = Popen(command, stdout=fp, stderr=fp)
@@ -166,7 +174,7 @@ class Gamecontroller(object):
                 autoref_proto_unix_io.send_proto(Referee, data)
 
         self.receive_referee_command = tbots_cpp.SSLRefereeProtoListener(
-            Gamecontroller.REFEREE_IP, self.referee_port, __send_referee_command, True,
+            self.REFEREE_IP, self.referee_port, __send_referee_command, True,
         )
 
         blue_full_system_proto_unix_io.register_observer(

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -107,7 +107,7 @@ class Gamecontroller(object):
             )
             manual_command = self.command_override_buffer.get(return_cached=False)
 
-    def is_valid_port(self, port):
+    def is_valid_port(self, port:int) -> bool:
         """
         Check if a port is available 
 
@@ -123,11 +123,11 @@ class Gamecontroller(object):
         except OSError:
             return False
 
-    def next_free_port(self, start_port: int = 40000, max_port: int = 65535) -> None:
+    def next_free_port(self, start_port: int = 40000, max_port: int = 65535) -> int:
         """Find the next free port. We need to find 2 free ports to use for the gamecontroller
         so that we can run multiple gamecontroller instances in parallel.
 
-        :param port: The port to start looking from
+        :param start_port: The port to start looking from
         :param max_port: The maximum port to look up to
         :return: The next free port
 

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -40,10 +40,9 @@ class Gamecontroller(object):
         
         self.ci_port = gamecontroller_port
         if self.ci_port is None: 
-            self.ci_port = self.next_free_port()
-
-        if not self.is_valid_port(self.ci_port):
-            raise Exception("Port: {} is not available!".format(self.ci_port))
+            self.ci_port = self.next_free_port(40000)
+        else:
+            self.ci_port = self.next_free_port(self.ci_port)
 
         # this allows gamecontroller to listen to override commands
         self.command_override_buffer = ThreadSafeBuffer(
@@ -124,7 +123,7 @@ class Gamecontroller(object):
         except OSError:
             return False
 
-    def next_free_port(self, port: int = 40000, max_port: int = 65535) -> None:
+    def next_free_port(self, start_port: int = 40000, max_port: int = 65535) -> None:
         """Find the next free port. We need to find 2 free ports to use for the gamecontroller
         so that we can run multiple gamecontroller instances in parallel.
 
@@ -133,10 +132,10 @@ class Gamecontroller(object):
         :return: The next free port
 
         """
-        while port <= max_port:
-            if self.is_valid_port(port):
-                return port
-            port += 1
+        while start_port <= max_port:
+            if self.is_valid_port(start_port):
+                return start_port
+            start_port += 1
 
         raise IOError("no free ports")
 

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -43,7 +43,6 @@ class Gamecontroller(object):
         self.REFEREE_IP = referee_addresse
         if referee_addresse is None: 
             self.REFEREE_IP = "224.5.23.1"
-        print(self.REFEREE_IP)
 
         self.ci_port = gamecontroller_port
         if self.ci_port is None:
@@ -67,7 +66,6 @@ class Gamecontroller(object):
         command += ["-publishAddress", f"{self.REFEREE_IP}:{self.referee_port}"]
         command += ["-ciAddress", f"localhost:{self.ci_port}"]
 
-        print(command)
         if self.supress_logs:
             with open(os.devnull, "w") as fp:
                 self.gamecontroller_proc = Popen(command, stdout=fp, stderr=fp)

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -39,7 +39,7 @@ class Gamecontroller(object):
         self.referee_port = self.next_free_port()
         
         self.ci_port = gamecontroller_port
-        if gamecontroller_port is None: 
+        if self.ci_port is None: 
             self.ci_port = self.next_free_port()
 
         if not self.is_valid_port(self.ci_port):

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -27,7 +27,12 @@ class Gamecontroller(object):
     REFEREE_IP = "224.5.23.1"
     CI_MODE_OUTPUT_RECEIVE_BUFFER_SIZE = 9000
 
-    def __init__(self, supress_logs: bool = False, gamecontroller_port:int =None, referee_addresse:int= None) -> None:
+    def __init__(
+        self,
+        supress_logs: bool = False,
+        gamecontroller_port: int = None,
+        referee_addresse: int = None,
+    ) -> None:
         """Run Gamecontroller
 
         :param supress_logs: Whether to suppress the logs
@@ -41,7 +46,7 @@ class Gamecontroller(object):
         self.referee_port = self.next_free_port()
 
         self.REFEREE_IP = referee_addresse
-        if referee_addresse is None: 
+        if referee_addresse is None:
             self.REFEREE_IP = "224.5.23.1"
 
         self.ci_port = gamecontroller_port
@@ -113,7 +118,7 @@ class Gamecontroller(object):
             )
             manual_command = self.command_override_buffer.get(return_cached=False)
 
-    def is_valid_port(self, port:int) -> bool:
+    def is_valid_port(self, port: int) -> bool:
         """
         Check if a port is available 
 

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -37,9 +37,9 @@ class Gamecontroller(object):
         # We need to find 2 free ports to use for the gamecontroller
         # so that we can run multiple gamecontroller instances in parallel
         self.referee_port = self.next_free_port()
-        
+
         self.ci_port = gamecontroller_port
-        if self.ci_port is None: 
+        if self.ci_port is None:
             self.ci_port = self.next_free_port(40000)
         else:
             self.ci_port = self.next_free_port(self.ci_port)

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -45,7 +45,6 @@ class Gamecontroller(object):
         if not self.is_valid_port(self.ci_port):
             raise Exception("Port: {} is not available!".format(self.ci_port))
 
-        print("I am using: {} port".format(self.ci_port))
         # this allows gamecontroller to listen to override commands
         self.command_override_buffer = ThreadSafeBuffer(
             buffer_size=2, protobuf_type=ManualGCCommand
@@ -112,6 +111,8 @@ class Gamecontroller(object):
 
     def is_valid_port(self, port):
         """
+        Check if a port is available 
+
         :param port: the port we are checking
         :return: True if the port is available, False otherwise
         """

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -54,6 +54,19 @@ class Gamecontroller(object):
             buffer_size=2, protobuf_type=ManualGCCommand
         )
 
+    @staticmethod
+    def get_referee_port_staticmethod(gamecontroller: Gamecontroller):
+        """
+        return the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
+
+        :param gamecontroller: the gamecontroller we are using
+        :return: the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
+        """
+        if gamecontroller is not None:
+            return gamecontroller.get_referee_port()
+
+        return 40000
+
     def get_referee_port(self) -> int:
         """
         Sometimes, the port that we are using changes depending on context.

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -31,7 +31,7 @@ class Gamecontroller(object):
         self,
         supress_logs: bool = False,
         use_unconventional_port: bool = False,
-        not_launch_gc:bool = True
+        not_launch_gc: bool = True,
     ) -> None:
         """
         Run Gamecontroller
@@ -45,8 +45,8 @@ class Gamecontroller(object):
         self.not_launch_gc = not_launch_gc
 
         if use_unconventional_port:
-            # the intention of setting this port is to ensure that we don't listen other people's 
-            # gamecontroller. It is highly unlikely that other people would use port 12393 since 
+            # the intention of setting this port is to ensure that we don't listen other people's
+            # gamecontroller. It is highly unlikely that other people would use port 12393 since
             # this is a random number that was set by us!
             self.referee_port = self.next_free_port(start_port=12393)
         else:
@@ -76,7 +76,7 @@ class Gamecontroller(object):
         :return: gamecontroller context managed instance
 
         """
-        # sometimes we do not want to launch the gameconntroller because we are in robocup 
+        # sometimes we do not want to launch the gameconntroller because we are in robocup
         # the referee at robotcup would be the person launching the gamecontroller.
         if not self.not_launch_gc:
             command = ["/opt/tbotspython/gamecontroller", "--timeAcquisitionMode", "ci"]
@@ -193,10 +193,7 @@ class Gamecontroller(object):
                 autoref_proto_unix_io.send_proto(Referee, data)
 
         self.receive_referee_command = tbots_cpp.SSLRefereeProtoListener(
-            self.REFEREE_IP,
-            self.referee_port,
-            __send_referee_command,
-            True,
+            self.REFEREE_IP, self.referee_port, __send_referee_command, True,
         )
 
         blue_full_system_proto_unix_io.register_observer(

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -32,21 +32,19 @@ class Gamecontroller(object):
         """Run Gamecontroller
 
         :param supress_logs: Whether to suppress the logs
-        :not_launch_gc Whether to launch the gamecontroller or not!
+        :param use_conventional_port: whether or not to use the conventional port!
         """
 
         self.supress_logs = supress_logs
 
         self.ci_port = self.next_free_port()
-        # we are not using conventional by default since most of the time
-        # we are not in competition and. Thus, we would be conflicting with
-        # each other if we are using conventional port
         self.referee_port = self.next_free_port(random.randint(1024, 65535))
+        # We default to using a non-conventional port to avoid emitting on the same port as what other teams may be listening on.
         if use_conventional_port:
-            if not self.is_valid_port(40000):
+            if not self.is_valid_port(SSL_REFEREE_PORT):
                 raise OSError("Cannot use port 40000 for Gamecontroller")
 
-            self.referee_port = 40000
+            self.referee_port = SSL_REFEREE_PORT
 
         self.ci_port = self.next_free_port()
         # this allows gamecontroller to listen to override commands
@@ -55,14 +53,9 @@ class Gamecontroller(object):
         )
 
     @staticmethod
-    def get_referee_port_staticmethod(gamecontroller: Gamecontroller):
+    def get_referee_port_static(gamecontroller: Gamecontroller):
         """
         return the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
-
-        This function is used situation like the following: https://github.com/Mr-Anyone/Thunderbot_Software/blob/cf668bfeaff698097aadce1d01c60b4c731322c6/src/software/thunderscope/thunderscope_main.py#L322. 
-        In otherwords, the instance of gamecontroller has type None, but we want a function or staticmethod to return the default port of the referee 
-        Since the type is None, we cannot call self.get_referee_port, and thus this function is declared as a static method. If the gamecontroller has type None. We want to listen to the default port instead!
-
 
         :param gamecontroller: the gamecontroller we are using
         :return: the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
@@ -70,7 +63,7 @@ class Gamecontroller(object):
         if gamecontroller is not None:
             return gamecontroller.get_referee_port()
 
-        return 40000
+        return SSL_REFEREE_PORT
 
     def get_referee_port(self) -> int:
         """

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -41,7 +41,7 @@ class Gamecontroller(object):
         # on the same port as what other teams may be listening on.
         if use_conventional_port:
             if not self.is_valid_port(SSL_REFEREE_PORT):
-                raise OSError("Cannot use port 40000 for Gamecontroller")
+                raise OSError(f"Cannot use port {SSL_REFEREE_PORT} for Gamecontroller")
 
             self.referee_port = SSL_REFEREE_PORT
         else:

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -37,14 +37,15 @@ class Gamecontroller(object):
 
         self.supress_logs = supress_logs
 
-        self.ci_port = self.next_free_port()
-        self.referee_port = self.next_free_port(random.randint(1024, 65535))
-        # We default to using a non-conventional port to avoid emitting on the same port as what other teams may be listening on.
+        # We default to using a non-conventional port to avoid emitting 
+        # on the same port as what other teams may be listening on.
         if use_conventional_port:
             if not self.is_valid_port(SSL_REFEREE_PORT):
                 raise OSError("Cannot use port 40000 for Gamecontroller")
 
             self.referee_port = SSL_REFEREE_PORT
+        else:
+            self.referee_port = self.next_free_port(random.randint(1024, 65535))
 
         self.ci_port = self.next_free_port()
         # this allows gamecontroller to listen to override commands

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -38,11 +38,11 @@ class Gamecontroller(object):
         self.supress_logs = supress_logs
 
         self.ci_port = self.next_free_port()
-        # we are not using conventional by default since most of the time 
-        # we are not in competition and. Thus, we would be conflicting with 
+        # we are not using conventional by default since most of the time
+        # we are not in competition and. Thus, we would be conflicting with
         # each other if we are using conventional port
         self.referee_port = self.next_free_port(random.randint(1024, 65535))
-        if use_conventional_port: 
+        if use_conventional_port:
             if not self.is_valid_port(40000):
                 raise OSError("Cannot use port 40000 for Gamecontroller")
 

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -37,7 +37,7 @@ class Gamecontroller(object):
 
         self.supress_logs = supress_logs
 
-        # We default to using a non-conventional port to avoid emitting 
+        # We default to using a non-conventional port to avoid emitting
         # on the same port as what other teams may be listening on.
         if use_conventional_port:
             if not self.is_valid_port(SSL_REFEREE_PORT):

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -59,6 +59,11 @@ class Gamecontroller(object):
         """
         return the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
 
+        This function is used situation like the following: https://github.com/Mr-Anyone/Thunderbot_Software/blob/cf668bfeaff698097aadce1d01c60b4c731322c6/src/software/thunderscope/thunderscope_main.py#L322. 
+        In otherwords, the instance of gamecontroller has type None, but we want a function or staticmethod to return the default port of the referee 
+        Since the type is None, we cannot call self.get_referee_port, and thus this function is declared as a static method. If the gamecontroller has type None. We want to listen to the default port instead!
+
+
         :param gamecontroller: the gamecontroller we are using
         :return: the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
         """

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -27,6 +27,8 @@ class RobotCommunication(object):
         estop_path: os.PathLike = None,
         estop_baudrate: int = 115200,
         enable_radio: bool = False,
+        referee_address: str = None, 
+        sslvision_address: str = None, 
     ):
         """Initialize the communication with the robots
 
@@ -100,19 +102,27 @@ class RobotCommunication(object):
             except Exception:
                 raise Exception(f"Invalid Estop found at location {self.estop_path}")
 
+        self.ssl_vision_address = sslvision_address
+        if self.ssl_vision_address is None:
+            self.ssl_vision_address = SSL_VISION_ADDRESS
+
+        self.referee_address = referee_address
+        if self.ssl_vision_address is None:
+            self.ssl_vision_address = SSL_REFEREE_ADDRESS
+
     def setup_for_fullsystem(self) -> None:
         """
         Sets up a listener for SSL vision and referee data, and connects all robots to fullsystem as default
         """
         self.receive_ssl_wrapper = tbots_cpp.SSLWrapperPacketProtoListener(
-            SSL_VISION_ADDRESS,
+            self.ssl_vision_address,
             SSL_VISION_PORT,
             lambda data: self.__forward_to_proto_unix_io(SSL_WrapperPacket, data),
             True,
         )
 
         self.receive_ssl_referee_proto = tbots_cpp.SSLRefereeProtoListener(
-            SSL_REFEREE_ADDRESS,
+            self.referee_address,
             SSL_REFEREE_PORT,
             lambda data: self.current_proto_unix_io.send_proto(Referee, data),
             True,

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -27,8 +27,8 @@ class RobotCommunication(object):
         estop_path: os.PathLike = None,
         estop_baudrate: int = 115200,
         enable_radio: bool = False,
-        referee_address: str = None, 
-        sslvision_address: str = None, 
+        referee_address: str = None,
+        sslvision_address: str = None,
     ):
         """Initialize the communication with the robots
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -111,7 +111,6 @@ class RobotCommunication(object):
             except Exception:
                 raise Exception(f"Invalid Estop found at location {self.estop_path}")
 
-
     def setup_for_fullsystem(self) -> None:
         """
         Sets up a listener for SSL vision and referee data, and connects all robots to fullsystem as default

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -41,6 +41,15 @@ class RobotCommunication(object):
         :param enable_radio: Whether to use radio to send primitives to robots
 
         """
+        # setting up the ssl vision and referee addresses
+        self.ssl_vision_address = sslvision_address
+        if self.ssl_vision_address is None:
+            self.ssl_vision_address = SSL_VISION_ADDRESS
+
+        self.referee_address = referee_address
+        if self.referee_address is None:
+            self.referee_address = SSL_REFEREE_ADDRESS
+
         self.receive_ssl_referee_proto = None
         self.receive_ssl_wrapper = None
         self.sequence_number = 0
@@ -102,13 +111,6 @@ class RobotCommunication(object):
             except Exception:
                 raise Exception(f"Invalid Estop found at location {self.estop_path}")
 
-        self.ssl_vision_address = sslvision_address
-        if self.ssl_vision_address is None:
-            self.ssl_vision_address = SSL_VISION_ADDRESS
-
-        self.referee_address = referee_address
-        if self.ssl_vision_address is None:
-            self.ssl_vision_address = SSL_REFEREE_ADDRESS
 
     def setup_for_fullsystem(self) -> None:
         """

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -109,7 +109,7 @@ class RobotCommunication(object):
         Sets up a listener for SSL vision and referee data, and connects all robots to fullsystem as default
         """
         self.receive_ssl_wrapper = tbots_cpp.SSLWrapperPacketProtoListener(
-            self.ssl_vision_address,
+            SSL_VISION_ADDRESS,
             SSL_VISION_PORT,
             lambda data: self.__forward_to_proto_unix_io(SSL_WrapperPacket, data),
             True,

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -27,8 +27,7 @@ class RobotCommunication(object):
         estop_path: os.PathLike = None,
         estop_baudrate: int = 115200,
         enable_radio: bool = False,
-        sslvision_address: str = None,
-        referee_port: int = SSL_REFEREE_PORT,
+        referee_port: int = SSL_REFEREE_PORT
     ):
         """Initialize the communication with the robots
 
@@ -39,15 +38,11 @@ class RobotCommunication(object):
         :param estop_path: The path to the estop
         :param estop_baudrate: The baudrate of the estop
         :param enable_radio: Whether to use radio to send primitives to robots
+        :param referee_port: the referee port that we are using
 
         """
-        # setting up the ssl vision and referee addresses
-        self.ssl_vision_address = sslvision_address
-        if self.ssl_vision_address is None:
-            self.ssl_vision_address = SSL_VISION_ADDRESS
 
         self.referee_port = referee_port
-
         self.receive_ssl_referee_proto = None
         self.receive_ssl_wrapper = None
         self.sequence_number = 0
@@ -122,7 +117,7 @@ class RobotCommunication(object):
 
         self.receive_ssl_referee_proto = tbots_cpp.SSLRefereeProtoListener(
             SSL_REFEREE_ADDRESS,
-            SSL_REFEREE_PORT,
+            self.referee_port,
             lambda data: self.current_proto_unix_io.send_proto(Referee, data),
             True,
         )

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -28,7 +28,7 @@ class RobotCommunication(object):
         estop_baudrate: int = 115200,
         enable_radio: bool = False,
         sslvision_address: str = None,
-        referee_port:int = SSL_REFEREE_PORT
+        referee_port: int = SSL_REFEREE_PORT,
     ):
         """Initialize the communication with the robots
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -27,8 +27,8 @@ class RobotCommunication(object):
         estop_path: os.PathLike = None,
         estop_baudrate: int = 115200,
         enable_radio: bool = False,
-        referee_address: str = None,
         sslvision_address: str = None,
+        referee_port:int = SSL_REFEREE_PORT
     ):
         """Initialize the communication with the robots
 
@@ -46,9 +46,7 @@ class RobotCommunication(object):
         if self.ssl_vision_address is None:
             self.ssl_vision_address = SSL_VISION_ADDRESS
 
-        self.referee_address = referee_address
-        if self.referee_address is None:
-            self.referee_address = SSL_REFEREE_ADDRESS
+        self.referee_port = referee_port
 
         self.receive_ssl_referee_proto = None
         self.receive_ssl_wrapper = None
@@ -123,7 +121,7 @@ class RobotCommunication(object):
         )
 
         self.receive_ssl_referee_proto = tbots_cpp.SSLRefereeProtoListener(
-            self.referee_address,
+            SSL_REFEREE_ADDRESS,
             SSL_REFEREE_PORT,
             lambda data: self.current_proto_unix_io.send_proto(Referee, data),
             True,

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -27,7 +27,7 @@ class RobotCommunication(object):
         estop_path: os.PathLike = None,
         estop_baudrate: int = 115200,
         enable_radio: bool = False,
-        referee_port: int = SSL_REFEREE_PORT
+        referee_port: int = SSL_REFEREE_PORT,
     ):
         """Initialize the communication with the robots
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -38,7 +38,7 @@ class RobotCommunication(object):
         :param estop_path: The path to the estop
         :param estop_baudrate: The baudrate of the estop
         :param enable_radio: Whether to use radio to send primitives to robots
-        :param referee_port: the referee port that we are using
+        :param referee_port: the referee port that we are using. If this is None, the default port is used
 
         """
 

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -330,6 +330,8 @@ if __name__ == "__main__":
             estop_mode=estop_mode,
             estop_path=estop_path,
             enable_radio=args.enable_radio,
+            referee_address=args.sslreferee_multicast_address,
+            sslvision_address=args.sslvision_multicast_address
         ) as robot_communication:
 
             if estop_mode == EstopMode.KEYBOARD_ESTOP:

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -217,6 +217,8 @@ if __name__ == "__main__":
         default=False,
         help="Whether to populate with default robot positions (False) or start with an empty field (True) for AI vs AI",
     )
+    
+    parser.add_argument('--gamecontroller_port', type=int, default=None, help='The port number for the game controller.')
 
     args = parser.parse_args()
 
@@ -224,6 +226,7 @@ if __name__ == "__main__":
     if args.run_blue or args.run_yellow:
         if args.interface is None:
             parser.error("Must specify interface")
+
 
     ###########################################################################
     #                      Visualize CPP Tests                                #
@@ -428,7 +431,8 @@ if __name__ == "__main__":
             should_restart_on_crash=False,
             run_sudo=args.sudo,
         ) as yellow_fs, Gamecontroller(
-            supress_logs=(not args.verbose)
+            supress_logs=(not args.verbose),
+            gamecontroller_port=args.gamecontroller_port
         ) as gamecontroller, (
             # Here we only initialize autoref if the --enable_autoref flag is requested.
             # To avoid nested Python withs, the autoref is initialized as None when this flag doesn't exist.

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -232,9 +232,6 @@ if __name__ == "__main__":
 
 
     args = parser.parse_args()
-    
-    print(args.sslvision_multicast_address)
-    print(args.sslreferee_multicast_address)
 
     # Sanity check that an interface was provided
     if args.run_blue or args.run_yellow:

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -27,6 +27,7 @@ from software.thunderscope.util import *
 from software.thunderscope.binary_context_managers.full_system import FullSystem
 from software.thunderscope.binary_context_managers.simulator import Simulator
 from software.thunderscope.binary_context_managers.game_controller import Gamecontroller
+
 from software.thunderscope.binary_context_managers.tigers_autoref import TigersAutoref
 
 
@@ -224,8 +225,16 @@ if __name__ == "__main__":
         default=None,
         help="The port number for the game controller.",
     )
+     
+    parser.add_argument("--sslvision_multicast_address", type=str, default=None, help="the multicast address for ssl vision")
+
+    parser.add_argument("--sslreferee_multicast_address", type=str, default=None, help="the multicast address for referee (game controller likely)")
+
 
     args = parser.parse_args()
+    
+    print(args.sslvision_multicast_address)
+    print(args.sslreferee_multicast_address)
 
     # Sanity check that an interface was provided
     if args.run_blue or args.run_yellow:
@@ -437,6 +446,7 @@ if __name__ == "__main__":
         ) as yellow_fs, Gamecontroller(
             supress_logs=(not args.verbose),
             gamecontroller_port=args.gamecontroller_port,
+            referee_addresse=args.sslreferee_multicast_address
         ) as gamecontroller, (
             # Here we only initialize autoref if the --enable_autoref flag is requested.
             # To avoid nested Python withs, the autoref is initialized as None when this flag doesn't exist.

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -340,7 +340,7 @@ if __name__ == "__main__":
             estop_path=estop_path,
             enable_radio=args.enable_radio,
             referee_address=args.sslreferee_multicast_address,
-            sslvision_address=args.sslvision_multicast_address
+            sslvision_address=args.sslvision_multicast_address,
         ) as robot_communication:
 
             if estop_mode == EstopMode.KEYBOARD_ESTOP:

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -225,11 +225,20 @@ if __name__ == "__main__":
         default=None,
         help="The port number for the game controller.",
     )
-     
-    parser.add_argument("--sslvision_multicast_address", type=str, default=None, help="the multicast address for ssl vision")
 
-    parser.add_argument("--sslreferee_multicast_address", type=str, default=None, help="the multicast address for referee (game controller likely)")
+    parser.add_argument(
+        "--sslvision_multicast_address",
+        type=str,
+        default=None,
+        help="the multicast address for ssl vision",
+    )
 
+    parser.add_argument(
+        "--sslreferee_multicast_address",
+        type=str,
+        default=None,
+        help="the multicast address for referee (game controller likely)",
+    )
 
     args = parser.parse_args()
 
@@ -443,7 +452,7 @@ if __name__ == "__main__":
         ) as yellow_fs, Gamecontroller(
             supress_logs=(not args.verbose),
             gamecontroller_port=args.gamecontroller_port,
-            referee_addresse=args.sslreferee_multicast_address
+            referee_addresse=args.sslreferee_multicast_address,
         ) as gamecontroller, (
             # Here we only initialize autoref if the --enable_autoref flag is requested.
             # To avoid nested Python withs, the autoref is initialized as None when this flag doesn't exist.

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -217,8 +217,13 @@ if __name__ == "__main__":
         default=False,
         help="Whether to populate with default robot positions (False) or start with an empty field (True) for AI vs AI",
     )
-    
-    parser.add_argument('--gamecontroller_port', type=int, default=None, help='The port number for the game controller.')
+
+    parser.add_argument(
+        "--gamecontroller_port",
+        type=int,
+        default=None,
+        help="The port number for the game controller.",
+    )
 
     args = parser.parse_args()
 
@@ -226,7 +231,6 @@ if __name__ == "__main__":
     if args.run_blue or args.run_yellow:
         if args.interface is None:
             parser.error("Must specify interface")
-
 
     ###########################################################################
     #                      Visualize CPP Tests                                #
@@ -432,7 +436,7 @@ if __name__ == "__main__":
             run_sudo=args.sudo,
         ) as yellow_fs, Gamecontroller(
             supress_logs=(not args.verbose),
-            gamecontroller_port=args.gamecontroller_port
+            gamecontroller_port=args.gamecontroller_port,
         ) as gamecontroller, (
             # Here we only initialize autoref if the --enable_autoref flag is requested.
             # To avoid nested Python withs, the autoref is initialized as None when this flag doesn't exist.

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -220,24 +220,10 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--sslvision_multicast_address",
-        type=str,
-        default=SSL_VISION_ADDRESS,
-        help="the multicast address for ssl vision",
-    )
-
-    parser.add_argument(
-        "--use_unconventional_port",
+        "--launch_gc",
         action="store_true",
         default=False,
-        help="setting this option would cause gamecontroller to bind on an unconventional port, likely 12393",
-    )
-
-    parser.add_argument(
-        "--not_launch_gc",
-        action="store_true",
-        default=False,
-        help="whether we are launching gamecontroller or not",
+        help="wheter or not to launch the gamecontroller when --run_blue or --run_yellow is ran",
     )
 
     args = parser.parse_args()
@@ -310,7 +296,10 @@ if __name__ == "__main__":
             args.run_diagnostics,
             args.visualization_buffer_size,
         )
-        tscope = Thunderscope(config=tscope_config, layout_path=args.layout,)
+        tscope = Thunderscope(
+            config=tscope_config,
+            layout_path=args.layout,
+        )
 
         current_proto_unix_io = None
 
@@ -332,14 +321,25 @@ if __name__ == "__main__":
             args.keyboard_estop, args.disable_communication
         )
 
-        with RobotCommunication(
+        def get_referee_port(gamecontroller: Gamecontroller):
+            if gamecontroller is not None:
+                print("Using a weird gamecontroller port")
+                return gamecontroller.get_referee_port()
+            print("Using default port")
+            return 40000
+
+        with (
+            Gamecontroller(supress_logs=(not args.verbose), use_conventional_port=False)
+            if args.launch_gc
+            else contextlib.nullcontext()
+        ) as gamecontroller, RobotCommunication(
             current_proto_unix_io=current_proto_unix_io,
             multicast_channel=getRobotMulticastChannel(args.channel),
             interface=args.interface,
             estop_mode=estop_mode,
             estop_path=estop_path,
             enable_radio=args.enable_radio,
-            sslvision_address=args.sslvision_multicast_address,
+            referee_port=get_referee_port(gamecontroller),
         ) as robot_communication:
 
             if estop_mode == EstopMode.KEYBOARD_ESTOP:
@@ -366,7 +366,9 @@ if __name__ == "__main__":
                     if args.run_blue
                     else args.yellow_full_system_runtime_dir
                 )
-                with ProtoLogger(full_system_runtime_dir,) as logger, FullSystem(
+                with ProtoLogger(
+                    full_system_runtime_dir,
+                ) as logger, FullSystem(
                     full_system_runtime_dir=runtime_dir,
                     debug_full_system=debug,
                     friendly_colour_yellow=friendly_colour_yellow,
@@ -389,7 +391,9 @@ if __name__ == "__main__":
     elif args.blue_log or args.yellow_log:
         tscope = Thunderscope(
             config=config.configure_replay_view(
-                args.blue_log, args.yellow_log, args.visualization_buffer_size,
+                args.blue_log,
+                args.yellow_log,
+                args.visualization_buffer_size,
             ),
             layout_path=args.layout,
         )
@@ -502,7 +506,9 @@ if __name__ == "__main__":
                 autoref_proto_unix_io,
             )
             if args.enable_autoref:
-                autoref.setup_ssl_wrapper_packets(autoref_proto_unix_io,)
+                autoref.setup_ssl_wrapper_packets(
+                    autoref_proto_unix_io,
+                )
 
             # Start the simulator
             sim_ticker_thread = threading.Thread(

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -237,7 +237,7 @@ if __name__ == "__main__":
         "--not_launch_gc",
         action="store_true",
         default=False,
-        help="whether we are launching gamecontroller or not"
+        help="whether we are launching gamecontroller or not",
     )
 
     args = parser.parse_args()
@@ -310,10 +310,7 @@ if __name__ == "__main__":
             args.run_diagnostics,
             args.visualization_buffer_size,
         )
-        tscope = Thunderscope(
-            config=tscope_config,
-            layout_path=args.layout,
-        )
+        tscope = Thunderscope(config=tscope_config, layout_path=args.layout,)
 
         current_proto_unix_io = None
 
@@ -369,9 +366,7 @@ if __name__ == "__main__":
                     if args.run_blue
                     else args.yellow_full_system_runtime_dir
                 )
-                with ProtoLogger(
-                    full_system_runtime_dir,
-                ) as logger, FullSystem(
+                with ProtoLogger(full_system_runtime_dir,) as logger, FullSystem(
                     full_system_runtime_dir=runtime_dir,
                     debug_full_system=debug,
                     friendly_colour_yellow=friendly_colour_yellow,
@@ -394,9 +389,7 @@ if __name__ == "__main__":
     elif args.blue_log or args.yellow_log:
         tscope = Thunderscope(
             config=config.configure_replay_view(
-                args.blue_log,
-                args.yellow_log,
-                args.visualization_buffer_size,
+                args.blue_log, args.yellow_log, args.visualization_buffer_size,
             ),
             layout_path=args.layout,
         )
@@ -509,9 +502,7 @@ if __name__ == "__main__":
                 autoref_proto_unix_io,
             )
             if args.enable_autoref:
-                autoref.setup_ssl_wrapper_packets(
-                    autoref_proto_unix_io,
-                )
+                autoref.setup_ssl_wrapper_packets(autoref_proto_unix_io,)
 
             # Start the simulator
             sim_ticker_thread = threading.Thread(

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -459,9 +459,7 @@ if __name__ == "__main__":
             should_restart_on_crash=False,
             run_sudo=args.sudo,
         ) as yellow_fs, Gamecontroller(
-            supress_logs=(not args.verbose),
-            use_unconventional_port=args.use_unconventional_port,
-            not_launch_gc=args.not_launch_gc,
+            supress_logs=(not args.verbose)
         ) as gamecontroller, (
             # Here we only initialize autoref if the --enable_autoref flag is requested.
             # To avoid nested Python withs, the autoref is initialized as None when this flag doesn't exist.

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
         "--launch_gc",
         action="store_true",
         default=False,
-        help="wheter or not to launch the gamecontroller when --run_blue or --run_yellow is ran",
+        help="whether or not to launch the gamecontroller when --run_blue or --run_yellow is ran",
     )
 
     args = parser.parse_args()

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -318,7 +318,6 @@ if __name__ == "__main__":
             args.keyboard_estop, args.disable_communication
         )
 
-
         with (
             Gamecontroller(supress_logs=(not args.verbose), use_conventional_port=False)
             if args.launch_gc

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -228,6 +228,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    # we only have --launch_gc parameter but not args.run_yellow and args.run_blue
+    if not args.run_blue and not args.run_yellow and args.launch_gc:
+        parser.error("--launch_gc has to be ran with --run_blue argument")
+
     # Sanity check that an interface was provided
     if args.run_blue or args.run_yellow:
         if args.interface is None:
@@ -329,7 +333,7 @@ if __name__ == "__main__":
             estop_mode=estop_mode,
             estop_path=estop_path,
             enable_radio=args.enable_radio,
-            referee_port=Gamecontroller.get_referee_port_staticmethod(gamecontroller),
+            referee_port=Gamecontroller.get_referee_port_static(gamecontroller),
         ) as robot_communication:
 
             if estop_mode == EstopMode.KEYBOARD_ESTOP:

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -322,10 +322,14 @@ if __name__ == "__main__":
         )
 
         def get_referee_port(gamecontroller: Gamecontroller):
+            """
+            return the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
+
+            :param gamecontroller: the gamecontroller we are using
+            :return: the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
+            """
             if gamecontroller is not None:
-                print("Using a weird gamecontroller port")
                 return gamecontroller.get_referee_port()
-            print("Using default port")
             return 40000
 
         with (

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -229,14 +229,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--sslvision_multicast_address",
         type=str,
-        default=None,
+        default=SSL_VISION_ADDRESS,
         help="the multicast address for ssl vision",
     )
 
     parser.add_argument(
         "--sslreferee_multicast_address",
         type=str,
-        default=None,
+        default=SSL_REFEREE_ADDRESS,
         help="the multicast address for referee (game controller likely)",
     )
 

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -296,10 +296,7 @@ if __name__ == "__main__":
             args.run_diagnostics,
             args.visualization_buffer_size,
         )
-        tscope = Thunderscope(
-            config=tscope_config,
-            layout_path=args.layout,
-        )
+        tscope = Thunderscope(config=tscope_config, layout_path=args.layout,)
 
         current_proto_unix_io = None
 
@@ -370,9 +367,7 @@ if __name__ == "__main__":
                     if args.run_blue
                     else args.yellow_full_system_runtime_dir
                 )
-                with ProtoLogger(
-                    full_system_runtime_dir,
-                ) as logger, FullSystem(
+                with ProtoLogger(full_system_runtime_dir,) as logger, FullSystem(
                     full_system_runtime_dir=runtime_dir,
                     debug_full_system=debug,
                     friendly_colour_yellow=friendly_colour_yellow,
@@ -395,9 +390,7 @@ if __name__ == "__main__":
     elif args.blue_log or args.yellow_log:
         tscope = Thunderscope(
             config=config.configure_replay_view(
-                args.blue_log,
-                args.yellow_log,
-                args.visualization_buffer_size,
+                args.blue_log, args.yellow_log, args.visualization_buffer_size,
             ),
             layout_path=args.layout,
         )
@@ -508,9 +501,7 @@ if __name__ == "__main__":
                 autoref_proto_unix_io,
             )
             if args.enable_autoref:
-                autoref.setup_ssl_wrapper_packets(
-                    autoref_proto_unix_io,
-                )
+                autoref.setup_ssl_wrapper_packets(autoref_proto_unix_io,)
 
             # Start the simulator
             sim_ticker_thread = threading.Thread(

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -318,16 +318,6 @@ if __name__ == "__main__":
             args.keyboard_estop, args.disable_communication
         )
 
-        def get_referee_port(gamecontroller: Gamecontroller):
-            """
-            return the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
-
-            :param gamecontroller: the gamecontroller we are using
-            :return: the default port if gamecontroller is None, otherwise the port that the gamecontroller is using.
-            """
-            if gamecontroller is not None:
-                return gamecontroller.get_referee_port()
-            return 40000
 
         with (
             Gamecontroller(supress_logs=(not args.verbose), use_conventional_port=False)
@@ -340,7 +330,7 @@ if __name__ == "__main__":
             estop_mode=estop_mode,
             estop_path=estop_path,
             enable_radio=args.enable_radio,
-            referee_port=get_referee_port(gamecontroller),
+            referee_port=Gamecontroller.get_referee_port_staticmethod(gamecontroller),
         ) as robot_communication:
 
             if estop_mode == EstopMode.KEYBOARD_ESTOP:


### PR DESCRIPTION
### Description
Game controller can now bind on a different port

### Testing Done

Ran the following commands: 
```
./tbots.py test kickoff_play_test --gamecontroller_port 50000 --enable_thunderscope
./tbots.py run thunderscope --gamecontroller_port 50001 
```

and when each of the command from above is running, I ran 

```
ps aux | grep gamecontroller
```
### Resolved Issues

resolves #3160

### Length Justification and Key Files to Review

N/A

### Review Checklist


**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

