### PR TITLE
Annie/ implementation for enemy goal obstacle check

### DIFF
--- a/src/proto/primitive.proto
+++ b/src/proto/primitive.proto
@@ -50,6 +50,8 @@ enum MotionConstraint
     ENEMY_HALF_WITHOUT_CENTRE_CIRCLE = 9;
     // The friendly goal
     FRIENDLY_GOAL = 10;
+    // The enemy goal
+    ENEMY_GOAL = 11;
 }
 
 enum DribblerMode

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
@@ -83,14 +83,10 @@ def ball_placement_play_setup(
         (tbots_cpp.Point(-4.7, 2.0), tbots_cpp.Point(0, 0.5)),
         # test when ball starting point is outside of the side lines
         (tbots_cpp.Point(-2.0, 3.2), tbots_cpp.Point(0, -0.5)),
-
         # test when ball starting point is inside of enemy net
         (tbots_cpp.Point(4.0, 0), tbots_cpp.Point(2.0, 2.0)),
-
         # test when ball starting point is in friendly net
-        (tbots_cpp.Point(-4.0, 0), tbots_cpp.Point(-2.0, 2.0))
-
-
+        (tbots_cpp.Point(-4.0, 0), tbots_cpp.Point(-2.0, 2.0)),
     ],
 )
 def test_two_ai_ball_placement(

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
@@ -83,6 +83,14 @@ def ball_placement_play_setup(
         (tbots_cpp.Point(-4.7, 2.0), tbots_cpp.Point(0, 0.5)),
         # test when ball starting point is outside of the side lines
         (tbots_cpp.Point(-2.0, 3.2), tbots_cpp.Point(0, -0.5)),
+
+        # test when ball starting point is inside of enemy net
+        (tbots_cpp.Point(4.0, 0), tbots_cpp.Point(2.0, 2.0)),
+
+        # test when ball starting point is in friendly net
+        (tbots_cpp.Point(-4.0, 0), tbots_cpp.Point(-2.0, 2.0))
+
+
     ],
 )
 def test_two_ai_ball_placement(

--- a/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_set_builder.cpp
@@ -16,6 +16,7 @@ std::set<TbotsProto::MotionConstraint> buildMotionConstraintSet(
         tactic, current_motion_constraints);
 
     current_motion_constraints.insert(TbotsProto::MotionConstraint::FRIENDLY_GOAL);
+    current_motion_constraints.insert(TbotsProto::MotionConstraint::ENEMY_GOAL);
 
     return current_motion_constraints;
 }

--- a/src/software/ai/motion_constraint/motion_constraint_set_builder_test.cpp
+++ b/src/software/ai/motion_constraint/motion_constraint_set_builder_test.cpp
@@ -88,16 +88,19 @@ namespace
         {TbotsProto::MotionConstraint::INFLATED_ENEMY_DEFENSE_AREA,
          TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
          TbotsProto::MotionConstraint::FRIENDLY_GOAL,
+         TbotsProto::MotionConstraint::ENEMY_GOAL,
          TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA});
 
     auto gamestart_or_us_motion_constraints = std::set<TbotsProto::MotionConstraint>(
         {TbotsProto::MotionConstraint::INFLATED_ENEMY_DEFENSE_AREA,
          TbotsProto::MotionConstraint::FRIENDLY_GOAL,
+         TbotsProto::MotionConstraint::ENEMY_GOAL,
          TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA});
 
     auto kickoff_motion_constraints = std::set<TbotsProto::MotionConstraint>(
         {TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA,
          TbotsProto::MotionConstraint::FRIENDLY_GOAL,
+         TbotsProto::MotionConstraint::ENEMY_GOAL,
          TbotsProto::MotionConstraint::CENTER_CIRCLE,
          TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
          TbotsProto::MotionConstraint::ENEMY_HALF});
