### PR TITLE
Remove flaky ball placement play tests for now

### DIFF
--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
@@ -164,26 +164,6 @@ def run_ball_placement_scenario(
         ]
     ]
 
-    simulated_test_runner.run_test(
-        setup=lambda test_setup_arg: ball_placement_play_setup(
-            test_setup_arg["ball_start_point"],
-            test_setup_arg["ball_placement_point"],
-            simulated_test_runner,
-            blue_only,
-        ),
-        params=[
-            {
-                "ball_start_point": ball_start_point,
-                "ball_placement_point": ball_placement_point,
-            }
-        ],
-        inv_always_validation_sequence_set=[[]],
-        inv_eventually_validation_sequence_set=placement_eventually_validation_sequence_set,
-        ag_always_validation_sequence_set=[[]],
-        ag_eventually_validation_sequence_set=placement_eventually_validation_sequence_set,
-        test_timeout_s=[15],
-    )
-
     # Drop Ball Always Validation
     drop_ball_always_validation_sequence_set = [
         [
@@ -207,6 +187,26 @@ def run_ball_placement_scenario(
             ),
         ]
     ]
+
+    simulated_test_runner.run_test(
+        setup=lambda test_setup_arg: ball_placement_play_setup(
+            test_setup_arg["ball_start_point"],
+            test_setup_arg["ball_placement_point"],
+            simulated_test_runner,
+            blue_only,
+        ),
+        params=[
+            {
+                "ball_start_point": ball_start_point,
+                "ball_placement_point": ball_placement_point,
+            }
+        ],
+        inv_always_validation_sequence_set=[[]],
+        inv_eventually_validation_sequence_set=placement_eventually_validation_sequence_set,
+        ag_always_validation_sequence_set=[[]],
+        ag_eventually_validation_sequence_set=placement_eventually_validation_sequence_set,
+        test_timeout_s=[15],
+    )
 
     simulated_test_runner.run_test(
         # setup argument isn't passed to preserve world state from previous test run

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
@@ -181,7 +181,7 @@ def run_ball_placement_scenario(
         inv_eventually_validation_sequence_set=placement_eventually_validation_sequence_set,
         ag_always_validation_sequence_set=[[]],
         ag_eventually_validation_sequence_set=placement_eventually_validation_sequence_set,
-        test_timeout_s=[20],
+        test_timeout_s=[15],
     )
 
     # Drop Ball Always Validation
@@ -214,7 +214,7 @@ def run_ball_placement_scenario(
         inv_eventually_validation_sequence_set=drop_ball_eventually_validation_sequence_set,
         ag_always_validation_sequence_set=drop_ball_always_validation_sequence_set,
         ag_eventually_validation_sequence_set=drop_ball_eventually_validation_sequence_set,
-        test_timeout_s=[30],
+        test_timeout_s=[5],
     )
 
 

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
@@ -116,23 +116,24 @@ def test_two_ai_ball_placement(
 @pytest.mark.parametrize(
     "ball_start_point, ball_placement_point",
     [
-        # 2023 RoboCup ball placement scenarios
-        # Scenario 1
-        (tbots_cpp.Point(-0.2, -2.8), tbots_cpp.Point(-0.2, 2.8)),
-        # Scenario 2
-        (tbots_cpp.Point(-3.5, -2.25), tbots_cpp.Point(0, 0)),
-        # Scenario 3
-        (tbots_cpp.Point(-1.5, -2.25), tbots_cpp.Point(-0.2, -2.8)),
-        # Scenario 4
-        (tbots_cpp.Point(-4.4, -2.9), tbots_cpp.Point(-0.2, 2.8)),
-        # Scenario 5
-        (tbots_cpp.Point(-0.5, -0), tbots_cpp.Point(-4.3, 2.8)),
-        # Scenario 6
-        (tbots_cpp.Point(-1, -3.15), tbots_cpp.Point(-3.5, -2.8)),
-        # Scenario 7
-        (tbots_cpp.Point(-1, 3.15), tbots_cpp.Point(-3.5, 2.8)),
-        # Scenario 8
-        (tbots_cpp.Point(-4.45, -0.1), tbots_cpp.Point(-0.5, 2.8)),
+        # TODO: Remove these ball placement tests until #3561 is resolved
+        # # 2023 RoboCup ball placement scenarios
+        # # Scenario 1
+        # (tbots_cpp.Point(-0.2, -2.8), tbots_cpp.Point(-0.2, 2.8)),
+        # # Scenario 2
+        # (tbots_cpp.Point(-3.5, -2.25), tbots_cpp.Point(0, 0)),
+        # # Scenario 3
+        # (tbots_cpp.Point(-1.5, -2.25), tbots_cpp.Point(-0.2, -2.8)),
+        # # Scenario 4
+        # (tbots_cpp.Point(-4.4, -2.9), tbots_cpp.Point(-0.2, 2.8)),
+        # # Scenario 5
+        # (tbots_cpp.Point(-0.5, -0), tbots_cpp.Point(-4.3, 2.8)),
+        # # Scenario 6
+        # (tbots_cpp.Point(-1, -3.15), tbots_cpp.Point(-3.5, -2.8)),
+        # # Scenario 7
+        # (tbots_cpp.Point(-1, 3.15), tbots_cpp.Point(-3.5, 2.8)),
+        # # Scenario 8
+        # (tbots_cpp.Point(-4.45, -0.1), tbots_cpp.Point(-0.5, 2.8)),
     ],
 )
 def test_robocup_technical_challenge_placement(


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Removes 2023 Robocup Ball Placement tests that are currently flaky #3561, there are multiple non-trivial bugs causing this issue. For now we should remove these extended tests so that development can continue.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
