### PR TITLE
Fix int configs on Thunderscope

### DIFF
--- a/src/software/thunderscope/common/proto_parameter_tree_util.py
+++ b/src/software/thunderscope/common/proto_parameter_tree_util.py
@@ -37,8 +37,8 @@ def __create_int_parameter_writable(key, value, descriptor):
 
     try:
         minimum, maximum = (
-            options.Extensions[bounds].min_double_value,
-            options.Extensions[bounds].max_double_value,
+            options.Extensions[bounds].min_int_value,
+            options.Extensions[bounds].max_int_value,
         )
     except KeyError:
         raise KeyError("{} missing ParameterRangeOptions".format(key))


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Previously, Thunderscope failed to recongize the integer configurations in [parameters.proto](https://github.com/UBC-Thunderbots/Software/blob/34baf232e0c6f6fa5d393a9902a20a10a7f137e6/src/proto/parameters.proto#L121-L123). Specifically, thunderscope fills in 0 for these fields if you switch to the parameters tab. The min bound, max bound and the default value of uint64, uint32, etc. fields are affected. (An example of this is `pass_gen_num_samples_per_robot`)

After the fix:

https://github.com/user-attachments/assets/ca22ae3f-eff6-49b9-ad3f-975ac907b6e5


### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
1. Manual tests
2. CIs

Please assert
For int fields, the max bound, min bound, and default value are correctly recognized as the demo video above suggested.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