@@ -105,17 +108,20 @@ namespace
     auto our_penalty_motion_constraints = std::set<TbotsProto::MotionConstraint>(
         {TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA,
          TbotsProto::MotionConstraint::FRIENDLY_GOAL,
+         TbotsProto::MotionConstraint::ENEMY_GOAL,
          TbotsProto::MotionConstraint::ENEMY_HALF});
 
     auto them_penalty_motion_constraints = std::set<TbotsProto::MotionConstraint>(
         {TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA,
          TbotsProto::MotionConstraint::FRIENDLY_GOAL,
+         TbotsProto::MotionConstraint::ENEMY_GOAL,
          TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
          TbotsProto::MotionConstraint::FRIENDLY_HALF});
 
     auto them_ball_placement = std::set<TbotsProto::MotionConstraint>(
         {TbotsProto::MotionConstraint::HALF_METER_AROUND_BALL,
          TbotsProto::MotionConstraint::FRIENDLY_GOAL,
+         TbotsProto::MotionConstraint::ENEMY_GOAL,
          TbotsProto::MotionConstraint::FRIENDLY_DEFENSE_AREA,
          TbotsProto::MotionConstraint::AVOID_BALL_PLACEMENT_INTERFERENCE});
 }  // namespace

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -111,15 +111,19 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraint(
         case TbotsProto::MotionConstraint::FRIENDLY_GOAL:
         {
             const Rectangle &friendly_goal = field.friendlyGoal();
-            std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(friendly_goal, true);
-            obstacles.insert(obstacles.end(), goal_obstacles.begin(), goal_obstacles.end());
+            std::vector<ObstaclePtr> goal_obstacles =
+                createGoalObstacles(friendly_goal, true);
+            obstacles.insert(obstacles.end(), goal_obstacles.begin(),
+                             goal_obstacles.end());
             break;
         }
         case TbotsProto::MotionConstraint::ENEMY_GOAL:
         {
             const Rectangle &enemy_goal = field.enemyGoal();
-            std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(enemy_goal, false);
-            obstacles.insert(obstacles.end(), goal_obstacles.begin(), goal_obstacles.end());
+            std::vector<ObstaclePtr> goal_obstacles =
+                createGoalObstacles(enemy_goal, false);
+            obstacles.insert(obstacles.end(), goal_obstacles.begin(),
+                             goal_obstacles.end());
             break;
         }
 
@@ -132,8 +136,8 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraint(
     return obstacles;
 }
 
-std::vector<ObstaclePtr>
-RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal, bool isFriendly) const
+std::vector<ObstaclePtr> RobotNavigationObstacleFactory::createGoalObstacles(
+    const Rectangle &goal, bool isFriendly) const
 {
     // Adjust the goal obstacle radius slightly
     const double goal_obstacle_radius = ROBOT_MAX_RADIUS_METERS - 0.01;
@@ -148,14 +152,18 @@ RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal, bool 
     obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(
         Segment(goal.posXNegYCorner(), goal.negXNegYCorner()), goal_obstacle_radius)));
 
-	// Create left and right goal wall obstacle
-    if (isFriendly) {
+    // Create left and right goal wall obstacle
+    if (isFriendly)
+    {
         Segment segment = Segment(goal.negXPosYCorner(), goal.negXNegYCorner());
-        obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(segment, goal_obstacle_radius)));
-
-    } else {
-	  	Segment segment = Segment(goal.posXPosYCorner(), goal.posXNegYCorner());
-        obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(segment, goal_obstacle_radius)));
+        obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(
+            Stadium(segment, goal_obstacle_radius)));
+    }
+    else
+    {
+        Segment segment = Segment(goal.posXPosYCorner(), goal.posXNegYCorner());
+        obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(
+            Stadium(segment, goal_obstacle_radius)));
     }
 
     return obstacles;

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -148,7 +148,6 @@ RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal, bool 
     obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(
         Segment(goal.posXNegYCorner(), goal.negXNegYCorner()), goal_obstacle_radius)));
 
-
 	// Create left and right goal wall obstacle
     if (isFriendly) {
         Segment segment = Segment(goal.negXPosYCorner(), goal.negXNegYCorner());
@@ -157,14 +156,7 @@ RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal, bool 
     } else {
 	  	Segment segment = Segment(goal.posXPosYCorner(), goal.posXNegYCorner());
         obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(segment, goal_obstacle_radius)));
-
     }
