### PR TITLE
Optimize replay mode seek bar stuttering

### DIFF
--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -138,7 +138,7 @@ class ProtoPlayer:
         Build the chunk index and store the index into the index file
 
         NOTE:
-        A chunk index entry contains (start timestamp, end timestamp, filename)
+        A chunk index entry is a key value pair [filename: (start timestamp, end timestamp)]
         Start timestamp: timestamp of the first log entry in the chunk
         End timestamp: timestamp of the last log entry in the chunk
         Filename: chunk file name (%d.reply)
@@ -166,9 +166,19 @@ class ProtoPlayer:
 
 
     def is_chunk_indexed(self) -> bool:
+        """
+        Returns true if the chunk index is already built.
+
+        :return: if the chunk index file exists
+        """
         return os.path.exists(os.path.join(self.log_folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME))
 
     def load_chunk_index(self) -> dict[str: tuple[float, float]]:
+        """
+        Loads the chunk index file.
+
+        :return: the chunk indices.
+        """
         chunk_indices: dict[str: tuple[float, float]] = dict()
         try:
             with open(os.path.join(self.log_folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME), 'r') as index_file:
@@ -187,6 +197,12 @@ class ProtoPlayer:
         return chunk_indices
 
     def get_chunk_index(self) -> dict[str: tuple[float, float]]:
+        """
+        Returns the chunk indices.
+        NOTE: if the chunk index was not built, this function will automatically build one.
+
+        :return: chunk indices.
+        """
         if not self.is_chunk_indexed():
             return self.build_chunk_index()
         else:

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -157,7 +157,7 @@ class ProtoPlayer:
             with open(os.path.join(self.log_folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME), 'w') as index_file:
                 index_file.write(f'Generated on {time.time()}\n')
                 for key, value in chunk_indices.items():
-                    index_file.write(f'{value[0]}, {value[1]}, {key}\n')
+                    index_file.write(f'{value}, {key}\n')
             logging.info('Created chunk index file successfully.')
         else:
             logging.warning(f'Failed to build chunk index for {self.log_folder_path}')

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -144,7 +144,7 @@ class ProtoPlayer:
         ----
         A chunk index entry is a key value pair [filename: start timestamp]
          - Start timestamp: timestamp of the first log entry in the chunk
-         - Filename: replay chunk file name (%d.reply)
+         - Filename: replay chunk file name (%d.replay)
 
         :param folder_path: folder containing all the replay files
 

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -171,7 +171,9 @@ class ProtoPlayer:
             except Exception as e:
                 logging.warning(f"Failed to build chunk index for {folder_path}: {e}")
         else:
-            logging.warning(f"Failed to build chunk index for {folder_path} : No chunk data.")
+            logging.warning(
+                f"Failed to build chunk index for {folder_path} : No chunk data."
+            )
         return chunk_indices
 
     def is_chunk_indexed(self) -> bool:

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -43,7 +43,7 @@ class ProtoPlayer:
     """
 
     PLAY_PAUSE_POLL_INTERVAL_SECONDS = 0.1
-    CHUNK_INDEX_FILENAME = 'chunks.index'
+    CHUNK_INDEX_FILENAME = "chunks.index"
 
     def __init__(self, log_folder_path: str, proto_unix_io: ProtoUnixIO) -> None:
         """Creates a proto player that plays back all protos
@@ -134,11 +134,11 @@ class ProtoPlayer:
         except Exception:
             return True
 
-    def build_chunk_index(self, folder_path: str) -> dict[str: float]:
-        """
-        Build the chunk index and store the index into the index file
+    def build_chunk_index(self, folder_path: str) -> dict[str:float]:
+        """Build the chunk index and store the index into the index file
 
-        NOTE:
+        Note:
+        ----
         A chunk index entry is a key value pair [filename: start timestamp]
          - Start timestamp: timestamp of the first log entry in the chunk
          - Filename: replay chunk file name (%d.reply)
@@ -147,48 +147,53 @@ class ProtoPlayer:
 
         :return: a dictionary for mapping replay filename to the start
             timestamp of the first entry in the chunk.
