### PR TITLE
Fix toolchain for aarch64

### DIFF
--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -31,7 +31,8 @@ register_toolchains("//py_toolchain:py_toolchain")
 
 register_toolchains(
     "//py_toolchain:k8_jetson_nano_cross_compile_py_cc_toolchain",
-    "//py_toolchain:py_cc_toolchain_for_host_x86_64",
+    "//py_toolchain:py_cc_toolchain_host_x86_64",
+    "//py_toolchain:py_cc_toolchain_host_aarch64",
 )
 
 load("@rules_python//python:pip.bzl", "pip_parse")
@@ -417,7 +418,7 @@ register_toolchains(
 )
 
 new_local_repository(
-    name = "py_cc_toolchain_for_host_x86_64",
+    name = "py_cc_toolchain_host",
     build_file = "@//extlibs:py_cc_toolchain.BUILD",
     path = "/usr/include/python3.12/",
 )

--- a/src/py_toolchain/BUILD
+++ b/src/py_toolchain/BUILD
@@ -22,7 +22,7 @@ toolchain(
 )
 
 toolchain(
-    name = "py_cc_toolchain_for_host_x86_64",
+    name = "py_cc_toolchain_host_x86_64",
     exec_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
@@ -31,13 +31,27 @@ toolchain(
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
-    toolchain = ":py_cc_toolchain_for_host_x86_64_data",
+    toolchain = ":py_cc_toolchain_host_data",
+    toolchain_type = "@rules_python//python/cc:toolchain_type",
+)
+
+toolchain(
+    name = "py_cc_toolchain_host_aarch64",
+    exec_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    toolchain = ":py_cc_toolchain_host_data",
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
 py_cc_toolchain(
-    name = "py_cc_toolchain_for_host_x86_64_data",
-    headers = "@py_cc_toolchain_for_host_x86_64//:headers",
+    name = "py_cc_toolchain_host_data",
+    headers = "@py_cc_toolchain_host//:headers",
     libs = ":empty",
     python_version = "3.12",
 )


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

### Description
Toolchain was spotted broken on ARM after RobotDiagnosticCLI was merged. 
Specific symptoms (on master):
```shell
minghao@minghao:~/Projects/Software/src$ bazel run //software/thunderscope:thunderscope_main --verbose_failures -- --enable_autoref
Starting local Bazel server and connecting to it...
INFO: Invocation ID: b6f0f4ec-2d21-4596-9208-0306e6ac3703
ERROR: /home/minghao/.cache/bazel/_bazel_minghao/6913180ba03656085c5e813cbbf9d21a/external/rules_python/python/cc/BUILD.bazel:15:22: While resolving toolchains for target @rules_python//python/cc:current_py_cc_headers: no matching toolchains found for types @rules_python//python/cc:toolchain_type
ERROR: Analysis of target '//software/thunderscope:thunderscope_main' failed; build aborted: 
INFO: Elapsed time: 10.381s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (111 packages loaded, 6968 targets configured)
FAILED: Build did NOT complete successfully (111 packages loaded, 6968 targets configured)

```

### Why
Python toolchain seems to be only defined for x86, but not for aarch64 architecture.

### How
Add the toolchain definition to make it also available for aarch64, so mac vm users can run it as well.

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
1. Manual testing through running `bazel run //software/thunderscope:thunderscope_main --verbose_failures -- --enable_autoref` and assert thunderscope runs
2. CIs
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests
and list the key files that contain the main idea of your PR -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->

### NOTES:
If possible, could I get some help on validing the fix does not break x86 build process + it works fine for robot code compile as well.