-
-
-
-
-
-
 
     return obstacles;
 }

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -111,15 +111,19 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraint(
         case TbotsProto::MotionConstraint::FRIENDLY_GOAL:
         {
             const Rectangle &friendly_goal = field.friendlyGoal();
-            std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(friendly_goal, true);
-            obstacles.insert(obstacles.end(), goal_obstacles.begin(), goal_obstacles.end());
+            std::vector<ObstaclePtr> goal_obstacles =
+                createGoalObstacles(friendly_goal, true);
+            obstacles.insert(obstacles.end(), goal_obstacles.begin(),
+                             goal_obstacles.end());
             break;
         }
         case TbotsProto::MotionConstraint::ENEMY_GOAL:
         {
             const Rectangle &enemy_goal = field.enemyGoal();
-            std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(enemy_goal, false);
-            obstacles.insert(obstacles.end(), goal_obstacles.begin(), goal_obstacles.end());
+            std::vector<ObstaclePtr> goal_obstacles =
+                createGoalObstacles(enemy_goal, false);
+            obstacles.insert(obstacles.end(), goal_obstacles.begin(),
+                             goal_obstacles.end());
             break;
         }
 
@@ -132,8 +136,8 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraint(
     return obstacles;
 }
 
-std::vector<ObstaclePtr>
-RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal, bool isFriendly) const
+std::vector<ObstaclePtr> RobotNavigationObstacleFactory::createGoalObstacles(
+    const Rectangle &goal, bool isFriendly) const
 {
     // Adjust the goal obstacle radius slightly
     const double goal_obstacle_radius = ROBOT_MAX_RADIUS_METERS - 0.01;
@@ -149,20 +153,19 @@ RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal, bool 
         Segment(goal.posXNegYCorner(), goal.negXNegYCorner()), goal_obstacle_radius)));
 
 
-	// Create left and right goal wall obstacle
-    if (isFriendly) {
+    // Create left and right goal wall obstacle
+    if (isFriendly)
+    {
         Segment segment = Segment(goal.negXPosYCorner(), goal.negXNegYCorner());
-        obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(segment, goal_obstacle_radius)));
-
-    } else {
-	  	Segment segment = Segment(goal.posXPosYCorner(), goal.posXNegYCorner());
-        obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(segment, goal_obstacle_radius)));
-
+        obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(
+            Stadium(segment, goal_obstacle_radius)));
     }
-
-
-
-
+    else
+    {
+        Segment segment = Segment(goal.posXPosYCorner(), goal.posXNegYCorner());
+        obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(
+            Stadium(segment, goal_obstacle_radius)));
+    }
 
 
 

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -110,16 +110,18 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraint(
 
         case TbotsProto::MotionConstraint::FRIENDLY_GOAL:
         {
-            const Rectangle &friendly_goal = field.friendlyGoal();
+            const Rectangle &friendly_goal          = field.friendlyGoal();
             std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(friendly_goal);
-            obstacles.insert(obstacles.end(), goal_obstacles.begin(), goal_obstacles.end());
+            obstacles.insert(obstacles.end(), goal_obstacles.begin(),
+                             goal_obstacles.end());
             break;
         }
         case TbotsProto::MotionConstraint::ENEMY_GOAL:
         {
-            const Rectangle &enemy_goal = field.enemyGoal();
+            const Rectangle &enemy_goal             = field.enemyGoal();
             std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(enemy_goal);
-            obstacles.insert(obstacles.end(), goal_obstacles.begin(), goal_obstacles.end());
+            obstacles.insert(obstacles.end(), goal_obstacles.begin(),
+                             goal_obstacles.end());
             break;
         }
 
@@ -132,8 +134,8 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraint(
     return obstacles;
 }
 
-std::vector<ObstaclePtr>
-RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal) const
+std::vector<ObstaclePtr> RobotNavigationObstacleFactory::createGoalObstacles(
+    const Rectangle &goal) const
 {
     // Adjust the goal obstacle radius slightly
     const double goal_obstacle_radius = ROBOT_MAX_RADIUS_METERS - 0.01;

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -107,29 +107,22 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraint(
                     createFromShape(Circle(world.ball().position(), 0.5)));
             }
             break;
