### PR TITLE
replaced end_autoref bool with threading event

### DIFF
--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -21,7 +21,6 @@ import threading
 import time
 from typing import override
 
-
 class TigersAutoref(TimeProvider):
     """A wrapper over the TigersAutoref binary. It coordinates communication between the
     Simulator, TigersAutoref and Gamecontroller.
@@ -66,7 +65,7 @@ class TigersAutoref(TimeProvider):
         self.auto_ref_proc_thread = None
         self.auto_ref_wrapper_thread = None
         self.ci_mode = ci_mode
-        self.end_autoref = False
+        self.end_autoref = threading.Event()
         self.wrapper_buffer = ThreadSafeBuffer(buffer_size, SSL_WrapperPacket)
         self.referee_buffer = ThreadSafeBuffer(buffer_size, Referee)
         self.gamecontroller = gc
@@ -172,7 +171,7 @@ class TigersAutoref(TimeProvider):
             gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN
         )
 
-        while not self.end_autoref:
+        while not self.end_autoref.is_set():
             try:
                 ssl_wrapper = self.wrapper_buffer.get(
                     block=True, timeout=TigersAutoref.BUFFER_TIMEOUT
@@ -259,7 +258,7 @@ class TigersAutoref(TimeProvider):
         autoref_proto_unix_io.register_observer(Referee, self.referee_buffer)
 
     def __exit__(self, type, value, traceback) -> None:
-        self.end_autoref = True
+        self.end_autoref.set()
         if self.tigers_autoref_proc:
             self.tigers_autoref_proc.terminate()
             self.tigers_autoref_proc.wait()

--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -21,6 +21,7 @@ import threading
 import time
 from typing import override
 
+
 class TigersAutoref(TimeProvider):
     """A wrapper over the TigersAutoref binary. It coordinates communication between the
     Simulator, TigersAutoref and Gamecontroller.


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Converted the bool implementation of end_autoref to a threading event implementation.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Thunderscope runs with ./tbots.py run thunderscope_main --enable_autoref and closes with no issues.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

Resolves #3471

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
