### PR TITLE
Minor fixes from field testing

### DIFF
--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.cpp
@@ -273,13 +273,13 @@ Angle BallPlacementPlayFSM::calculateWallKickoffAngle(const Point &ball_pos,
 
 void BallPlacementPlayFSM::setupMoveTactics(const Update &event)
 {
-    if (event.common.num_tactics <= 1)
+    // assign all but one of the robots to line up away from the ball placing robot
+    int num_move_tactics = event.common.num_tactics - 1;
+
+    if (num_move_tactics <= 0)
     {
         return;
     }
-
-    // assign all but one of the robots to line up away from the ball placing robot
-    unsigned int num_move_tactics = event.common.num_tactics - 1;
 
     move_tactics = std::vector<std::shared_ptr<PlaceBallMoveTactic>>(num_move_tactics);
     std::generate(move_tactics.begin(), move_tactics.end(),

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.cpp
@@ -273,13 +273,13 @@ Angle BallPlacementPlayFSM::calculateWallKickoffAngle(const Point &ball_pos,
 
 void BallPlacementPlayFSM::setupMoveTactics(const Update &event)
 {
-    // assign all but one of the robots to line up away from the ball placing robot
-    unsigned int num_move_tactics = event.common.num_tactics - 1;
-
-    if (num_move_tactics == 0)
+    if (event.common.num_tactics <= 1)
     {
         return;
     }
+
+    // assign all but one of the robots to line up away from the ball placing robot
+    unsigned int num_move_tactics = event.common.num_tactics - 1;
 
     move_tactics = std::vector<std::shared_ptr<PlaceBallMoveTactic>>(num_move_tactics);
     std::generate(move_tactics.begin(), move_tactics.end(),

--- a/src/software/jetson_nano/services/network/network.cpp
+++ b/src/software/jetson_nano/services/network/network.cpp
@@ -69,13 +69,6 @@ void NetworkService::primitiveSetCallback(TbotsProto::PrimitiveSet input)
     {
         primitive_set_msg = input;
     }
-
-    float primitive_set_loss_rate = primitive_tracker.getLossRate();
-    if (primitive_set_loss_rate > PROTO_LOSS_WARNING_THRESHOLD)
-    {
-        LOG(WARNING) << "Primitive set loss rate is " << primitive_set_loss_rate * 100
-                     << "%";
-    }
 }
 
 void NetworkService::logNewPrimitiveSet(const TbotsProto::PrimitiveSet& new_primitive_set)

--- a/src/software/jetson_nano/services/network/network.h
+++ b/src/software/jetson_nano/services/network/network.h
@@ -75,7 +75,6 @@ class NetworkService
     double getCurrentEpochTimeInSeconds();
 
     // Constants
-    static constexpr float PROTO_LOSS_WARNING_THRESHOLD          = 0.1f;
     static constexpr unsigned int ROBOT_STATUS_BROADCAST_RATE_HZ = 30;
     static constexpr double ROBOT_STATUS_TO_THUNDERLOOP_HZ_RATIO =
         ROBOT_STATUS_BROADCAST_RATE_HZ / (THUNDERLOOP_HZ + 1.0);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description
Some minor fixes after field testing a few days ago. One includes ball placement causing a segfault when `num_tactics == 0` due to an underflow issue with `num_tactic - 1`. The other is related to logs being spammed from the robot when we disable-enable the estop.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Changes should not affect any logic.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
