### PR TITLE
Final_speed and Target_spins_per_s

### DIFF
--- a/src/proto/tactic.proto
+++ b/src/proto/tactic.proto
@@ -124,7 +124,7 @@ message MoveTactic
     required Point destination = 1;
     // The orientation the robot should have when it arrives at its destination
     required Angle final_orientation = 2;
-    // 3 reserved field number
+    reserved 3, 8;
     // How to run the dribbler
     required DribblerMode dribbler_mode = 4;
     // How to navigate around the ball

--- a/src/proto/tactic.proto
+++ b/src/proto/tactic.proto
@@ -133,7 +133,6 @@ message MoveTactic
     required AutoChipOrKick auto_chip_or_kick = 6;
     // The maximum allowed speed mode
     required MaxAllowedSpeedMode max_allowed_speed_mode = 7;
-    // 8 Reserved field number
     // The obstacle avoidance mode to use while moving
     required ObstacleAvoidanceMode obstacle_avoidance_mode = 9;
 }

--- a/src/proto/tactic.proto
+++ b/src/proto/tactic.proto
@@ -124,8 +124,6 @@ message MoveTactic
     required Point destination = 1;
     // The orientation the robot should have when it arrives at its destination
     required Angle final_orientation = 2;
-    // The speed the robot should have when it arrives at its destination
-    required double final_speed = 3;
     // How to run the dribbler
     required DribblerMode dribbler_mode = 4;
     // How to navigate around the ball
@@ -134,8 +132,6 @@ message MoveTactic
     required AutoChipOrKick auto_chip_or_kick = 6;
     // The maximum allowed speed mode
     required MaxAllowedSpeedMode max_allowed_speed_mode = 7;
-    // The target spin while moving in revolutions per second
-    required double target_spin_rev_per_s = 8;
     // The obstacle avoidance mode to use while moving
     required ObstacleAvoidanceMode obstacle_avoidance_mode = 9;
 }

--- a/src/proto/tactic.proto
+++ b/src/proto/tactic.proto
@@ -124,6 +124,7 @@ message MoveTactic
     required Point destination = 1;
     // The orientation the robot should have when it arrives at its destination
     required Angle final_orientation = 2;
+    // 3 reserved field number
     // How to run the dribbler
     required DribblerMode dribbler_mode = 4;
     // How to navigate around the ball
@@ -132,6 +133,7 @@ message MoveTactic
     required AutoChipOrKick auto_chip_or_kick = 6;
     // The maximum allowed speed mode
     required MaxAllowedSpeedMode max_allowed_speed_mode = 7;
+    // 8 Reserved field number
     // The obstacle avoidance mode to use while moving
     required ObstacleAvoidanceMode obstacle_avoidance_mode = 9;
 }

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.cpp
@@ -56,10 +56,10 @@ void BallPlacementPlayFSM::alignPlacement(const Update &event)
                       2 * alignment_vector * ROBOT_MAX_RADIUS_METERS;
 
         align_placement_tactic->updateControlParams(
-            setup_point, setup_angle, 0.0, TbotsProto::DribblerMode::OFF,
+            setup_point, setup_angle, TbotsProto::DribblerMode::OFF,
             TbotsProto::BallCollisionType::AVOID, {AutoChipOrKickMode::OFF, 0},
             TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
-            TbotsProto::ObstacleAvoidanceMode::SAFE, 0.0);
+            TbotsProto::ObstacleAvoidanceMode::SAFE);
 
         tactics_to_run[0].emplace_back(align_placement_tactic);
 
@@ -143,10 +143,10 @@ void BallPlacementPlayFSM::retreat(const Update &event)
 
         // setup ball placement tactic for ball placing robot
         retreat_tactic->updateControlParams(
-            retreat_position, final_orientation, 0.0, TbotsProto::DribblerMode::OFF,
+            retreat_position, final_orientation, TbotsProto::DribblerMode::OFF,
             TbotsProto::BallCollisionType::AVOID, {AutoChipOrKickMode::OFF, 0},
             TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
-            TbotsProto::ObstacleAvoidanceMode::SAFE, 0.0);
+            TbotsProto::ObstacleAvoidanceMode::SAFE);
         tactics_to_run[0].emplace_back(retreat_tactic);
 
         event.common.set_tactics(tactics_to_run);
@@ -303,7 +303,7 @@ void BallPlacementPlayFSM::setupMoveTactics(const Update &event)
             waiting_line_vector.normalize(waiting_line_vector.length() * i /
                                           static_cast<double>(move_tactics.size()));
         move_tactics.at(i)->updateControlParams(
-            waiting_destination, Angle::zero(), 0.0,
+            waiting_destination, Angle::zero(),
             TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
             TbotsProto::ObstacleAvoidanceMode::SAFE);
     }

--- a/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_fsm.cpp
@@ -95,13 +95,13 @@ void EnemyBallPlacementPlayFSM::avoid(const Update& event)
             }
             // Move to destination point while aligning to the ball
             avoid_interference_tactics[idx]->updateControlParams(
-                destination, (ball_pos - robot.position()).orientation(), 0);
+                destination, (ball_pos - robot.position()).orientation());
         }
         else
         {
             // Stay in place while aligning to the ball
             avoid_interference_tactics[idx]->updateControlParams(
-                robot.position(), (ball_pos - robot.position()).orientation(), 0);
+                robot.position(), (ball_pos - robot.position()).orientation());
         }
         tactics_to_run[0].emplace_back(avoid_interference_tactics[idx]);
         idx++;
@@ -140,11 +140,10 @@ void EnemyBallPlacementPlayFSM::enterDefensiveFormation(const Update& event)
     Point right  = world_ptr->ball().position() + right_vector;
 
     move_tactics[0]->updateControlParams(
-        center, positioning_vector.orientation() + Angle::half(), 0);
-    move_tactics[1]->updateControlParams(left, left_vector.orientation() + Angle::half(),
-                                         0);
+        center, positioning_vector.orientation() + Angle::half());
+    move_tactics[1]->updateControlParams(left, left_vector.orientation() + Angle::half());
     move_tactics[2]->updateControlParams(right,
-                                         right_vector.orientation() + Angle::half(), 0);
+                                         right_vector.orientation() + Angle::half());
     tactics_to_run[0].emplace_back(move_tactics[0]);
     tactics_to_run[0].emplace_back(move_tactics[1]);
     tactics_to_run[0].emplace_back(move_tactics[2]);