+
         """
-        chunk_indices: dict[str: float] = dict()
+        chunk_indices: dict[str:float] = dict()
         for chunk_name in self.sorted_chunks:
-            chunk_data = ProtoPlayer.load_replay_chunk(
-                chunk_name, self.version
-            )
+            chunk_data = ProtoPlayer.load_replay_chunk(chunk_name, self.version)
             if chunk_data:
-                start_timestamp, _, _ = ProtoPlayer.unpack_log_entry(chunk_data[0], self.version)
+                start_timestamp, _, _ = ProtoPlayer.unpack_log_entry(
+                    chunk_data[0], self.version
+                )
                 chunk_indices[os.path.basename(chunk_name)] = start_timestamp
         if chunk_indices:
-            with open(os.path.join(folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME), 'w') as index_file:
-                index_file.write(f'Generated on {time.time()}\n')
+            with open(
+                os.path.join(folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME), "w"
+            ) as index_file:
+                index_file.write(f"Generated on {time.time()}\n")
                 for key, value in chunk_indices.items():
-                    index_file.write(f'{value}, {key}\n')
-            logging.info('Created chunk index file successfully.')
+                    index_file.write(f"{value}, {key}\n")
+            logging.info("Created chunk index file successfully.")
         else:
-            logging.warning(f'Failed to build chunk index for {folder_path}')
+            logging.warning(f"Failed to build chunk index for {folder_path}")
         return chunk_indices
 
-
     def is_chunk_indexed(self) -> bool:
-        """
-        Returns true if the chunk index is already built.
+        """Returns true if the chunk index is already built.
 
         :return: if the chunk index file exists
         """
-        return os.path.exists(os.path.join(self.log_folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME))
+        return os.path.exists(
+            os.path.join(self.log_folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME)
+        )
 
-    def load_chunk_index(self) -> dict[str: float]:
-        """
-        Loads the chunk index file.
+    def load_chunk_index(self) -> dict[str:float]:
+        """Loads the chunk index file.
 
         :return: the chunk indices.
         """
-        chunk_indices: dict[str: float] = dict()
+        chunk_indices: dict[str:float] = dict()
         try:
-            with open(os.path.join(self.log_folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME), 'r') as index_file:
+            with open(
+                os.path.join(self.log_folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME),
+                "r",
+            ) as index_file:
                 # skip the first timestamp line
                 index_file.readline()
 
                 for line in index_file:
-                    start_timestamp, chunk_name = line.split(',')
+                    start_timestamp, chunk_name = line.split(",")
                     start_timestamp = float(start_timestamp)
                     chunk_name = chunk_name.strip()
                     chunk_indices[chunk_name] = start_timestamp
@@ -197,9 +202,8 @@ class ProtoPlayer:
             logging.warning(f"An Exception occurred when loading chunk index file {e}")
         return chunk_indices
 
-    def get_chunk_index(self) -> dict[str: float]:
-        """
-        Returns the chunk indices.
+    def get_chunk_index(self) -> dict[str:float]:
+        """Returns the chunk indices.
         NOTE: if the chunk index was not built, this function will automatically build one.
 
         :return: chunk indices.
@@ -210,9 +214,10 @@ class ProtoPlayer:
             try:
                 return self.load_chunk_index()
             except Exception as e:
-                logging.log(f"Exception occurred when loading chunk index, trying to rebuild. Message: {e}")
+                logging.log(
+                    f"Exception occurred when loading chunk index, trying to rebuild. Message: {e}"
+                )
                 return self.build_chunk_index(self.log_folder_path)
-
 
     def is_proto_player_playing(self) -> bool:
         """Return whether or not the proto player is being played.
@@ -415,7 +420,7 @@ class ProtoPlayer:
                         logging.info("Clip saved!")
                         self.build_chunk_index(directory)
                         return
-            # Load the next chunk
+                # Load the next chunk
                 self.current_chunk_index += 1
                 replay_index += 1
 
@@ -508,12 +513,14 @@ class ProtoPlayer:
                 return self.chunks_indices[os.path.basename(chunk)]
             else:
                 logging.warning(
-                   f"Use old algorithm to jump, which might result in lagging " +
-                   f"Please try deleting {ProtoPlayer.CHUNK_INDEX_FILENAME} in the replay file folder" +
-                   f" and re-run Thunderscope to enable the indexing for faster speed!"
+                    "Use old algorithm to jump, which might result in lagging "
+                    + f"Please try deleting {ProtoPlayer.CHUNK_INDEX_FILENAME} in the replay file folder"
+                    + " and re-run Thunderscope to enable the indexing for faster speed!"
                 )
                 chunk = ProtoPlayer.load_replay_chunk(chunk, self.version)
