### PR TITLE
Full system flags compatability

### DIFF
--- a/src/software/thunderscope/binary_context_managers/full_system.py
+++ b/src/software/thunderscope/binary_context_managers/full_system.py
@@ -105,7 +105,7 @@ class FullSystem:
             logging.debug("Binary support flags: {}".format(supported_flags))
         else:
             logging.warning(
-                "Could not discovery flags for path: '{}'. Continuing...".format(
+                "Could not discover flags for path: '{}'. Continuing...".format(
                     self.path_to_binary
                 )
             )

--- a/src/software/thunderscope/binary_context_managers/full_system.py
+++ b/src/software/thunderscope/binary_context_managers/full_system.py
@@ -62,18 +62,13 @@ class FullSystem:
         :return a set of supported flags
         """
         try:
-           result = subprocess.run(
-                [path_to_binary, "--help"],
-                capture_output=True,
-                text=True,
-                timeout=3
-                )
-           flags = re.findall(r'--(\w+)', result.stdout)
-           return set(flags)
+            result = subprocess.run(
+                [path_to_binary, "--help"], capture_output=True, text=True, timeout=3
+            )
+            flags = re.findall(r"--(\w+)", result.stdout)
+            return set(flags)
         except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError):
-           return set()
-
-
+            return set()
 
     def __enter__(self) -> FullSystem:
         """Enter the full_system context manager.
@@ -94,23 +89,26 @@ class FullSystem:
         supported_flags = self.discover_supported_flags(self.path_to_binary)
 
         cmd_parts = [self.path_to_binary]
-         # runtime_dir is always required (core functionality)                                                                                                                                                                       
+        # runtime_dir is always required (core functionality)
         cmd_parts.append("--runtime_dir={}".format(self.full_system_runtime_dir))
-                                                                                                                                                                                                                                     
-        # Optional flags - only add if supported                                                                                                                                                                                     
-        if self.friendly_colour_yellow and "friendly_colour_yellow" in supported_flags:                                                                                                                                              
+
+        # Optional flags - only add if supported
+        if self.friendly_colour_yellow and "friendly_colour_yellow" in supported_flags:
             cmd_parts.append("--friendly_colour_yellow")
-        if not self.running_in_realtime and "ci" in supported_flags:                                                                                                                                                             
-            cmd_parts.append("--ci")                                                                                                                                                                                                                                                                                                                                                                                                                          
-        if "log_level" in supported_flags:       
+        if not self.running_in_realtime and "ci" in supported_flags:
+            cmd_parts.append("--ci")
+        if "log_level" in supported_flags:
             cmd_parts.append("--log_level={}".format(self.log_level.value))
-        
+
         # Log supported flags info based on importance level
         if supported_flags:
             logging.debug("Binary support flags: {}".format(supported_flags))
         else:
-            logging.warning("Could not discovery flags for path: '{}'. Continuing...".format(self.path_to_binary))
-        
+            logging.warning(
+                "Could not discovery flags for path: '{}'. Continuing...".format(
+                    self.path_to_binary
+                )
+            )
 
         self.full_system = " ".join(cmd_parts)
 

--- a/src/software/thunderscope/binary_context_managers/full_system.py
+++ b/src/software/thunderscope/binary_context_managers/full_system.py
@@ -189,7 +189,7 @@ gdb --args bazel-bin/{self.full_system}
                     "--runtime_dir={}".format(self.full_system_runtime_dir),
                 ]
             ):
-                relf.full_system_proc = Popen(self.full_system.split(" "))
+                self.full_system_proc = Popen(self.full_system.split(" "))
                 logging.info("FullSystem has restarted.")
 
             time.sleep(1)

--- a/src/software/thunderscope/binary_context_managers/full_system.py
+++ b/src/software/thunderscope/binary_context_managers/full_system.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import logging
 import os
+import subprocess
 import threading
 import time
 from subprocess import Popen, TimeoutExpired
+import re
 
 from software.py_constants import *
 from software.python_bindings import *
@@ -53,6 +55,26 @@ class FullSystem:
         self.log_level = log_level
         self.thread = threading.Thread(target=self.__restart__, daemon=True)
 
+    def discover_supported_flags(self, path_to_binary: str) -> set[str]:
+        """Discover what binary flags are supported by provided binary
+
+        :param path_to_binary path to specific binary
+        :return a set of supported flags
+        """
+        try:
+           result = subprocess.run(
+                [path_to_binary, "--help"],
+                capture_output=True,
+                text=True,
+                timeout=3
+                )
+           flags = re.findall(r'--(\w+)', result.stdout)
+           return set(flags)
+        except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError):
+           return set()
+
+
+
     def __enter__(self) -> FullSystem:
         """Enter the full_system context manager.
 
@@ -69,13 +91,28 @@ class FullSystem:
         except:
             pass
 
-        self.full_system = "{} --runtime_dir={} {} {} --log_level={}".format(
-            self.path_to_binary,
-            self.full_system_runtime_dir,
-            "--friendly_colour_yellow" if self.friendly_colour_yellow else "",
-            "--ci" if not self.running_in_realtime else "",
-            self.log_level.value,
-        )
+        supported_flags = self.discover_supported_flags(self.path_to_binary)
+
+        cmd_parts = [self.path_to_binary]
+         # runtime_dir is always required (core functionality)                                                                                                                                                                       
+        cmd_parts.append("--runtime_dir={}".format(self.full_system_runtime_dir))
+                                                                                                                                                                                                                                     
+        # Optional flags - only add if supported                                                                                                                                                                                     
+        if self.friendly_colour_yellow and "friendly_colour_yellow" in supported_flags:                                                                                                                                              
+            cmd_parts.append("--friendly_colour_yellow")
+        if not self.running_in_realtime and "ci" in supported_flags:                                                                                                                                                             
+            cmd_parts.append("--ci")                                                                                                                                                                                                                                                                                                                                                                                                                          
+        if "log_level" in supported_flags:       
+            cmd_parts.append("--log_level={}".format(self.log_level.value))
+        
+        # Log supported flags info based on importance level
+        if supported_flags:
+            logging.debug("Binary support flags: {}".format(supported_flags))
+        else:
+            logging.warning("Could not discovery flags for path: '{}'. Continuing...".format(self.path_to_binary))
+        
+
+        self.full_system = " ".join(cmd_parts)
 
         if self.should_run_under_sudo:
             if not is_cmd_running(
@@ -152,7 +189,7 @@ gdb --args bazel-bin/{self.full_system}
                     "--runtime_dir={}".format(self.full_system_runtime_dir),
                 ]
             ):
-                self.full_system_proc = Popen(self.full_system.split(" "))
+                relf.full_system_proc = Popen(self.full_system.split(" "))
                 logging.info("FullSystem has restarted.")
 
             time.sleep(1)


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->


### Description
This PR resolves #3582, making sure full system binaries are only launched with flags compatible with the full system.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
Tested with PR #3507. First launched latest full system (blue) vs old full system 3507 (yellow) on master branch. Failed because yellow bots failed and old full system crashed.
Then launched same teams on the current branch. Yellow bots didn't crash and plays normally.

Also tested helper function `discover_supported_flags` by  logging the set of available flags of different binaries. It logged the correct available flags.
### Resolved Issues
#3582 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
#3582 
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
