### PR TITLE
Fix missing trajectory planner sub-destination distance

### DIFF
--- a/src/software/ai/navigator/trajectory/trajectory_planner.h
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.h
@@ -142,8 +142,8 @@ class TrajectoryPlanner
     static std::vector<Vector> getRelativeSubDestinations();
 
     const std::vector<Vector> relative_sub_destinations;
-    static constexpr std::array<double, 4> SUB_DESTINATION_DISTANCES_METERS = {1.1, 2.3,
-                                                                               3};
+    static constexpr std::array<double, 4> SUB_DESTINATION_DISTANCES_METERS = {0.4, 1.1,
+                                                                               2.3, 3};
     static constexpr unsigned int NUM_SUB_DESTINATION_ANGLES                = 16;
     static constexpr Angle MIN_SUB_DESTINATION_ANGLE = Angle::fromDegrees(20);
     static constexpr Angle MAX_SUB_DESTINATION_ANGLE = Angle::fromDegrees(140);


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description
Oops. I removed an element from `SUB_DESTINATION_DISTANCES_METERS` a while ago, and forgot to decrease the `std::array` size, so a sub-destination distance of 0 was also being considered. Given some recent testing, I've seen some edge cases where the robot is trying to move around a small obstacle (e.g. Avoid ball obstacle) and it draws a large trajectory around it, so for now I've decided to add back a distance. In the future, if we wanted to improve the trajectory planner's performance, we could also just remove it again and actually reduce the array size to 3, since it seems like we've been fine with the 3 distances as well.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Ran AI vs AI again
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
