### PR TITLE
3304: Limit number of crease defenders

### DIFF
--- a/src/proto/parameters.proto
+++ b/src/proto/parameters.proto
@@ -527,11 +527,8 @@ message DefensePlayConfig
         ];
 
         // The max number of crease defender can be created at a moment
-        required uint32 max_num_crease_defenders = 6 [
-            default                   = 1,
-            (bounds).min_int_value    = 1,
-            (bounds).max_int_value    = 3
-        ];
+        required uint32 max_num_crease_defenders = 6
+            [default = 1, (bounds).min_int_value = 1, (bounds).max_int_value = 3];
     }
 
     // The distance at which a threat is considered "immediate" if there is only 1
@@ -641,7 +638,7 @@ message NetworkConfig
 
 message CreaseDefenderConfig
 {
-   // Unique steal config for crease defenders
+    // Unique steal config for crease defenders
     required DefenderStealConfig defender_steal_config = 1;
 
     // The additional buffer length for each side of the goal

--- a/src/proto/parameters.proto
+++ b/src/proto/parameters.proto
@@ -525,6 +525,13 @@ message DefensePlayConfig
             (bounds).min_double_value = 0.0,
             (bounds).max_double_value = 10.0
         ];
+
+        // The max number of crease defender can be created at a moment
+        required uint32 max_num_crease_defenders = 6 [
+            default                   = 1,
+            (bounds).min_int_value    = 1,
+            (bounds).max_int_value    = 3
+        ];
     }
 
     // The distance at which a threat is considered "immediate" if there is only 1
@@ -634,12 +641,13 @@ message NetworkConfig
 
 message CreaseDefenderConfig
 {
+   // Unique steal config for crease defenders
+    required DefenderStealConfig defender_steal_config = 1;
+
     // The additional buffer length for each side of the goal
     // to determine if crease defender chipping is "towards goal"
     required double goal_post_offset_chipping = 4
         [default = 0.5, (bounds).min_double_value = 0.0, (bounds).max_double_value = 2.0];
-    // Unique steal config for crease defenders
-    required DefenderStealConfig defender_steal_config = 1;
 }
 
 message PassDefenderConfig

--- a/src/software/ai/hl/stp/play/defense/defense_play_fsm.cpp
+++ b/src/software/ai/hl/stp/play/defense/defense_play_fsm.cpp
@@ -14,7 +14,8 @@ void DefensePlayFSM::defendAgainstThreats(const Update& event)
         event.common.world_ptr->field(), event.common.world_ptr->friendlyTeam(),
         event.common.world_ptr->enemyTeam(), event.common.world_ptr->ball(), false);
 
-    auto defender_assignment_config = ai_config.defense_play_config().defender_assignment_config();
+    auto defender_assignment_config =
+        ai_config.defense_play_config().defender_assignment_config();
     auto assignments = getAllDefenderAssignments(
         enemy_threats, event.common.world_ptr->field(), event.common.world_ptr->ball(),
         defender_assignment_config);
@@ -24,7 +25,8 @@ void DefensePlayFSM::defendAgainstThreats(const Update& event)
         return;
     }
 
-    unsigned int max_num_crease_defenders = defender_assignment_config.max_num_crease_defenders();
+    unsigned int max_num_crease_defenders =
+        defender_assignment_config.max_num_crease_defenders();
 
     // Choose which defender assignments to assign defenders to based on number
     // of tactics available to set

