### PR TITLE
Add ability to run Thunderloop without power board/motors + locally on PC

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -362,6 +362,34 @@ To update binaries on a working robot, you can run:
 
 Where `<platform>` is the robot platform you are deploying to (`PI` or `NANO`), and `<robot_ip>` is the IP address of the robot you are deploying to. The `robot_password` is the password used to login to the `robot` user on the robot.
 
+## Testing Robot Software locally
+
+It is possible to run Thunderloop without having a fully-working robot. Using this mode is useful when testing features that don't require the power board or motors.
+
+1. To run Thunderloop locally on your computer
+    1. First, you must ensure that `redis` is installed. Installation instructions can be found [here](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/install-redis-on-linux/). The result of these installation directions will likely enable `redis-server` as a service that starts on boot. You may want to run `sudo systemctl disable redis-server` to prevent this.
+    2. Next, run the command `redis-server` in a terminal.
+    3. Set up the following required REDIS constants by running the following commands in the terminal:
+        - `redis-cli set /robot_id "{robot_id}"` where `{robot_id}` is the robot's ID (e.g. `1`, `2`, etc.)
+        - `redis-cli set /network_interface "{network_interface}"` where `{network_interface}` is one of the interfaces listed by `ip a`.
+        - `redis-cli set /channel_id "{channel_id}"` where `{channel_id}` is the channel id of the robot (e.g. `1`, `2`, etc.)
+        - `redis-cli set /kick_coeff "{kick_coeff}"` where `{kick_coeff}` is a calibrated kicking parameter. When running locally, this parameter doesn't matter so `0` is fine.
+        - `redis-cli set /kick_constant "{kick_constant}"` where `{kick_constant}` is a calibrated kicking parameter. When running locally, this parameter doesn't matter so `0` is fine.
+        - `redis-cli set /chip_pulse_width "{chip_pulse_width}"` where `{chip_pulse_width}` is a calibrated kicking parameter. When running locally, this parameter doesn't matter so `0` is fine.
+    4. Now, run Thunderloop with the following command:
+        - `bazel run //software/embedded:thunderloop_main --//software/embedded:host_platform=LIMITED`
+
+2. If you have a robot PC that doesn't have proper communication with the power or motor board, you can still run Thunderloop in a limited capacity to test software features (eg. networking).
+    1. First, build the Thunderloop binary:
+        - `bazel build //software/embedded:thunderloop_main --//software/embedded:host_platform=LIMITED --platforms=//cc_toolchain:robot`
+    2. Find the `<robot_ip>` of the robot you want to run Thunderloop on. This guide may help you find the IP address of the robot: [Useful Robot Commands](useful-robot-commands.md#Wifi-Disclaimer).
+    3. Copy the binary to the robot:
+        - `scp bazel-bin/software/embedded/thunderloop_main robot@<robot_ip>:/home/robot/thunderloop_main`
+    4. SSH into the robot using the following command:
+        - `ssh robot@<robot_ip>`
+    5. Run the Thunderloop binary on the robot:
+        - `sudo ./thunderloop_main`
+
 ## Setting up Virtual Robocup 2021
 
 ### Setting up the SSL Simulation Environment
@@ -369,15 +397,6 @@ Where `<platform>` is the robot platform you are deploying to (`PI` or `NANO`), 
 1. Fork the [SSL-Simulation-Setup](https://github.com/RoboCup-SSL/ssl-simulation-setup) repository.  
 2. Clone it.
 3. Follow these [instructions](https://github.com/RoboCup-SSL/ssl-simulation-setup/blob/master/Readme.md) to set up and run the repository.
-
-### Pushing a Dockerfile to dockerhub
-
-After editing the dockerfile, build the image and push it to dockerhub with the following steps
-
-1. To build the image, make sure that you are in the same directory as your image, and then run `docker build -t ubcthunderbots/<image name>[:tag] .` Make sure that your chosen image name matches a repository in dockerhub. Here's an example with the Robocup 2021 setup image: `docker build -t ubcthunderbots/tbots-software-env:0.0.1`
-2. Now, push your image to dockerhub. Get the credentials for the Thunderbots dockerhub account from a software lead.
-   1. Log into the docker account with `docker login`. You will be prompted for a username and password
-   2. Now, push this image by its name: `docker push ubcthunderbots/<image name>[:tag]`
 
 # Workflow
 

--- a/docs/useful-robot-commands.md
+++ b/docs/useful-robot-commands.md
@@ -78,9 +78,13 @@ flowchart TD
 
 ## Wifi Disclaimer
 
-To use most of these commands you will either need to be on the tbots wifi network (no internet access) or on a wifi with internet access (shawopen, ubc wifi) and connected to the Jetson Nano through ethernet tethering. 
+To use most of these commands you will either need to be on the tbots wifi network (no internet access) or on a WiFi with internet access (`ubcvisitor`) and connected to the robot through ethernet tethering. Note that ethernet tethering doesn't work on `ubcsecure` or `eduroam`.
 
-The IP address of the robots on the tbots network is `192.168.0.20<robot_id>` so for robot id `1` the IP is `192.168.0.201`. If you are using ethernet tethering you will need to use a network utility (tshark, wireshark, arp) to determine the IP address.
+On the tbots network:
+- Jetson Nano robots will have an IP address of `192.168.0.20<robot_id>` so for robot id `1` the IP is `192.168.0.201`.
+- Raspberry Pi robots will have an IP address of `192.168.6.20<robot_id>` so for robot id `1` the IP is `192.168.6.201`. Occasionally, these robots may have an IP address of `192.168.5.20<robot_id>`.
+
+If you are not using the tbots network you will need to use a network utility (`tshark`, `wireshark`, `arp`) to determine the IP address.
 
 ## Miscellaneous Ansible Tasks & Options
 

--- a/src/software/embedded/BUILD
+++ b/src/software/embedded/BUILD
@@ -16,12 +16,20 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "build_limited",
+    flag_values = {
+        ":host_platform": "LIMITED",
+    },
+)
+
 string_flag(
     name = "host_platform",
     build_setting_default = "PI",
     values = [
         "PI",
         "NANO",
+        "LIMITED",
     ],
 )
 
@@ -89,10 +97,6 @@ cc_binary(
     linkopts = [
         "-lpthread",
         "-lrt",
-    ],
-    target_compatible_with = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:linux",
     ],
     deps = [
         ":thunderloop",

--- a/src/software/embedded/constants/BUILD
+++ b/src/software/embedded/constants/BUILD
@@ -5,11 +5,13 @@ cc_library(
     hdrs = [
         "constants.h",
         "jetson_constants.h",
+        "limited_constants.h",
         "pi_constants.h",
     ],
     defines = select({
         "//software/embedded:build_nano": ["NANO"],
         "//software/embedded:build_pi": ["PI"],
+        "//software/embedded:build_limited": ["LIMITED"],
     }),
     deps = [
         "//software/embedded:platform",

--- a/src/software/embedded/constants/constants.h
+++ b/src/software/embedded/constants/constants.h
@@ -4,4 +4,6 @@
 #include "software/embedded/constants/jetson_constants.h"
 #elif PI
 #include "software/embedded/constants/pi_constants.h"
+#elif LIMITED
+#include "software/embedded/constants/limited_constants.h"
 #endif

--- a/src/software/embedded/constants/limited_constants.h
+++ b/src/software/embedded/constants/limited_constants.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "software/embedded/platform.h"
+
+// Dummy constants. Under this compilation mode, the motor control code shouldn't execute.
+constexpr int SPI_CS_DRIVER_TO_CONTROLLER_MUX_0_GPIO = 0;
+constexpr int SPI_CS_DRIVER_TO_CONTROLLER_MUX_1_GPIO = 0;
+constexpr int MOTOR_DRIVER_RESET_GPIO                = 0;
+constexpr int DRIVER_CONTROL_ENABLE_GPIO             = 0;
+
+// Path to the CPU thermal zone temperature file
+constexpr const char CPU_TEMP_FILE_PATH[] = "/sys/class/thermal/thermal_zone0/temp";
+
+constexpr Platform PLATFORM = Platform::LIMITED_BUILD;

--- a/src/software/embedded/platform.h
+++ b/src/software/embedded/platform.h
@@ -2,4 +2,4 @@
 
 #include "software/util/make_enum/make_enum.hpp"
 
-MAKE_ENUM(Platform, RASP_PI, JETSON_NANO);
+MAKE_ENUM(Platform, RASP_PI, JETSON_NANO, LIMITED_BUILD);

--- a/src/software/embedded/services/BUILD
+++ b/src/software/embedded/services/BUILD
@@ -8,6 +8,7 @@ cc_library(
         select({
             "//software/embedded:build_nano": ["NANO"],
             "//software/embedded:build_pi": ["PI"],
+            "//software/embedded:build_limited": ["LIMITED"],
         }),
     deps = [
         "//proto:tbots_cc_proto",

--- a/src/software/embedded/services/motor.h
+++ b/src/software/embedded/services/motor.h
@@ -436,13 +436,13 @@ std::unique_ptr<Gpio> MotorService::setupGpio(const T& gpio_number,
                                               GpioDirection direction,
                                               GpioState initial_state)
 {
-    if constexpr (PLATFORM == Platform::RASP_PI)
+    if constexpr (PLATFORM == Platform::JETSON_NANO)
     {
-        return std::make_unique<GpioCharDev>(gpio_number, direction, initial_state,
-                                             "/dev/gpiochip4");
+        return std::make_unique<GpioSysfs>(gpio_number, direction, initial_state);
     }
     else
     {
-        return std::make_unique<GpioSysfs>(gpio_number, direction, initial_state);
+        return std::make_unique<GpioCharDev>(gpio_number, direction, initial_state,
+                                             "/dev/gpiochip4");
     }
 }

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -118,7 +118,7 @@ Thunderloop::Thunderloop(const RobotConstants_t& robot_constants, bool enable_lo
     LOG(INFO)
         << "THUNDERLOOP: Network Service initialized! Next initializing Power Service";
 
-    if (PLATFORM == Platform::LIMITED_BUILD)
+    if constexpr (PLATFORM == Platform::LIMITED_BUILD)
     {
         return;
     }

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -50,8 +50,7 @@ extern "C"
         // to log messages
         std::cerr << "\n\n!!!\nReceived termination signal: "
                   << g3::signalToStr(signal_num) << std::endl;
-        std::cerr << "Thunderloop shutting down\n!!!\n"
-                  << std::endl;
+        std::cerr << "Thunderloop shutting down\n!!!\n" << std::endl;
 
         TbotsProto::RobotCrash crash_msg;
         auto dump = g3::internal::stackdump();
@@ -321,7 +320,8 @@ void Thunderloop::runLoop()
             }
 
             // Motor Service: execute the motor control command
-            motor_status_ = pollMotorService(poll_time, direct_control_.motor_control(), time_since_prev_iter);
+            motor_status_ = pollMotorService(poll_time, direct_control_.motor_control(),
+                                             time_since_prev_iter);
             thunderloop_status_.set_motor_service_poll_time_ms(
                 getMilliseconds(poll_time));
 
@@ -412,8 +412,9 @@ double Thunderloop::getCpuTemperature()
     }
 }
 
-TbotsProto::MotorStatus Thunderloop::pollMotorService(struct timespec& poll_time,
-        const TbotsProto::MotorControl& motor_control, const struct timespec& time_since_prev_iteration)
+TbotsProto::MotorStatus Thunderloop::pollMotorService(
+    struct timespec& poll_time, const TbotsProto::MotorControl& motor_control,
+    const struct timespec& time_since_prev_iteration)
 {
     ScopedTimespecTimer timer(&poll_time);
 

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -417,12 +417,12 @@ TbotsProto::MotorStatus Thunderloop::pollMotorService(struct timespec& poll_time
 {
     ScopedTimespecTimer timer(&poll_time);
 
+    ZoneNamedN(_tracy_motor_service_poll, "Thunderloop: Poll MotorService", true);
+
     if constexpr (PLATFORM == Platform::LIMITED_BUILD)
     {
         return TbotsProto::MotorStatus();
     }
-
-    ZoneNamedN(_tracy_motor_service_poll, "Thunderloop: Poll MotorService", true);
 
     double time_since_prev_iteration_s =
         getMilliseconds(time_since_prev_iteration) * SECONDS_PER_MILLISECOND;
@@ -433,12 +433,12 @@ TbotsProto::PowerStatus Thunderloop::pollPowerService(struct timespec& poll_time
 {
     ScopedTimespecTimer timer(&poll_time);
 
+    ZoneNamedN(_tracy_power_service_poll, "Thunderloop: Poll PowerService", true);
+
     if constexpr (PLATFORM == Platform::LIMITED_BUILD)
     {
         return TbotsProto::PowerStatus();
     }
-
-    ZoneNamedN(_tracy_power_service_poll, "Thunderloop: Poll PowerService", true);
 
     return power_service_->poll(direct_control_.power_control(), kick_coeff_,
                                 kick_constant_, chip_pulse_width_);

--- a/src/software/embedded/thunderloop.h
+++ b/src/software/embedded/thunderloop.h
@@ -100,6 +100,16 @@ class Thunderloop
     void updateErrorCodes();
 
     /**
+     * Poll the motor service.
+     *
+     * @param poll_time Populates the time taken to poll the service
+     * @param motor_control Control message for the motors
+     * @param time_elapsed_since_last_poll_s Time elapsed since the last poll
+     */
+    TbotsProto::MotorStatus pollMotorService(struct timespec &poll_time, const TbotsProto::MotorControl& motor_control,
+            const struct timespec& time_since_prev_iteration);
+
+    /**
      * Poll the power service
      *
      * @param poll_time Populates the time taken to poll the service

--- a/src/software/embedded/thunderloop.h
+++ b/src/software/embedded/thunderloop.h
@@ -104,7 +104,7 @@ class Thunderloop
      *
      * @param poll_time Populates the time taken to poll the service
      * @param motor_control Control message for the motors
-     * @param time_elapsed_since_last_poll_s Time elapsed since the last poll
+     * @param time_since_prev_iteration Stores the time difference since the last call
      */
     TbotsProto::MotorStatus pollMotorService(struct timespec &poll_time, const TbotsProto::MotorControl& motor_control,
             const struct timespec& time_since_prev_iteration);

--- a/src/software/embedded/thunderloop.h
+++ b/src/software/embedded/thunderloop.h
@@ -106,8 +106,9 @@ class Thunderloop
      * @param motor_control Control message for the motors
      * @param time_since_prev_iteration Stores the time difference since the last call
      */
-    TbotsProto::MotorStatus pollMotorService(struct timespec &poll_time, const TbotsProto::MotorControl& motor_control,
-            const struct timespec& time_since_prev_iteration);
+    TbotsProto::MotorStatus pollMotorService(
+        struct timespec &poll_time, const TbotsProto::MotorControl &motor_control,
+        const struct timespec &time_since_prev_iteration);
 
     /**
      * Poll the power service
@@ -116,7 +117,7 @@ class Thunderloop
      *
      * @return The polled power status message
      */
-    TbotsProto::PowerStatus pollPowerService(struct timespec& poll_time);
+    TbotsProto::PowerStatus pollPowerService(struct timespec &poll_time);
 
     /**
      * Wait for networking communication to be established. This function is blocking.

--- a/src/software/embedded/thunderloop.h
+++ b/src/software/embedded/thunderloop.h
@@ -100,6 +100,15 @@ class Thunderloop
     void updateErrorCodes();
 
     /**
+     * Poll the power service
+     *
+     * @param poll_time Populates the time taken to poll the service
+     *
+     * @return The polled power status message
+     */
+    TbotsProto::PowerStatus pollPowerService(struct timespec& poll_time);
+
+    /**
      * Wait for networking communication to be established. This function is blocking.
      */
     void waitForNetworkUp();

--- a/src/tbots.py
+++ b/src/tbots.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         "-pl",
         "--platform",
         type=str,
-        choices=["PI", "NANO"],
+        choices=["PI", "NANO", "HOST"],
         help="The platform to build Thunderloop for",
         action="store",
     )

--- a/src/tbots.py
+++ b/src/tbots.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         "-pl",
         "--platform",
         type=str,
-        choices=["PI", "NANO", "HOST"],
+        choices=["PI", "NANO", "LIMITED"],
         help="The platform to build Thunderloop for",
         action="store",
     )


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

This will be useful for another PR I'm working on.

When testing Thunderloop, a lot of us have resorted to manually commenting out the power and motor service when running on a plain Jetson/Pi.

With this config option, we can run Thunderloop locally and on Jetson/Pis with broken power + motor boards when working on software changes.

\+ Some doc changes

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Local testing

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
