### PR TITLE
Add macOS ARM support for Thunderscope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,7 @@ src/.clangd
 
 # external is a special directory for bazel so it should be ignored
 src/external
+
+# macOS folder info
+.DS_Store
+

--- a/environment_setup/macos_requirements.txt
+++ b/environment_setup/macos_requirements.txt
@@ -1,0 +1,13 @@
+ansible-lint==24.12.2
+pyqtgraph==0.13.7
+thefuzz==0.19.0
+iterfzf==0.5.0.20.0
+python-Levenshtein==0.25.1
+psutil==5.9.0
+PyOpenGL==3.1.6
+ruff==0.5.5
+pyqt-toast-notification==1.3.2
+grpcio-tools==1.71.0
+platformio==6.1.18
+pyqt6==6.9.1
+

--- a/environment_setup/setup_software.sh
+++ b/environment_setup/setup_software.sh
@@ -158,6 +158,7 @@ print_status_msg "Done setting up cross compiler for robot software"
 
 print_status_msg "Setting Up Python Development Headers"
 install_python_dev_cross_compile_headers $g_arch
+install_python_toolchain_headers
 print_status_msg "Done Setting Up Python Development Headers"
 
 print_status_msg "Setting Up PlatformIO"

--- a/environment_setup/setup_software_mac.sh
+++ b/environment_setup/setup_software_mac.sh
@@ -83,6 +83,10 @@ sudo chmod +x "$CURR_DIR/../src/software/autoref/run_autoref.sh"
 sudo cp "$CURR_DIR/../src/software/autoref/DIV_B.txt" "/opt/tbotspython/autoReferee/config/geometry/DIV_B.txt"
 print_status_msg "Finished setting up AutoRef"
 
+print_status_msg "Setting up cross compiler for robot software"
+install_cross_compiler_mac
+print_status_msg "Done setting up cross compiler for robot software"
+
 print_status_msg "Setting Up Python Development Headers"
 install_python_toolchain_headers_macos
 print_status_msg "Done Setting Up Python Development Headers"

--- a/environment_setup/setup_software_mac.sh
+++ b/environment_setup/setup_software_mac.sh
@@ -88,7 +88,7 @@ install_cross_compiler_mac
 print_status_msg "Done setting up cross compiler for robot software"
 
 print_status_msg "Setting Up Python Development Headers"
-install_python_toolchain_headers_macos
+install_python_toolchain_headers
 print_status_msg "Done Setting Up Python Development Headers"
 
 print_status_msg "Granting Permissions to /opt/tbotspython"

--- a/environment_setup/setup_software_mac.sh
+++ b/environment_setup/setup_software_mac.sh
@@ -12,21 +12,9 @@ cd "$CURR_DIR" || exit
 
 source util.sh
 
-arch=$(uname -s)
-print_status_msg "Detected architecture: ${arch}"
-
-# Check for Homebrew and install if missing
-if ! command -v brew &>/dev/null; then
-    print_status_msg "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-    # Configure Homebrew in current shell
-    if [ "$arch" = "arm64" ]; then
-        eval "$(/opt/homebrew/bin/brew shellenv)"
-    else
-        eval "$(/usr/local/bin/brew shellenv)"
-    fi
-fi
+# Since we only support MacOS Arm chips (M series), we can use "Darwin" as the identifier
+# for mac setup procedures and ignore the architecture for now.
+sys=$(uname -s)
 
 print_status_msg "Installing Utilities and Dependencies"
 
@@ -73,16 +61,16 @@ sudo pip install -r macos_requirements.txt
 print_status_msg "Done Setting Up Python Environment"
 
 print_status_msg "Fetching game controller"
-install_gamecontroller $arch
+install_gamecontroller $sys
 
 print_status_msg "Setting up TIGERS AutoRef"
-install_autoref $arch
+install_autoref $sys
 sudo chmod +x "$CURR_DIR/../src/software/autoref/run_autoref.sh"
 sudo cp "$CURR_DIR/../src/software/autoref/DIV_B.txt" "/opt/tbotspython/autoReferee/config/geometry/DIV_B.txt"
 print_status_msg "Finished setting up AutoRef"
 
 print_status_msg "Setting up cross compiler for robot software"
-install_cross_compiler $arch
+install_cross_compiler $sys
 print_status_msg "Done setting up cross compiler for robot software"
 
 print_status_msg "Setting Up Python Development Headers"
@@ -93,7 +81,9 @@ print_status_msg "Granting Permissions to /opt/tbotspython"
 sudo chown -R $(id -u):$(id -g) /opt/tbotspython
 print_status_msg "Done Granting Permissions to /opt/tbotspython"
 
-print_status_msg "Done Environment Configuration"
+print_status_msg "Set up ansible-lint"
+/opt/tbotspython/bin/ansible-galaxy collection install ansible.posix
+print_status_msg "Finished setting up ansible-lint"
 
 print_status_msg "Software Setup Complete"
 print_status_msg "Note: Some changes require a new terminal session to take effect"

--- a/environment_setup/setup_software_mac.sh
+++ b/environment_setup/setup_software_mac.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -x
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# UBC Thunderbots macOS Software Setup
+#
+# This script will install all required libraries and dependencies to build
+# and run the Thunderbots codebase on macOS, including the AI and unit tests.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+
+# Save the parent dir of this script
+CURR_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$CURR_DIR" || exit
+
+source util.sh
+
+arch=$(uname -m)
+print_status_msg "Detected architecture: ${arch}"
+
+# Check for Homebrew and install if missing
+if ! command -v brew &>/dev/null; then
+    print_status_msg "Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    # Configure Homebrew in current shell
+    if [ "$arch" = "arm64" ]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    else
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+fi
+
+print_status_msg "Installing Utilities and Dependencies"
+
+# Update Homebrew
+brew update
+
+# Install required packages
+host_software_packages=(
+    cmake@4
+    python@3.12
+    bazelisk
+    openjdk@21
+    pyqt@6
+    qt@6
+    node@20
+    go@1.24
+    clang-format@20
+)
+
+for pkg in "${host_software_packages[@]}"; do
+    if ! brew list "$pkg" &>/dev/null; then
+        print_status_msg "Installing $pkg..."
+        brew install "$pkg"
+    else
+        print_status_msg "$pkg already installed, skipping..."
+    fi
+done
+
+# Set up cache
+mkdir /tmp/tbots_download_cache
+
+# Set up Python
+print_status_msg "Setting Up Python Environment"
+
+# Create virtual environment
+sudo python3.12 -m venv /opt/tbotspython
+chmod
+source /opt/tbotspython/bin/activate
+
+# Install Python dependencies
+sudo pip install --upgrade pip
+sudo pip install -r macos_requirements.txt
+
+print_status_msg "Done Setting Up Python Environment"
+
+print_status_msg "Fetching game controller"
+install_gamecontroller_macos
+
+print_status_msg "Setting up TIGERS AutoRef"
+install_java_macos
+install_autoref_macos
+sudo chmod +x "$CURR_DIR/../src/software/autoref/run_autoref.sh"
+sudo cp "$CURR_DIR/../src/software/autoref/DIV_B.txt" "/opt/tbotspython/autoReferee/config/geometry/DIV_B.txt"
+print_status_msg "Finished setting up AutoRef"
+
+print_status_msg "Setting Up Python Development Headers"
+install_python_toolchain_headers_macos
+print_status_msg "Done Setting Up Python Development Headers"
+
+print_status_msg "Granting Permissions to /opt/tbotspython"
+sudo chown -R $(id -u):$(id -g) /opt/tbotspython
+print_status_msg "Done Granting Permissions to /opt/tbotspython"
+
+print_status_msg "Done Environment Configuration"
+
+print_status_msg "Software Setup Complete"
+print_status_msg "Note: Some changes require a new terminal session to take effect"
+