--- a/src/software/ai/hl/stp/play/example_play.cpp
+++ b/src/software/ai/hl/stp/play/example_play.cpp
@@ -25,7 +25,7 @@ void ExamplePlay::getNextTactics(TacticCoroutine::push_type &yield,
                 world_ptr->ball().position() +
                     Vector::createFromAngle(angle_between_robots *
                                             static_cast<double>(k + 1)),
-                (angle_between_robots * static_cast<double>(k + 1)) + Angle::half(), 0);
+                (angle_between_robots * static_cast<double>(k + 1)) + Angle::half());
         }
 
         // yield the Tactics this Play wants to run, in order of priority

--- a/src/software/ai/hl/stp/play/free_kick/free_kick_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/free_kick/free_kick_play_fsm.cpp
@@ -69,7 +69,7 @@ void FreeKickPlayFSM::updateReceiverPositioningTactics(
         Angle receiver_orientation =
             (world->ball().position() - best_receiving_positions[i]).orientation();
         receiver_positioning_tactics[i]->updateControlParams(
-            best_receiving_positions[i], receiver_orientation, 0.0,
+            best_receiving_positions[i], receiver_orientation,
             TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
             TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE);
     }
@@ -125,7 +125,7 @@ void FreeKickPlayFSM::updateAlignToBallTactic(const WorldPtr &world_ptr)
 
     align_to_ball_tactic->updateControlParams(
         ball_pos - direction_to_face.normalize(ROBOT_MAX_RADIUS_METERS * 2),
-        direction_to_face.orientation(), 0);
+        direction_to_face.orientation());
 }
 
 bool FreeKickPlayFSM::shotFound(const Update &event)

--- a/src/software/ai/hl/stp/play/hardware_challenge_plays/dribbling_parcour_play.cpp
+++ b/src/software/ai/hl/stp/play/hardware_challenge_plays/dribbling_parcour_play.cpp
@@ -28,7 +28,7 @@ void DribblingParcourPlay::getNextTactics(TacticCoroutine::push_type &yield,
         }
         else
         {
-            move_tactic->updateControlParams(Point(0, 0), Angle::zero(), 0.0);
+            move_tactic->updateControlParams(Point(0, 0), Angle::zero());
             result.emplace_back(move_tactic);
         }
         yield({result});

--- a/src/software/ai/hl/stp/play/hardware_challenge_plays/pass_endurance_play.cpp
+++ b/src/software/ai/hl/stp/play/hardware_challenge_plays/pass_endurance_play.cpp
@@ -31,8 +31,7 @@ void PassEndurancePlay::getNextTactics(TacticCoroutine::push_type &yield,
                     world_ptr->ball().position() +
                         Vector::createFromAngle(angle_between_robots *
                                                 static_cast<double>(k + 1)),
-                    (angle_between_robots * static_cast<double>(k + 1)) + Angle::half(),
-                    0);
+                    (angle_between_robots * static_cast<double>(k + 1)) + Angle::half());
             }
         }
         else
@@ -44,7 +43,7 @@ void PassEndurancePlay::getNextTactics(TacticCoroutine::push_type &yield,
                 auto next_position = Point(
                     world_ptr->field().centerPoint().x(),
                     (initial_offset + static_cast<int>(k)) * 4 * ROBOT_MAX_RADIUS_METERS);
-                move_tactics[k]->updateControlParams(next_position, Angle::zero(), 0);
+                move_tactics[k]->updateControlParams(next_position, Angle::zero());
             }
         }
         result.insert(result.end(), move_tactics.begin(), move_tactics.end());

--- a/src/software/ai/hl/stp/play/hardware_challenge_plays/scoring_from_contested_possession_play.cpp
+++ b/src/software/ai/hl/stp/play/hardware_challenge_plays/scoring_from_contested_possession_play.cpp
@@ -30,7 +30,7 @@ void ScoringFromContestedPossessionPlay::getNextTactics(TacticCoroutine::push_ty
         else
         {
             // TODO (#2107): implement face ball opposite attacker 0.3m away
-            move_tactic->updateControlParams(Point(0, 0), Angle::zero(), 0.0);
+            move_tactic->updateControlParams(Point(0, 0), Angle::zero());
             result.emplace_back(move_tactic);
         }
         yield({result});

--- a/src/software/ai/hl/stp/play/hardware_challenge_plays/scoring_with_static_defenders_play.cpp
+++ b/src/software/ai/hl/stp/play/hardware_challenge_plays/scoring_with_static_defenders_play.cpp
@@ -29,7 +29,7 @@ void ScoringWithStaticDefendersPlay::getNextTactics(TacticCoroutine::push_type &
                 auto next_position = Point(
                     world_ptr->field().centerPoint().x(),
                     (initial_offset + static_cast<int>(k)) * 4 * ROBOT_MAX_RADIUS_METERS);
-                move_tactics[k]->updateControlParams(next_position, Angle::zero(), 0);
+                move_tactics[k]->updateControlParams(next_position, Angle::zero());
             }
         }
         else if (world_ptr->gameState().isOurFreeKick())
@@ -46,8 +46,7 @@ void ScoringWithStaticDefendersPlay::getNextTactics(TacticCoroutine::push_type &
                     world_ptr->ball().position() +
                         Vector::createFromAngle(angle_between_robots *
                                                 static_cast<double>(k + 1)),
-                    (angle_between_robots * static_cast<double>(k + 1)) + Angle::half(),
-                    0);
+                    (angle_between_robots * static_cast<double>(k + 1)) + Angle::half());
             }
         }
         result.insert(result.end(), move_tactics.begin(), move_tactics.end());

--- a/src/software/ai/hl/stp/play/kickoff_enemy_play.cpp
+++ b/src/software/ai/hl/stp/play/kickoff_enemy_play.cpp
@@ -125,7 +125,7 @@ void KickoffEnemyPlay::getNextTactics(TacticCoroutine::push_type &yield,
                 // listed above
                 move_tactics.at(defense_position_index)
                     ->updateControlParams(defense_positions.at(defense_position_index),
-                                          Angle::zero(), 0);
+                                          Angle::zero());
                 result[0].emplace_back(move_tactics.at(defense_position_index));
                 defense_position_index++;
             }
@@ -138,7 +138,7 @@ void KickoffEnemyPlay::getNextTactics(TacticCoroutine::push_type &yield,
                                    world_ptr->field().friendlyGoalpostNeg(),
                                    world_ptr->field().centerPoint(),
                                    ROBOT_MAX_RADIUS_METERS),
-                Angle::zero(), 0, TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
+                Angle::zero(), TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
                 TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE);
         result[0].emplace_back(move_tactics.at(defense_position_index));
 

--- a/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
+++ b/src/software/ai/hl/stp/play/kickoff_friendly_play.cpp
@@ -93,7 +93,7 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield,
         for (unsigned i = 0; i < kickoff_setup_positions.size(); i++)
         {
             move_tactics.at(i)->updateControlParams(kickoff_setup_positions.at(i),
-                                                    Angle::zero(), 0);
+                                                    Angle::zero());
             result[0].emplace_back(move_tactics.at(i));
         }
 