-                start_timestamp, _, _ = ProtoPlayer.unpack_log_entry(chunk[0], self.version)
+                start_timestamp, _, _ = ProtoPlayer.unpack_log_entry(
+                    chunk[0], self.version
+                )
                 return start_timestamp
 
         with self.replay_controls_mutex:

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -115,7 +115,7 @@ class ProtoPlayer:
             )
 
         # Sort the files by their chunk index
-        def __sort_replay_chunks(file_path: str):
+        def __sort_replay_chunks(file_path: os.PathLike):
             head, tail = os.path.split(file_path)
             replay_index, _ = tail.split(".")
             return int(replay_index)
@@ -160,15 +160,18 @@ class ProtoPlayer:
                 )
                 chunk_indices[os.path.basename(chunk_name)] = start_timestamp
         if chunk_indices:
-            with open(
-                os.path.join(folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME), "w"
-            ) as index_file:
-                index_file.write(f"Generated on {time.time()}\n")
-                for filename, start_timestamp in chunk_indices.items():
-                    index_file.write(f"{start_timestamp}, {filename}\n")
-            logging.info("Created chunk index file successfully.")
+            try:
+                with open(
+                    os.path.join(folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME), "w"
+                ) as index_file:
+                    index_file.write(f"Generated on {time.time()}\n")
+                    for filename, start_timestamp in chunk_indices.items():
+                        index_file.write(f"{start_timestamp}, {filename}\n")
+                logging.info("Created chunk index file successfully.")
+            except Exception as e:
+                logging.warning(f"Failed to build chunk index for {folder_path}: {e}")
         else:
-            logging.warning(f"Failed to build chunk index for {folder_path}")
+            logging.warning(f"Failed to build chunk index for {folder_path} : No chunk data.")
         return chunk_indices
 
     def is_chunk_indexed(self) -> bool:

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -13,7 +13,7 @@ from software.thunderscope.constants import ProtoPlayerFlags
 from software.thunderscope.proto_unix_io import ProtoUnixIO
 import software.python_bindings as tbots_cpp
 from google.protobuf.message import Message
-from typing import Callable, Type, List
+from typing import Callable, Type
 
 
 class ProtoPlayer:

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -191,7 +191,7 @@ class ProtoPlayer:
                     end_timestamp = float(end_timestamp)
                     chunk_name = chunk_name.strip()
                     chunk_indices[chunk_name] = (start_timestamp, end_timestamp)
-            logging.info("Pre-existing chunk index file found and loaded." + str(chunk_indices))
+            logging.info("Pre-existing chunk index file found and loaded.")
         except Exception as e:
             logging.warning(f"An Exception occurred when loading chunk index file {e}")
         return chunk_indices

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -411,8 +411,9 @@ class ProtoPlayer:
                     self.current_entry_index += 1
                     if self.current_packet_time >= end_time:
                         logging.info("Clip saved!")
+                        self.build_chunk_index()
                         return
-                # Load the next chunk
+            # Load the next chunk
                 self.current_chunk_index += 1
                 replay_index += 1
 

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -497,8 +497,13 @@ class ProtoPlayer:
         # to seek to.
         def __bisect_chunks_by_timestamp(chunk: str) -> None:
             if self.chunks_indices and os.path.basename(chunk) in self.chunks_indices:
-                return self.chunks_indices[os.path.basename(chunk)][0]
+                return self.chunks_indices[os.path.basename(chunk)]
             else:
