### PR TITLE
Speed up Thunderscope launch time

### DIFF
--- a/src/software/thunderscope/thunderscope.py
+++ b/src/software/thunderscope/thunderscope.py
@@ -220,7 +220,6 @@ class Thunderscope(object):
     def show(self) -> None:
         """Show the main window"""
 
-        self.window.show()
         self.window.showMaximized()
         pyqtgraph.exec()
 

--- a/src/software/thunderscope/thunderscope_config.py
+++ b/src/software/thunderscope/thunderscope_config.py
@@ -182,7 +182,7 @@ def configure_base_fullsystem(
             anchor="Field",
             position="left",
             has_refresh_func=False,
-            stretch=WidgetStretchData(x=3),
+            stretch=WidgetStretchData(x=5),
         ),
         TScopeWidget(
             name="Error Log",
@@ -191,19 +191,21 @@ def configure_base_fullsystem(
             ),
             anchor="Parameters",
             position="above",
+            stretch=WidgetStretchData(x=5),
         ),
         TScopeWidget(
             name="Logs",
             widget=setup_log_widget(**{"proto_unix_io": full_system_proto_unix_io}),
             anchor="Parameters",
             position="above",
-            stretch=WidgetStretchData(x=3),
+            stretch=WidgetStretchData(x=5),
         ),
         TScopeWidget(
             name="Referee Info",
             widget=setup_referee_info(**{"proto_unix_io": full_system_proto_unix_io}),
             anchor="Field",
             position="bottom",
+            stretch=WidgetStretchData(y=4),
         ),
         TScopeWidget(
             name="Performance",
@@ -217,6 +219,7 @@ def configure_base_fullsystem(
             in_window=True,
             anchor="Referee Info",
             position="below",
+            stretch=WidgetStretchData(y=4),
         ),
         TScopeWidget(
             name="FPS Widget",
@@ -228,12 +231,14 @@ def configure_base_fullsystem(
             ),
             anchor="Performance",
             position="below",
+            stretch=WidgetStretchData(y=4),
         ),
         TScopeWidget(
             name="Play Info",
             widget=setup_play_info(**{"proto_unix_io": full_system_proto_unix_io}),
             anchor="Referee Info",
             position="above",
+            stretch=WidgetStretchData(y=4),
         ),
     ] + extra_widgets
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->
### Description
For the past few months I have been noticing that often Thunderscope takes noticeably longer to launch compared to before. After using [`git bisect`](https://git-scm.com/docs/git-bisect) (pretty useful tool for tracking down regressions that I just learned about) I was able to narrow down the problem to #2788 where the `sync_simulation` function was refactored that added up to 6 seconds to the launch time on my PC. 

There were two other smaller changes that I also included in this PR. One was removing an extra `window.show()` call for Thunderscope, and another being how large the widgets are at launch time of Thunderscope.

### Testing Done
Measured the time between `self.window.showMaximized()` call and `pyqtgraph.exec()` across multiple commits to verify the issue, then I verified that the time reduced from 6-8 seconds to 0.3-1 second.

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