@@ -123,7 +123,7 @@ void KickoffFriendlyPlay::getNextTactics(TacticCoroutine::push_type &yield,
         for (unsigned i = 1; i < kickoff_setup_positions.size(); i++)
         {
             move_tactics.at(i)->updateControlParams(kickoff_setup_positions.at(i),
-                                                    Angle::zero(), 0);
+                                                    Angle::zero());
             result[0].emplace_back(move_tactics.at(i));
         }
 

--- a/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_fsm.cpp
@@ -48,12 +48,11 @@ void PenaltyKickPlayFSM::setupPosition(const Update &event)
                           ROBOT_MAX_RADIUS_METERS;
         penalty_setup_tactics.at(i)->updateControlParams(
             Point(ball_position_x - 1.25, y_offset),
-            event.common.world_ptr->field().enemyGoalCenter().toVector().orientation(),
-            0);
+            event.common.world_ptr->field().enemyGoalCenter().toVector().orientation());
     }
 
     // Move shooting robot behind the ball
-    penalty_setup_tactics.back()->updateControlParams(behind_ball, shoot_angle, 0.0);
+    penalty_setup_tactics.back()->updateControlParams(behind_ball, shoot_angle);
 
     tactics_to_run[0].insert(tactics_to_run[0].end(), penalty_setup_tactics.begin(),
                              penalty_setup_tactics.end());

--- a/src/software/ai/hl/stp/play/penalty_kick_enemy/penalty_kick_enemy_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/penalty_kick_enemy/penalty_kick_enemy_play_fsm.cpp
@@ -26,8 +26,7 @@ void PenaltyKickEnemyPlayFSM::setupPosition(const Update &event)
         move_tactics.at(i)->updateControlParams(
             Point(event.common.world_ptr->field().enemyPenaltyMark().x() + 1.75,
                   y_offset),
-            event.common.world_ptr->field().enemyGoalCenter().toVector().orientation(),
-            0);
+            event.common.world_ptr->field().enemyGoalCenter().toVector().orientation());
     }
 
     // Move goalie to the goal line

--- a/src/software/ai/hl/stp/play/shoot_or_chip_play.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_chip_play.cpp
@@ -79,7 +79,7 @@ void ShootOrChipPlay::getNextTactics(TacticCoroutine::push_type &yield,
                 chip_targets[i].origin() -
                 Vector::createFromAngle(orientation).normalize(ROBOT_MAX_RADIUS_METERS);
             ;
-            move_to_open_area_tactics[i]->updateControlParams(position, orientation, 0.0);
+            move_to_open_area_tactics[i]->updateControlParams(position, orientation);
             result[0].emplace_back(move_to_open_area_tactics[i]);
         }
 

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.cpp
@@ -50,7 +50,7 @@ void ShootOrPassPlayFSM::updateOffensivePositioningTactics(
         Angle receiver_orientation =
             (world->ball().position() - best_receiving_positions[i]).orientation();
         offensive_positioning_tactics[i]->updateControlParams(
-            best_receiving_positions[i], receiver_orientation, 0.0,
+            best_receiving_positions[i], receiver_orientation,
             TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
             TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE);
     }