+
         case TbotsProto::MotionConstraint::FRIENDLY_GOAL:
         {
             const Rectangle &friendly_goal = field.friendlyGoal();
-
-            // Reduce the size of the goal obstacle slightly to avoid the goalie
-            // appear to be inside the obstacle if it is touching one of the goal
-            // walls (e.g. due to noisy vision).
-            const double goal_obstacle_radius = ROBOT_MAX_RADIUS_METERS - 0.01;
-
-            // Top goal post
-            obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(
-                Segment(friendly_goal.posXPosYCorner(), friendly_goal.negXPosYCorner()),
-                goal_obstacle_radius)));
-            // Bottom goal post
-            obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(
-                Segment(friendly_goal.posXNegYCorner(), friendly_goal.negXNegYCorner()),
-                goal_obstacle_radius)));
-            // Left goal wall
-            obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(
-                Segment(friendly_goal.negXPosYCorner(), friendly_goal.negXNegYCorner()),
-                goal_obstacle_radius)));
+            std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(friendly_goal);
+            obstacles.insert(obstacles.end(), goal_obstacles.begin(), goal_obstacles.end());
             break;
         }
+        case TbotsProto::MotionConstraint::ENEMY_GOAL:
+        {
+            const Rectangle &enemy_goal = field.enemyGoal();
+            std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(enemy_goal);
+            obstacles.insert(obstacles.end(), goal_obstacles.begin(), goal_obstacles.end());
+            break;
+        }
+
         case TbotsProto::MotionConstraint::MotionConstraint_INT_MIN_SENTINEL_DO_NOT_USE_:;
             break;
         case TbotsProto::MotionConstraint::MotionConstraint_INT_MAX_SENTINEL_DO_NOT_USE_:;
@@ -138,6 +131,31 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraint(
 
     return obstacles;
 }
+
+std::vector<ObstaclePtr>
+RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal) const
+{
+    // Adjust the goal obstacle radius slightly
+    const double goal_obstacle_radius = ROBOT_MAX_RADIUS_METERS - 0.01;
+
+    std::vector<ObstaclePtr> obstacles;
+
+    // Create top goal post obstacle
+    obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(
+        Segment(goal.posXPosYCorner(), goal.negXPosYCorner()), goal_obstacle_radius)));
+
+    // Create bottom goal post obstacle
+    obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(
+        Segment(goal.posXNegYCorner(), goal.negXNegYCorner()), goal_obstacle_radius)));
+
+    // Create left goal wall obstacle
+    obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(
+        Segment(goal.negXPosYCorner(), goal.negXNegYCorner()), goal_obstacle_radius)));
+
+    return obstacles;
+}
+
+
 
 std::vector<ObstaclePtr>
 RobotNavigationObstacleFactory::createObstaclesFromMotionConstraints(
@@ -154,6 +172,7 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraints(
 
     return obstacles;
 }
+
 
 ObstaclePtr RobotNavigationObstacleFactory::createFromBallPosition(
     const Point &ball_position) const

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.cpp
@@ -111,14 +111,14 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraint(
         case TbotsProto::MotionConstraint::FRIENDLY_GOAL:
         {
             const Rectangle &friendly_goal = field.friendlyGoal();
-            std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(friendly_goal);
+            std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(friendly_goal, true);
             obstacles.insert(obstacles.end(), goal_obstacles.begin(), goal_obstacles.end());
             break;
         }
         case TbotsProto::MotionConstraint::ENEMY_GOAL:
         {
             const Rectangle &enemy_goal = field.enemyGoal();
-            std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(enemy_goal);
+            std::vector<ObstaclePtr> goal_obstacles = createGoalObstacles(enemy_goal, false);
             obstacles.insert(obstacles.end(), goal_obstacles.begin(), goal_obstacles.end());
             break;
         }
@@ -133,7 +133,7 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraint(
 }
 
 std::vector<ObstaclePtr>
-RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal) const
+RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal, bool isFriendly) const
 {
     // Adjust the goal obstacle radius slightly
     const double goal_obstacle_radius = ROBOT_MAX_RADIUS_METERS - 0.01;
@@ -148,14 +148,26 @@ RobotNavigationObstacleFactory::createGoalObstacles(const Rectangle &goal) const
     obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(
         Segment(goal.posXNegYCorner(), goal.negXNegYCorner()), goal_obstacle_radius)));
 
