### PR TITLE
Fixed SimulatedTestRunner delayed commands and fixed halt_play_test.py

### DIFF
--- a/environment_setup/ubuntu20_requirements.txt
+++ b/environment_setup/ubuntu20_requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint==25.7.0
+ansible-lint==25.8.1
 pyqtgraph==0.13.7
 pyqt6==6.6.1
 PyQt6-Qt6==6.6.1

--- a/environment_setup/ubuntu22_requirements.txt
+++ b/environment_setup/ubuntu22_requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint==25.7.0
+ansible-lint==25.8.1
 pyqtgraph==0.13.7
 pyqt6==6.6.1
 PyQt6-Qt6==6.6.1

--- a/environment_setup/ubuntu24_requirements.txt
+++ b/environment_setup/ubuntu24_requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint==25.7.0
+ansible-lint==25.8.1
 pyqtgraph==0.13.7
 thefuzz==0.19.0
 iterfzf==0.5.0.20.0

--- a/src/software/ai/hl/stp/play/halt_play/halt_play_test.py
+++ b/src/software/ai/hl/stp/play/halt_play/halt_play_test.py
@@ -72,7 +72,10 @@ def test_halt_play(simulated_test_runner):
         ag_eventually_validation_sequence_set=[
             [RobotSpeedEventuallyBelowThreshold(1e-3)]
         ],
-        ci_cmd_with_delay=[(3, Command.Type.HALT, Team.BLUE), (3, Command.Type.HALT, Team.YELLOW)],
+        ci_cmd_with_delay=[
+            (3, Command.Type.HALT, Team.BLUE),
+            (3, Command.Type.HALT, Team.YELLOW),
+        ],
         test_timeout_s=10,
     )
 

--- a/src/software/ai/hl/stp/play/halt_play/halt_play_test.py
+++ b/src/software/ai/hl/stp/play/halt_play/halt_play_test.py
@@ -46,10 +46,6 @@ def test_halt_play(simulated_test_runner):
             gc_command=Command.Type.FORCE_START, team=Team.UNKNOWN
         )
 
-        # Structure for a delayed call is tuple (delay in seconds, command, team)
-        (3, Command.Type.HALT, Team.BLUE)
-        (3, Command.Type.HALT, Team.YELLOW)
-
         # No plays to override. AI does whatever for 3 seconds before HALT CMD
         # is issued
 
@@ -76,6 +72,7 @@ def test_halt_play(simulated_test_runner):
         ag_eventually_validation_sequence_set=[
             [RobotSpeedEventuallyBelowThreshold(1e-3)]
         ],
+        ci_cmd_with_delay=[(3, Command.Type.HALT, Team.BLUE), (3, Command.Type.HALT, Team.YELLOW)],
         test_timeout_s=10,
     )
 

--- a/src/software/embedded/ansible/requirements.in
+++ b/src/software/embedded/ansible/requirements.in
@@ -1,1 +1,1 @@
-ansible==10.5.0
+ansible==11.9.0

--- a/src/software/embedded/ansible/requirements_lock.txt
+++ b/src/software/embedded/ansible/requirements_lock.txt
@@ -4,13 +4,13 @@
 #
 #    bazel run //software/embedded/ansible:requirements.update
 #
-ansible==10.5.0 \
-    --hash=sha256:1d10bddba58f1edd0fe0b8e0387e0fafc519535066bb3c919c33b6ea3ec32a0f \
-    --hash=sha256:ba2045031a7d60c203b6e5fe1f8eaddd53ae076f7ada910e636494384135face
+ansible==11.9.0 \
+    --hash=sha256:528ca5a408f11cf1fea00daea7570e68d40e167be38b90c119a7cb45729e4921 \
+    --hash=sha256:79b087ef38105b93e0e092e7013a0f840e154a6a8ce9b5fddd1b47593adc542a
     # via -r software/embedded/ansible/requirements.in
-ansible-core==2.17.5 \
-    --hash=sha256:10f165b475cf2bc8d886e532cadb32c52ee6a533649793101d3166bca9bd3ea3 \
-    --hash=sha256:ae7f51fd13dc9d57c9bcd43ef23f9c255ca8f18f4b5c0011a4f9b724d92c5a8e
+ansible-core==2.18.8 \
+    --hash=sha256:b0766215a96a47ce39933d27e1e996ca2beb54cf1b3907c742d35c913b1f78cd \
+    --hash=sha256:b60bc23b2f11fd0559a79d10ac152b52f58a18ca1b7be0a620dfe87f34ced689
     # via ansible
 cffi==1.16.0 \
     --hash=sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc \

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -8,7 +8,6 @@ import os
 import pytest
 from proto.import_all_protos import *
 
-from proto.ssl_gc_common_pb2 import Team as SslTeam
 from software.networking.ssl_proto_communication import *
 from software.simulated_tests import validation
 from software.simulated_tests.tbots_test_runner import TbotsTestRunner

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -243,13 +243,12 @@ class SimulatedTestRunner(TbotsTestRunner):
         :param tick_duration_s: length of a tick
         :param index: index of the current test. default is 0 (invariant test)
                       values can be passed in during aggregate testing for different timeout durations
