### PR TITLE
Replace remaining `new_git_repository` rules with `http_archive`

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -218,16 +218,16 @@ http_archive(
 
 http_archive(
     name = "LTC4151",
-    url = "https://github.com/kerrydwong/LTC4151/archive/729952f10bcdcf359877b6f728565c17a8f17423.tar.gz",
-    sha256 = "6aa2dd380a13b08366338cdf0fbbeeeed96887512ac7b0753ee6ea1e8856df31",
     build_file = "@//extlibs:LTC4151.BUILD",
+    sha256 = "6aa2dd380a13b08366338cdf0fbbeeeed96887512ac7b0753ee6ea1e8856df31",
+    url = "https://github.com/kerrydwong/LTC4151/archive/729952f10bcdcf359877b6f728565c17a8f17423.tar.gz",
 )
 
 http_archive(
     name = "trinamic",
-    url = "https://github.com/analogdevicesinc/TMC-API/archive/0cd695fab6d43ceb121af4b8608e5d92b14e1ce9.tar.gz",
-    sha256 = "4c1640a87347afdc4d5954752f0e773f6d9fbb0ea0fb1481dbdb3012ec00ef8b",
     build_file = "@//extlibs:trinamic.BUILD",
+    sha256 = "4c1640a87347afdc4d5954752f0e773f6d9fbb0ea0fb1481dbdb3012ec00ef8b",
+    url = "https://github.com/analogdevicesinc/TMC-API/archive/0cd695fab6d43ceb121af4b8608e5d92b14e1ce9.tar.gz",
 )
 
 ##############################################

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -228,7 +228,7 @@ http_archive(
     name = "trinamic",
     build_file = "@//extlibs:trinamic.BUILD",
     sha256 = "4c1640a87347afdc4d5954752f0e773f6d9fbb0ea0fb1481dbdb3012ec00ef8b",
-    strip_prefix = "trinamic-0cd695fab6d43ceb121af4b8608e5d92b14e1ce9",
+    strip_prefix = "TMC-API-0cd695fab6d43ceb121af4b8608e5d92b14e1ce9",
     url = "https://github.com/analogdevicesinc/TMC-API/archive/0cd695fab6d43ceb121af4b8608e5d92b14e1ce9.tar.gz",
 )
 

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -216,26 +216,18 @@ http_archive(
     url = "https://github.com/saebyn/munkres-cpp/archive/61086fcf5b3a8ad4bda578cdc2d1dca57b548786.tar.gz",
 )
 
-##############################################
-# Add new git repos (these cannot be used offline)
-# All of this SHOULD BE REMOVED in favour of archive_override
-##############################################
-new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
-
-new_git_repository(
+http_archive(
     name = "LTC4151",
+    url = "https://github.com/kerrydwong/LTC4151/archive/729952f10bcdcf359877b6f728565c17a8f17423.tar.gz",
+    sha256 = "6aa2dd380a13b08366338cdf0fbbeeeed96887512ac7b0753ee6ea1e8856df31",
     build_file = "@//extlibs:LTC4151.BUILD",
-    commit = "729952f10bcdcf359877b6f728565c17a8f17423",
-    remote = "https://github.com/kerrydwong/LTC4151.git",
-    shallow_since = "1397951678 -0400",
 )
 
-new_git_repository(
+http_archive(
     name = "trinamic",
+    url = "https://github.com/analogdevicesinc/TMC-API/archive/0cd695fab6d43ceb121af4b8608e5d92b14e1ce9.tar.gz",
+    sha256 = "4c1640a87347afdc4d5954752f0e773f6d9fbb0ea0fb1481dbdb3012ec00ef8b",
     build_file = "@//extlibs:trinamic.BUILD",
-    commit = "0cd695fab6d43ceb121af4b8608e5d92b14e1ce9",
-    remote = "https://github.com/trinamic/TMC-API.git",
-    shallow_since = "1631132123 +0200",
 )
 
 ##############################################

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -220,6 +220,7 @@ http_archive(
     name = "LTC4151",
     build_file = "@//extlibs:LTC4151.BUILD",
     sha256 = "6aa2dd380a13b08366338cdf0fbbeeeed96887512ac7b0753ee6ea1e8856df31",
+    strip_prefix = "LTC4151-729952f10bcdcf359877b6f728565c17a8f17423",
     url = "https://github.com/kerrydwong/LTC4151/archive/729952f10bcdcf359877b6f728565c17a8f17423.tar.gz",
 )
 
@@ -227,6 +228,7 @@ http_archive(
     name = "trinamic",
     build_file = "@//extlibs:trinamic.BUILD",
     sha256 = "4c1640a87347afdc4d5954752f0e773f6d9fbb0ea0fb1481dbdb3012ec00ef8b",
+    strip_prefix = "trinamic-0cd695fab6d43ceb121af4b8608e5d92b14e1ce9",
     url = "https://github.com/analogdevicesinc/TMC-API/archive/0cd695fab6d43ceb121af4b8608e5d92b14e1ce9.tar.gz",
 )
 


### PR DESCRIPTION
### Description

Replace remaining `new_git_repository` usages with `http_archive` rule in Bazel (LTC4151 and trinamic packages)

### Testing Done

Compiles on my machine, fails here (still working on it)

### Resolved Issues

Resolves #3469 

### Review Checklist

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