-    // Create left goal wall obstacle
-    obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(
-        Segment(goal.negXPosYCorner(), goal.negXNegYCorner()), goal_obstacle_radius)));
+
+	// Create left and right goal wall obstacle
+    if (isFriendly) {
+        Segment segment = Segment(goal.negXPosYCorner(), goal.negXNegYCorner());
+        obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(segment, goal_obstacle_radius)));
+
+    } else {
+	  	Segment segment = Segment(goal.posXPosYCorner(), goal.posXNegYCorner());
+        obstacles.push_back(std::make_shared<GeomObstacle<Stadium>>(Stadium(segment, goal_obstacle_radius)));
+
+    }
+
+
+
+
+
+
 
     return obstacles;
 }
-
-
 
 std::vector<ObstaclePtr>
 RobotNavigationObstacleFactory::createObstaclesFromMotionConstraints(
@@ -172,7 +184,6 @@ RobotNavigationObstacleFactory::createObstaclesFromMotionConstraints(
 
     return obstacles;
 }
-
 
 ObstaclePtr RobotNavigationObstacleFactory::createFromBallPosition(
     const Point &ball_position) const

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
@@ -162,4 +162,18 @@ class RobotNavigationObstacleFactory
                                          const Rectangle &field_lines,
                                          const Rectangle &field_boundary,
                                          double additional_expansion_amount = 0.0) const;
+
+
+    /**
+     * creates a set of obstacles for a specified goal (friendly or enemy)
+     * generates a collection of obstacles representing the posts and walls of specified goal. The obstacles are created with a slight expansion to
+     * avoid interference with goalkeepers or other objects that might be near the goal.
+     * @param goal the friendly_goal or enemy_goal
+     *
+     * @return A vector of obstacle pointers (`std::vector<ObstaclePtr>`) representing the obstacles at the goal.
+     */
+    std::vector<ObstaclePtr> createGoalObstacles(const Rectangle &goal) const;
+
+
+
 };

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
@@ -168,11 +168,14 @@ class RobotNavigationObstacleFactory
      * creates a set of obstacles for a specified goal (friendly or enemy)
      * generates a collection of obstacles representing the posts and walls of specified goal. The obstacles are created with a slight expansion to
      * avoid interference with goalkeepers or other objects that might be near the goal.
+     * if isFriendly is true, line segment is from negXPosYCorner to negXNegYCorner, otherwide the line segment for enemy net
+     * is from posXPosYCorner to posXNegYCorner
      * @param goal the friendly_goal or enemy_goal
+     * @param isFriendly is either true or false
      *
      * @return A vector of obstacle pointers (`std::vector<ObstaclePtr>`) representing the obstacles at the goal.
      */
-    std::vector<ObstaclePtr> createGoalObstacles(const Rectangle &goal) const;
+    std::vector<ObstaclePtr> createGoalObstacles(const Rectangle &goal, bool isFriendly) const;
 
 
 

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
@@ -166,14 +166,13 @@ class RobotNavigationObstacleFactory
 
     /**
      * creates a set of obstacles for a specified goal (friendly or enemy)
-     * generates a collection of obstacles representing the posts and walls of specified goal. The obstacles are created with a slight expansion to
-     * avoid interference with goalkeepers or other objects that might be near the goal.
+     * generates a collection of obstacles representing the posts and walls of specified
+     * goal. The obstacles are created with a slight expansion to avoid interference with
+     * goalkeepers or other objects that might be near the goal.
      * @param goal the friendly_goal or enemy_goal
      *
-     * @return A vector of obstacle pointers (`std::vector<ObstaclePtr>`) representing the obstacles at the goal.
+     * @return A vector of obstacle pointers (`std::vector<ObstaclePtr>`) representing the
+     * obstacles at the goal.
      */
     std::vector<ObstaclePtr> createGoalObstacles(const Rectangle &goal) const;
-
-
-
 };

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
@@ -163,22 +163,25 @@ class RobotNavigationObstacleFactory
                                          const Rectangle &field_boundary,
                                          double additional_expansion_amount = 0.0) const;
 