--- a/src/software/ai/hl/stp/play/stop_play.cpp
+++ b/src/software/ai/hl/stp/play/stop_play.cpp
@@ -80,15 +80,15 @@ void StopPlay::getNextTactics(TacticCoroutine::push_type &yield,
 
         move_tactics.at(0)->updateControlParams(
             ball_defense_point_center,
-            (world_ptr->ball().position() - ball_defense_point_center).orientation(), 0,
+            (world_ptr->ball().position() - ball_defense_point_center).orientation(),
             stop_mode, TbotsProto::ObstacleAvoidanceMode::SAFE);
         move_tactics.at(1)->updateControlParams(
             ball_defense_point_left,
-            (world_ptr->ball().position() - ball_defense_point_left).orientation(), 0,
+            (world_ptr->ball().position() - ball_defense_point_left).orientation(),
             stop_mode, TbotsProto::ObstacleAvoidanceMode::SAFE);
         move_tactics.at(2)->updateControlParams(
             ball_defense_point_right,
-            (world_ptr->ball().position() - ball_defense_point_right).orientation(), 0,
+            (world_ptr->ball().position() - ball_defense_point_right).orientation(),
             stop_mode, TbotsProto::ObstacleAvoidanceMode::SAFE);
 
         std::get<0>(crease_defender_tactics)

--- a/src/software/ai/hl/stp/play/test_plays/move_test_play.cpp
+++ b/src/software/ai/hl/stp/play/test_plays/move_test_play.cpp
@@ -23,8 +23,7 @@ void MoveTestPlay::getNextTactics(TacticCoroutine::push_type &yield,
             TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
             TbotsProto::ObstacleAvoidanceMode::SAFE);
         move_test_tactic_center_field->updateControlParams(
-            Point(0, 0), Angle::zero(),
-            TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
+            Point(0, 0), Angle::zero(), TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
             TbotsProto::ObstacleAvoidanceMode::SAFE);
 
         yield({{move_test_tactic_center_field, move_test_tactic_friendly_goal,

--- a/src/software/ai/hl/stp/play/test_plays/move_test_play.cpp
+++ b/src/software/ai/hl/stp/play/test_plays/move_test_play.cpp
@@ -15,15 +15,15 @@ void MoveTestPlay::getNextTactics(TacticCoroutine::push_type &yield,
     do
     {
         move_test_tactic_friendly_goal->updateControlParams(
-            world_ptr->field().friendlyGoalCenter(), Angle::zero(), 0,
+            world_ptr->field().friendlyGoalCenter(), Angle::zero(),
             TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
             TbotsProto::ObstacleAvoidanceMode::SAFE);
         move_test_tactic_enemy_goal->updateControlParams(
-            world_ptr->field().enemyGoalCenter(), Angle::zero(), 0,
+            world_ptr->field().enemyGoalCenter(), Angle::zero(),
             TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
             TbotsProto::ObstacleAvoidanceMode::SAFE);
         move_test_tactic_center_field->updateControlParams(
-            Point(0, 0), Angle::zero(), 0,
+            Point(0, 0), Angle::zero(),
             TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
             TbotsProto::ObstacleAvoidanceMode::SAFE);
 

--- a/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
+++ b/src/software/ai/hl/stp/stp_tactic_assignment_test.cpp
@@ -72,9 +72,9 @@ TEST_F(STPTacticAssignmentTest,
     auto move_tactic_1 = std::make_shared<MoveTactic>();
     auto move_tactic_2 = std::make_shared<MoveTactic>();
 
-    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
-    move_tactic_2->updateControlParams(Point(1, 0), Angle::zero(), 0,
+    move_tactic_2->updateControlParams(Point(1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {move_tactic_1, move_tactic_2};
@@ -96,9 +96,9 @@ TEST_F(STPTacticAssignmentTest,
     auto move_tactic_1 = std::make_shared<MoveTactic>();
     auto move_tactic_2 = std::make_shared<MoveTactic>();
 
-    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
-    move_tactic_2->updateControlParams(Point(1, 0), Angle::zero(), 0,
+    move_tactic_2->updateControlParams(Point(1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {move_tactic_1, move_tactic_2};
@@ -122,7 +122,7 @@ TEST_F(STPTacticAssignmentTest,
 
     auto move_tactic_1 = std::make_shared<MoveTactic>();
 
-    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {move_tactic_1};
@@ -140,7 +140,7 @@ TEST_F(STPTacticAssignmentTest, test_0_tactics_returned_when_there_are_no_robots
 
     auto move_tactic_1 = std::make_shared<MoveTactic>();
 
-    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {move_tactic_1};
@@ -162,7 +162,7 @@ TEST_F(STPTacticAssignmentTest,
     auto move_tactic_1 = std::make_shared<MoveTactic>();
     auto stop_tactic_1 = std::make_shared<StopTactic>();
 
-    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {move_tactic_1, stop_tactic_1};
@@ -193,7 +193,7 @@ TEST_F(STPTacticAssignmentTest, test_assigning_1_tactic_to_1_robot)
 
     auto move_tactic_1 = std::make_shared<MoveTactic>();
 
-    move_tactic_1->updateControlParams(Point(2, -3.2), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(2, -3.2), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {move_tactic_1};
@@ -221,9 +221,9 @@ TEST_F(STPTacticAssignmentTest, test_assigning_2_robots_to_2_tactics_no_overlap)
     auto move_tactic_1 = std::make_shared<MoveTactic>();
     auto move_tactic_2 = std::make_shared<MoveTactic>();
 
-    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
-    move_tactic_2->updateControlParams(Point(1, 0), Angle::zero(), 0,
+    move_tactic_2->updateControlParams(Point(1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {move_tactic_1, move_tactic_2};
@@ -263,9 +263,9 @@ TEST_F(STPTacticAssignmentTest, test_assigning_2_robots_to_2_tactics_with_overla
     auto move_tactic_1 = std::make_shared<MoveTactic>();
     auto move_tactic_2 = std::make_shared<MoveTactic>();
 
-    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
-    move_tactic_2->updateControlParams(Point(1, 0), Angle::zero(), 0,
+    move_tactic_2->updateControlParams(Point(1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {move_tactic_1, move_tactic_2};
@@ -298,9 +298,9 @@ TEST_F(STPTacticAssignmentTest, test_assigning_3_robots_to_2_tactics)
     auto move_tactic_1 = std::make_shared<MoveTactic>();
     auto move_tactic_2 = std::make_shared<MoveTactic>();
 
-    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
-    move_tactic_2->updateControlParams(Point(1, 0), Angle::zero(), 0,
+    move_tactic_2->updateControlParams(Point(1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {move_tactic_1, move_tactic_2};
@@ -366,7 +366,7 @@ TEST_F(STPTacticAssignmentTest,
     // The destination of the move_tactic is relatively close to the robot positions, so
     // the cost of assigning any robot to the move_tactic should be less than the
     // stop_tactics
-    move_tactic_1->updateControlParams(Point(0, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(0, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {stop_tactic_1, move_tactic_1, stop_tactic_2};
@@ -397,7 +397,7 @@ TEST_F(STPTacticAssignmentTest,
 
     auto move_tactic_1 = std::make_shared<MoveTactic>();
 
-    move_tactic_1->updateControlParams(Point(0, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(0, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics = {move_tactic_1};
@@ -466,7 +466,7 @@ TEST_F(STPTacticAssignmentTest,
 
     auto move_tactic_1 = std::make_shared<MoveTactic>();
 
-    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(-1, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstTacticVector tactics                   = {move_tactic_1};
@@ -513,9 +513,9 @@ TEST_F(STPTacticAssignmentTest, test_greediness_of_tiered_assignment)
     auto move_tactic_0 = std::make_shared<MoveTactic>();
     auto move_tactic_1 = std::make_shared<MoveTactic>();
 
-    move_tactic_0->updateControlParams(Point(0, 0), Angle::zero(), 0,
+    move_tactic_0->updateControlParams(Point(0, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
-    move_tactic_1->updateControlParams(Point(2, 0), Angle::zero(), 0,
+    move_tactic_1->updateControlParams(Point(2, 0), Angle::zero(),
                                        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT);
 
     ConstPriorityTacticVector normal_tactics = {{move_tactic_0, move_tactic_1}};

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.cpp
@@ -144,13 +144,11 @@ void CreaseDefenderFSM::blockThreat(
     MoveFSM::ControlParams control_params{
         .destination             = destination,
         .final_orientation       = face_threat_orientation,
-        .final_speed             = 0.0,
         .dribbler_mode           = TbotsProto::DribblerMode::OFF,
         .ball_collision_type     = ball_collision_type,
         .auto_chip_or_kick       = auto_chip_or_kick,
         .max_allowed_speed_mode  = event.control_params.max_allowed_speed_mode,
-        .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE,
-        .target_spin_rev_per_s   = 0.0};
+        .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE};
 
     // Update the get behind ball fsm
     processEvent(MoveFSM::Update(control_params, event.common));

--- a/src/software/ai/hl/stp/tactic/move/move_fsm.h
+++ b/src/software/ai/hl/stp/tactic/move/move_fsm.h
@@ -17,8 +17,6 @@ struct MoveFSM
         Point destination;
         // The orientation the robot should have when it arrives at its destination
         Angle final_orientation;
-        // The speed the robot should have when it arrives at its destination
-        double final_speed;
         // How to run the dribbler
         TbotsProto::DribblerMode dribbler_mode;
         // How to navigate around the ball
@@ -29,8 +27,6 @@ struct MoveFSM
         TbotsProto::MaxAllowedSpeedMode max_allowed_speed_mode;
         // The obstacle avoidance mode
         TbotsProto::ObstacleAvoidanceMode obstacle_avoidance_mode;
-        // The target spin while moving in revolutions per second
-        double target_spin_rev_per_s;
     };
 
     // this struct defines the only event that the MoveFSM responds to

--- a/src/software/ai/hl/stp/tactic/move/move_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/move/move_fsm_test.cpp
@@ -11,13 +11,11 @@ TEST(MoveFSMTest, test_transitions)
     MoveFSM::ControlParams control_params{
         .destination             = Point(2, 3),
         .final_orientation       = Angle::half(),
-        .final_speed             = 0.0,
         .dribbler_mode           = TbotsProto::DribblerMode::OFF,
         .ball_collision_type     = TbotsProto::BallCollisionType::AVOID,
         .auto_chip_or_kick       = AutoChipOrKick{AutoChipOrKickMode::OFF, 0},
         .max_allowed_speed_mode  = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
-        .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::SAFE,
-        .target_spin_rev_per_s   = 0.0};
+        .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::SAFE};
 
     FSM<MoveFSM> fsm;
     EXPECT_TRUE(fsm.is(boost::sml::state<MoveFSM::MoveState>));
@@ -45,13 +43,11 @@ TEST(MoveFSMTest, test_transitions)
     control_params = MoveFSM::ControlParams{
         .destination             = Point(1, -3),
         .final_orientation       = Angle::half(),
-        .final_speed             = 0.0,
-        .dribbler_mode           = TbotsProto::DribblerMode::OFF,
+	.dribbler_mode           = TbotsProto::DribblerMode::OFF,
         .ball_collision_type     = TbotsProto::BallCollisionType::AVOID,
         .auto_chip_or_kick       = AutoChipOrKick{AutoChipOrKickMode::OFF, 0},
-        .max_allowed_speed_mode  = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
-        .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::SAFE,
-        .target_spin_rev_per_s   = 0.0};
+	.max_allowed_speed_mode  = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
+        .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::SAFE};
     fsm.process_event(MoveFSM::Update(
         control_params, TacticUpdate(robot, world, [](std::shared_ptr<Primitive>) {})));
     EXPECT_TRUE(fsm.is(boost::sml::state<MoveFSM::MoveState>));

--- a/src/software/ai/hl/stp/tactic/move/move_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/move/move_fsm_test.cpp
@@ -43,10 +43,10 @@ TEST(MoveFSMTest, test_transitions)
     control_params = MoveFSM::ControlParams{
         .destination             = Point(1, -3),
         .final_orientation       = Angle::half(),
-	.dribbler_mode           = TbotsProto::DribblerMode::OFF,
+        .dribbler_mode           = TbotsProto::DribblerMode::OFF,
         .ball_collision_type     = TbotsProto::BallCollisionType::AVOID,
         .auto_chip_or_kick       = AutoChipOrKick{AutoChipOrKickMode::OFF, 0},
-	.max_allowed_speed_mode  = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
+        .max_allowed_speed_mode  = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
         .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::SAFE};
     fsm.process_event(MoveFSM::Update(
         control_params, TacticUpdate(robot, world, [](std::shared_ptr<Primitive>) {})));

--- a/src/software/ai/hl/stp/tactic/move/move_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/move/move_tactic.cpp
@@ -21,8 +21,7 @@ MoveTactic::MoveTactic()
 }
 
 void MoveTactic::updateControlParams(
-    Point destination, Angle final_orientation, 
-    TbotsProto::DribblerMode dribbler_mode,
+    Point destination, Angle final_orientation, TbotsProto::DribblerMode dribbler_mode,
     TbotsProto::BallCollisionType ball_collision_type, AutoChipOrKick auto_chip_or_kick,
     TbotsProto::MaxAllowedSpeedMode max_allowed_speed_mode,
     TbotsProto::ObstacleAvoidanceMode obstacle_avoidance_mode)

--- a/src/software/ai/hl/stp/tactic/move/move_tactic.cpp
+++ b/src/software/ai/hl/stp/tactic/move/move_tactic.cpp
@@ -8,13 +8,11 @@ MoveTactic::MoveTactic()
       control_params{
           .destination             = Point(),
           .final_orientation       = Angle::zero(),
-          .final_speed             = 0.0,
           .dribbler_mode           = TbotsProto::DribblerMode::OFF,
           .ball_collision_type     = TbotsProto::BallCollisionType::AVOID,
           .auto_chip_or_kick       = {AutoChipOrKickMode::OFF, 0},
           .max_allowed_speed_mode  = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
-          .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE,
-          .target_spin_rev_per_s   = 0.0}
+          .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE}
 {
     for (RobotId id = 0; id < MAX_ROBOT_IDS; id++)
     {
@@ -23,40 +21,35 @@ MoveTactic::MoveTactic()
 }
 
 void MoveTactic::updateControlParams(
-    Point destination, Angle final_orientation, double final_speed,
+    Point destination, Angle final_orientation, 
     TbotsProto::DribblerMode dribbler_mode,
     TbotsProto::BallCollisionType ball_collision_type, AutoChipOrKick auto_chip_or_kick,
-    TbotsProto::MaxAllowedSpeedMode max_allowed_speed_mode,
-    TbotsProto::ObstacleAvoidanceMode obstacle_avoidance_mode,
-    double target_spin_rev_per_s)
-{
-    // Update the control parameters stored by this Tactic
-    control_params.destination             = destination;
-    control_params.final_orientation       = final_orientation;
-    control_params.final_speed             = final_speed;
-    control_params.dribbler_mode           = dribbler_mode;
-    control_params.ball_collision_type     = ball_collision_type;
-    control_params.auto_chip_or_kick       = auto_chip_or_kick;
-    control_params.max_allowed_speed_mode  = max_allowed_speed_mode;
-    control_params.obstacle_avoidance_mode = obstacle_avoidance_mode;
-    control_params.target_spin_rev_per_s   = target_spin_rev_per_s;
-}
-
-void MoveTactic::updateControlParams(
-    Point destination, Angle final_orientation, double final_speed,
     TbotsProto::MaxAllowedSpeedMode max_allowed_speed_mode,
     TbotsProto::ObstacleAvoidanceMode obstacle_avoidance_mode)
 {
     // Update the control parameters stored by this Tactic
     control_params.destination             = destination;
     control_params.final_orientation       = final_orientation;
-    control_params.final_speed             = final_speed;
+    control_params.dribbler_mode           = dribbler_mode;
+    control_params.ball_collision_type     = ball_collision_type;
+    control_params.auto_chip_or_kick       = auto_chip_or_kick;
+    control_params.max_allowed_speed_mode  = max_allowed_speed_mode;
+    control_params.obstacle_avoidance_mode = obstacle_avoidance_mode;
+}
+
+void MoveTactic::updateControlParams(
+    Point destination, Angle final_orientation,
+    TbotsProto::MaxAllowedSpeedMode max_allowed_speed_mode,
+    TbotsProto::ObstacleAvoidanceMode obstacle_avoidance_mode)
+{
+    // Update the control parameters stored by this Tactic
+    control_params.destination             = destination;
+    control_params.final_orientation       = final_orientation;
     control_params.dribbler_mode           = TbotsProto::DribblerMode::OFF;
     control_params.ball_collision_type     = TbotsProto::BallCollisionType::AVOID;
     control_params.auto_chip_or_kick       = {AutoChipOrKickMode::OFF, 0};
     control_params.max_allowed_speed_mode  = max_allowed_speed_mode;
     control_params.obstacle_avoidance_mode = obstacle_avoidance_mode;
-    control_params.target_spin_rev_per_s   = 0.0;
 }
 
 void MoveTactic::updatePrimitive(const TacticUpdate &tactic_update, bool reset_fsm)

--- a/src/software/ai/hl/stp/tactic/move/move_tactic.h
+++ b/src/software/ai/hl/stp/tactic/move/move_tactic.h
@@ -21,17 +21,15 @@ class MoveTactic : public Tactic
      * @param destination The destination to move to (in global coordinates)
      * @param final_orientation The final orientation the robot should have at
      * the destination
-     * @param final_speed The final speed the robot should have at the destination
      * @param dribbler_mode The dribbler mode
      * @param ball_collision_type how to navigate around the ball
      * @param auto_chip_or_kick The command to autochip or autokick
      * @param max_allowed_speed_mode The mode of maximum speed allowed
      * @param obstacle_avoidance_mode How safe we should be when avoiding obstacles,
      * particularly enemy robots
-     * @param target_spin_rev_per_s The target spin while moving in revolutions per second
      */
     void updateControlParams(
-        Point destination, Angle final_orientation, double final_speed,
+        Point destination, Angle final_orientation,
         TbotsProto::DribblerMode dribbler_mode = TbotsProto::DribblerMode::OFF,
         TbotsProto::BallCollisionType ball_collision_type =
             TbotsProto::BallCollisionType::AVOID,
@@ -39,8 +37,7 @@ class MoveTactic : public Tactic
         TbotsProto::MaxAllowedSpeedMode max_allowed_speed_mode =
             TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
         TbotsProto::ObstacleAvoidanceMode obstacle_avoidance_mode =
-            TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE,
-        double target_spin_rev_per_s = 0.0);
+            TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE);
 
     /**
      * Updates the params assuming that the dribbler and chicker and while avoiding the
@@ -49,13 +46,11 @@ class MoveTactic : public Tactic
      * @param destination The destination to move to (in global coordinates)
      * @param final_orientation The final orientation the robot should have at
      * the destination
-     * @param final_speed The final speed the robot should have at the destination
      * @param max_allowed_speed_mode The mode of maximum speed allowed
      * @param obstacle_avoidance_mode How safe we should be when avoiding obstacles,
      * particularly enemy robots
      */
     void updateControlParams(Point destination, Angle final_orientation,
-                             double final_speed,
                              TbotsProto::MaxAllowedSpeedMode max_allowed_speed_mode,
                              TbotsProto::ObstacleAvoidanceMode obstacle_avoidance_mode);
 

--- a/src/software/ai/hl/stp/tactic/move/move_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/move/move_tactic_test.cpp
@@ -72,11 +72,11 @@ TEST_F(MoveTacticTest, test_autochip_move)
          field.enemyDefenseArea().negXPosYCorner()});
 
     auto tactic = std::make_shared<MoveTactic>();
-    tactic->updateControlParams(
-        destination, Angle::zero(), TbotsProto::DribblerMode::OFF,
-        TbotsProto::BallCollisionType::ALLOW, {AutoChipOrKickMode::AUTOCHIP, 2.0},
-        TbotsProto::MaxAllowedSpeedMode::COLLISIONS_ALLOWED,
-        TbotsProto::ObstacleAvoidanceMode::SAFE);
+    tactic->updateControlParams(destination, Angle::zero(), TbotsProto::DribblerMode::OFF,
+                                TbotsProto::BallCollisionType::ALLOW,
+                                {AutoChipOrKickMode::AUTOCHIP, 2.0},
+                                TbotsProto::MaxAllowedSpeedMode::COLLISIONS_ALLOWED,
+                                TbotsProto::ObstacleAvoidanceMode::SAFE);
     setTactic(1, tactic);
 
     std::vector<ValidationFunction> terminating_validation_functions = {
@@ -161,11 +161,11 @@ TEST_F(MoveTacticTest, test_spinning_move_clockwise)
     auto enemy_robots    = TestUtil::createStationaryRobotStatesWithId({Point(4, 0)});
 
     auto tactic = std::make_shared<MoveTactic>();
-    tactic->updateControlParams(
-        destination, Angle::zero(), TbotsProto::DribblerMode::OFF,
-        TbotsProto::BallCollisionType::ALLOW, {AutoChipOrKickMode::OFF, 0.0},
-        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
-        TbotsProto::ObstacleAvoidanceMode::SAFE);
+    tactic->updateControlParams(destination, Angle::zero(), TbotsProto::DribblerMode::OFF,
+                                TbotsProto::BallCollisionType::ALLOW,
+                                {AutoChipOrKickMode::OFF, 0.0},
+                                TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
+                                TbotsProto::ObstacleAvoidanceMode::SAFE);
     setTactic(0, tactic);
 
     std::vector<ValidationFunction> terminating_validation_functions = {
@@ -208,11 +208,11 @@ TEST_F(MoveTacticTest, test_spinning_move_counter_clockwise)
     auto enemy_robots    = TestUtil::createStationaryRobotStatesWithId({Point(4, 0)});
 
     auto tactic = std::make_shared<MoveTactic>();
-    tactic->updateControlParams(
-        destination, Angle::half(), TbotsProto::DribblerMode::OFF,
-        TbotsProto::BallCollisionType::ALLOW, {AutoChipOrKickMode::OFF, 0.0},
-        TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
-        TbotsProto::ObstacleAvoidanceMode::SAFE);
+    tactic->updateControlParams(destination, Angle::half(), TbotsProto::DribblerMode::OFF,
+                                TbotsProto::BallCollisionType::ALLOW,
+                                {AutoChipOrKickMode::OFF, 0.0},
+                                TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
+                                TbotsProto::ObstacleAvoidanceMode::SAFE);
     setTactic(0, tactic);
 
     std::vector<ValidationFunction> terminating_validation_functions = {

--- a/src/software/ai/hl/stp/tactic/move/move_tactic_test.cpp
+++ b/src/software/ai/hl/stp/tactic/move/move_tactic_test.cpp
@@ -33,7 +33,7 @@ TEST_F(MoveTacticTest, test_move_across_field)
          field.enemyDefenseArea().negXPosYCorner()});
 
     auto tactic = std::make_shared<MoveTactic>();
-    tactic->updateControlParams(destination, Angle::zero(), 0);
+    tactic->updateControlParams(destination, Angle::zero());
     setTactic(1, tactic);
 
     std::vector<ValidationFunction> terminating_validation_functions = {
@@ -73,10 +73,10 @@ TEST_F(MoveTacticTest, test_autochip_move)
 
     auto tactic = std::make_shared<MoveTactic>();
     tactic->updateControlParams(
-        destination, Angle::zero(), 0, TbotsProto::DribblerMode::OFF,
+        destination, Angle::zero(), TbotsProto::DribblerMode::OFF,
         TbotsProto::BallCollisionType::ALLOW, {AutoChipOrKickMode::AUTOCHIP, 2.0},
         TbotsProto::MaxAllowedSpeedMode::COLLISIONS_ALLOWED,
-        TbotsProto::ObstacleAvoidanceMode::SAFE, 0.0);
+        TbotsProto::ObstacleAvoidanceMode::SAFE);
     setTactic(1, tactic);
 
     std::vector<ValidationFunction> terminating_validation_functions = {
@@ -119,10 +119,10 @@ TEST_F(MoveTacticTest, test_autokick_move)
 
     auto tactic = std::make_shared<MoveTactic>();
     tactic->updateControlParams(
-        destination, Angle::threeQuarter(), 0, TbotsProto::DribblerMode::OFF,
+        destination, Angle::threeQuarter(), TbotsProto::DribblerMode::OFF,
         TbotsProto::BallCollisionType::ALLOW, {AutoChipOrKickMode::AUTOKICK, 3.0},
         TbotsProto::MaxAllowedSpeedMode::COLLISIONS_ALLOWED,
-        TbotsProto::ObstacleAvoidanceMode::SAFE, 0.0);
+        TbotsProto::ObstacleAvoidanceMode::SAFE);
     setTactic(0, tactic);
 
     std::vector<ValidationFunction> terminating_validation_functions = {
@@ -162,10 +162,10 @@ TEST_F(MoveTacticTest, test_spinning_move_clockwise)
 
     auto tactic = std::make_shared<MoveTactic>();
     tactic->updateControlParams(
-        destination, Angle::zero(), 0, TbotsProto::DribblerMode::OFF,
+        destination, Angle::zero(), TbotsProto::DribblerMode::OFF,
         TbotsProto::BallCollisionType::ALLOW, {AutoChipOrKickMode::OFF, 0.0},
         TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
-        TbotsProto::ObstacleAvoidanceMode::SAFE, 0.0);
+        TbotsProto::ObstacleAvoidanceMode::SAFE);
     setTactic(0, tactic);
 
     std::vector<ValidationFunction> terminating_validation_functions = {
@@ -209,10 +209,10 @@ TEST_F(MoveTacticTest, test_spinning_move_counter_clockwise)
 
     auto tactic = std::make_shared<MoveTactic>();
     tactic->updateControlParams(
-        destination, Angle::half(), 0, TbotsProto::DribblerMode::OFF,
+        destination, Angle::half(), TbotsProto::DribblerMode::OFF,
         TbotsProto::BallCollisionType::ALLOW, {AutoChipOrKickMode::OFF, 0.0},
         TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
-        TbotsProto::ObstacleAvoidanceMode::SAFE, -4.0);
+        TbotsProto::ObstacleAvoidanceMode::SAFE);
     setTactic(0, tactic);
 
     std::vector<ValidationFunction> terminating_validation_functions = {

--- a/src/software/ai/hl/stp/tactic/shadow_enemy/shadow_enemy_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy/shadow_enemy_fsm.cpp
@@ -102,13 +102,11 @@ void ShadowEnemyFSM::blockShot(const Update &event,
     MoveFSM::ControlParams control_params{
         .destination             = position_to_block,
         .final_orientation       = face_ball_orientation,
-        .final_speed             = 0.0,
         .dribbler_mode           = TbotsProto::DribblerMode::OFF,
         .ball_collision_type     = TbotsProto::BallCollisionType::AVOID,
         .auto_chip_or_kick       = AutoChipOrKick{AutoChipOrKickMode::OFF, 0},
         .max_allowed_speed_mode  = TbotsProto::MaxAllowedSpeedMode::PHYSICAL_LIMIT,
-        .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE,
-        .target_spin_rev_per_s   = 0.0};
+        .obstacle_avoidance_mode = TbotsProto::ObstacleAvoidanceMode::AGGRESSIVE};
 
     processEvent(MoveFSM::Update(control_params, event.common));
 }

--- a/src/software/ai/hl/stp/tactic/tactic_factory.cpp
+++ b/src/software/ai/hl/stp/tactic/tactic_factory.cpp
@@ -141,8 +141,8 @@ std::shared_ptr<Tactic> createTactic(const TbotsProto::MoveTactic &tactic_proto,
     auto tactic = std::make_shared<MoveTactic>();
     tactic->updateControlParams(
         createPoint(tactic_proto.destination()),
-        createAngle(tactic_proto.final_orientation()),
-        tactic_proto.dribbler_mode(), tactic_proto.ball_collision_type(),
+        createAngle(tactic_proto.final_orientation()), tactic_proto.dribbler_mode(),
+        tactic_proto.ball_collision_type(),
         createAutoChipOrKick(tactic_proto.auto_chip_or_kick()),
         tactic_proto.max_allowed_speed_mode(), tactic_proto.obstacle_avoidance_mode());
     return tactic;

--- a/src/software/ai/hl/stp/tactic/tactic_factory.cpp
+++ b/src/software/ai/hl/stp/tactic/tactic_factory.cpp
@@ -141,11 +141,10 @@ std::shared_ptr<Tactic> createTactic(const TbotsProto::MoveTactic &tactic_proto,
     auto tactic = std::make_shared<MoveTactic>();
     tactic->updateControlParams(
         createPoint(tactic_proto.destination()),
-        createAngle(tactic_proto.final_orientation()), tactic_proto.final_speed(),
+        createAngle(tactic_proto.final_orientation()),
         tactic_proto.dribbler_mode(), tactic_proto.ball_collision_type(),
         createAutoChipOrKick(tactic_proto.auto_chip_or_kick()),
-        tactic_proto.max_allowed_speed_mode(), tactic_proto.obstacle_avoidance_mode(),
-        tactic_proto.target_spin_rev_per_s());
+        tactic_proto.max_allowed_speed_mode(), tactic_proto.obstacle_avoidance_mode());
     return tactic;
 }
 

--- a/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
+++ b/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
@@ -541,7 +541,6 @@ def get_move_update_control_params(
     robot_id: int,
     destination: tbots.Point,
     desired_orientation: tbots.Angle,
-    final_speed: float,
     params: AssignedTacticPlayControlParams = None,
 ):
     """Constructs the control params for a Move Tactic for a single robot
@@ -551,7 +550,6 @@ def get_move_update_control_params(
     :param robot_id: the id of the robot who will be assigned these params
     :param destination: the destination of the robot
     :param desired_orientation: the desired orientation of the robot
-    :param final_speed: the final speed of the robot
     :param params: AssignedTacticPlayControlParams message
                    if not None, add this robot's params to this
                    else, create a new message and add
@@ -562,12 +560,10 @@ def get_move_update_control_params(
         MoveTactic(
             destination=Point(x_meters=destination.x(), y_meters=destination.y()),
             final_orientation=Angle(radians=desired_orientation.toRadians()),
-            final_speed=final_speed,
             dribbler_mode=DribblerMode.OFF,
             ball_collision_type=BallCollisionType.ALLOW,
             auto_chip_or_kick=AutoChipOrKick(autokick_speed_m_per_s=0.0),
             max_allowed_speed_mode=MaxAllowedSpeedMode.PHYSICAL_LIMIT,
-            target_spin_rev_per_s=0.0,
             obstacle_avoidance_mode=ObstacleAvoidanceMode.AGGRESSIVE,
         )
     )

--- a/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
+++ b/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
@@ -206,7 +206,6 @@ def hrvo_setup(
                 if friendly_robots_final_orientations
                 else desired_orientation
             ),
-            0,
             params=blue_params,
         )
 
@@ -217,7 +216,7 @@ def hrvo_setup(
 
     for index, destination in enumerate(enemy_robots_destinations):
         yellow_params = get_move_update_control_params(
-            index, destination, tbots.Angle.fromRadians(0), 0, params=yellow_params
+            index, destination, tbots.Angle.fromRadians(0), params=yellow_params
         )
 
     simulated_test_runner.set_tactics(yellow_params, False)

--- a/src/software/field_tests/movement_robot_field_test.py
+++ b/src/software/field_tests/movement_robot_field_test.py
@@ -26,14 +26,12 @@ logger = createLogger(__name__)
 #
 #     move_tactic = MoveTactic()
 #     move_tactic.destination.CopyFrom(rob_pos_p)
-#     move_tactic.final_speed = 0.0
 #     move_tactic.dribbler_mode = DribblerMode.OFF
 #     move_tactic.final_orientation.CopyFrom(Angle(radians=angle))
 #     move_tactic.ball_collision_type = BallCollisionType.AVOID
 #     move_tactic.auto_chip_or_kick.CopyFrom(AutoChipOrKick(autokick_speed_m_per_s=0.0))
 #     move_tactic.max_allowed_speed_mode = MaxAllowedSpeedMode.PHYSICAL_LIMIT
 #     move_tactic.obstacle_avoidance_mode = ObstacleAvoidanceMode.SAFE
-#     move_tactic.target_spin_rev_per_s = 0.0
 #
 #     # setup world state
 #     initial_worldstate = create_world_state(
@@ -95,7 +93,6 @@ def test_basic_rotation(field_test_runner):
     for angle in test_angles:
         move_tactic = MoveTactic()
         move_tactic.destination.CopyFrom(rob_pos_p)
-        move_tactic.final_speed = 0.0
         move_tactic.dribbler_mode = DribblerMode.OFF
         move_tactic.final_orientation.CopyFrom(Angle(radians=angle))
         move_tactic.ball_collision_type = BallCollisionType.AVOID
@@ -104,7 +101,6 @@ def test_basic_rotation(field_test_runner):
         )
         move_tactic.max_allowed_speed_mode = MaxAllowedSpeedMode.PHYSICAL_LIMIT
         move_tactic.obstacle_avoidance_mode = ObstacleAvoidanceMode.SAFE
-        move_tactic.target_spin_rev_per_s = 0.0
 
         # Setup Tactic
         params = AssignedTacticPlayControlParams()
@@ -153,47 +149,39 @@ def test_one_robots_square(field_test_runner):
 
     tactic_0 = MoveTactic(
         destination=point1,
-        final_speed=0.0,
         dribbler_mode=DribblerMode.OFF,
         final_orientation=Angle(radians=-math.pi / 2),
         ball_collision_type=BallCollisionType.AVOID,
         auto_chip_or_kick=AutoChipOrKick(autokick_speed_m_per_s=0.0),
         max_allowed_speed_mode=MaxAllowedSpeedMode.PHYSICAL_LIMIT,
         obstacle_avoidance_mode=ObstacleAvoidanceMode.SAFE,
-        target_spin_rev_per_s=0.0,
     )
     tactic_1 = MoveTactic(
         destination=point2,
-        final_speed=0.0,
         dribbler_mode=DribblerMode.OFF,
         final_orientation=Angle(radians=-math.pi / 2),
         ball_collision_type=BallCollisionType.AVOID,
         auto_chip_or_kick=AutoChipOrKick(autokick_speed_m_per_s=0.0),
         max_allowed_speed_mode=MaxAllowedSpeedMode.PHYSICAL_LIMIT,
         obstacle_avoidance_mode=ObstacleAvoidanceMode.SAFE,
-        target_spin_rev_per_s=0.0,
     )
     tactic_2 = MoveTactic(
         destination=point3,
-        final_speed=0.0,
         dribbler_mode=DribblerMode.OFF,
         final_orientation=Angle(radians=-math.pi / 2),
         ball_collision_type=BallCollisionType.AVOID,
         auto_chip_or_kick=AutoChipOrKick(autokick_speed_m_per_s=0.0),
         max_allowed_speed_mode=MaxAllowedSpeedMode.PHYSICAL_LIMIT,
         obstacle_avoidance_mode=ObstacleAvoidanceMode.SAFE,
-        target_spin_rev_per_s=0.0,
     )
     tactic_3 = MoveTactic(
         destination=point4,
-        final_speed=0.0,
         dribbler_mode=DribblerMode.OFF,
         final_orientation=Angle(radians=-math.pi / 2),
         ball_collision_type=BallCollisionType.AVOID,
         auto_chip_or_kick=AutoChipOrKick(autokick_speed_m_per_s=0.0),
         max_allowed_speed_mode=MaxAllowedSpeedMode.PHYSICAL_LIMIT,
         obstacle_avoidance_mode=ObstacleAvoidanceMode.SAFE,
-        target_spin_rev_per_s=0.0,
     )
     tactics = [tactic_0, tactic_1, tactic_2, tactic_3]
 


### PR DESCRIPTION
The full deletion of anything having to do with target_spin_rev_per_s and final_speed as being control params especially being updated

Testing involved building all files and watching thunderscope gameplay to ensure nothing seemed off

### Resolved Issues

resolves #3145 

### Length Justification and Key Files to Review

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

Just if you could recheck it builds would be lovely thanks!