+                logging.warning(
+                   f"Use old algorithm to jump, which might result in lagging " +
+                   f"Please try deleting {ProtoPlayer.CHUNK_INDEX_FILENAME} in the replay file folder" +
+                   f" and re-run Thunderscope to enable the indexing for faster speed!"
+                )
                 chunk = ProtoPlayer.load_replay_chunk(chunk, self.version)
                 start_timestamp, _, _ = ProtoPlayer.unpack_log_entry(chunk[0], self.version)
                 return start_timestamp

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -104,7 +104,7 @@ class ProtoPlayer:
         :return: the sorted replay files
         """
         # Load up all replay files in the log folder
-        replay_files = glob.glob(os.path.join(log_folder_path, f"/*.{REPLAY_FILE_EXTENSION}"))
+        replay_files = glob.glob(f"{log_folder_path}/*.{REPLAY_FILE_EXTENSION}")
 
         if len(replay_files) == 0:
             raise ValueError(

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -165,8 +165,10 @@ class ProtoPlayer:
                 with open(
                     os.path.join(folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME), "w"
                 ) as index_file:
-                    index_file.write(f"Version: {ProtoPlayer.CHUNK_INDEX_FILE_VERSION}, "
-                                     f"Generated on {time.time():.0f}\n")
+                    index_file.write(
+                        f"Version: {ProtoPlayer.CHUNK_INDEX_FILE_VERSION}, "
+                        f"Generated on {time.time():.0f}\n"
+                    )
                     for filename, start_timestamp in chunk_indices.items():
                         index_file.write(f"{start_timestamp}, {filename}\n")
                 logging.info("Created chunk index file successfully.")

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -44,6 +44,7 @@ class ProtoPlayer:
 
     PLAY_PAUSE_POLL_INTERVAL_SECONDS = 0.1
     CHUNK_INDEX_FILENAME = "chunks.index"
+    CHUNK_INDEX_FILE_VERSION = 1
 
     def __init__(
         self, log_folder_path: os.PathLike, proto_unix_io: ProtoUnixIO
@@ -164,7 +165,8 @@ class ProtoPlayer:
                 with open(
                     os.path.join(folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME), "w"
                 ) as index_file:
-                    index_file.write(f"Generated on {time.time()}\n")
+                    index_file.write(f"Version: {ProtoPlayer.CHUNK_INDEX_FILE_VERSION}, "
+                                     f"Generated on {time.time():.0f}\n")
                     for filename, start_timestamp in chunk_indices.items():
                         index_file.write(f"{start_timestamp}, {filename}\n")
                 logging.info("Created chunk index file successfully.")

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -134,16 +134,17 @@ class ProtoPlayer:
         except Exception:
             return True
 
-    def build_chunk_index(self) -> dict[str: tuple[float, float]]:
+    def build_chunk_index(self) -> dict[str: float]:
         """
         Build the chunk index and store the index into the index file
 
         NOTE:
         A chunk index entry is a key value pair [filename: start timestamp]
-        Start timestamp: timestamp of the first log entry in the chunk
-        Filename: chunk file name (%d.reply)
+         - Start timestamp: timestamp of the first log entry in the chunk
+         - Filename: replay chunk file name (%d.reply)
 
-        :return: list of chunk index file entry
+        :return: a dictionary for mapping replay filename to the start
+            timestamp of the first entry in the chunk.
         """
         chunk_indices: dict[str: float] = dict()
         for chunk_name in self.sorted_chunks:
@@ -172,7 +173,7 @@ class ProtoPlayer:
         """
         return os.path.exists(os.path.join(self.log_folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME))
 
-    def load_chunk_index(self) -> dict[str: tuple[float]]:
+    def load_chunk_index(self) -> dict[str: float]:
         """
         Loads the chunk index file.
 
@@ -194,7 +195,7 @@ class ProtoPlayer:
             logging.warning(f"An Exception occurred when loading chunk index file {e}")
         return chunk_indices
 
-    def get_chunk_index(self) -> dict[str: tuple[float, float]]:
+    def get_chunk_index(self) -> dict[str: float]:
         """
         Returns the chunk indices.
         NOTE: if the chunk index was not built, this function will automatically build one.
@@ -204,7 +205,11 @@ class ProtoPlayer:
         if not self.is_chunk_indexed():
             return self.build_chunk_index()
         else:
-            return self.load_chunk_index()
+            try:
+                return self.load_chunk_index()
+            except Exception as e:
+                logging.log(f"Exception occurred when loading chunk index, trying to rebuild. Message: {e}")
+                return self.build_chunk_index()
 
 
     def is_proto_player_playing(self) -> bool:

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -157,9 +157,9 @@ class ProtoPlayer:
         if chunk_indices:
             with open(os.path.join(self.log_folder_path, ProtoPlayer.CHUNK_INDEX_FILENAME), 'w') as index_file:
                 index_file.write(f'Generated on {time.time()}\n')