- /**
-  * Creates a set of obstacles around a specified goal (friendly or enemy).
-  * This function generates obstacles for the goal's posts and surrounding walls. It includes a slight expansion to avoid interference
-  * with goalkeepers or nearby objects.
-  *
-  * - If `isFriendly` is true, the goal is set as the friendly goal, and the obstacles are generated from negXPosYCorner to negXNegYCorner.
-  * - If `isFriendly` is false, the goal is the enemy goal, and the obstacles are generated from posXPosYCorner to posXNegYCorner.
-  *
-  * @param goal The goal type (either friendly_goal or enemy_goal).
-  * @param isFriendly A boolean indicating whether the goal is friendly (true) or enemy (false).
-  *
-  * @return A vector of obstacle pointers (`std::vector<ObstaclePtr>`) representing the obstacles around the goal.
-  */
+    /**
+     * Creates a set of obstacles around a specified goal (friendly or enemy).
+     * This function generates obstacles for the goal's posts and surrounding walls. It
+     * includes a slight expansion to avoid interference with goalkeepers or nearby
+     * objects.
+     *
+     * - If `isFriendly` is true, the goal is set as the friendly goal, and the obstacles
+     * are generated from negXPosYCorner to negXNegYCorner.
+     * - If `isFriendly` is false, the goal is the enemy goal, and the obstacles are
+     * generated from posXPosYCorner to posXNegYCorner.
+     *
+     * @param goal The goal type (either friendly_goal or enemy_goal).
+     * @param isFriendly A boolean indicating whether the goal is friendly (true) or enemy
+     * (false).
+     *
+     * @return A vector of obstacle pointers (`std::vector<ObstaclePtr>`) representing the
+     * obstacles around the goal.
+     */
 
-    std::vector<ObstaclePtr> createGoalObstacles(const Rectangle &goal, bool isFriendly) const;
-
-
-
+    std::vector<ObstaclePtr> createGoalObstacles(const Rectangle &goal,
+                                                 bool isFriendly) const;
 };

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
@@ -163,18 +163,20 @@ class RobotNavigationObstacleFactory
                                          const Rectangle &field_boundary,
                                          double additional_expansion_amount = 0.0) const;
 
+ /**
+  * Creates a set of obstacles around a specified goal (friendly or enemy).
+  * This function generates obstacles for the goal's posts and surrounding walls. It includes a slight expansion to avoid interference
+  * with goalkeepers or nearby objects.
+  *
+  * - If `isFriendly` is true, the goal is set as the friendly goal, and the obstacles are generated from negXPosYCorner to negXNegYCorner.
+  * - If `isFriendly` is false, the goal is the enemy goal, and the obstacles are generated from posXPosYCorner to posXNegYCorner.
+  *
+  * @param goal The goal type (either friendly_goal or enemy_goal).
+  * @param isFriendly A boolean indicating whether the goal is friendly (true) or enemy (false).
+  *
+  * @return A vector of obstacle pointers (`std::vector<ObstaclePtr>`) representing the obstacles around the goal.
+  */
 
-    /**
-     * creates a set of obstacles for a specified goal (friendly or enemy)
-     * generates a collection of obstacles representing the posts and walls of specified goal. The obstacles are created with a slight expansion to
-     * avoid interference with goalkeepers or other objects that might be near the goal.
-     * if isFriendly is true, line segment is from negXPosYCorner to negXNegYCorner, otherwide the line segment for enemy net
-     * is from posXPosYCorner to posXNegYCorner
-     * @param goal the friendly_goal or enemy_goal
-     * @param isFriendly is either true or false
-     *
-     * @return A vector of obstacle pointers (`std::vector<ObstaclePtr>`) representing the obstacles at the goal.
-     */
     std::vector<ObstaclePtr> createGoalObstacles(const Rectangle &goal, bool isFriendly) const;
 
 

