### PR TITLE
Fix transition between ball placement and free kick

### DIFF
--- a/docs/fsm-diagrams.md
+++ b/docs/fsm-diagrams.md
@@ -17,9 +17,13 @@ Stop --> SetPlay : [gameStateSetupRestart]\n<i>setupSetPlay</i>
 Playing --> Halt : [gameStateHalted]\n<i>setupHaltPlay</i>
 Playing --> Stop : [gameStateStopped]\n<i>setupStopPlay</i>
 Playing --> SetPlay : [gameStateSetupRestart]\n<i>setupSetPlay</i>
-SetPlay --> Halt : [gameStateHalted]\n<i>setupHaltPlay</i>
-SetPlay --> Stop : [gameStateStopped]\n<i>setupStopPlay</i>
-SetPlay --> Playing : [gameStatePlaying]\n<i>setupOffensePlay</i>
+SetPlay --> SetPlay : [gameStateHalted]\n<i>(resetSetPlay</i>
+setupHaltPlay_A) --> Halt
+SetPlay --> SetPlay : [gameStateStopped]\n<i>(resetSetPlay</i>
+setupStopPlay_A) --> Stop
+SetPlay --> SetPlay : [gameStatePlaying]\n<i>(resetSetPlay</i>
+setupOffensePlay_A) --> Playing
+SetPlay --> SetPlay : [gameStateSetupRestart]\n<i>setupSetPlay</i>
 Terminate:::terminate --> Terminate:::terminate
 
 ```

--- a/src/software/ai/play_selection_fsm.cpp
+++ b/src/software/ai/play_selection_fsm.cpp
@@ -14,8 +14,8 @@
 #include "software/ai/hl/stp/play/stop_play.h"
 
 
-PlaySelectionFSM::PlaySelectionFSM(TbotsProto::AiConfig ai_config) : 
-    ai_config(ai_config), current_set_play(NONE)
+PlaySelectionFSM::PlaySelectionFSM(TbotsProto::AiConfig ai_config)
+    : ai_config(ai_config), current_set_play(NONE)
 {
 }
 
@@ -125,5 +125,5 @@ void PlaySelectionFSM::setupOffensePlay(const Update& event)
 
 void PlaySelectionFSM::resetSetPlay(const Update& event)
 {
-    current_set_play = NONE;   
+    current_set_play = NONE;
 }

--- a/src/software/ai/play_selection_fsm.cpp
+++ b/src/software/ai/play_selection_fsm.cpp
@@ -15,7 +15,7 @@
 
 
 PlaySelectionFSM::PlaySelectionFSM(TbotsProto::AiConfig ai_config)
-    : ai_config(ai_config), current_set_play(NONE)
+    : ai_config(ai_config), current_set_play(std::nullopt)
 {
 }
 
@@ -43,66 +43,66 @@ void PlaySelectionFSM::setupSetPlay(const Update& event)
 {
     if (event.game_state.isOurBallPlacement())
     {
-        if (current_set_play != FRIENDLY_BALL_PLACEMENT)
+        if (current_set_play != TbotsProto::PlayName::BallPlacementPlay)
         {
-            current_set_play = FRIENDLY_BALL_PLACEMENT;
+            current_set_play = TbotsProto::PlayName::BallPlacementPlay;
             event.set_current_play(std::make_unique<BallPlacementPlay>(ai_config));
         }
     }
     else if (event.game_state.isTheirBallPlacement())
     {
-        if (current_set_play != ENEMY_BALL_PLACEMENT)
+        if (current_set_play != TbotsProto::PlayName::EnemyBallPlacementPlay)
         {
-            current_set_play = ENEMY_BALL_PLACEMENT;
+            current_set_play = TbotsProto::PlayName::EnemyBallPlacementPlay;
             event.set_current_play(std::make_unique<EnemyBallPlacementPlay>(ai_config));
         }
     }
     else if (event.game_state.isOurKickoff())
     {
-        if (current_set_play != FRIENDLY_KICKOFF)
+        if (current_set_play != TbotsProto::PlayName::KickoffFriendlyPlay)
         {
-            current_set_play = FRIENDLY_KICKOFF;
+            current_set_play = TbotsProto::PlayName::KickoffFriendlyPlay;
             event.set_current_play(std::make_unique<KickoffFriendlyPlay>(ai_config));
         }
     }
     else if (event.game_state.isTheirKickoff())
     {
-        if (current_set_play != ENEMY_KICKOFF)
+        if (current_set_play != TbotsProto::PlayName::KickoffEnemyPlay)
         {
-            current_set_play = ENEMY_KICKOFF;
+            current_set_play = TbotsProto::PlayName::KickoffEnemyPlay;
             event.set_current_play(std::make_unique<KickoffEnemyPlay>(ai_config));
         }
     }
     else if (event.game_state.isOurPenalty())
     {
-        if (current_set_play != FRIENDLY_PENALTY_KICK)
+        if (current_set_play != TbotsProto::PlayName::PenaltyKickPlay)
         {
-            current_set_play = FRIENDLY_PENALTY_KICK;
+            current_set_play = TbotsProto::PlayName::PenaltyKickPlay;
             event.set_current_play(std::make_unique<PenaltyKickPlay>(ai_config));
         }
     }
     else if (event.game_state.isTheirPenalty())
     {
-        if (current_set_play != ENEMY_PENALTY_KICK)
+        if (current_set_play != TbotsProto::PlayName::PenaltyKickEnemyPlay)
         {
-            current_set_play = ENEMY_PENALTY_KICK;
+            current_set_play = TbotsProto::PlayName::PenaltyKickEnemyPlay;
             event.set_current_play(std::make_unique<PenaltyKickEnemyPlay>(ai_config));
         }
     }
     else if (event.game_state.isOurDirectFree() || event.game_state.isOurIndirectFree())
     {
-        if (current_set_play != FRIENDLY_FREE_KICK)
+        if (current_set_play != TbotsProto::PlayName::FreeKickPlay)
         {
-            current_set_play = FRIENDLY_FREE_KICK;
+            current_set_play = TbotsProto::PlayName::FreeKickPlay;
             event.set_current_play(std::make_unique<FreeKickPlay>(ai_config));
         }
     }
     else if (event.game_state.isTheirDirectFree() ||
              event.game_state.isTheirIndirectFree())
     {
-        if (current_set_play != ENEMY_FREE_KICK)
+        if (current_set_play != TbotsProto::PlayName::EnemyFreeKickPlay)
         {
-            current_set_play = ENEMY_FREE_KICK;
+            current_set_play = TbotsProto::PlayName::EnemyFreeKickPlay;
             event.set_current_play(std::make_unique<EnemyFreeKickPlay>(ai_config));
         }
     }
@@ -125,5 +125,5 @@ void PlaySelectionFSM::setupOffensePlay(const Update& event)
 
 void PlaySelectionFSM::resetSetPlay(const Update& event)
 {
-    current_set_play = NONE;
+    current_set_play.reset();
 }

--- a/src/software/ai/play_selection_fsm.cpp
+++ b/src/software/ai/play_selection_fsm.cpp
@@ -14,8 +14,8 @@
 #include "software/ai/hl/stp/play/stop_play.h"
 
 
-PlaySelectionFSM::PlaySelectionFSM(TbotsProto::AiConfig ai_config)
-    : ai_config(ai_config), current_play(std::make_unique<HaltPlay>(ai_config))
+PlaySelectionFSM::PlaySelectionFSM(TbotsProto::AiConfig ai_config) : 
+    ai_config(ai_config), current_set_play(NONE)
 {
 }
 
@@ -41,45 +41,70 @@ bool PlaySelectionFSM::gameStateSetupRestart(const Update& event)
 
 void PlaySelectionFSM::setupSetPlay(const Update& event)
 {
-    current_play.reset();
     if (event.game_state.isOurBallPlacement())
     {
-        event.set_current_play(std::make_unique<BallPlacementPlay>(ai_config));
+        if (current_set_play != FRIENDLY_BALL_PLACEMENT)
+        {
+            current_set_play = FRIENDLY_BALL_PLACEMENT;
+            event.set_current_play(std::make_unique<BallPlacementPlay>(ai_config));
+        }
     }
-
-    if (event.game_state.isTheirBallPlacement())
+    else if (event.game_state.isTheirBallPlacement())
     {
-        event.set_current_play(std::make_unique<EnemyBallPlacementPlay>(ai_config));
+        if (current_set_play != ENEMY_BALL_PLACEMENT)
+        {
+            current_set_play = ENEMY_BALL_PLACEMENT;
+            event.set_current_play(std::make_unique<EnemyBallPlacementPlay>(ai_config));
+        }
     }
-
-    if (event.game_state.isOurKickoff())
+    else if (event.game_state.isOurKickoff())
     {
-        event.set_current_play(std::make_unique<KickoffFriendlyPlay>(ai_config));
+        if (current_set_play != FRIENDLY_KICKOFF)
+        {
+            current_set_play = FRIENDLY_KICKOFF;
+            event.set_current_play(std::make_unique<KickoffFriendlyPlay>(ai_config));
+        }
     }
-
-    if (event.game_state.isTheirKickoff())
+    else if (event.game_state.isTheirKickoff())
     {
-        event.set_current_play(std::make_unique<KickoffEnemyPlay>(ai_config));
+        if (current_set_play != ENEMY_KICKOFF)
+        {
+            current_set_play = ENEMY_KICKOFF;
+            event.set_current_play(std::make_unique<KickoffEnemyPlay>(ai_config));
+        }
     }
-
-    if (event.game_state.isOurPenalty())
+    else if (event.game_state.isOurPenalty())
     {
-        event.set_current_play(std::make_unique<PenaltyKickPlay>(ai_config));
+        if (current_set_play != FRIENDLY_PENALTY_KICK)
+        {
+            current_set_play = FRIENDLY_PENALTY_KICK;
+            event.set_current_play(std::make_unique<PenaltyKickPlay>(ai_config));
+        }
     }
-
-    if (event.game_state.isTheirPenalty())
+    else if (event.game_state.isTheirPenalty())
     {
-        event.set_current_play(std::make_unique<PenaltyKickEnemyPlay>(ai_config));
+        if (current_set_play != ENEMY_PENALTY_KICK)
+        {
+            current_set_play = ENEMY_PENALTY_KICK;
+            event.set_current_play(std::make_unique<PenaltyKickEnemyPlay>(ai_config));
+        }
     }
-
-    if (event.game_state.isOurDirectFree() || event.game_state.isOurIndirectFree())
+    else if (event.game_state.isOurDirectFree() || event.game_state.isOurIndirectFree())
     {
-        event.set_current_play(std::make_unique<FreeKickPlay>(ai_config));
+        if (current_set_play != FRIENDLY_FREE_KICK)
+        {
+            current_set_play = FRIENDLY_FREE_KICK;
+            event.set_current_play(std::make_unique<FreeKickPlay>(ai_config));
+        }
     }
-
-    if (event.game_state.isTheirDirectFree() || event.game_state.isTheirIndirectFree())
+    else if (event.game_state.isTheirDirectFree() ||
+             event.game_state.isTheirIndirectFree())
     {
-        event.set_current_play(std::make_unique<EnemyFreeKickPlay>(ai_config));
+        if (current_set_play != ENEMY_FREE_KICK)
+        {
+            current_set_play = ENEMY_FREE_KICK;
+            event.set_current_play(std::make_unique<EnemyFreeKickPlay>(ai_config));
+        }
     }
 }
 
@@ -96,4 +121,9 @@ void PlaySelectionFSM::setupHaltPlay(const Update& event)
 void PlaySelectionFSM::setupOffensePlay(const Update& event)
 {
     event.set_current_play(std::make_unique<OffensePlay>(ai_config));
+}
+
+void PlaySelectionFSM::resetSetPlay(const Update& event)
+{
+    current_set_play = NONE;   
 }

--- a/src/software/ai/play_selection_fsm.h
+++ b/src/software/ai/play_selection_fsm.h
@@ -46,25 +46,22 @@ struct PlaySelectionFSM
     bool gameStateSetupRestart(const Update& event);
 
     /**
-     * Guards for whether the play is being overridden
-     *
-     * @param event The PlaySelection::Update event
-     *
-     * @return whether the play is being overridden
-     */
-    bool playOverridden(const Update& event);
-
-    /**
      * Action to set up the OverridePlay, SetPlay, StopPlay, HaltPlay, or OffensePlay
      *
      * @param event The PlaySelection::Update event
      *
      */
-    void setupOverridePlay(Update event);
     void setupSetPlay(const Update& event);
     void setupStopPlay(const Update& event);
     void setupHaltPlay(const Update& event);
     void setupOffensePlay(const Update& event);
+
+    /**
+     * Action to reset the current SetPlay to none
+     *
+     * @param event The PlaySelection::Update event
+     */
+    void resetSetPlay(const Update& event);
 
     auto operator()()
     {
@@ -86,6 +83,7 @@ struct PlaySelectionFSM
         DEFINE_SML_ACTION(setupStopPlay)
         DEFINE_SML_ACTION(setupHaltPlay)
         DEFINE_SML_ACTION(setupOffensePlay)
+        DEFINE_SML_ACTION(resetSetPlay)
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state
@@ -110,14 +108,32 @@ struct PlaySelectionFSM
 
             // Check for transitions to other states, if not then default to running the
             // current play
-            SetPlay_S + Update_E[gameStateHalted_G] / setupHaltPlay_A     = Halt_S,
-            SetPlay_S + Update_E[gameStateStopped_G] / setupStopPlay_A    = Stop_S,
-            SetPlay_S + Update_E[gameStatePlaying_G] / setupOffensePlay_A = Playing_S,
+            SetPlay_S + Update_E[gameStateHalted_G] / (resetSetPlay_A, setupHaltPlay_A) =
+                Halt_S,
+            SetPlay_S + Update_E[gameStateStopped_G] / (resetSetPlay_A, setupStopPlay_A) =
+                Stop_S,
+            SetPlay_S + Update_E[gameStatePlaying_G] /
+                            (resetSetPlay_A, setupOffensePlay_A) = Playing_S,
+            SetPlay_S + Update_E[gameStateSetupRestart_G] / setupSetPlay_A,
 
             X + Update_E = X);
     }
 
    private:
     TbotsProto::AiConfig ai_config;
-    std::shared_ptr<Play> current_play;
+
+    enum SetPlayType
+    {
+        NONE,
+        FRIENDLY_BALL_PLACEMENT,
+        ENEMY_BALL_PLACEMENT,
+        FRIENDLY_KICKOFF,
+        ENEMY_KICKOFF,
+        FRIENDLY_PENALTY_KICK,
+        ENEMY_PENALTY_KICK,
+        FRIENDLY_FREE_KICK,
+        ENEMY_FREE_KICK,
+    };
+
+    SetPlayType current_set_play;
 };

--- a/src/software/ai/play_selection_fsm.h
+++ b/src/software/ai/play_selection_fsm.h
@@ -121,19 +121,5 @@ struct PlaySelectionFSM
 
    private:
     TbotsProto::AiConfig ai_config;
-
-    enum SetPlayType
-    {
-        NONE,
-        FRIENDLY_BALL_PLACEMENT,
-        ENEMY_BALL_PLACEMENT,
-        FRIENDLY_KICKOFF,
-        ENEMY_KICKOFF,
-        FRIENDLY_PENALTY_KICK,
-        ENEMY_PENALTY_KICK,
-        FRIENDLY_FREE_KICK,
-        ENEMY_FREE_KICK,
-    };
-
-    SetPlayType current_set_play;
+    std::optional<TbotsProto::PlayName> current_set_play;
 };


### PR DESCRIPTION
### Description

Fixes broken transitions between SetPlays in `PlaySelectionFSM` (notably, ball placement to free kick). This PR adds an internal transition for `SetPlay_S` and updates `setupSetPlay` to only construct a new SetPlay if it is not already the current play.

### Testing Done

Added test in `play_selection_fsm_test.cpp`

### Resolved Issues

Resolves #3237 

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