--- a/src/software/ai/hl/stp/tactic/defender/defender_fsm_base.cpp
+++ b/src/software/ai/hl/stp/tactic/defender/defender_fsm_base.cpp
@@ -24,7 +24,7 @@ bool DefenderFSMBase::ballNearbyWithoutThreat(
         world_ptr->enemyTeam().getNearestRobot(robot_position);
 
     if (nearest_friendly_to_ball.has_value() &&
-             robot.id() != nearest_friendly_to_ball.value().id())
+        robot.id() != nearest_friendly_to_ball.value().id())
     {
         // Do nothing if this robot is not the closest to the ball. Resolves issue of
         // multiple simultaneous steals

--- a/src/software/ai/hl/stp/tactic/defender/defender_fsm_base.cpp
+++ b/src/software/ai/hl/stp/tactic/defender/defender_fsm_base.cpp
@@ -9,6 +9,12 @@ bool DefenderFSMBase::ballNearbyWithoutThreat(
     const TbotsProto::BallStealMode& ball_steal_mode,
     const TbotsProto::DefenderStealConfig& defender_steal_config)
 {
+    if (ball_steal_mode == TbotsProto::BallStealMode::IGNORE)
+    {
+        // Do nothing if stealing is disabled
+        return false;
+    }
+
     Point robot_position = robot.position();
     Point ball_position  = world_ptr->ball().position();
 
@@ -16,41 +22,36 @@ bool DefenderFSMBase::ballNearbyWithoutThreat(
         world_ptr->friendlyTeam().getNearestRobot(ball_position);
     std::optional<Robot> nearest_enemy_to_ball =
         world_ptr->enemyTeam().getNearestRobot(robot_position);
-    if (ball_steal_mode == TbotsProto::BallStealMode::IGNORE)
-    {
-        // Do nothing if stealing is disabled
-        return false;
-    }
-    else if (nearest_friendly_to_ball.has_value() &&
+
+    if (nearest_friendly_to_ball.has_value() &&
              robot.id() != nearest_friendly_to_ball.value().id())
     {
         // Do nothing if this robot is not the closest to the ball. Resolves issue of
         // multiple simultaneous steals
         return false;
     }
-    if (nearest_enemy_to_ball.has_value())
-    {
-        // Get the ball if ball is closer to robot than enemy threat by threshold ratio
-        // and within max range
-        double ball_distance_to_friendly = distance(robot_position, ball_position);
-        double ball_distance_to_enemy =
-            distance(nearest_enemy_to_ball.value().position(), ball_position);
 
-        bool ball_is_near_friendly =
-            ball_distance_to_friendly <
-            ball_distance_to_enemy *
-                (1.0 - defender_steal_config.max_get_ball_ratio_threshold());
-        bool ball_is_within_max_range =
-            ball_distance_to_friendly <= defender_steal_config.max_get_ball_radius_m();
-        bool ball_is_slow = world_ptr->ball().velocity().length() <=
-                            defender_steal_config.max_ball_speed_to_get_m_per_s();
-
-        return ball_is_near_friendly && ball_is_within_max_range && ball_is_slow;
-    }
-    else
+    if (!nearest_enemy_to_ball.has_value())
     {
         return true;
     }
+
+    // Get the ball if ball is closer to robot than enemy threat by threshold ratio
+    // and within max range
+    double ball_distance_to_friendly = distance(robot_position, ball_position);
+    double ball_distance_to_enemy =
+        distance(nearest_enemy_to_ball.value().position(), ball_position);
+
+    bool ball_is_near_friendly =
+        ball_distance_to_friendly <
+        ball_distance_to_enemy *
+            (1.0 - defender_steal_config.max_get_ball_ratio_threshold());
+    bool ball_is_within_max_range =
+        ball_distance_to_friendly <= defender_steal_config.max_get_ball_radius_m();
+    bool ball_is_slow = world_ptr->ball().velocity().length() <=
+                        defender_steal_config.max_ball_speed_to_get_m_per_s();
+
+    return ball_is_near_friendly && ball_is_within_max_range && ball_is_slow;
 }
 
 void DefenderFSMBase::prepareGetPossession(

--- a/src/software/ai/hl/stp/tactic/defender/defender_fsm_base.cpp
+++ b/src/software/ai/hl/stp/tactic/defender/defender_fsm_base.cpp
@@ -44,8 +44,7 @@ bool DefenderFSMBase::ballNearbyWithoutThreat(
 
     bool ball_is_near_friendly =
         ball_distance_to_friendly <
-        ball_distance_to_enemy *
-            (1.0 - defender_steal_config.max_get_ball_ratio_threshold());
+        ball_distance_to_enemy * defender_steal_config.max_get_ball_ratio_threshold();
     bool ball_is_within_max_range =
         ball_distance_to_friendly <= defender_steal_config.max_get_ball_radius_m();
     bool ball_is_slow = world_ptr->ball().velocity().length() <=


### PR DESCRIPTION
### Description
In general: improve aggressiveness of defense

Particularly:
- [X] Refactor defender_fsm_base logics (added early stop to prevent unnecessary computation)
- [X] Move max number of crease defender to ai_config, which allows dynamic configuration on the max number of crease defender. Originally the max number of crease defender could be up to 3 at a moment. This looks like we are having an exceeding number of robots being assigned to passively block the enemies. To make the overall defense strategy to be more aggressive, we should assign fewer crease defender.
- [Not implemented in this PR, instead see #3450] Implement a new fsm `active_defender`, following the below logic:
~An active defender is promoted from a pass defender when~
~1. It is closest to the ball or the enemy player that carries the ball~
~2. There is no other active defender on the team at the moment~

~The specific active defender behavor is still WIP.~

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
Closes #3304 
Related to #3450 

Have synced with @zuperzane and we have the same idea on the shadow defender (or active defender). The actual defense logic will be implemented in his PR #3450 

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
