### PR TITLE
Add directional color variation for robots in Thunderscope

### DIFF
--- a/src/software/thunderscope/gl/graphics/gl_robot.py
+++ b/src/software/thunderscope/gl/graphics/gl_robot.py
@@ -11,8 +11,10 @@ from typing import Optional
 import numpy as np
 
 
-ROBOT_SHADER = shaders.ShaderProgram("robot-shader", [
-    shaders.VertexShader("""
+ROBOT_SHADER = shaders.ShaderProgram(
+    "robot-shader",
+    [
+        shaders.VertexShader("""
         varying vec3 normal;
         void main() {
             // find vertex normals and positions
@@ -22,7 +24,7 @@ ROBOT_SHADER = shaders.ShaderProgram("robot-shader", [
             gl_Position = ftransform();
         }
     """),
-    shaders.FragmentShader("""
+        shaders.FragmentShader("""
         varying vec3 normal;
         void main() {
             // create an alternate robot color (blue becomes teal, yellow becomes orange)
@@ -37,7 +39,8 @@ ROBOT_SHADER = shaders.ShaderProgram("robot-shader", [
             gl_FragColor = vec4(mix(color, color_bright, fac), 1.0);
         }
     """),
-])
+    ],
+)
 
 
 class GLRobot(GLMeshItem):

--- a/src/software/thunderscope/gl/graphics/gl_robot.py
+++ b/src/software/thunderscope/gl/graphics/gl_robot.py
@@ -15,30 +15,30 @@ ROBOT_SHADER = shaders.ShaderProgram(
     "robot-shader",
     [
         shaders.VertexShader("""
-        varying vec3 normal;
-        void main() {
-            // find vertex normals and positions
-            normal = normalize(gl_Normal);
-            gl_FrontColor = gl_Color;
-            gl_BackColor = gl_Color;
-            gl_Position = ftransform();
-        }
-    """),
+            varying vec3 normal;
+            void main() {
+                // find vertex normals and positions
+                normal = normalize(gl_Normal);
+                gl_FrontColor = gl_Color;
+                gl_BackColor = gl_Color;
+                gl_Position = ftransform();
+            }
+        """),
         shaders.FragmentShader("""
-        varying vec3 normal;
-        void main() {
-            // create an alternate robot color (blue becomes teal, yellow becomes orange)
-            vec3 color = gl_Color.rgb;
-            vec3 color_bright = vec3(color.r, 0.65, color.b);
+            varying vec3 normal;
+            void main() {
+                // create an alternate robot color (blue becomes teal, yellow becomes orange)
+                vec3 color = gl_Color.rgb;
+                vec3 color_bright = vec3(color.r, 0.65, color.b);
 
-            // this is the vector pointing forward from the robot
-            vec3 front = vec3(-1.0, 1.0, 0.0);
+                // this is the vector pointing forward from the robot
+                vec3 front = vec3(-1.0, 1.0, 0.0);
 
-            // mix colors depending on proximity of the face to the front of the robot
-            float fac = pow(max(dot(normal, front), 0.0), 0.5);
-            gl_FragColor = vec4(mix(color, color_bright, fac), 1.0);
-        }
-    """),
+                // mix colors depending on proximity of the face to the front of the robot
+                float fac = pow(max(dot(normal, front), 0.0), 0.5);
+                gl_FragColor = vec4(mix(color, color_bright, fac), 1.0);
+            }
+        """),
     ],
 )
 

--- a/src/software/thunderscope/gl/graphics/gl_robot.py
+++ b/src/software/thunderscope/gl/graphics/gl_robot.py
@@ -11,6 +11,35 @@ from typing import Optional
 import numpy as np
 
 
+ROBOT_SHADER = shaders.ShaderProgram("robot-shader", [
+    shaders.VertexShader("""
+        varying vec3 normal;
+        void main() {
+            // find vertex normals and positions
+            normal = normalize(gl_Normal);
+            gl_FrontColor = gl_Color;
+            gl_BackColor = gl_Color;
+            gl_Position = ftransform();
+        }
+    """),
+    shaders.FragmentShader("""
+        varying vec3 normal;
+        void main() {
+            // create an alternate robot color (blue becomes teal, yellow becomes orange)
+            vec3 color = gl_Color.rgb;
+            vec3 color_bright = vec3(color.r, 0.65, color.b);
+
+            // this is the vector pointing forward from the robot
+            vec3 front = vec3(-1.0, 1.0, 0.0);
+
+            // mix colors depending on proximity of the face to the front of the robot
+            float fac = pow(max(dot(normal, front), 0.0), 0.5);
+            gl_FragColor = vec4(mix(color, color_bright, fac), 1.0);
+        }
+    """),
+])
+
+
 class GLRobot(GLMeshItem):
     """Displays a 3D mesh representing a robot"""
 
@@ -28,6 +57,8 @@ class GLRobot(GLMeshItem):
             parentItem=parent_item,
             meshdata=self.__get_mesh_data(),
             color=color,
+            smooth=False,
+            shader=ROBOT_SHADER,
         )
 
         self.x = 0

--- a/src/software/thunderscope/gl/graphics/gl_robot_outline.py
+++ b/src/software/thunderscope/gl/graphics/gl_robot_outline.py
@@ -40,7 +40,7 @@ class GLRobotOutline(GLShape):
 
     @staticmethod
     def get_robot_outline(
-        z_coordinate: float = 0, num_points: int = 10
+        z_coordinate: float = 0, num_points: int = 20
     ) -> list[tuple[float, float, float]]:
         """Returns a list of points that represent the outline of a robot.
         The points will be on a plane parallel to the x-y plane.

--- a/src/software/thunderscope/gl/layers/gl_world_layer.py
+++ b/src/software/thunderscope/gl/layers/gl_world_layer.py
@@ -469,7 +469,7 @@ class GLWorldLayer(GLLayer):
         :param robot_names: A dict mapping ids to names of robots
         """
         # Ensure we have the same number of graphics as robots
-        robot_graphics.resize(len(robots), lambda: GLRobot())
+        robot_graphics.resize(len(robots), lambda: GLRobot(color=color))
         robot_id_graphics.resize(
             len(robots),
             lambda: GLTextItem(


### PR DESCRIPTION
### Description

Adds shading for robots in Thunderscope depending on their direction so it's easier to see which way they're facing

<img width="3132" height="1168" alt="image" src="https://github.com/user-attachments/assets/07353039-f43c-4020-9d88-6ca9bbcffee6" />

Justification for "magic numbers" in shader code: It'll only be used in that one place and it's all arbitrary values that are tuned for it to look good instead of being numbers with an interpretable value

### Testing Done

No regressions (At least I think so, idk about the flaky tests)

### Resolved Issues

Resolves #3510

### Review Checklist

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