--- a/environment_setup/setup_software_mac.sh
+++ b/environment_setup/setup_software_mac.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 # UBC Thunderbots macOS Software Setup
 #
@@ -13,7 +12,7 @@ cd "$CURR_DIR" || exit
 
 source util.sh
 
-arch=$(uname -m)
+arch=$(uname -s)
 print_status_msg "Detected architecture: ${arch}"
 
 # Check for Homebrew and install if missing
@@ -74,17 +73,16 @@ sudo pip install -r macos_requirements.txt
 print_status_msg "Done Setting Up Python Environment"
 
 print_status_msg "Fetching game controller"
-install_gamecontroller_macos
+install_gamecontroller $arch
 
 print_status_msg "Setting up TIGERS AutoRef"
-install_java_macos
-install_autoref_macos
+install_autoref $arch
 sudo chmod +x "$CURR_DIR/../src/software/autoref/run_autoref.sh"
 sudo cp "$CURR_DIR/../src/software/autoref/DIV_B.txt" "/opt/tbotspython/autoReferee/config/geometry/DIV_B.txt"
 print_status_msg "Finished setting up AutoRef"
 
 print_status_msg "Setting up cross compiler for robot software"
-install_cross_compiler_mac
+install_cross_compiler $arch
 print_status_msg "Done setting up cross compiler for robot software"
 
 print_status_msg "Setting Up Python Development Headers"

--- a/environment_setup/util.sh
+++ b/environment_setup/util.sh
@@ -8,6 +8,15 @@ install_autoref() {
     rm -rf /tmp/tbots_download_cache/autoReferee.zip /tmp/tbots_download_cache/AutoReferee-${autoref_commit}
 }
 
