### PR TITLE
Sync time on raspberry pi before running setup script

### DIFF
--- a/src/software/embedded/ansible/playbooks/setup_pi.yml
+++ b/src/software/embedded/ansible/playbooks/setup_pi.yml
@@ -12,7 +12,7 @@
         file: ../tasks/check_internet.yml
 
     - name: Time sync by enabling NTP
-      tags: configure_pi
+      tags: dependencies
       ansible.builtin.import_tasks:
         file: ../tasks/enable_ntp.yml
 

--- a/src/software/embedded/ansible/playbooks/setup_pi.yml
+++ b/src/software/embedded/ansible/playbooks/setup_pi.yml
@@ -11,6 +11,11 @@
       ansible.builtin.import_tasks:
         file: ../tasks/check_internet.yml
 
+    - name: Time sync by enabling ntp
+      tags: configure_pi
+      ansible.builtin.import_tasks:
+        file: ../tasks/enable_ntp.yml
+
     - name: Enable passwordless sudo for rsync
       tags:
         - dependencies

--- a/src/software/embedded/ansible/playbooks/setup_pi.yml
+++ b/src/software/embedded/ansible/playbooks/setup_pi.yml
@@ -11,7 +11,7 @@
       ansible.builtin.import_tasks:
         file: ../tasks/check_internet.yml
 
-    - name: Time sync by enabling ntp
+    - name: Time sync by enabling NTP
       tags: configure_pi
       ansible.builtin.import_tasks:
         file: ../tasks/enable_ntp.yml

--- a/src/software/embedded/ansible/tasks/enable_ntp.yml
+++ b/src/software/embedded/ansible/tasks/enable_ntp.yml
@@ -9,5 +9,4 @@
       ansible.builtin.systemd_service:
         name: systemd-timesyncd
         state: started
-        enabled: yes
-
+        enabled: true

--- a/src/software/embedded/ansible/tasks/enable_ntp.yml
+++ b/src/software/embedded/ansible/tasks/enable_ntp.yml
@@ -6,7 +6,9 @@
       register: ntp_enabled
 
     - name: Enable automatic time synchronization
-      ansible.builtin.command: sudo timedatectl set-ntp on
+      ansible.builtin.command: timedatectl set-ntp on
+      become_method: ansible.builtin.sudo
+      become: true
       when: ntp_enabled.stdout == "no"
 
     - name: Ensure the systemd-timesyncd service is running and enabled

--- a/src/software/embedded/ansible/tasks/enable_ntp.yml
+++ b/src/software/embedded/ansible/tasks/enable_ntp.yml
@@ -1,0 +1,12 @@
+---
+- name: Make sure NTP is enabled to sync time for set_up.yml
+  block:
+    - name: Enable automatic time synchronization
+      ansible.builtin.command: timedatectl set-ntp on
+      changed_when: true
+
+    - name: Ensure the systemd-timesyncd service is running and enabled
+      ansible.builtin.systemd_service:
+        name: systemd-timesyncd
+        state: started
+        enabled: yes

--- a/src/software/embedded/ansible/tasks/enable_ntp.yml
+++ b/src/software/embedded/ansible/tasks/enable_ntp.yml
@@ -2,7 +2,7 @@
 - name: Make sure NTP is enabled to sync time for set_up.yml
   block:
     - name: Enable automatic time synchronization
-      ansible.builtin.command: timedatectl set-ntp on
+      ansible.builtin.command: sudo timedatectl set-ntp on
       changed_when: true
 
     - name: Ensure the systemd-timesyncd service is running and enabled
@@ -10,3 +10,4 @@
         name: systemd-timesyncd
         state: started
         enabled: yes
+

--- a/src/software/embedded/ansible/tasks/enable_ntp.yml
+++ b/src/software/embedded/ansible/tasks/enable_ntp.yml
@@ -4,10 +4,12 @@
     - name: Check if NTP is enabled
       ansible.builtin.command: timedatectl show --property=NTP --value
       register: ntp_enabled
+      changed_when: false
 
     - name: Enable automatic time synchronization
       ansible.builtin.command: sudo timedatectl set-ntp on
       when: ntp_enabled.stdout == "no"
+      changed_when: true
 
     - name: Ensure the systemd-timesyncd service is running and enabled
       ansible.builtin.systemd:

--- a/src/software/embedded/ansible/tasks/enable_ntp.yml
+++ b/src/software/embedded/ansible/tasks/enable_ntp.yml
@@ -2,16 +2,16 @@
 - name: Make sure NTP is enabled to sync time for setup_pi.yml
   block:
     - name: Check if NTP is enabled
-      ansible.builtin.command: timedatectl status
-      register: timedatectl_result
+      ansible.builtin.command: timedatectl show --property=NTP --value
+      register: ntp_enabled
 
-    - name: Enable automatic time synchronization
+    - name: Enable automatic time synchronization {{ntp_enabled.stdout}}
       ansible.builtin.command: timedatectl set-ntp on
-      when: "{{'NTP service: active' not in timedatectl_result.stdout}}"
+      when: ntp_enabled.stdout == "no"
       become: true
 
     - name: Ensure the systemd-timesyncd service is running and enabled
-      ansible.builtin.systemd_service:
+      ansible.builtin.systemd:
         name: systemd-timesyncd
         state: started
         enabled: true

--- a/src/software/embedded/ansible/tasks/enable_ntp.yml
+++ b/src/software/embedded/ansible/tasks/enable_ntp.yml
@@ -1,9 +1,14 @@
 ---
-- name: Make sure NTP is enabled to sync time for set_up.yml
+- name: Make sure NTP is enabled to sync time for setup_pi.yml
   block:
+    - name: Check if NTP is enabled
+      ansible.builtin.command: timedatectl status
+      register: timedatectl_result
+
     - name: Enable automatic time synchronization
-      ansible.builtin.command: sudo timedatectl set-ntp on
-      changed_when: true
+      ansible.builtin.command: timedatectl set-ntp on
+      when: "{{'NTP service: active' not in timedatectl_result.stdout}}"
+      become: true
 
     - name: Ensure the systemd-timesyncd service is running and enabled
       ansible.builtin.systemd_service:

--- a/src/software/embedded/ansible/tasks/enable_ntp.yml
+++ b/src/software/embedded/ansible/tasks/enable_ntp.yml
@@ -5,10 +5,9 @@
       ansible.builtin.command: timedatectl show --property=NTP --value
       register: ntp_enabled
 
-    - name: Enable automatic time synchronization {{ntp_enabled.stdout}}
-      ansible.builtin.command: timedatectl set-ntp on
+    - name: Enable automatic time synchronization
+      ansible.builtin.command: sudo timedatectl set-ntp on
       when: ntp_enabled.stdout == "no"
-      become: true
 
     - name: Ensure the systemd-timesyncd service is running and enabled
       ansible.builtin.systemd:


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->
This PR resolve #3615 . It adds an ansible task to enable ntp before running the setup_pi.yml script to ensure time in synced with local machine. 

After enabling ntp, the time on the raspberry pi synced to the local machine. This enabled the setup script to run correctly.
<img width="1822" height="347" alt="image" src="https://github.com/user-attachments/assets/a80d461f-786e-4c8b-bed2-c050c8902b7e" />

Set up pi. 
<img width="714" height="460" alt="image" src="https://github.com/user-attachments/assets/fc47fab0-1de9-4353-98b2-ba1a8da198f0" />

### Description
																														
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
#3615 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
