### PR TITLE
Make optimize build the default when using `./tbots.py`

### DIFF
--- a/src/software/thunderscope/binary_context_managers/full_system.py
+++ b/src/software/thunderscope/binary_context_managers/full_system.py
@@ -75,7 +75,7 @@ class FullSystem(object):
 Run Fullsystem under sudo ==============
 1. Build the full system:
 
-./tbots.py build unix_full_system -o
+./tbots.py build unix_full_system
 
 2. Run the following binaries from src to run under sudo:
 

--- a/src/tbots.py
+++ b/src/tbots.py
@@ -32,12 +32,24 @@ if __name__ == "__main__":
         help="Print the generated Bazel command",
     )
     parser.add_argument(
-        "-o",
-        "--optimized_build",
+        "-no",
+        "--no_optimized_build",
         action="store_true",
-        help="Compile binaries with -O3 optimizations",
+        default=False,
+        help="Compile binaries without -O3 optimizations",
     )
-    parser.add_argument("-d", "--debug_build", action="store_true")
+    parser.add_argument(
+        "-d",
+        "--debug_build",
+        action="store_true",
+        help="Compile binaries with debug symbols",
+    )
+    parser.add_argument(
+        "-gdb",
+        "--run_under_gdb",
+        action="store_true",
+        help="Run the binaries under gdb",
+    )
     parser.add_argument(
         "-ds",
         "--select_debug_binaries",
@@ -51,7 +63,7 @@ if __name__ == "__main__":
         "--flash_robots",
         nargs="+",
         type=int,
-        help="A list of space seperated integers representing the robot IDs "
+        help="A list of space separated integers representing the robot IDs "
         "that should be flashed by the deploy_nano Ansible playbook",
         action="store",
     )
@@ -137,9 +149,9 @@ if __name__ == "__main__":
     if args.debug_build or args.select_debug_binaries:
         command += ["-c", "dbg"]
 
-    # Trigger an optimized build. Note that Thunderloop should always be
-    # compiled with optimizations for best formance
-    if args.optimized_build or args.flash_robots:
+    # Trigger an optimized build by default. Note that Thunderloop should always be
+    # compiled with optimizations for best performance
+    if not args.no_optimized_build or args.flash_robots:
         command += ["--copt=-O3"]
 
     # Used for when flashing Jetsons
@@ -159,7 +171,7 @@ if __name__ == "__main__":
     # because it relies on --debug_simulator, --debug_blue_full_system and
     # --debug_yellow_full_system prompts the user to run the command under gdb
     # instead. So we only run_under gdb if its _not_ a thunderscope debug command
-    if args.action in "run" and args.debug_build:
+    if args.action in "run" and args.debug_build and args.run_under_gdb:
         if (
             "--debug_yellow_full_system" not in unknown_args
             and "--debug_blue_full_system" not in unknown_args

--- a/src/tbots.py
+++ b/src/tbots.py
@@ -45,12 +45,6 @@ if __name__ == "__main__":
         help="Compile binaries with debug symbols",
     )
     parser.add_argument(
-        "-gdb",
-        "--run_under_gdb",
-        action="store_true",
-        help="Run the binaries under gdb",
-    )
-    parser.add_argument(
         "-ds",
         "--select_debug_binaries",
         choices=["sim", "blue", "yellow"],
@@ -166,18 +160,6 @@ if __name__ == "__main__":
             unknown_args += ["--debug_blue_full_system"]
         if "yellow" in args.select_debug_binaries:
             unknown_args += ["--debug_yellow_full_system"]
-
-    # If its a binary, then run under gdb. We need to special case thunderscope
-    # because it relies on --debug_simulator, --debug_blue_full_system and
-    # --debug_yellow_full_system prompts the user to run the command under gdb
-    # instead. So we only run_under gdb if its _not_ a thunderscope debug command
-    if args.action in "run" and args.debug_build and args.run_under_gdb:
-        if (
-            "--debug_yellow_full_system" not in unknown_args
-            and "--debug_blue_full_system" not in unknown_args
-            and "--debug_simulator" not in unknown_args
-        ):
-            command += ["--run_under=gdb"]
 
     # To run the Tracy profile, enable the TRACY_ENABLE macro
     if args.tracy:


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description
Many of our members often forget to build with optimized flags, so this PR updates `./tbots.py` to use `-O3` by default, as it can improve the runtime performance significantly. It is also easy to forget in scenarios such as watching a replay, which can result in all Thunderscope dependencies to be recompiled without optimized flags, if you had previously built using it. `-o` has been removed, and now `-no` can be used instead to disable the default optimized builds if that's what you prefer.

Also updated the debug compilation flag to not default to running under GDB (an additional arg was added for being able to still run under GDB using `./tbots.py`). This should make it simpler to debug Thunderscope using a remote debugger like the one in CLion, since you can run thunderscope with `-d`, and attach a debugger to the running process once it is launched. This is much simpler than previous methods of having to run the binary manually in C++ and run Thunderscope separately.

:exclamation: Note that if you use `bazel` command manually, or build using your IDE (not in the terminal), then you will need to manually add the `--copt=-O3` argument! This change only affects use cases of the `./tbots.py` script.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Some of us have been using optimized flags for over a year now, and it works great! You can use it with debug symbols as well, however, given the compiler optimizations, not every line of your code may be hit. Personally, I havent noticed any significant change in compile time either (First time compilation took a while before, and it still does :sweat_smile:). 
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