+install_autoref_macos() {
+    autoref_version=1.5.5
+    curl -L https://github.com/TIGERs-Mannheim/AutoReferee/releases/download/${autoref_version}/autoReferee.zip -o /tmp/tbots_download_cache/autoReferee.zip
+    unzip -q -o -d /tmp/tbots_download_cache/ /tmp/tbots_download_cache/autoReferee.zip
+
+    sudo mv /tmp/tbots_download_cache/autoReferee /opt/tbotspython/
+    rm -rf /tmp/tbots_download_cache/autoReferee.zip
+}
+
 install_bazel() {
     download=https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-arm64 
 
@@ -46,6 +55,19 @@ install_gamecontroller () {
     sudo chmod +x /opt/tbotspython/gamecontroller
 }
 
+install_gamecontroller_macos () {
+    curl -L https://github.com/RoboCup-SSL/ssl-game-controller/archive/refs/tags/v3.17.0.zip -o /tmp/tbots_download_cache/ssl-game-controller.zip
+    unzip -q -o -d /tmp/tbots_download_cache/ /tmp/tbots_download_cache/ssl-game-controller.zip
+    cd /tmp/tbots_download_cache/ssl-game-controller-3.17.0
+    make install
+    go build cmd/ssl-game-controller/main.go
+    sudo mv main /opt/tbotspython/gamecontroller
+    sudo chmod +x /opt/tbotspython/gamecontroller
+
+    cd -
+    sudo rm -rf /tmp/tbots_download_cache/ssl-game-controller-3.17.0 /tmp/tbots_download_cache/go /tmp/tbots_download_cache/go.tar.gz /tmp/tbots_download_cache/ssl-game-controller.zip
+}
+
 install_java () {
     java_home=""
     java_download=https://download.oracle.com/java/21/latest/jdk-21_linux-aarch64_bin.tar.gz
@@ -56,6 +78,17 @@ install_java () {
     tar -xzf /tmp/tbots_download_cache/jdk-21.tar.gz -C /opt/tbotspython/
     mv /opt/tbotspython/jdk-21* /opt/tbotspython/bin/jdk
     rm /tmp/tbots_download_cache/jdk-21.tar.gz
+}
+
+install_java_macos () {
+    java_home=""
+    java_download=https://download.oracle.com/java/21/latest/jdk-21_macos-aarch64_bin.tar.gz
+    curl -L $java_download -o /tmp/tbots_download_cache/jdk-21.tar.gz
+    mkdir /tmp/tbots_download_cache/jdk
+    tar -xzf /tmp/tbots_download_cache/jdk-21.tar.gz -C /tmp/tbots_download_cache
+    sudo mv /tmp/tbots_download_cache/jdk-21*/Contents/Home /opt/tbotspython/bin/jdk
+    rm /tmp/tbots_download_cache/jdk-21.tar.gz
+    rm -rf /tmp/tbots_download_cache/jdk
 }
 
 install_python_dev_cross_compile_headers() {
@@ -88,6 +121,11 @@ install_python_dev_cross_compile_headers() {
     cd -
     rm -rf /tmp/tbots_download_cache/Python-3.12.0
     rm -rf /tmp/tbots_download_cache/python-3.12.0.tar.xz
+}
+
+install_python_toolchain_headers_macos() {
+  sudo mkdir -p /opt/tbotspython/py_headers/include/
+  sudo ln -sfn "$(python3.12-config --includes | awk '{for(i=1;i<=NF;++i) if ($i ~ /^-I/) print substr($i, 3)}' | head -n1)" /opt/tbotspython/py_headers/include/
 }
 
 is_x86() {

--- a/environment_setup/util.sh
+++ b/environment_setup/util.sh
@@ -44,6 +44,16 @@ install_cross_compiler() {
     rm /tmp/tbots_download_cache/$full_file_name
 }
 
+install_cross_compiler_mac() {
+    file_name=aarch64-tbots-linux-gnu-for-aarch64
+    full_file_name=$file_name.tar.xz
+    curl -L "https://raw.githubusercontent.com/UBC-Thunderbots/Software-External-Dependencies/refs/heads/main/toolchain/$full_file_name" \
+        -o /tmp/tbots_download_cache/$full_file_name
+    tar -xf /tmp/tbots_download_cache/$full_file_name -C /tmp/tbots_download_cache/
+    sudo mv /tmp/tbots_download_cache/aarch64-tbots-linux-gnu /opt/tbotspython
+    rm /tmp/tbots_download_cache/$full_file_name
+}
+
 install_gamecontroller () {
     arch=arm64
     if is_x86 $1; then

--- a/environment_setup/util.sh
+++ b/environment_setup/util.sh
@@ -133,7 +133,7 @@ install_python_dev_cross_compile_headers() {
     rm -rf /tmp/tbots_download_cache/python-3.12.0.tar.xz
 }
 
-install_python_toolchain_headers_macos() {
+install_python_toolchain_headers() {
   sudo mkdir -p /opt/tbotspython/py_headers/include/
   sudo ln -sfn "$(python3.12-config --includes | awk '{for(i=1;i<=NF;++i) if ($i ~ /^-I/) print substr($i, 3)}' | head -n1)" /opt/tbotspython/py_headers/include/
 }

--- a/environment_setup/util.sh
+++ b/environment_setup/util.sh
@@ -1,20 +1,20 @@
 install_autoref() {
-    autoref_commit=b30660b78728c3ce159de8ae096181a1ec52e9ba
-    wget -N https://github.com/TIGERs-Mannheim/AutoReferee/archive/${autoref_commit}.zip -O /tmp/tbots_download_cache/autoReferee.zip
-    unzip -q -o -d /tmp/tbots_download_cache/ /tmp/tbots_download_cache/autoReferee.zip
+    if is_darwin $1; then
+        autoref_version=1.5.5
+        curl -L https://github.com/TIGERs-Mannheim/AutoReferee/releases/download/${autoref_version}/autoReferee.zip -o /tmp/tbots_download_cache/autoReferee.zip
+        unzip -q -o -d /tmp/tbots_download_cache/ /tmp/tbots_download_cache/autoReferee.zip
 
-    /tmp/tbots_download_cache/AutoReferee-${autoref_commit}/./gradlew installDist -p /tmp/tbots_download_cache/AutoReferee-${autoref_commit} -Dorg.gradle.java.home=/opt/tbotspython/bin/jdk
-    mv /tmp/tbots_download_cache/AutoReferee-${autoref_commit}/build/install/autoReferee /opt/tbotspython/
-    rm -rf /tmp/tbots_download_cache/autoReferee.zip /tmp/tbots_download_cache/AutoReferee-${autoref_commit}
-}
+        sudo mv /tmp/tbots_download_cache/autoReferee /opt/tbotspython/
+        rm -rf /tmp/tbots_download_cache/autoReferee.zip
+    else
+        autoref_commit=b30660b78728c3ce159de8ae096181a1ec52e9ba
+        wget -N https://github.com/TIGERs-Mannheim/AutoReferee/archive/${autoref_commit}.zip -O /tmp/tbots_download_cache/autoReferee.zip
+        unzip -q -o -d /tmp/tbots_download_cache/ /tmp/tbots_download_cache/autoReferee.zip
 
-install_autoref_macos() {
-    autoref_version=1.5.5
-    curl -L https://github.com/TIGERs-Mannheim/AutoReferee/releases/download/${autoref_version}/autoReferee.zip -o /tmp/tbots_download_cache/autoReferee.zip
-    unzip -q -o -d /tmp/tbots_download_cache/ /tmp/tbots_download_cache/autoReferee.zip
-
-    sudo mv /tmp/tbots_download_cache/autoReferee /opt/tbotspython/
-    rm -rf /tmp/tbots_download_cache/autoReferee.zip
+        /tmp/tbots_download_cache/AutoReferee-${autoref_commit}/./gradlew installDist -p /tmp/tbots_download_cache/AutoReferee-${autoref_commit} -Dorg.gradle.java.home=/opt/tbotspython/bin/jdk
+        mv /tmp/tbots_download_cache/AutoReferee-${autoref_commit}/build/install/autoReferee /opt/tbotspython/
+        rm -rf /tmp/tbots_download_cache/autoReferee.zip /tmp/tbots_download_cache/AutoReferee-${autoref_commit}
+    fi
 }
 
 install_bazel() {
@@ -34,48 +34,47 @@ install_clang_format() {
 
 install_cross_compiler() {
     file_name=aarch64-tbots-linux-gnu-for-aarch64
-    if is_x86 $1; then
-        file_name=aarch64-tbots-linux-gnu-for-x86
+    if is_darwin $1; then
+       full_file_name=$file_name.tar.xz
+       curl -L "https://raw.githubusercontent.com/UBC-Thunderbots/Software-External-Dependencies/refs/heads/main/toolchain/$full_file_name" \
+           -o /tmp/tbots_download_cache/$full_file_name
+       tar -xf /tmp/tbots_download_cache/$full_file_name -C /tmp/tbots_download_cache/
+       sudo mv /tmp/tbots_download_cache/aarch64-tbots-linux-gnu /opt/tbotspython
+       rm /tmp/tbots_download_cache/$full_file_name
+    else
+        if is_x86 $1; then
+            file_name=aarch64-tbots-linux-gnu-for-x86
+        fi
+        full_file_name=$file_name.tar.xz
+        wget https://raw.githubusercontent.com/UBC-Thunderbots/Software-External-Dependencies/refs/heads/main/toolchain/$full_file_name -O /tmp/tbots_download_cache/$full_file_name
+        tar -xf /tmp/tbots_download_cache/$full_file_name -C /tmp/tbots_download_cache/
+        sudo mv /tmp/tbots_download_cache/aarch64-tbots-linux-gnu /opt/tbotspython
+        rm /tmp/tbots_download_cache/$full_file_name
     fi
-    full_file_name=$file_name.tar.xz
-    wget https://raw.githubusercontent.com/UBC-Thunderbots/Software-External-Dependencies/refs/heads/main/toolchain/$full_file_name -O /tmp/tbots_download_cache/$full_file_name
-    tar -xf /tmp/tbots_download_cache/$full_file_name -C /tmp/tbots_download_cache/
-    sudo mv /tmp/tbots_download_cache/aarch64-tbots-linux-gnu /opt/tbotspython
-    rm /tmp/tbots_download_cache/$full_file_name
-}
-
-install_cross_compiler_mac() {
-    file_name=aarch64-tbots-linux-gnu-for-aarch64
-    full_file_name=$file_name.tar.xz
-    curl -L "https://raw.githubusercontent.com/UBC-Thunderbots/Software-External-Dependencies/refs/heads/main/toolchain/$full_file_name" \
-        -o /tmp/tbots_download_cache/$full_file_name
-    tar -xf /tmp/tbots_download_cache/$full_file_name -C /tmp/tbots_download_cache/
-    sudo mv /tmp/tbots_download_cache/aarch64-tbots-linux-gnu /opt/tbotspython
-    rm /tmp/tbots_download_cache/$full_file_name
 }
 
 install_gamecontroller () {
-    arch=arm64
-    if is_x86 $1; then
-        arch=amd64
+    if is_darwin $1; then
+        curl -L https://github.com/RoboCup-SSL/ssl-game-controller/archive/refs/tags/v3.17.0.zip -o /tmp/tbots_download_cache/ssl-game-controller.zip
+        unzip -q -o -d /tmp/tbots_download_cache/ /tmp/tbots_download_cache/ssl-game-controller.zip
+        cd /tmp/tbots_download_cache/ssl-game-controller-3.17.0
+        make install
+        go build cmd/ssl-game-controller/main.go
+        sudo mv main /opt/tbotspython/gamecontroller
+        sudo chmod +x /opt/tbotspython/gamecontroller
+
+        cd -
+        sudo rm -rf /tmp/tbots_download_cache/ssl-game-controller-3.17.0 /tmp/tbots_download_cache/go /tmp/tbots_download_cache/go.tar.gz /tmp/tbots_download_cache/ssl-game-controller.zip
+    else
+        arch=arm64
+        if is_x86 $1; then
+            arch=amd64
+        fi
+
+        wget https://github.com/RoboCup-SSL/ssl-game-controller/releases/download/v3.16.1/ssl-game-controller_v3.16.1_linux_${arch} -O /tmp/tbots_download_cache/gamecontroller
+        sudo mv /tmp/tbots_download_cache/gamecontroller /opt/tbotspython/gamecontroller
+        sudo chmod +x /opt/tbotspython/gamecontroller
     fi
-
-    wget https://github.com/RoboCup-SSL/ssl-game-controller/releases/download/v3.16.1/ssl-game-controller_v3.16.1_linux_${arch} -O /tmp/tbots_download_cache/gamecontroller
-    sudo mv /tmp/tbots_download_cache/gamecontroller /opt/tbotspython/gamecontroller
-    sudo chmod +x /opt/tbotspython/gamecontroller
-}
-
-install_gamecontroller_macos () {
-    curl -L https://github.com/RoboCup-SSL/ssl-game-controller/archive/refs/tags/v3.17.0.zip -o /tmp/tbots_download_cache/ssl-game-controller.zip
-    unzip -q -o -d /tmp/tbots_download_cache/ /tmp/tbots_download_cache/ssl-game-controller.zip
-    cd /tmp/tbots_download_cache/ssl-game-controller-3.17.0
-    make install
-    go build cmd/ssl-game-controller/main.go
-    sudo mv main /opt/tbotspython/gamecontroller
-    sudo chmod +x /opt/tbotspython/gamecontroller
-
-    cd -
-    sudo rm -rf /tmp/tbots_download_cache/ssl-game-controller-3.17.0 /tmp/tbots_download_cache/go /tmp/tbots_download_cache/go.tar.gz /tmp/tbots_download_cache/ssl-game-controller.zip
 }
 
 install_java () {
@@ -88,17 +87,6 @@ install_java () {
     tar -xzf /tmp/tbots_download_cache/jdk-21.tar.gz -C /opt/tbotspython/
     mv /opt/tbotspython/jdk-21* /opt/tbotspython/bin/jdk
     rm /tmp/tbots_download_cache/jdk-21.tar.gz
-}
-
-install_java_macos () {
-    java_home=""
-    java_download=https://download.oracle.com/java/21/latest/jdk-21_macos-aarch64_bin.tar.gz
-    curl -L $java_download -o /tmp/tbots_download_cache/jdk-21.tar.gz
-    mkdir /tmp/tbots_download_cache/jdk
-    tar -xzf /tmp/tbots_download_cache/jdk-21.tar.gz -C /tmp/tbots_download_cache
-    sudo mv /tmp/tbots_download_cache/jdk-21*/Contents/Home /opt/tbotspython/bin/jdk
-    rm /tmp/tbots_download_cache/jdk-21.tar.gz
-    rm -rf /tmp/tbots_download_cache/jdk
 }
 
 install_python_dev_cross_compile_headers() {
@@ -140,6 +128,14 @@ install_python_toolchain_headers() {
 
 is_x86() {
     if [[ $1 == "x86_64" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+is_darwin() {
+    if [[ $1 == "Darwin" ]]; then
         return 0
     else
         return 1

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -65,8 +65,8 @@ common --enable_platform_specific_config
 build --incompatible_remove_legacy_whole_archive=False
 
 # Escalate Warnings to fail Compile for Thunderbots code
-build --features=external_include_paths
-build --per_file_copt=proto/.*,proto/message_translation/.*,proto/primitive/.*,software/.*,shared/.*,-external/.*@-Wall,-Wextra,-Wno-unused-parameter,-Wno-deprecated,-Werror,-Wno-deprecated-declarations
+build:linux --features=external_include_paths
+build:linux --per_file_copt=proto/.*,proto/message_translation/.*,proto/primitive/.*,software/.*,shared/.*,-external/.*@-Wall,-Wextra,-Wno-unused-parameter,-Wno-deprecated,-Werror,-Wno-deprecated-declarations
 # TODO: #3492
 # build --per_file_copt=software/.*,shared/.*,-external/.*@-Wconversion
 

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -65,7 +65,7 @@ common --enable_platform_specific_config
 build --incompatible_remove_legacy_whole_archive=False
 
 # Escalate Warnings to fail Compile for Thunderbots code
-build:linux --features=external_include_paths
+build --features=external_include_paths
 build:linux --per_file_copt=proto/.*,proto/message_translation/.*,proto/primitive/.*,software/.*,shared/.*,-external/.*@-Wall,-Wextra,-Wno-unused-parameter,-Wno-deprecated,-Werror,-Wno-deprecated-declarations
 # TODO: #3492
 # build --per_file_copt=software/.*,shared/.*,-external/.*@-Wconversion

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -274,13 +274,13 @@ new_local_repository(
 new_local_repository(
     name = "py_cc_toolchain_host",
     build_file = "@//extlibs:py_cc_toolchain.BUILD",
-    path = "/usr/include/python3.12/",
+    path = "/opt/tbotspython/py_headers/include/python3.12/",
 )
 
 new_local_repository(
     name = "py_cc_toolchain_for_k8_jetson_nano_cross_compile",
     build_file = "@//extlibs:py_cc_toolchain.BUILD",
-    path = "/opt/tbotspython/cross_compile_headers/include/python3.12/",
+    path = "/opt/tbotspython/py_headers/include/python3.12/",
 )
 
 ##############################################

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -280,7 +280,7 @@ new_local_repository(
 new_local_repository(
     name = "py_cc_toolchain_for_k8_jetson_nano_cross_compile",
     build_file = "@//extlibs:py_cc_toolchain.BUILD",
-    path = "/opt/tbotspython/py_headers/include/python3.12/",
+    path = "/opt/tbotspython/cross_compile_headers/include/python3.12/",
 )
 
 ##############################################

--- a/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
@@ -682,7 +682,8 @@ void Simulator::handleSimulatorSetupCommand(const std::unique_ptr<amun::Command>
 
             if (realism.has_vision_processing_time())
             {
-                m_visionProcessingTime = std::max<int64_t>(0l, realism.vision_processing_time());
+                m_visionProcessingTime =
+                    std::max<int64_t>(0l, realism.vision_processing_time());
             }
 
             if (realism.has_simulate_dribbling())

--- a/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
@@ -677,12 +677,12 @@ void Simulator::handleSimulatorSetupCommand(const std::unique_ptr<amun::Command>
 
             if (realism.has_vision_delay())
             {
-                m_visionDelay = std::max(0l, realism.vision_delay());
+                m_visionDelay = std::max<int64_t>(0l, realism.vision_delay());
             }
 
             if (realism.has_vision_processing_time())
             {
-                m_visionProcessingTime = std::max(0l, realism.vision_processing_time());
+                m_visionProcessingTime = std::max<int64_t>(0l, realism.vision_processing_time());
             }
 
             if (realism.has_simulate_dribbling())

--- a/src/software/ai/hl/stp/play/play.cpp
+++ b/src/software/ai/hl/stp/play/play.cpp
@@ -206,7 +206,8 @@ std::unique_ptr<TbotsProto::PrimitiveSet> Play::get(
                  new_primitives_to_assign->robot_primitives())
             {
                 primitives_to_run->mutable_robot_primitives()->insert(
-                    google::protobuf::MapPair<uint32_t, TbotsProto::Primitive>(robot_id, primitive));
+                    google::protobuf::MapPair<uint32_t, TbotsProto::Primitive>(
+                        robot_id, primitive));
             }
 
             robots = remaining_robots;

--- a/src/software/ai/hl/stp/play/play.cpp
+++ b/src/software/ai/hl/stp/play/play.cpp
@@ -206,7 +206,7 @@ std::unique_ptr<TbotsProto::PrimitiveSet> Play::get(
                  new_primitives_to_assign->robot_primitives())
             {
                 primitives_to_run->mutable_robot_primitives()->insert(
-                    google::protobuf::MapPair(robot_id, primitive));
+                    google::protobuf::MapPair<uint32_t, TbotsProto::Primitive>(robot_id, primitive));
             }
 
             robots = remaining_robots;

--- a/src/software/logger/BUILD
+++ b/src/software/logger/BUILD
@@ -20,7 +20,10 @@ cc_library(
         "custom_logging_levels.h",
         "logger.h",
     ],
-    linkopts = ["-lstdc++fs"],
+    linkopts = select({
+           "@platforms//os:linux": ["-lstdc++fs"],
+           "//conditions:default": [],
+    }),
     deps = [
         ":coloured_cout_sink",
         ":csv_sink",

--- a/src/software/logger/BUILD
+++ b/src/software/logger/BUILD
@@ -10,6 +10,7 @@ cc_library(
     ],
     deps = [
         "@g3log",
+        ":time_compat",
     ],
 )
 
@@ -188,4 +189,9 @@ cc_library(
         "@boost//:filesystem",
         "@zlib",
     ],
+)
+
+cc_library(
+    name = "time_compat",
+    srcs = ["time_compat.h"],
 )

--- a/src/software/logger/BUILD
+++ b/src/software/logger/BUILD
@@ -10,7 +10,7 @@ cc_library(
     ],
     deps = [
         "@g3log",
-        ":time_compat",
+        ":compat_flags",
     ],
 )
 
@@ -29,6 +29,7 @@ cc_library(
         ":protobuf_sink",
         "@g3log",
         "@g3sinks",
+        ":compat_flags",
     ],
 )
 
@@ -105,6 +106,7 @@ cc_library(
     ],
     deps = [
         "@g3log",
+        ":compat_flags",
     ],
 )
 
@@ -188,10 +190,11 @@ cc_library(
         "@base64",
         "@boost//:filesystem",
         "@zlib",
+        ":compat_flags",
     ],
 )
 
 cc_library(
-    name = "time_compat",
-    srcs = ["time_compat.h"],
+    name = "compat_flags",
+    srcs = ["compat_flags.h"],
 )

--- a/src/software/logger/BUILD
+++ b/src/software/logger/BUILD
@@ -9,8 +9,8 @@ cc_library(
         "log_merger.h",
     ],
     deps = [
-        "@g3log",
         ":compat_flags",
+        "@g3log",
     ],
 )
 
@@ -21,18 +21,18 @@ cc_library(
         "logger.h",
     ],
     linkopts = select({
-           "@platforms//os:linux": ["-lstdc++fs"],
-           "//conditions:default": [],
+        "@platforms//os:linux": ["-lstdc++fs"],
+        "//conditions:default": [],
     }),
     deps = [
         ":coloured_cout_sink",
+        ":compat_flags",
         ":csv_sink",
         ":log_merger",
         ":plotjuggler_sink",
         ":protobuf_sink",
         "@g3log",
         "@g3sinks",
-        ":compat_flags",
     ],
 )
 
@@ -108,8 +108,8 @@ cc_library(
         "custom_logging_levels.h",
     ],
     deps = [
-        "@g3log",
         ":compat_flags",
+        "@g3log",
     ],
 )
 
@@ -188,12 +188,12 @@ cc_library(
         "proto_logger.h",
     ],
     deps = [
+        ":compat_flags",
         "//proto:tbots_cc_proto",
         "//software/multithreading:thread_safe_buffer",
         "@base64",
         "@boost//:filesystem",
         "@zlib",
-        ":compat_flags",
     ],
 )
 

--- a/src/software/logger/compat_flags.h
+++ b/src/software/logger/compat_flags.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <chrono>
+
+#if defined(__APPLE__)
+using Clock = std::chrono::system_clock;
+#else
+using Clock = std::chrono::_V2::system_clock;
+#endif
+
+#if __cplusplus > 201703L
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+

--- a/src/software/logger/compat_flags.h
+++ b/src/software/logger/compat_flags.h
@@ -5,7 +5,7 @@
 #if defined(__APPLE__)
 using Clock = std::chrono::system_clock;
 #else
-using Clock = std::chrono::_V2::system_clock;
+using Clock  = std::chrono::_V2::system_clock;
 #endif
 
 #if __cplusplus > 201703L
@@ -15,4 +15,3 @@ namespace fs = std::filesystem;
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
 #endif
-

--- a/src/software/logger/csv_sink.cpp
+++ b/src/software/logger/csv_sink.cpp
@@ -1,10 +1,6 @@
 #include "software/logger/csv_sink.h"
 
-#if __cplusplus > 201703L
-#include <filesystem>
-#else
-#include <experimental/filesystem>
-#endif
+#include "compat_flags.h"
 
 CSVSink::CSVSink(const std::string& log_directory) : log_directory(log_directory) {}
 

--- a/src/software/logger/log_merger.cpp
+++ b/src/software/logger/log_merger.cpp
@@ -11,8 +11,7 @@ std::list<g3::LogMessage> LogMerger::log(g3::LogMessage &log)
     {
         std::string msg = log.message();
 
-        Clock::time_point current_time =
-            std::chrono::system_clock::now();
+        Clock::time_point current_time = std::chrono::system_clock::now();
         // add passed time from testing
         current_time += passed_time;
         std::list<g3::LogMessage> messages_to_log = _getOldMessages(current_time);

--- a/src/software/logger/log_merger.cpp
+++ b/src/software/logger/log_merger.cpp
@@ -11,7 +11,7 @@ std::list<g3::LogMessage> LogMerger::log(g3::LogMessage &log)
     {
         std::string msg = log.message();
 
-        std::chrono::_V2::system_clock::time_point current_time =
+        Clock::time_point current_time =
             std::chrono::system_clock::now();
         // add passed time from testing
         current_time += passed_time;
@@ -38,8 +38,7 @@ std::list<g3::LogMessage> LogMerger::log(g3::LogMessage &log)
     }
 }
 
-std::list<g3::LogMessage> LogMerger::_getOldMessages(
-    std::chrono::_V2::system_clock::time_point current_time)
+std::list<g3::LogMessage> LogMerger::_getOldMessages(Clock::time_point current_time)
 {
     std::list<g3::LogMessage> result;
     while (message_list.size() > 0)

--- a/src/software/logger/log_merger.h
+++ b/src/software/logger/log_merger.h
@@ -4,6 +4,7 @@
 #include <list>
 #include <string>
 #include <unordered_map>
+
 #include "compat_flags.h"
 
 
@@ -56,8 +57,7 @@ class LogMerger
         std::string msg;
         Clock::time_point timestamp;
 
-        Message(g3::LogMessage &log, std::string msg,
-                Clock::time_point timestamp)
+        Message(g3::LogMessage &log, std::string msg, Clock::time_point timestamp)
             : log(log), msg(msg), timestamp(timestamp)
         {
         }

--- a/src/software/logger/log_merger.h
+++ b/src/software/logger/log_merger.h
@@ -4,6 +4,7 @@
 #include <list>
 #include <string>
 #include <unordered_map>
+#include "time_compat.h"
 
 
 /**
@@ -41,11 +42,9 @@ class LogMerger
      * Looks through the message list for expired messages, removes them from the list and
      * map, and returns them as strings
      */
-    std::list<g3::LogMessage> _getOldMessages(
-        std::chrono::_V2::system_clock::time_point current_time);
+    std::list<g3::LogMessage> _getOldMessages(Clock::time_point current_time);
 
-    const std::chrono::_V2::system_clock::duration LOG_MERGE_DURATION =
-        std::chrono::seconds(2);
+    const Clock::duration LOG_MERGE_DURATION = std::chrono::seconds(2);
 
    private:
     /**
@@ -55,10 +54,10 @@ class LogMerger
     {
         g3::LogMessage log;
         std::string msg;
-        std::chrono::_V2::system_clock::time_point timestamp;
+        Clock::time_point timestamp;
 
         Message(g3::LogMessage &log, std::string msg,
-                std::chrono::_V2::system_clock::time_point timestamp)
+                Clock::time_point timestamp)
             : log(log), msg(msg), timestamp(timestamp)
         {
         }
@@ -68,8 +67,7 @@ class LogMerger
         repeat_map;  // maps string messages to their number of repeats for fast access
     std::list<Message> message_list;  // used to keep track of time order for messages
 
-    std::chrono::_V2::system_clock::duration
-        passed_time;  // for testing, time passed manually
+    Clock::duration passed_time;  // for testing, time passed manually
 
     bool enable_merging;
 };

--- a/src/software/logger/log_merger.h
+++ b/src/software/logger/log_merger.h
@@ -4,7 +4,7 @@
 #include <list>
 #include <string>
 #include <unordered_map>
-#include "time_compat.h"
+#include "compat_flags.h"
 
 
 /**

--- a/src/software/logger/logger.h
+++ b/src/software/logger/logger.h
@@ -3,8 +3,6 @@
 #include <g3sinks/LogRotate.h>
 #include <g3sinks/LogRotateWithFilter.h>
 
-#include <experimental/filesystem>
-#include <g3log/g3log.hpp>
 #include <g3log/loglevels.hpp>
 #include <g3log/logmessage.hpp>
 #include <g3log/logworker.hpp>
@@ -14,6 +12,8 @@
 #include "software/logger/custom_logging_levels.h"
 #include "software/logger/plotjuggler_sink.h"
 #include "software/logger/protobuf_sink.h"
+
+#include "compat_flags.h"
 
 // This undefines LOG macro defined by g3log
 #undef LOG
@@ -90,9 +90,9 @@ class LoggerSingleton
         // hermetic build principles
 
         // if log dir doesn't exist, create it
-        if (!std::experimental::filesystem::exists(runtime_dir))
+        if (!fs::exists(runtime_dir))
         {
-            std::experimental::filesystem::create_directories(runtime_dir);
+            fs::create_directories(runtime_dir);
         }
 
         auto csv_sink_handle = logWorker->addSink(std::make_unique<CSVSink>(runtime_dir),

--- a/src/software/logger/logger.h
+++ b/src/software/logger/logger.h
@@ -7,13 +7,12 @@
 #include <g3log/logmessage.hpp>
 #include <g3log/logworker.hpp>
 
+#include "compat_flags.h"
 #include "software/logger/coloured_cout_sink.h"
 #include "software/logger/csv_sink.h"
 #include "software/logger/custom_logging_levels.h"
 #include "software/logger/plotjuggler_sink.h"
 #include "software/logger/protobuf_sink.h"
-
-#include "compat_flags.h"
 
 // This undefines LOG macro defined by g3log
 #undef LOG

--- a/src/software/logger/proto_logger.cpp
+++ b/src/software/logger/proto_logger.cpp
@@ -5,7 +5,6 @@
 
 #include <chrono>
 #include <ctime>
-#include <experimental/filesystem>
 #include <fstream>
 #include <iomanip>
 #include <optional>
@@ -13,6 +12,7 @@
 
 #include "base64.h"
 #include "shared/constants.h"
+#include "compat_flags.h"
 
 ProtoLogger::ProtoLogger(const std::string& log_path,
                          std::function<double()> time_provider,
@@ -31,7 +31,7 @@ ProtoLogger::ProtoLogger(const std::string& log_path,
     std::stringstream ss;
     ss << std::put_time(&tm, REPLAY_FILE_TIME_FORMAT.data());
     log_folder_ = log_path_ + "/" + REPLAY_FILE_PREFIX + ss.str() + "/";
-    std::experimental::filesystem::create_directories(log_folder_);
+    fs::create_directories(log_folder_);
 
     // Start logging in a separate thread
     log_thread_ = std::thread(&ProtoLogger::logProtobufs, this);

--- a/src/software/logger/proto_logger.cpp
+++ b/src/software/logger/proto_logger.cpp
@@ -11,8 +11,8 @@
 #include <vector>
 
 #include "base64.h"
-#include "shared/constants.h"
 #include "compat_flags.h"
+#include "shared/constants.h"
 
 ProtoLogger::ProtoLogger(const std::string& log_path,
                          std::function<double()> time_provider,

--- a/src/software/logger/time_compat.h
+++ b/src/software/logger/time_compat.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include <chrono>
-
-#if defined(__APPLE__)
-using Clock = std::chrono::system_clock;
-#else
-using Clock = std::chrono::_V2::system_clock;
-#endif

--- a/src/software/logger/time_compat.h
+++ b/src/software/logger/time_compat.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <chrono>
+
+#if defined(__APPLE__)
+using Clock = std::chrono::system_clock;
+#else
+using Clock = std::chrono::_V2::system_clock;
+#endif

--- a/src/software/thunderscope/BUILD
+++ b/src/software/thunderscope/BUILD
@@ -6,8 +6,8 @@ package(default_visibility = ["//visibility:public"])
 compile_pip_requirements(
     name = "requirements",
     src = "requirements.in",
-    requirements_txt = "requirements_lock.txt",
     requirements_darwin = "requirements_lock.darwin.txt",
+    requirements_txt = "requirements_lock.txt",
 )
 
 py_binary(

--- a/src/software/thunderscope/BUILD
+++ b/src/software/thunderscope/BUILD
@@ -7,6 +7,7 @@ compile_pip_requirements(
     name = "requirements",
     src = "requirements.in",
     requirements_txt = "requirements_lock.txt",
+    requirements_darwin = "requirements_lock.darwin.txt",
 )
 
 py_binary(

--- a/src/software/thunderscope/binary_context_managers/BUILD
+++ b/src/software/thunderscope/binary_context_managers/BUILD
@@ -22,8 +22,8 @@ py_library(
     deps = [
         "//proto:import_all_protos",
         "//software/networking:ssl_proto_communication",
-        "//software/thunderscope/common:thread_safe_circular_buffer",
         "//software/thunderscope:util",
+        "//software/thunderscope/common:thread_safe_circular_buffer",
     ],
 )
 

--- a/src/software/thunderscope/binary_context_managers/BUILD
+++ b/src/software/thunderscope/binary_context_managers/BUILD
@@ -23,6 +23,7 @@ py_library(
         "//proto:import_all_protos",
         "//software/networking:ssl_proto_communication",
         "//software/thunderscope/common:thread_safe_circular_buffer",
+        "//software/thunderscope:util",
     ],
 )
 

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -288,7 +288,6 @@ class Gamecontroller:
             if autoref_proto_unix_io is not None:
                 autoref_proto_unix_io.send_proto(Referee, data)
 
-
         if is_current_platform_macos():
             loopback_iface = "en0"
         else:

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -4,7 +4,6 @@ import queue
 import random
 import logging
 import os
-import socket
 import time
 from subprocess import Popen
 from typing import Any
@@ -21,6 +20,7 @@ from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
 from software.thunderscope.common.thread_safe_circular_buffer import (
     ThreadSafeCircularBuffer,
 )
+from software.thunderscope.util import is_current_platform_macos
 
 logger = logging.getLogger(__name__)
 import itertools
@@ -288,10 +288,16 @@ class Gamecontroller:
             if autoref_proto_unix_io is not None:
                 autoref_proto_unix_io.send_proto(Referee, data)
 
+
+        if is_current_platform_macos():
+            loopback_iface = "en0"
+        else:
+            loopback_iface = "lo"
+
         self.receive_referee_command = tbots_cpp.SSLRefereeProtoListener(
             Gamecontroller.REFEREE_IP,
             self.referee_port,
-            "lo",
+            loopback_iface,
             __send_referee_command,
             True,
         )

--- a/src/software/thunderscope/requirements.in
+++ b/src/software/thunderscope/requirements.in
@@ -1,6 +1,6 @@
 colorama==0.4.6
 netifaces==0.11.0
-evdev==1.7.0
+evdev==1.7.0; sys_platform == "linux"
 numpy==1.26.4
 protobuf==6.31.1
 pyqtgraph==0.13.7

--- a/src/software/thunderscope/requirements_lock.darwin.txt
+++ b/src/software/thunderscope/requirements_lock.darwin.txt
@@ -12,9 +12,6 @@ darkdetect==0.7.1 \
     --hash=sha256:3efe69f8ecd5f1b7f4fbb0d1d93f656b0e493c45cc49222380ffe2a529cbc866 \
     --hash=sha256:47be3cf5134432ddb616bbffc927237718407914993c82809983e7ccebf49013
     # via pyqtdarktheme-fork
-evdev==1.7.0 \
-    --hash=sha256:95bd2a1e0c6ce2cd7a2ecc6e6cd9736ff794b3ad5cb54d81d8cbc2e414d0b870
-    # via -r software/thunderscope/requirements.in
 netifaces==0.11.0 \
     --hash=sha256:043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32 \
     --hash=sha256:08e3f102a59f9eaef70948340aeb6c89bd09734e0dca0f3b82720305729f63ea \
@@ -123,13 +120,7 @@ pyqtgraph==0.13.7 \
     --hash=sha256:64f84f1935c6996d0e09b1ee66fe478a7771e3ca6f3aaa05f00f6e068321d9e3 \
     --hash=sha256:7754edbefb6c367fa0dfb176e2d0610da3ada20aa7a5318516c74af5fb72bf7a
     # via -r software/thunderscope/requirements.in
-qtawesome==1.4.0 \
-    --hash=sha256:783e414d1317f3e978bf67ea8e8a1b1498bad9dbd305dec814027e3b50521be6 \
-    --hash=sha256:a4d689fa071c595aa6184171ce1f0f847677cb8d2db45382c43129f1d72a3d93
-    # via -r software/thunderscope/requirements.in
 qtpy==2.4.2 \
     --hash=sha256:5a696b1dd7a354cb330657da1d17c20c2190c72d4888ba923f8461da67aa1a1c \
     --hash=sha256:9d6ec91a587cc1495eaebd23130f7619afa5cdd34a277acb87735b4ad7c65156
-    # via
-    #   pyqt-toast-notification
-    #   qtawesome
+    # via pyqt-toast-notification

--- a/src/software/thunderscope/requirements_lock.txt
+++ b/src/software/thunderscope/requirements_lock.txt
@@ -12,9 +12,6 @@ darkdetect==0.7.1 \
     --hash=sha256:3efe69f8ecd5f1b7f4fbb0d1d93f656b0e493c45cc49222380ffe2a529cbc866 \
     --hash=sha256:47be3cf5134432ddb616bbffc927237718407914993c82809983e7ccebf49013
     # via pyqtdarktheme-fork
-evdev==1.7.0 \
-    --hash=sha256:95bd2a1e0c6ce2cd7a2ecc6e6cd9736ff794b3ad5cb54d81d8cbc2e414d0b870
-    # via -r software/thunderscope/requirements.in
 netifaces==0.11.0 \
     --hash=sha256:043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32 \
     --hash=sha256:08e3f102a59f9eaef70948340aeb6c89bd09734e0dca0f3b82720305729f63ea \

--- a/src/software/thunderscope/requirements_lock.txt
+++ b/src/software/thunderscope/requirements_lock.txt
@@ -12,7 +12,7 @@ darkdetect==0.7.1 \
     --hash=sha256:3efe69f8ecd5f1b7f4fbb0d1d93f656b0e493c45cc49222380ffe2a529cbc866 \
     --hash=sha256:47be3cf5134432ddb616bbffc927237718407914993c82809983e7ccebf49013
     # via pyqtdarktheme-fork
-evdev==1.7.0 \
+evdev==1.7.0 ; sys_platform == "linux" \
     --hash=sha256:95bd2a1e0c6ce2cd7a2ecc6e6cd9736ff794b3ad5cb54d81d8cbc2e414d0b870
     # via -r software/thunderscope/requirements.in
 netifaces==0.11.0 \

--- a/src/software/thunderscope/robot_diagnostics/BUILD
+++ b/src/software/thunderscope/robot_diagnostics/BUILD
@@ -35,8 +35,12 @@ py_library(
         ":handheld_controller",
         "//software/thunderscope:constants",
         requirement("pyqtgraph"),
-        requirement("evdev"),
-    ],
+    ] + select({
+        # TODO: remove this selection when we replace evdev to
+        #   other macos supported libs.
+        "@platforms//os:linux": [requirement("evdev")],
+        "//conditions:default": [],
+    }),
 )
 
 py_library(

--- a/src/software/thunderscope/robot_diagnostics/handheld_controller.py
+++ b/src/software/thunderscope/robot_diagnostics/handheld_controller.py
@@ -1,6 +1,11 @@
 import numpy
 
-from evdev import InputDevice, ecodes
+# TODO: remove the try-catch when we rewrite this with macOS-compatible lib
+try:
+    from evdev import InputDevice, ecodes
+except ImportError:
+    pass
+
 from threading import Thread
 
 

--- a/src/software/thunderscope/robot_diagnostics/handheld_controller_widget.py
+++ b/src/software/thunderscope/robot_diagnostics/handheld_controller_widget.py
@@ -1,7 +1,11 @@
 import numpy
 
-import evdev
-from evdev import ecodes
+# TODO: remove the try-catch when we rewrite this with macOS-compatible lib
+try:
+    import evdev
+    from evdev import ecodes
+except ImportError:
+    pass
 
 from proto.import_all_protos import *
 from pyqtgraph.Qt.QtWidgets import *

--- a/src/software/thunderscope/util.py
+++ b/src/software/thunderscope/util.py
@@ -197,9 +197,9 @@ def color_from_gradient(
                         int(a_range[i] + (a_range[i + 1] - a_range[i]) * sig_val),
                     )
 
+
 def is_current_platform_macos() -> bool:
-    """
-    Return True if the current process is running on macOS.
+    """Return True if the current process is running on macOS.
     Uses platform.system(), which should reliably return 'Darwin' on macOS.
     """
     return platform.system().lower() == "darwin"

--- a/src/software/thunderscope/util.py
+++ b/src/software/thunderscope/util.py
@@ -1,3 +1,4 @@
+import platform
 from typing import Callable, NoReturn, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -195,3 +196,10 @@ def color_from_gradient(
                         int(b_range[i] + (b_range[i + 1] - b_range[i]) * sig_val),
                         int(a_range[i] + (a_range[i + 1] - a_range[i]) * sig_val),
                     )
+
+def is_current_platform_macos() -> bool:
+    """
+    Return True if the current process is running on macOS.
+    Uses platform.system(), which should reliably return 'Darwin' on macOS.
+    """
+    return platform.system().lower() == "darwin"


### PR DESCRIPTION
closes #3529 

### Description

This PR introduces **native macOS ARM support for Thunderscope**. 

Currently, this PR is experimental and is just providing a minimal working demo on my macbook M1. 

Out of scope for this PR:

1. Cross-compilation and robot hardware interactions
2. Support for Intel (x86) MacBooks

<!--  
    Provide a high-level overview of the changes introduced in this PR  
-->  

### Testing Done

* [ ] Run extensive tests on additional macOS ARM machines. My current laptop includes many pre-installed developer tools, so the setup script may need updates to ensure a clean installation experience.
* [ ] Verify functionality on Ubuntu machines to confirm no regressions were introduced.

### TODO List

**For this PR:**

* [x] Fix the broken `local_new_repositories` and confirm compatibility with Ubuntu
* [x] Separate linux and macos requirements lock files, because `evdev` does not exist for macos.

**Maybe for future PRs or possibly this PR:**

* [ ] If necessary, re-implement handheld controller widgets using a macOS-compatible library
* [ ] Deduplicate `TbotsProto.ObstacleList` to prevent system network buffer overload (#3104). This is impacting the stability of thunderscope on macOS. I am currently working on a sliding window cache that hopefully can mitigate this issue.
* [ ] Fix unit tests
