### PR TITLE
Fix BallPlacement in CI*

### DIFF
--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.cpp
@@ -98,7 +98,7 @@ void BallPlacementPlayFSM::placeBall(const Update &event)
 
 void BallPlacementPlayFSM::startWait(const Update &event)
 {
-    start_time = std::chrono::steady_clock::now();
+    start_time = event.common.world_ptr->getMostRecentTimestamp();
 }
 
 void BallPlacementPlayFSM::retreat(const Update &event)
@@ -208,11 +208,8 @@ bool BallPlacementPlayFSM::ballPlaced(const Update &event)
 
 bool BallPlacementPlayFSM::waitDone(const Update &event)
 {
-    std::chrono::time_point<std::chrono::steady_clock> current_time =
-        std::chrono::steady_clock::now();
-    return static_cast<double>(
-               std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time)
-                   .count()) > BALL_IS_PLACED_WAIT_S;
+    Timestamp current_time = event.common.world_ptr->getMostRecentTimestamp();
+    return (current_time - start_time) > Duration::fromSeconds(BALL_IS_PLACED_WAIT_S);
 }
 
 bool BallPlacementPlayFSM::retreatDone(const Update &event)

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.h
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <chrono>
-
 #include "proto/parameters.pb.h"
 #include "shared/constants.h"
 #include "software/ai/hl/stp/play/play_fsm.h"

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.h
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.h
@@ -197,7 +197,7 @@ struct BallPlacementPlayFSM
     std::shared_ptr<MoveTactic> retreat_tactic;
     std::vector<std::shared_ptr<PlaceBallMoveTactic>> move_tactics;
     Point setup_point;
-    std::chrono::time_point<std::chrono::steady_clock> start_time;
+    Timestamp start_time;
     constexpr static double const WALL_KICKOFF_VELOCITY_M_PER_S   = 3.0;
     constexpr static double const RETREAT_DISTANCE_METERS         = 0.6;
     constexpr static double const PLACEMENT_DIST_THRESHOLD_METERS = 0.15;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

*maybe

The issue is likely that `WaitState` uses clock time while the simulation time is running much faster on CI. If we look at the CI replay logs, we see this in the failing test:

https://github.com/UBC-Thunderbots/Software/assets/42703774/289595fc-f724-467a-bd02-73b39d313ffc

The bug: `BallPlacementPlayFSM` stays in `WaitState` for longer than 3.0 seconds. We use system time to decide how long to stay in `WaitState` and I think CI time is passing much faster than system time. In other words, 3.0 seconds of system time is longer than the time passed during simulations, causing us to fail the validation within the timeout of the test.


### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