-                for key, value in chunk_indices:
+                for key, value in chunk_indices.items():
                     index_file.write(f'{value[0]}, {value[1]}, {key}\n')
-            logging.info('Wrote chunk index files')
+            logging.info('Created chunk index file successfully.')
         else:
             logging.warning(f'Failed to build chunk index for {self.log_folder_path}')
         return chunk_indices

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -77,6 +77,7 @@ class ProtoPlayer:
             self.sorted_chunks[0]
         )
 
+        # build or load index for chunks
         self.chunks_indices = self.get_chunk_index()
 
         # We can get the total runtime of the log from the last entry in the last chunk

--- a/src/software/thunderscope/replay/proto_player.py
+++ b/src/software/thunderscope/replay/proto_player.py
@@ -45,7 +45,9 @@ class ProtoPlayer:
     PLAY_PAUSE_POLL_INTERVAL_SECONDS = 0.1
     CHUNK_INDEX_FILENAME = "chunks.index"
 
-    def __init__(self, log_folder_path: os.PathLike, proto_unix_io: ProtoUnixIO) -> None:
+    def __init__(
+        self, log_folder_path: os.PathLike, proto_unix_io: ProtoUnixIO
+    ) -> None:
         """Creates a proto player that plays back all protos
 
         :param log_folder_path: The path to the log file.

--- a/src/software/thunderscope/replay/test/BUILD
+++ b/src/software/thunderscope/replay/test/BUILD
@@ -23,18 +23,18 @@ py_test(
 py_test(
     name = "replay_indexing_test",
     srcs = [
-        "replay_indexing_test.py"
+        "replay_indexing_test.py",
     ],
     data = [
-        "//software:py_constants.so"
+        "//software:py_constants.so",
     ],
     deps = [
-            "//extlibs/er_force_sim/src/protobuf:erforce_py_proto",
-            "//proto:import_all_protos",
-            "//software:conftest",
-            "//software/thunderscope:proto_unix_io",
-            "//software/thunderscope/replay:proto_player",
-            "//software/thunderscope/replay/test:replay_corruption_test",
-            requirement("pytest"),
+        "//extlibs/er_force_sim/src/protobuf:erforce_py_proto",
+        "//proto:import_all_protos",
+        "//software:conftest",
+        "//software/thunderscope:proto_unix_io",
+        "//software/thunderscope/replay:proto_player",
+        "//software/thunderscope/replay/test:replay_corruption_test",
+        requirement("pytest"),
     ],
 )

--- a/src/software/thunderscope/replay/test/BUILD
+++ b/src/software/thunderscope/replay/test/BUILD
@@ -19,3 +19,22 @@ py_test(
         requirement("pytest"),
     ],
 )
+
+py_test(
+    name = "replay_indexing_test",
+    srcs = [
+        "replay_indexing_test.py"
+    ],
+    data = [
+        "//software:py_constants.so"
+    ],
+    deps = [
+            "//extlibs/er_force_sim/src/protobuf:erforce_py_proto",
+            "//proto:import_all_protos",
+            "//software:conftest",
+            "//software/thunderscope:proto_unix_io",
+            "//software/thunderscope/replay:proto_player",
+            "//software/thunderscope/replay/test:replay_corruption_test",
+            requirement("pytest"),
+    ],
+)

--- a/src/software/thunderscope/replay/test/replay_corruption_test.py
+++ b/src/software/thunderscope/replay/test/replay_corruption_test.py
@@ -9,7 +9,7 @@ Steps to test:
     2. we create invalid entries of two type: the data is actually corrupted, and we are missing a delimiter. We
         mixed those replay entries with valid replay entries to check if proto player could actually player those
         entries
-    3. we check to see if there are uncaught exception. If there are, we know fore sure proto player wouldn't work!
+    3. we check to see if there are uncaught exception. If there are, we know for sure proto player wouldn't work!
 """
 
 import time