-        :param ci_cmd_with_delay: A list consisting of a duration, and a
-                        tuple forming a ci command
-                        {
-                            (time, command, team),
-                            (time, command, team),
-                            ...
-                        }
+        :param ci_cmd_with_delay: A list consisting of tuples with a duration and CI command, e.g.
+                                  [
+                                      (time, command, team),
+                                      (time, command, team),
+                                      ...
+                                  ]
         :param run_till_end: If true, test runs till the end even if eventually validation passes
                              If false, test stops once eventually validation passes and fails if time out
         """

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -8,7 +8,8 @@ import os
 import pytest
 from proto.import_all_protos import *
 
-
+from proto.ssl_gc_common_pb2 import Team as SslTeam
+from software.networking.ssl_proto_communication import *
 from software.simulated_tests import validation
 from software.simulated_tests.tbots_test_runner import TbotsTestRunner
 from software.thunderscope.thunderscope import Thunderscope
@@ -130,7 +131,7 @@ class SimulatedTestRunner(TbotsTestRunner):
                 # If delay matches time
                 if delay <= time_elapsed_s:
                     # send command
-                    self.gamecontroller.send_ci_input(cmd, team)
+                    self.gamecontroller.send_gc_command(gc_command=cmd, team=team)
                     # remove command from the list
                     ci_cmd_with_delay.remove((delay, cmd, team))
 
@@ -233,6 +234,7 @@ class SimulatedTestRunner(TbotsTestRunner):
         test_timeout_s=3,
         tick_duration_s=0.0166,
         index=0,
+        ci_cmd_with_delay=[],
         run_till_end=True,
         **kwargs,
     ):
@@ -244,6 +246,13 @@ class SimulatedTestRunner(TbotsTestRunner):
         :param tick_duration_s: length of a tick
         :param index: index of the current test. default is 0 (invariant test)
                       values can be passed in during aggregate testing for different timeout durations
+        :param ci_cmd_with_delay: A list consisting of a duration, and a
+                        tuple forming a ci command
+                        {
+                            (time, command, team),
+                            (time, command, team),
+                            ...
+                        }
         :param run_till_end: If true, test runs till the end even if eventually validation passes
                              If false, test stops once eventually validation passes and fails if time out
         """
@@ -271,7 +280,7 @@ class SimulatedTestRunner(TbotsTestRunner):
                     eventually_validation_sequence_set,
                     test_timeout_duration,
                     tick_duration_s,
-                    [],
+                    ci_cmd_with_delay,
                     run_till_end,
                 ],
             )
@@ -289,6 +298,7 @@ class SimulatedTestRunner(TbotsTestRunner):
                 eventually_validation_sequence_set,
                 test_timeout_duration,
                 tick_duration_s,
+                ci_cmd_with_delay=ci_cmd_with_delay,
                 run_till_end=run_till_end,
             )
 

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -106,13 +106,12 @@ class SimulatedTestRunner(TbotsTestRunner):
         :param test_timeout_s: The timeout for the test, if any eventually_validations
                                 remain after the timeout, the test fails.
         :param tick_duration_s: The simulation step duration
-        :param ci_cmd_with_delay: A list consisting of a duration, and a
-                                tuple forming a ci command
-                                {
-                                    (time, command, team),
-                                    (time, command, team),
-                                    ...
-                                }
+        :param ci_cmd_with_delay: A list consisting of tuples with a duration and CI command, e.g.
+                                  [
+                                      (time, command, team),
+                                      (time, command, team),
+                                      ...
+                                  ]
         :param run_till_end: If true, test runs till the end even if eventually validation passes
                              If false, test stops once eventually validation passes and fails if time out
         """

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -9,7 +9,6 @@ import pytest
 from proto.import_all_protos import *
 
 from proto.ssl_gc_common_pb2 import Team as SslTeam
-from software.networking.ssl_proto_communication import *
 from software.simulated_tests import validation
 from software.simulated_tests.tbots_test_runner import TbotsTestRunner
 from software.thunderscope.thunderscope import Thunderscope

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -8,7 +8,6 @@ import os
 import pytest
 from proto.import_all_protos import *
 
-from software.networking.ssl_proto_communication import *
 from software.simulated_tests import validation
 from software.simulated_tests.tbots_test_runner import TbotsTestRunner
 from software.thunderscope.thunderscope import Thunderscope


### PR DESCRIPTION
<!---
Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    fixed SimulatedTestRunner's run_test and runner method to allow ci_cmd_with_delay to be used properly. Used it to fix halt_play_test.py so that the robots actually stop after 3 seconds.
-->

### Testing Done
Changed halt_play_test.py and watched the recording.
[https://youtu.be/fT0M6haEt_o](url)

### Resolved Issues
Problem was discovered the day before this PR, no issue opened. 

### Length Justification and Key Files to Review
Maybe 3 lines were changed.

/src/software/simulated_tests/simulated_test_fixture.py
/src/software/ai/hl/stp/play/halt_play/halt_play_test.py

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

