### PR TITLE
Return trajectory early over threshold

### DIFF
--- a/src/software/ai/hl/stp/tactic/move_primitive.cpp
+++ b/src/software/ai/hl/stp/tactic/move_primitive.cpp
@@ -113,7 +113,7 @@ MovePrimitive::generatePrimitiveProtoMessage(
 
     if (!traj_path.has_value())
     {
-        LOG(WARNING) << "Could not find trajectory path for robot " << robot.id()
+		LOG(WARNING) << "Could not find trajectory path for robot " << robot.id()
                      << " to move to " << destination;
         return std::make_pair(std::nullopt, std::move(createStopPrimitiveProto()));
     }

--- a/src/software/ai/hl/stp/tactic/move_primitive.cpp
+++ b/src/software/ai/hl/stp/tactic/move_primitive.cpp
@@ -113,7 +113,7 @@ MovePrimitive::generatePrimitiveProtoMessage(
 
     if (!traj_path.has_value())
     {
-		LOG(WARNING) << "Could not find trajectory path for robot " << robot.id()
+        LOG(WARNING) << "Could not find trajectory path for robot " << robot.id()
                      << " to move to " << destination;
         return std::make_pair(std::nullopt, std::move(createStopPrimitiveProto()));
     }

--- a/src/software/ai/navigator/trajectory/collision_evaluator.cpp
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.cpp
@@ -1,5 +1,8 @@
 #include "software/ai/navigator/trajectory/collision_evaluator.h"
 
+const double FRONT_COLLISION_COST_CONST = 3.0;
+const double BACK_COLLISION_COST_CONST = 1.0;
+const double MID_TRAJ_COST_CONST = 6.0;
 CollisionEvaluator::CollisionEvaluator(const std::vector<ObstaclePtr> &obstacles)
     : obstacles(obstacles)
 {
@@ -41,7 +44,7 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
     traj_with_cost.collision_duration_front_s = first_non_collision_time;
 
 	// 2 .Add first front collision to total cost
-	total_cost += 3 * first_non_collision_time;
+	total_cost += FRONT_COLLISION_COST_CONST * first_non_collision_time;
 
     // Return early if current cost already higher than max cost
 	if (total_cost >= max_cost){
@@ -58,7 +61,7 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
         search_end_time_s - last_non_collision_time;
 
 	// 3. Add back collision to total cost
-	total_cost += 1 * traj_with_cost.collision_duration_back_s;
+	total_cost += BACK_COLLISION_COST_CONST * traj_with_cost.collision_duration_back_s;
 
     // Return early if current cost already higher than max cost
 	if (total_cost >= max_cost){
@@ -88,7 +91,7 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
 	
     // 4. Add 6.0 to collision if mid-trajectory collision exist
 	if (traj_with_cost.colliding_obstacle != nullptr){
-		total_cost += 6.0;
+		total_cost += MID_TRAJ_COST_CONST;
 	}
 
     // 5: Add distance from first collision to destination                                                                                                                                   

--- a/src/software/ai/navigator/trajectory/collision_evaluator.cpp
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.cpp
@@ -8,7 +8,7 @@ CollisionEvaluator::CollisionEvaluator(const std::vector<ObstaclePtr> &obstacles
 TrajectoryPathWithCost CollisionEvaluator::evaluate(
     const TrajectoryPath &trajectory,
     const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-    const std::optional<double> sub_traj_duration_s, const std::optional<double> max_cost)
+    const std::optional<double> sub_traj_duration_s, const double max_cost)
 {
     TrajectoryPathWithCost traj_with_cost(trajectory);
 

--- a/src/software/ai/navigator/trajectory/collision_evaluator.cpp
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.cpp
@@ -21,13 +21,11 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
         std::min(trajectory.getTotalTime(), MAX_FUTURE_COLLISION_CHECK_SEC);
     const Point destination = traj_with_cost.traj_path.getDestination();
 
-	// 1. Initialize total cost as trajectory time
+	// Initialize total cost as trajectory time
 	double total_cost = traj_time;
 
 
-    /**
-     * Find the start duration before the trajectory leaves all obstacles
-     */
+    // Find the start duration before the trajectory leaves all obstacles
     double first_non_collision_time;
     // Avoid finding the first non-collision time if the cache sub-trajectory
     // has a collision time.
@@ -43,7 +41,7 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
     }
     traj_with_cost.collision_duration_front_s = first_non_collision_time;
 
-	// 2 .Add first front collision to total cost
+	// Add first front collision to total cost
 	total_cost += FRONT_COLLISION_COST_CONST * first_non_collision_time;
 
     // Return early if current cost already higher than max cost
@@ -52,15 +50,13 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
 		return traj_with_cost;
 	}
 
-    /**
-     * Find the duration we're within an obstacle before search_end_time_s
-     */
+    // Find the duration we're within an obstacle before search_end_time_s
     double last_non_collision_time =
         getLastNonCollisionTime(trajectory, search_end_time_s);
     traj_with_cost.collision_duration_back_s =
         search_end_time_s - last_non_collision_time;
 
-	// 3. Add back collision to total cost
+	// Add back collision to total cost
 	total_cost += BACK_COLLISION_COST_CONST * traj_with_cost.collision_duration_back_s;
 
     // Return early if current cost already higher than max cost
@@ -70,10 +66,8 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
 	}
 
 
-    /**
-     * Get the first collision time, excluding the time at the start and end of path
-     * that we may be in an obstacle for.
-     */
+    // Get the first collision time, excluding the time at the start and end of path
+    // that we may be in an obstacle for.
     if (sub_traj_with_cost.has_value() &&
         sub_traj_with_cost->first_collision_time_s < sub_traj_duration_s)
     {
@@ -89,16 +83,16 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
         traj_with_cost.colliding_obstacle     = collision.second;
     }
 	
-    // 4. Add 6.0 to collision if mid-trajectory collision exist
+    // Add 6.0 to collision if mid-trajectory collision exist
 	if (traj_with_cost.colliding_obstacle != nullptr){
 		total_cost += MID_TRAJ_COST_CONST;
 	}
 
-    // 5: Add distance from first collision to destination                                                                                                                                   
+    //  Add distance from first collision to destination                                                                                                                                   
     Point first_collision_position = trajectory.getPosition(traj_with_cost.first_collision_time_s);                                                                                               
     total_cost += (first_collision_position - destination).length();                                                                                                                            
                                                                                                                                                                                                   
-    // 6: Add early collision penalty                                                                                                                                                        
+    //  Add early collision penalty                                                                                                                                                        
     total_cost += std::max(0.0, MAX_FUTURE_COLLISION_CHECK_SEC - traj_with_cost.first_collision_time_s);                                                                                        
 
 	traj_with_cost.cost = total_cost;

--- a/src/software/ai/navigator/trajectory/collision_evaluator.cpp
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.cpp
@@ -9,11 +9,11 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
     const TrajectoryPath &trajectory,
     const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
     const std::optional<double> sub_traj_duration_s,
-	const std::optional<double> max_cost)
+	const double max_cost)
 {
     TrajectoryPathWithCost traj_with_cost(trajectory);	
 
-	const double traj_time = trajectory.getTotalTime;
+	const double traj_time = trajectory.getTotalTime();
     const double search_end_time_s =
         std::min(trajectory.getTotalTime(), MAX_FUTURE_COLLISION_CHECK_SEC);
     const Point destination = traj_with_cost.traj_path.getDestination();
@@ -87,16 +87,16 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
     }
 	
     // 4. Add 6.0 to collision if mid-trajectory collision exist
-	if (traj_with_cost.colliding_obstacle != std::nullptr){
+	if (traj_with_cost.colliding_obstacle != nullptr){
 		total_cost += 6.0;
 	}
 
-    // 5: Add distance from first collision to destination                                                                                                                                   │
-    Point first_collision_position = trajectory.getPosition(traj_with_cost.first_collision_time_s);                                                                                               │
-    total_cost += (first_collision_position - destination).length();                                                                                                                            │
-                                                                                                                                                                                                  │
-    // 6: Add early collision penalty                                                                                                                                                        │
-    total_cost += std::max(0.0, MAX_FUTURE_COLLISION_CHECK_SEC - traj_with_cost.first_collision_time_s);                                                                                        │
+    // 5: Add distance from first collision to destination                                                                                                                                   
+    Point first_collision_position = trajectory.getPosition(traj_with_cost.first_collision_time_s);                                                                                               
+    total_cost += (first_collision_position - destination).length();                                                                                                                            
+                                                                                                                                                                                                  
+    // 6: Add early collision penalty                                                                                                                                                        
+    total_cost += std::max(0.0, MAX_FUTURE_COLLISION_CHECK_SEC - traj_with_cost.first_collision_time_s);                                                                                        
 
 	traj_with_cost.cost = total_cost;
     return traj_with_cost;

--- a/src/software/ai/navigator/trajectory/collision_evaluator.cpp
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.cpp
@@ -9,7 +9,7 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
     const TrajectoryPath &trajectory,
     const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
     const std::optional<double> sub_traj_duration_s,
-	const double max_cost)
+	const std::optional<double> max_cost)
 {
     TrajectoryPathWithCost traj_with_cost(trajectory);	
 

--- a/src/software/ai/navigator/trajectory/collision_evaluator.cpp
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.cpp
@@ -1,8 +1,5 @@
 #include "software/ai/navigator/trajectory/collision_evaluator.h"
 
-const double FRONT_COLLISION_COST_CONST = 3.0;
-const double BACK_COLLISION_COST_CONST  = 1.0;
-const double MID_TRAJ_COST_CONST        = 6.0;
 CollisionEvaluator::CollisionEvaluator(const std::vector<ObstaclePtr> &obstacles)
     : obstacles(obstacles)
 {

--- a/src/software/ai/navigator/trajectory/collision_evaluator.cpp
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.cpp
@@ -8,12 +8,19 @@ CollisionEvaluator::CollisionEvaluator(const std::vector<ObstaclePtr> &obstacles
 TrajectoryPathWithCost CollisionEvaluator::evaluate(
     const TrajectoryPath &trajectory,
     const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-    const std::optional<double> sub_traj_duration_s)
+    const std::optional<double> sub_traj_duration_s,
+	const std::optional<double> max_cost)
 {
-    TrajectoryPathWithCost traj_with_cost(trajectory);
+    TrajectoryPathWithCost traj_with_cost(trajectory);	
 
+	const double traj_time = trajectory.getTotalTime;
     const double search_end_time_s =
         std::min(trajectory.getTotalTime(), MAX_FUTURE_COLLISION_CHECK_SEC);
+    const Point destination = traj_with_cost.traj_path.getDestination();
+
+	// 1. Initialize total cost as trajectory time
+	double total_cost = traj_time;
+
 
     /**
      * Find the start duration before the trajectory leaves all obstacles
@@ -33,6 +40,15 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
     }
     traj_with_cost.collision_duration_front_s = first_non_collision_time;
 
+	// 2 .Add first front collision to total cost
+	total_cost += 3 * first_non_collision_time;
+
+    // Return early if current cost already higher than max cost
+	if (total_cost >= max_cost){
+		traj_with_cost.cost = total_cost;
+		return traj_with_cost;
+	}
+
     /**
      * Find the duration we're within an obstacle before search_end_time_s
      */
@@ -40,6 +56,16 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
         getLastNonCollisionTime(trajectory, search_end_time_s);
     traj_with_cost.collision_duration_back_s =
         search_end_time_s - last_non_collision_time;
+
+	// 3. Add back collision to total cost
+	total_cost += 1 * traj_with_cost.collision_duration_back_s;
+
+    // Return early if current cost already higher than max cost
+	if (total_cost >= max_cost){
+		traj_with_cost.cost = total_cost;
+		return traj_with_cost;
+	}
+
 
     /**
      * Get the first collision time, excluding the time at the start and end of path
@@ -59,7 +85,20 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
         traj_with_cost.first_collision_time_s = collision.first;
         traj_with_cost.colliding_obstacle     = collision.second;
     }
+	
+    // 4. Add 6.0 to collision if mid-trajectory collision exist
+	if (traj_with_cost.colliding_obstacle != std::nullptr){
+		total_cost += 6.0;
+	}
 
+    // 5: Add distance from first collision to destination                                                                                                                                   │
+    Point first_collision_position = trajectory.getPosition(traj_with_cost.first_collision_time_s);                                                                                               │
+    total_cost += (first_collision_position - destination).length();                                                                                                                            │
+                                                                                                                                                                                                  │
+    // 6: Add early collision penalty                                                                                                                                                        │
+    total_cost += std::max(0.0, MAX_FUTURE_COLLISION_CHECK_SEC - traj_with_cost.first_collision_time_s);                                                                                        │
+
+	traj_with_cost.cost = total_cost;
     return traj_with_cost;
 }
 

--- a/src/software/ai/navigator/trajectory/collision_evaluator.cpp
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.cpp
@@ -81,7 +81,7 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
         traj_with_cost.colliding_obstacle     = collision.second;
     }
 
-    // Add 6.0 to collision if mid-trajectory collision exist
+    // Add penalty if mid-trajectory collision exists
     if (traj_with_cost.colliding_obstacle != nullptr)
     {
         total_cost += MID_TRAJ_COST_CONST;

--- a/src/software/ai/navigator/trajectory/collision_evaluator.cpp
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.cpp
@@ -1,8 +1,8 @@
 #include "software/ai/navigator/trajectory/collision_evaluator.h"
 
 const double FRONT_COLLISION_COST_CONST = 3.0;
-const double BACK_COLLISION_COST_CONST = 1.0;
-const double MID_TRAJ_COST_CONST = 6.0;
+const double BACK_COLLISION_COST_CONST  = 1.0;
+const double MID_TRAJ_COST_CONST        = 6.0;
 CollisionEvaluator::CollisionEvaluator(const std::vector<ObstaclePtr> &obstacles)
     : obstacles(obstacles)
 {
@@ -11,18 +11,17 @@ CollisionEvaluator::CollisionEvaluator(const std::vector<ObstaclePtr> &obstacles
 TrajectoryPathWithCost CollisionEvaluator::evaluate(
     const TrajectoryPath &trajectory,
     const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-    const std::optional<double> sub_traj_duration_s,
-	const std::optional<double> max_cost)
+    const std::optional<double> sub_traj_duration_s, const std::optional<double> max_cost)
 {
-    TrajectoryPathWithCost traj_with_cost(trajectory);	
+    TrajectoryPathWithCost traj_with_cost(trajectory);
 
-	const double traj_time = trajectory.getTotalTime();
+    const double traj_time = trajectory.getTotalTime();
     const double search_end_time_s =
         std::min(trajectory.getTotalTime(), MAX_FUTURE_COLLISION_CHECK_SEC);
     const Point destination = traj_with_cost.traj_path.getDestination();
 
-	// Initialize total cost as trajectory time
-	double total_cost = traj_time;
+    // Initialize total cost as trajectory time
+    double total_cost = traj_time;
 
 
     // Find the start duration before the trajectory leaves all obstacles
@@ -41,14 +40,15 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
     }
     traj_with_cost.collision_duration_front_s = first_non_collision_time;
 
-	// Add first front collision to total cost
-	total_cost += FRONT_COLLISION_COST_CONST * first_non_collision_time;
+    // Add first front collision to total cost
+    total_cost += FRONT_COLLISION_COST_CONST * first_non_collision_time;
 
     // Return early if current cost already higher than max cost
-	if (total_cost >= max_cost){
-		traj_with_cost.cost = total_cost;
-		return traj_with_cost;
-	}
+    if (total_cost >= max_cost)
+    {
+        traj_with_cost.cost = total_cost;
+        return traj_with_cost;
+    }
 
     // Find the duration we're within an obstacle before search_end_time_s
     double last_non_collision_time =
@@ -56,14 +56,15 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
     traj_with_cost.collision_duration_back_s =
         search_end_time_s - last_non_collision_time;
 
-	// Add back collision to total cost
-	total_cost += BACK_COLLISION_COST_CONST * traj_with_cost.collision_duration_back_s;
+    // Add back collision to total cost
+    total_cost += BACK_COLLISION_COST_CONST * traj_with_cost.collision_duration_back_s;
 
     // Return early if current cost already higher than max cost
-	if (total_cost >= max_cost){
-		traj_with_cost.cost = total_cost;
-		return traj_with_cost;
-	}
+    if (total_cost >= max_cost)
+    {
+        traj_with_cost.cost = total_cost;
+        return traj_with_cost;
+    }
 
 
     // Get the first collision time, excluding the time at the start and end of path
@@ -82,20 +83,23 @@ TrajectoryPathWithCost CollisionEvaluator::evaluate(
         traj_with_cost.first_collision_time_s = collision.first;
         traj_with_cost.colliding_obstacle     = collision.second;
     }
-	
+
     // Add 6.0 to collision if mid-trajectory collision exist
-	if (traj_with_cost.colliding_obstacle != nullptr){
-		total_cost += MID_TRAJ_COST_CONST;
-	}
+    if (traj_with_cost.colliding_obstacle != nullptr)
+    {
+        total_cost += MID_TRAJ_COST_CONST;
+    }
 
-    //  Add distance from first collision to destination                                                                                                                                   
-    Point first_collision_position = trajectory.getPosition(traj_with_cost.first_collision_time_s);                                                                                               
-    total_cost += (first_collision_position - destination).length();                                                                                                                            
-                                                                                                                                                                                                  
-    //  Add early collision penalty                                                                                                                                                        
-    total_cost += std::max(0.0, MAX_FUTURE_COLLISION_CHECK_SEC - traj_with_cost.first_collision_time_s);                                                                                        
+    //  Add distance from first collision to destination
+    Point first_collision_position =
+        trajectory.getPosition(traj_with_cost.first_collision_time_s);
+    total_cost += (first_collision_position - destination).length();
 
-	traj_with_cost.cost = total_cost;
+    //  Add early collision penalty
+    total_cost += std::max(
+        0.0, MAX_FUTURE_COLLISION_CHECK_SEC - traj_with_cost.first_collision_time_s);
+
+    traj_with_cost.cost = total_cost;
     return traj_with_cost;
 }
 

--- a/src/software/ai/navigator/trajectory/collision_evaluator.h
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.h
@@ -35,6 +35,8 @@ class CollisionEvaluator
      *        collision interval.
      * @param sub_traj_duration_s
      *        The duration (in seconds) of the prefix trajectory within trajectory.
+	 * #param max_cost
+	 *		Current maximum cost of best path
      * @return
      *         A TrajectoryPathWithCost< containing the trajectory along with
      *         computed collision timing information and total cost.
@@ -42,7 +44,7 @@ class CollisionEvaluator
     TrajectoryPathWithCost evaluate(
         const TrajectoryPath &trajectory,
         const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-        std::optional<double> sub_traj_duration_s);
+        std::optional<double> sub_traj_duration_s, const double max_cost);
 
    private:
     std::vector<ObstaclePtr> obstacles;

--- a/src/software/ai/navigator/trajectory/collision_evaluator.h
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.h
@@ -47,7 +47,7 @@ class CollisionEvaluator
     TrajectoryPathWithCost evaluate(
         const TrajectoryPath &trajectory,
         const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-        std::optional<double> sub_traj_duration_s, const std::optional<double> max_cost);
+        std::optional<double> sub_traj_duration_s, double max_cost);
 
    private:
     std::vector<ObstaclePtr> obstacles;

--- a/src/software/ai/navigator/trajectory/collision_evaluator.h
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.h
@@ -27,18 +27,13 @@ class CollisionEvaluator
      * If a prefix trajectory is provided, collision information that occurs entirely
      * before the given prefix duration may be reused to avoid redundant collision
      * checking. Collision checks beyond the prefix duration are computed normally.
-     * @param trajectory
-     *        The trajectory to evaluate for collisions and cost.
-     * @param sub_traj_with_cost
-     *        An optional previously evaluated prefix trajectory whose collision
-     *        information may be reused if the prefix fully covers the relevant
-     *        collision interval.
-     * @param sub_traj_duration_s
-     *        The duration (in seconds) of the prefix trajectory within trajectory.
-	 * @param max_cost
-	 *		Current maximum cost of best path
-     * @return
-     *         A TrajectoryPathWithCost< containing the trajectory along with
+     * @param trajectory The trajectory to evaluate for collisions and cost.
+     * @param sub_traj_with_cost An optional previously evaluated prefix trajectory whose collision
+     * information may be reused if the prefix fully covers the relevant
+     * collision interval.
+     * @param sub_traj_duration_s The duration (in seconds) of the prefix trajectory within trajectory.
+	 * @param max_cost Current maximum cost of best path
+     * @return A TrajectoryPathWithCost< containing the trajectory along with
      *         computed collision timing information and total cost.
      */
     TrajectoryPathWithCost evaluate(

--- a/src/software/ai/navigator/trajectory/collision_evaluator.h
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.h
@@ -12,13 +12,12 @@
  **/
 class CollisionEvaluator
 {
-
-   static constexpr double COLLISION_CHECK_STEP_INTERVAL_SEC         = 0.1;
-   static constexpr double FORWARD_COLLISION_CHECK_STEP_INTERVAL_SEC = 0.05;
-   static constexpr double MAX_FUTURE_COLLISION_CHECK_SEC            = 2.0;
-   static constexpr double FRONT_COLLISION_COST_CONST = 3.0;
-   static constexpr double BACK_COLLISION_COST_CONST  = 1.0;
-   static constexpr double MID_TRAJ_COST_CONST        = 6.0;
+    static constexpr double COLLISION_CHECK_STEP_INTERVAL_SEC         = 0.1;
+    static constexpr double FORWARD_COLLISION_CHECK_STEP_INTERVAL_SEC = 0.05;
+    static constexpr double MAX_FUTURE_COLLISION_CHECK_SEC            = 2.0;
+    static constexpr double FRONT_COLLISION_COST_CONST                = 3.0;
+    static constexpr double BACK_COLLISION_COST_CONST                 = 1.0;
+    static constexpr double MID_TRAJ_COST_CONST                       = 6.0;
 
    public:
     /**
@@ -95,5 +94,3 @@ class CollisionEvaluator
     double getLastNonCollisionTime(const TrajectoryPath &traj_path,
                                    const double search_end_time_s) const;
 };
-
-

--- a/src/software/ai/navigator/trajectory/collision_evaluator.h
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.h
@@ -44,7 +44,7 @@ class CollisionEvaluator
     TrajectoryPathWithCost evaluate(
         const TrajectoryPath &trajectory,
         const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-        std::optional<double> sub_traj_duration_s, const double max_cost);
+        std::optional<double> sub_traj_duration_s, const std::optional<double> max_cost);
 
    private:
     std::vector<ObstaclePtr> obstacles;

--- a/src/software/ai/navigator/trajectory/collision_evaluator.h
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.h
@@ -28,11 +28,12 @@ class CollisionEvaluator
      * before the given prefix duration may be reused to avoid redundant collision
      * checking. Collision checks beyond the prefix duration are computed normally.
      * @param trajectory The trajectory to evaluate for collisions and cost.
-     * @param sub_traj_with_cost An optional previously evaluated prefix trajectory whose collision
-     * information may be reused if the prefix fully covers the relevant
+     * @param sub_traj_with_cost An optional previously evaluated prefix trajectory whose
+     * collision information may be reused if the prefix fully covers the relevant
      * collision interval.
-     * @param sub_traj_duration_s The duration (in seconds) of the prefix trajectory within trajectory.
-	 * @param max_cost Current maximum cost of best path
+     * @param sub_traj_duration_s The duration (in seconds) of the prefix trajectory
+     * within trajectory.
+     * @param max_cost Current maximum cost of best path
      * @return A TrajectoryPathWithCost< containing the trajectory along with
      *         computed collision timing information and total cost.
      */

--- a/src/software/ai/navigator/trajectory/collision_evaluator.h
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.h
@@ -12,6 +12,14 @@
  **/
 class CollisionEvaluator
 {
+
+   static constexpr double COLLISION_CHECK_STEP_INTERVAL_SEC         = 0.1;
+   static constexpr double FORWARD_COLLISION_CHECK_STEP_INTERVAL_SEC = 0.05;
+   static constexpr double MAX_FUTURE_COLLISION_CHECK_SEC            = 2.0;
+   static constexpr double FRONT_COLLISION_COST_CONST = 3.0;
+   static constexpr double BACK_COLLISION_COST_CONST  = 1.0;
+   static constexpr double MID_TRAJ_COST_CONST        = 6.0;
+
    public:
     /**
      * Constructor
@@ -88,6 +96,4 @@ class CollisionEvaluator
                                    const double search_end_time_s) const;
 };
 
-const double COLLISION_CHECK_STEP_INTERVAL_SEC         = 0.1;
-const double FORWARD_COLLISION_CHECK_STEP_INTERVAL_SEC = 0.05;
-const double MAX_FUTURE_COLLISION_CHECK_SEC            = 2.0;
+

--- a/src/software/ai/navigator/trajectory/collision_evaluator.h
+++ b/src/software/ai/navigator/trajectory/collision_evaluator.h
@@ -35,7 +35,7 @@ class CollisionEvaluator
      *        collision interval.
      * @param sub_traj_duration_s
      *        The duration (in seconds) of the prefix trajectory within trajectory.
-	 * #param max_cost
+	 * @param max_cost
 	 *		Current maximum cost of best path
      * @return
      *         A TrajectoryPathWithCost< containing the trajectory along with

--- a/src/software/ai/navigator/trajectory/trajectory_planner.cpp
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.cpp
@@ -3,6 +3,7 @@
 #include "collision_evaluator.h"
 #include "software/geom/algorithms/contains.h"
 #include "software/geom/algorithms/distance.h"
+#include "software/logger/logger.h"
 
 TrajectoryPlanner::TrajectoryPlanner()
     : relative_sub_destinations(getRelativeSubDestinations())

--- a/src/software/ai/navigator/trajectory/trajectory_planner.cpp
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.cpp
@@ -109,8 +109,9 @@ std::optional<TrajectoryPath> TrajectoryPlanner::findTrajectory(
                 break;
             }
 
-            TrajectoryPathWithCost full_traj_with_cost = getTrajectoryWithCost(
-                traj_path_to_dest, obstacles, sub_trajectory, connection_time, best_traj_with_cost.cost);
+            TrajectoryPathWithCost full_traj_with_cost =
+                getTrajectoryWithCost(traj_path_to_dest, obstacles, sub_trajectory,
+                                      connection_time, best_traj_with_cost.cost);
             full_traj_with_cost.cost += cost_offset;
             if (full_traj_with_cost.cost < best_traj_with_cost.cost)
             {
@@ -133,14 +134,14 @@ std::optional<TrajectoryPath> TrajectoryPlanner::findTrajectory(
         }
     }
 
-	return best_traj_with_cost.traj_path;
+    return best_traj_with_cost.traj_path;
 }
 
 TrajectoryPathWithCost TrajectoryPlanner::getDirectTrajectoryWithCost(
     const Point &start, const Point &destination, const Vector &initial_velocity,
     const KinematicConstraints &constraints, const std::vector<ObstaclePtr> &obstacles)
 {
-	// Calculate full new cost regardless by passing in maximum max cost
+    // Calculate full new cost regardless by passing in maximum max cost
     return getTrajectoryWithCost(
         TrajectoryPath(std::make_shared<BangBangTrajectory2D>(
                            start, destination, initial_velocity, constraints),
@@ -151,14 +152,12 @@ TrajectoryPathWithCost TrajectoryPlanner::getDirectTrajectoryWithCost(
 TrajectoryPathWithCost TrajectoryPlanner::getTrajectoryWithCost(
     const TrajectoryPath &trajectory, const std::vector<ObstaclePtr> &obstacles,
     const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-    const std::optional<double> sub_traj_duration_s,
-	const std::optional<double> max_cost)
+    const std::optional<double> sub_traj_duration_s, const std::optional<double> max_cost)
 {
     CollisionEvaluator evaluator(obstacles);
-    TrajectoryPathWithCost traj_with_cost(
-        evaluator.evaluate(trajectory, sub_traj_with_cost, sub_traj_duration_s, max_cost));
-	
+    TrajectoryPathWithCost traj_with_cost(evaluator.evaluate(
+        trajectory, sub_traj_with_cost, sub_traj_duration_s, max_cost));
+
 
     return traj_with_cost;
 }
-

--- a/src/software/ai/navigator/trajectory/trajectory_planner.cpp
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.cpp
@@ -162,31 +162,3 @@ TrajectoryPathWithCost TrajectoryPlanner::getTrajectoryWithCost(
     return traj_with_cost;
 }
 
-double TrajectoryPlanner::calculateCost(
-    const TrajectoryPathWithCost &traj_with_cost) const
-{
-    double total_cost = traj_with_cost.traj_path.getTotalTime();
-
-    // Add a large cost if the trajectory collides with an obstacle
-    // Note that this ignores collisions that may be in at the
-    // start of the trajectory as those are unavoidable by all trajectories.
-    if (traj_with_cost.colliding_obstacle != nullptr)
-    {
-        total_cost += 6.0;
-    }
-
-    // The closer the collision is to the destination, the lower its cost will be
-    Point first_collision_position =
-        traj_with_cost.traj_path.getPosition(traj_with_cost.first_collision_time_s);
-    Point destination = traj_with_cost.traj_path.getDestination();
-    total_cost += (first_collision_position - destination).length();
-
-    total_cost += std::max(
-        0.0, (MAX_FUTURE_COLLISION_CHECK_SEC - traj_with_cost.first_collision_time_s));
-
-    total_cost += 3 * traj_with_cost.collision_duration_front_s;
-
-    total_cost += 1 * traj_with_cost.collision_duration_back_s;
-
-    return total_cost;
-}

--- a/src/software/ai/navigator/trajectory/trajectory_planner.cpp
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.cpp
@@ -110,7 +110,7 @@ std::optional<TrajectoryPath> TrajectoryPlanner::findTrajectory(
             }
 
             TrajectoryPathWithCost full_traj_with_cost = getTrajectoryWithCost(
-                traj_path_to_dest, obstacles, sub_trajectory, connection_time);
+                traj_path_to_dest, obstacles, sub_trajectory, connection_time, best_traj_with_cost.cost);
             full_traj_with_cost.cost += cost_offset;
             if (full_traj_with_cost.cost < best_traj_with_cost.cost)
             {
@@ -140,22 +140,24 @@ TrajectoryPathWithCost TrajectoryPlanner::getDirectTrajectoryWithCost(
     const Point &start, const Point &destination, const Vector &initial_velocity,
     const KinematicConstraints &constraints, const std::vector<ObstaclePtr> &obstacles)
 {
+	// Calculate full new cost regardless by passing in maximum max cost
     return getTrajectoryWithCost(
         TrajectoryPath(std::make_shared<BangBangTrajectory2D>(
                            start, destination, initial_velocity, constraints),
                        BangBangTrajectory2D::generator),
-        obstacles, std::nullopt, std::nullopt);
+        obstacles, std::nullopt, std::nullopt, std::numeric_limits<double>::max());
 }
 
 TrajectoryPathWithCost TrajectoryPlanner::getTrajectoryWithCost(
     const TrajectoryPath &trajectory, const std::vector<ObstaclePtr> &obstacles,
     const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-    const std::optional<double> sub_traj_duration_s)
+    const std::optional<double> sub_traj_duration_s,
+	const double max_cost)
 {
     CollisionEvaluator evaluator(obstacles);
     TrajectoryPathWithCost traj_with_cost(
-        evaluator.evaluate(trajectory, sub_traj_with_cost, sub_traj_duration_s));
-    traj_with_cost.cost = calculateCost(traj_with_cost);
+        evaluator.evaluate(trajectory, sub_traj_with_cost, sub_traj_duration_s, max_cost));
+	
 
     return traj_with_cost;
 }

--- a/src/software/ai/navigator/trajectory/trajectory_planner.cpp
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.cpp
@@ -152,7 +152,7 @@ TrajectoryPathWithCost TrajectoryPlanner::getTrajectoryWithCost(
     const TrajectoryPath &trajectory, const std::vector<ObstaclePtr> &obstacles,
     const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
     const std::optional<double> sub_traj_duration_s,
-	const double max_cost)
+	const std::optional<double> max_cost)
 {
     CollisionEvaluator evaluator(obstacles);
     TrajectoryPathWithCost traj_with_cost(

--- a/src/software/ai/navigator/trajectory/trajectory_planner.cpp
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.cpp
@@ -152,7 +152,7 @@ TrajectoryPathWithCost TrajectoryPlanner::getDirectTrajectoryWithCost(
 TrajectoryPathWithCost TrajectoryPlanner::getTrajectoryWithCost(
     const TrajectoryPath &trajectory, const std::vector<ObstaclePtr> &obstacles,
     const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-    const std::optional<double> sub_traj_duration_s, const std::optional<double> max_cost)
+    const std::optional<double> sub_traj_duration_s, double max_cost)
 {
     CollisionEvaluator evaluator(obstacles);
     TrajectoryPathWithCost traj_with_cost(evaluator.evaluate(

--- a/src/software/ai/navigator/trajectory/trajectory_planner.cpp
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.cpp
@@ -3,7 +3,6 @@
 #include "collision_evaluator.h"
 #include "software/geom/algorithms/contains.h"
 #include "software/geom/algorithms/distance.h"
-#include "software/logger/logger.h"
 
 TrajectoryPlanner::TrajectoryPlanner()
     : relative_sub_destinations(getRelativeSubDestinations())
@@ -134,7 +133,7 @@ std::optional<TrajectoryPath> TrajectoryPlanner::findTrajectory(
         }
     }
 
-    return best_traj_with_cost.traj_path;
+	return best_traj_with_cost.traj_path;
 }
 
 TrajectoryPathWithCost TrajectoryPlanner::getDirectTrajectoryWithCost(

--- a/src/software/ai/navigator/trajectory/trajectory_planner.h
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.h
@@ -74,7 +74,7 @@ class TrajectoryPlanner
         const TrajectoryPath &trajectory, const std::vector<ObstaclePtr> &obstacles,
         const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
         const std::optional<double> sub_traj_duration_s,
-		const double max_cost);
+		const std::optional<double> max_cost);
 
 
 

--- a/src/software/ai/navigator/trajectory/trajectory_planner.h
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.h
@@ -59,14 +59,14 @@ class TrajectoryPlanner
      * @param sub_traj_with_cost Optional cached trajectory path with cost of the sub
      * trajectory
      * @param sub_traj_duration_s Optional duration of the cached sub_traj_with_cost
-	 * @param max_cost Current maximum cost among calculated trajectories
+     * @param max_cost Current maximum cost among calculated trajectories
      * @return The trajectory path with its cost
      */
     TrajectoryPathWithCost getTrajectoryWithCost(
         const TrajectoryPath &trajectory, const std::vector<ObstaclePtr> &obstacles,
         const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
         const std::optional<double> sub_traj_duration_s,
-		const std::optional<double> max_cost);
+        const std::optional<double> max_cost);
 
 
 

--- a/src/software/ai/navigator/trajectory/trajectory_planner.h
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.h
@@ -66,7 +66,7 @@ class TrajectoryPlanner
         const TrajectoryPath &trajectory, const std::vector<ObstaclePtr> &obstacles,
         const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
         const std::optional<double> sub_traj_duration_s,
-        const std::optional<double> max_cost);
+        double max_cost);
 
 
 

--- a/src/software/ai/navigator/trajectory/trajectory_planner.h
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.h
@@ -65,8 +65,7 @@ class TrajectoryPlanner
     TrajectoryPathWithCost getTrajectoryWithCost(
         const TrajectoryPath &trajectory, const std::vector<ObstaclePtr> &obstacles,
         const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-        const std::optional<double> sub_traj_duration_s,
-        double max_cost);
+        const std::optional<double> sub_traj_duration_s, double max_cost);
 
 
 

--- a/src/software/ai/navigator/trajectory/trajectory_planner.h
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.h
@@ -36,14 +36,6 @@ class TrajectoryPlanner
 
    private:
     /**
-     * Calculate the cost of the given trajectory path with cost
-     *
-     * @param traj_with_cost A complete trajectory path with cost
-     * @return The cost of the trajectory
-     */
-    double calculateCost(const TrajectoryPathWithCost &traj_with_cost) const;
-
-    /**
      * Get a single trajectory with cost that goes directly from the start to the
      * destination.
      *

--- a/src/software/ai/navigator/trajectory/trajectory_planner.h
+++ b/src/software/ai/navigator/trajectory/trajectory_planner.h
@@ -67,12 +67,14 @@ class TrajectoryPlanner
      * @param sub_traj_with_cost Optional cached trajectory path with cost of the sub
      * trajectory
      * @param sub_traj_duration_s Optional duration of the cached sub_traj_with_cost
+	 * @param max_cost Current maximum cost among calculated trajectories
      * @return The trajectory path with its cost
      */
     TrajectoryPathWithCost getTrajectoryWithCost(
         const TrajectoryPath &trajectory, const std::vector<ObstaclePtr> &obstacles,
         const std::optional<TrajectoryPathWithCost> &sub_traj_with_cost,
-        const std::optional<double> sub_traj_duration_s);
+        const std::optional<double> sub_traj_duration_s,
+		const double max_cost);
 
 
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

This PR resolves #3591, which is a sub-issue of #3104. 

The goal was to reduce unnecessary calculations in collision evaluator (previously getTrajectoryWithCost). These calculations are expensive, as it simulates the robot's position along the trajectory path at discrete time intervals (0.05s - 0.1s steps) and checks each position against all obstacles for collision detection. These operations, including `getFirstNonCollisionTime()`, `getLastNonCollisionTime()`, and `getFirstCollisionTime()`, are O(t × n) where t is the number of time steps and n is the number of obstacles.

  By computing a running cost during evaluation and returning early when it exceeds the best known cost, we can skip:
  - The backward scan for back collision duration (getLastNonCollisionTime)
  - The most expensive mid-trajectory collision scan (getFirstCollisionTime)

  This is especially effective because the front collision penalty has a 3× weight, so trajectories starting in obstacles quickly exceed the cost threshold and bail out after just the first check.

Because the primary goal of this PR is to optimize, the final trajectory selection of the optimized method is the same as the old algorithm, this is also tested later.
<!--
    Give a high-level description of the changes in this PR
-->
### Results
This change was evaluated in two ways.

First, I logged the early returns in evaluations. 
[Screencast from 2026-02-01 21-37-44.webm](https://github.com/user-attachments/assets/86febba4-1ab1-44fb-9995-f6c14597819e)
As you can see in the video, there were a lot of early returns. This means many trajectories exceeded the cost threshold before the full simulation completed, allowing us to skip the remaining expensive calculations. This optimization significantly reduces CPU usage since we no longer waste computation on trajectories that would ultimately be rejected anyway.

To quantify the improvement, I benchmarked CPU usage between the optimized version and Unix v1.1.0 (baseline) by screenrecording thunderscope and system monitor, and plotting the results onto a graph. Both versions were tested under identical conditions, with blue/yellow teams swapped to ensure equivalency. Results below:
<img width="1528" height="369" alt="image" src="https://github.com/user-attachments/assets/8fb2e7a8-0080-4030-b521-f7f2e09afc65" />
The optimized versions shows notable reduction in cpu usage. Video recordings are below:

Blue optimized, yellow old:
[Screencast from 2026-02-01 13-14-51.webm](https://github.com/user-attachments/assets/1736c8d7-a8a3-4484-afd4-416a5eaa7462)

Blue old, yellow optimized:
[Screencast from 2026-02-01 13-32-43.webm](https://github.com/user-attachments/assets/2262c53e-8dd3-423f-933b-587d44c44a12)


### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

 **1. Same Trajectory Outcome**
The optimization must not change which trajectory is selected. This is guaranteed by the following invariant:
`The best trajectory always has its full cost calculated. it is never the result of an early return from the collision evaluator.`

To test this, I simply kept the calculateCost function, and logged the boolean of:
`best_traj.cost == calculateCost(best_traj)`
where calculate cost returns the full calculation.

This test passed, as in thunderscope logging, only 1s (True) were logged.

**2. Trajectory Correctness**
This was simply tested by running trajectory planner tests. All test cases passed.

**3. It is actually returning early**
This was tested in the results section by logging early returns.

### Resolved Issues
resolves #3591

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
