### PR TITLE
Fixed Setup Wifi Driver Task in Ansible setup_pi playbook

### DIFF
--- a/src/software/embedded/ansible/playbooks/setup_pi.yml
+++ b/src/software/embedded/ansible/playbooks/setup_pi.yml
@@ -83,12 +83,18 @@
             dest: ~/
             remote_src: true
 
-        - name: Set up Wifi drivers
+        - name: Set up Wifi drivers (copy from /home/robot to /lib/firmware)
           become: true
           become_method: ansible.builtin.sudo
-          ansible.builtin.command:
-            cmd: "mv /home/{{ ansible_user }}/iwlwifi* /lib/firmware/"
+          ansible.builtin.shell:
+            chdir: "/home/{{ ansible_user }}"
+            cmd: "cp iwlwifi* /lib/firmware/"
             creates: /lib/firmware/iwlwifi*.ucode
+          register: wifi_fw_copy_status
+        - name: Debug wifi copy status (add -v to command to see output)
+          ansible.builtin.debug:
+            var: wifi_fw_copy_status
+            verbosity: 1
         - name: Set up systemd Wifi interface name rule
           ansible.builtin.import_tasks:
             file: ../tasks/setup_wifi_interface.yml


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

This PR addresses issue #3616. 

Please check the issue as I added lots of context there. 

The issue (flaky wifi driver setup) is addressed by using `ansible.builtin.shell` instead of `ansible.builtin.command`. This is necessary because to setup the wifi drivers, wifi firmware files are transferred and this is done by using glob patterns. Glob patterns are not expanded by `ansible.builtin.command` but are correctly expanded by `ansible.builtin.shell`. 

This alone fixes the issue, but the following changes were also added:
- Copy (`cp`) files  instead of moving (`mv`) them. This adds redundancy. It does not incur overhead because the `creates: ` argument still maintains idempotency.
- Used `chdir` to change directory for cleaner style and more readable file transfer command.
- Added `wifi_fw_copy_status` to register task status/attributes
- Added debug task to print `wifi_fw_copy_status` attributes. This is only enabled in verbose level 1 (`-v`).

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

I rediscovered this bug while trying to set up a Raspberry Pi (bruhbot). After changing to `ansible.builtin.shell`, the issue was fixed. After making the additional changes mentioned above, I reran the `setup_pi` playbook to ensure the playbook continued to run successfully.  

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

#3616 

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