--- a/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
+++ b/src/software/ai/navigator/obstacle/robot_navigation_obstacle_factory.h
@@ -166,17 +166,17 @@ class RobotNavigationObstacleFactory
 
     /**
      * creates a set of obstacles for a specified goal (friendly or enemy)
-     * generates a collection of obstacles representing the posts and walls of specified goal. The obstacles are created with a slight expansion to
-     * avoid interference with goalkeepers or other objects that might be near the goal.
-     * if isFriendly is true, line segment is from negXPosYCorner to negXNegYCorner, otherwide the line segment for enemy net
-     * is from posXPosYCorner to posXNegYCorner
+     * generates a collection of obstacles representing the posts and walls of specified
+     * goal. The obstacles are created with a slight expansion to avoid interference with
+     * goalkeepers or other objects that might be near the goal. if isFriendly is true,
+     * line segment is from negXPosYCorner to negXNegYCorner, otherwide the line segment
+     * for enemy net is from posXPosYCorner to posXNegYCorner
      * @param goal the friendly_goal or enemy_goal
      * @param isFriendly is either true or false
      *
-     * @return A vector of obstacle pointers (`std::vector<ObstaclePtr>`) representing the obstacles at the goal.
+     * @return A vector of obstacle pointers (`std::vector<ObstaclePtr>`) representing the
+     * obstacles at the goal.
      */
-    std::vector<ObstaclePtr> createGoalObstacles(const Rectangle &goal, bool isFriendly) const;
-
-
-
+    std::vector<ObstaclePtr> createGoalObstacles(const Rectangle &goal,
+                                                 bool isFriendly) const;
 };

--- a/src/software/simulated_tests/ball_enters_region.py
+++ b/src/software/simulated_tests/ball_enters_region.py
@@ -41,9 +41,14 @@ class BallEntersRegion(Validation):
         return create_validation_geometry(self.regions)
 
     def __repr__(self):
-        return "Checking ball in regions " + ",".join(
-            repr(region) for region in self.regions
-        ) + ", ball position: " + str(self.ball_position) if self.ball_position else ""
+        return (
+            "Checking ball in regions "
+            + ",".join(repr(region) for region in self.regions)
+            + ", ball position: "
+            + str(self.ball_position)
+            if self.ball_position
+            else ""
+        )
 
 
 (

--- a/src/software/simulated_tests/ball_enters_region.py
+++ b/src/software/simulated_tests/ball_enters_region.py
@@ -13,6 +13,7 @@ class BallEntersRegion(Validation):
 
     def __init__(self, regions=None):
         self.regions = regions if regions else []
+        self.ball_position = None
 
     def get_validation_status(self, world) -> ValidationStatus:
         """Checks if the ball enters the provided regions
@@ -27,6 +28,7 @@ class BallEntersRegion(Validation):
             ):
                 return ValidationStatus.PASSING
 
+        self.ball_position = world.ball.current_state.global_position
         return ValidationStatus.FAILING
 
     def get_validation_geometry(self, world) -> ValidationGeometry:
@@ -41,7 +43,7 @@ class BallEntersRegion(Validation):
     def __repr__(self):
         return "Checking ball in regions " + ",".join(
             repr(region) for region in self.regions
-        )
+        ) + ", ball position: " + str(self.ball_position) if self.ball_position else ""
 
 
 (

--- a/src/software/simulated_tests/ball_enters_region.py
+++ b/src/software/simulated_tests/ball_enters_region.py
@@ -22,13 +22,12 @@ class BallEntersRegion(Validation):
         :return: FAILING until a ball enters any of the regions
                  PASSING when a ball enters
         """
+        self.ball_position = world.ball.current_state.global_position
         for region in self.regions:
             if tbots_cpp.contains(
                 region, tbots_cpp.createPoint(world.ball.current_state.global_position)
             ):
                 return ValidationStatus.PASSING
-
-        self.ball_position = world.ball.current_state.global_position
         return ValidationStatus.FAILING
 
     def get_validation_geometry(self, world) -> ValidationGeometry:


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description


 Added a new helper method, createGoalObstacles, within the robot_navigation_obstacle_factory to handle motion constraints for both FRIENDLY_GOAL and ENEMY_GOAL. This method, added to the interface, generates a set of obstacles for the specified goal, either friendly or enemy, to assist with navigation and collision detection.


### Testing Done


Added two tests where the starting point is within either the friendly or enemy goal, and the ball is brought out of the net. Ran the ball_placement_play_test with a successful build.

### Resolved Issues

 resolves #3356


### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x ] **Remove all commented out code**
- [ x] **Remove extra print statements**: for example, those just used for testing
- [ x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