@@ -94,7 +94,7 @@ def make_part_replay_chunks(
     save_path: str,
     duration: float,
     start_time: float,
-    gen_log_entry_func: Callable[[Message, float], None],
+    gen_log_entry_func: Callable[[Message, float], str],
     frequency=0.1,
 ):
     """Making a part of the replay chunks and appending it to the 0.replay file.

--- a/src/software/thunderscope/replay/test/replay_corruption_test.py
+++ b/src/software/thunderscope/replay/test/replay_corruption_test.py
@@ -9,7 +9,7 @@ Steps to test:
     2. we create invalid entries of two type: the data is actually corrupted, and we are missing a delimiter. We
         mixed those replay entries with valid replay entries to check if proto player could actually player those
         entries
-    4. we check to see if there are uncaught exception. If there are, we know fore sure proto player wouldn't work!
+    3. we check to see if there are uncaught exception. If there are, we know fore sure proto player wouldn't work!
 """
 
 import time

--- a/src/software/thunderscope/replay/test/replay_indexing_test.py
+++ b/src/software/thunderscope/replay/test/replay_indexing_test.py
@@ -1,8 +1,8 @@
-"""
-This test is for testing the chunk indexing function of the proto player.
+"""This test is for testing the chunk indexing function of the proto player.
 We are going to examine the index-building and index-loading functions.
 Those functions are first introduced to optimize the response time of the progress bar in the replay mode.
 """
+
 from typing import Callable
 import math
 import shutil
@@ -14,7 +14,10 @@ from software.py_constants import *
 from software.thunderscope.replay.proto_player import ProtoPlayer
 from software.thunderscope.proto_unix_io import ProtoUnixIO
 from software.simulated_tests.simulated_test_fixture import pytest_main
-from software.thunderscope.replay.test.replay_corruption_test import create_valid_log_entry, create_random_proto
+from software.thunderscope.replay.test.replay_corruption_test import (
+    create_valid_log_entry,
+    create_random_proto,
+)
 
 # location to store the generated files
 TMP_REPLAY_SAVE_PATH = "/tmp/test_indexing"
@@ -28,27 +31,28 @@ ENTRY_NUM_PER_FILE = 100
 # length of time that every chunk represents
 DURATION_PER_CHUNK = 5
 
+
 def create_test_player() -> ProtoPlayer:
-    """
-    Create a dummy protoplayer for testing
+    """Create a dummy protoplayer for testing
     :return: a protoplayer for testing
     """
     return ProtoPlayer(TMP_REPLAY_SAVE_PATH, ProtoUnixIO())
+
 
 def cleanup():
     """Clean up this test by deleting the replay files generated"""
     shutil.rmtree(TMP_REPLAY_SAVE_PATH)
 
+
 def generate_chunk(
-        list_of_protos: [Message],
-        save_path: str,
-        filename: str,
-        duration: float,
-        start_time: float,
-        gen_log_entry_func: Callable[[Message, float], str]
+    list_of_protos: [Message],
+    save_path: str,
+    filename: str,
+    duration: float,
+    start_time: float,
+    gen_log_entry_func: Callable[[Message, float], str],
 ):
-    """
-    Generate one replay chunk for testing.
+    """Generate one replay chunk for testing.
 
     :param list_of_protos: the list of proto being referenced when generating log entries
     :param save_path: directory for saving the chunk file
@@ -68,8 +72,7 @@ def generate_chunk(
 
 
 def test_for_building_index_on_valid_chunks():
-    """
-    Test building index file on correctly formatted replay files
+    """Test building index file on correctly formatted replay files
 
     Test steps:
     1. generate correctly formatted replay files (chunks)
@@ -88,7 +91,7 @@ def test_for_building_index_on_valid_chunks():
             f"{i}.replay",
             DURATION_PER_CHUNK,
             DURATION_PER_CHUNK * i,
-            create_valid_log_entry
+            create_valid_log_entry,
         )
 
     player = create_test_player()
@@ -119,5 +122,5 @@ def test_for_building_index_on_valid_chunks():
     cleanup()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest_main(__file__)

--- a/src/software/thunderscope/replay/test/replay_indexing_test.py
+++ b/src/software/thunderscope/replay/test/replay_indexing_test.py
@@ -94,7 +94,7 @@ def test_for_building_index_on_valid_chunks():
     player = create_test_player()
 
     # generate chunk index file
-    player.build_chunk_index()
+    player.build_chunk_index(player.log_folder_path)
 
     # validate index with load index function
     chunk_indices = player.load_chunk_index()

--- a/src/software/thunderscope/replay/test/replay_indexing_test.py
+++ b/src/software/thunderscope/replay/test/replay_indexing_test.py
@@ -101,9 +101,9 @@ def test_for_building_index_on_valid_chunks():
     # validate index with load index function
     chunk_indices = player.load_chunk_index()
     assert len(chunk_indices) == CHUNK_FILES_NUM
-    for filename, period in chunk_indices.items():
+    for filename, start_timestamp in chunk_indices.items():
         index_of_file = int(filename.replace(".replay", ""))
-        assert period[0] - 0.05 <= index_of_file * DURATION_PER_CHUNK
+        assert start_timestamp - 0.05 <= index_of_file * DURATION_PER_CHUNK
 
     # test seeking a timestamp
     # jump to the beginning of the chunk

--- a/src/software/thunderscope/replay/test/replay_indexing_test.py
+++ b/src/software/thunderscope/replay/test/replay_indexing_test.py
@@ -46,7 +46,7 @@ def cleanup():
 
 def generate_chunk(
     list_of_protos: [Message],
-    save_path: str,
+    save_path: os.PathLike,
     filename: str,
     duration: float,
     start_time: float,

--- a/src/software/thunderscope/replay/test/replay_indexing_test.py
+++ b/src/software/thunderscope/replay/test/replay_indexing_test.py
@@ -1,0 +1,129 @@
+"""
+This test is for testing the chunk indexing function of the proto player.
+We are going to examine the index-building and index-loading functions.
+Those functions are first introduced to optimize the response time of the progress bar in the replay mode.
+"""
+import time
+from typing import Callable
+import random
+import shutil
+import gzip
+import os
+from google.protobuf.message import Message
+from software.py_constants import *
+
+from software.thunderscope.constants import ProtoPlayerFlags
+from software.thunderscope.replay.proto_player import ProtoPlayer
+from software.thunderscope.proto_unix_io import ProtoUnixIO
+from software.simulated_tests.simulated_test_fixture import pytest_main
+from software.thunderscope.replay.test.replay_corruption_test import create_valid_log_entry, create_random_proto
+
+random.seed(0)
+
+# location to store the generated files
+TMP_REPLAY_SAVE_PATH = "/tmp/test_indexing"
+
+# number of chunk files being generated
+CHUNK_FILES_NUM = 100
+
+# number of entries per replay file
+ENTRY_NUM_PER_FILE = 100
+
+# length of time that every chunk represents
+DURATION_PER_CHUNK = 5
+
+def create_test_player() -> ProtoPlayer:
+    """
+    Create a dummy protoplayer for testing
+    :return: a protoplayer for testing
+    """
+    return ProtoPlayer(TMP_REPLAY_SAVE_PATH, ProtoUnixIO())
+
+def cleanup():
+    """Clean up this test by deleting the replay files generated"""
+    shutil.rmtree(TMP_REPLAY_SAVE_PATH)
+
+def generate_chunk(
+        list_of_protos: [Message],
+        save_path: str,
+        filename: str,
+        duration: float,
+        start_time: float,
+        gen_log_entry_func: Callable[[Message, float], str]
+):
+    """
+    Generate one replay chunk for testing.
+
+    :param list_of_protos: the list of proto being referenced when generating log entries
+    :param save_path: directory for saving the chunk file
+    :param filename: the name of the chunk file
+    :param duration: the length of the chunk (in seconds)
+    :param start_time: the start time (in seconds)
+    :param gen_log_entry_func: function used to generate log entries
+    """
+    os.makedirs(save_path, exist_ok=True)
+    path_to_replay_file = os.path.join(save_path, filename)
+
+    with gzip.open(path_to_replay_file, "wb") as log_file:
+        for i, proto in enumerate(list_of_protos):
+            proto_time = start_time + duration / len(list_of_protos) * i
+            log_entry = gen_log_entry_func(proto, proto_time)
+            log_file.write(bytes(log_entry, encoding="utf-8"))
+
+
+def test_for_building_index_on_valid_chunks():
+    """
+    Test building index file on correctly formatted replay files
+
+    Test steps:
+    1. generate correctly formatted replay files (chunks)
+    2. Build index files
+    3. Load index into memory and validate
+    3. Test ProtoPlayer.seek() to check if it can jump correctly to the proper chunk
+    """
+    # generate correctly formatted replay files
+    replay_proto = []
+    for _ in range(ENTRY_NUM_PER_FILE):
+        replay_proto.append(create_random_proto())
+    for i in range(CHUNK_FILES_NUM):
+        generate_chunk(
+            replay_proto,
+            TMP_REPLAY_SAVE_PATH,
+            f"{i}.replay",
+            DURATION_PER_CHUNK,
+            DURATION_PER_CHUNK * i,
+            create_valid_log_entry
+        )
+
+    player = create_test_player()
+
+    # generate chunk index file
+    player.build_chunk_index()
+
+    # validate index with load index function
+    chunk_indices = player.load_chunk_index()
+    assert len(chunk_indices) == CHUNK_FILES_NUM
+    for filename, period in chunk_indices.items():
+        index_of_file = int(filename.replace(".replay", ""))
+        assert period[0] - 0.05 <= index_of_file * DURATION_PER_CHUNK
+
+    # test seeking a timestamp
+    # jump to the beginning of the chunk
+    for i in range(CHUNK_FILES_NUM):
+        player.seek(i * DURATION_PER_CHUNK)
+        assert player.current_chunk_index == i
+
+    # jump to the middle of the chunk
+    for i in range(CHUNK_FILES_NUM):
+        player.seek(i * DURATION_PER_CHUNK + DURATION_PER_CHUNK / 2)
+        assert player.current_chunk_index == i
+
+    # jump to the ending of the chunk
+    for i in range(CHUNK_FILES_NUM):
+        player.seek(i * DURATION_PER_CHUNK + DURATION_PER_CHUNK - 0.05)
+        assert player.current_chunk_index == i
+    cleanup()
+
+
+if __name__ == '__main__':
+    pytest_main(__file__)

--- a/src/software/thunderscope/replay/test/replay_indexing_test.py
+++ b/src/software/thunderscope/replay/test/replay_indexing_test.py
@@ -98,7 +98,6 @@ def test_for_building_index_on_valid_chunks():
 
     # validate index with load index function
     chunk_indices = player.load_chunk_index()
-    print(chunk_indices)
     assert len(chunk_indices) == CHUNK_FILES_NUM
     assert player.chunks_indices
     for filename, start_timestamp in chunk_indices.items():

--- a/src/software/thunderscope/replay/test/replay_indexing_test.py
+++ b/src/software/thunderscope/replay/test/replay_indexing_test.py
@@ -3,7 +3,6 @@ This test is for testing the chunk indexing function of the proto player.
 We are going to examine the index-building and index-loading functions.
 Those functions are first introduced to optimize the response time of the progress bar in the replay mode.
 """
-import time
 from typing import Callable
 import random
 import shutil
@@ -12,7 +11,6 @@ import os
 from google.protobuf.message import Message
 from software.py_constants import *
 
-from software.thunderscope.constants import ProtoPlayerFlags
 from software.thunderscope.replay.proto_player import ProtoPlayer
 from software.thunderscope.proto_unix_io import ProtoUnixIO
 from software.simulated_tests.simulated_test_fixture import pytest_main


### PR DESCRIPTION
### Description
As stated in #3288, thunderscope was frozen for a few seconds when the user drags the seek bar.
This PR is introduced to reduce lagging.

### Testing Done

- replay_indexing_test.py passed
- replay_corruption_test.py passed
- Thunderscope run
- Manually run thunderscope and it's not frozen when dragging the seek bar
- Waiting for GitHub CI

### Resolved Issues

resolves #3288


### Investigation Details & Solution
_ProtoPlayer_ uses a binary search to search through all the replay chunks to figure out which chunk file contains the given timestamp. However, every time the binary search is performed, the program decompresses log(n) files (where n is the total number of replay files in the folder). This is a sequence of time-consuming IO operations. Please see the following code. This function is used as the _key_ for the binary search.
https://github.com/UBC-Thunderbots/Software/blob/bc475ca6932cd3335ec82477d17f10b8eaa710d9/src/software/thunderscope/replay/proto_player.py#L421-L424

This PR introduced a pre-built index file, "chunks.index" to avoid this massive IO operations. "chunks.index" keeps track of all the start timestamps of the first entry in *.replay files, and it is only time-consuming when it is generated for the first time. With this chunk index, we can make sure that jumping to another time point, only one decompressing IO operation is performed.

### Review Checklist


**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue