### PR TITLE
Fix flaky python simulated tests (no robots loading and ai running)

### DIFF
--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
@@ -1,93 +1,18 @@
 import pytest
-
 import software.python_bindings as tbots_cpp
 from software.py_constants import ENEMY_BALL_PLACEMENT_DISTANCE_METERS
-from proto.play_pb2 import Play, PlayName
-from software.simulated_tests.ball_enters_region import *
-from software.simulated_tests.ball_stops_in_region import *
-from software.simulated_tests.robot_enters_region import *
+
+from proto.import_all_protos import *
+from proto.ssl_gc_common_pb2 import Team
+from proto.message_translation.tbots_protobuf import create_world_state
+from software.simulated_tests.ball_enters_region import (
+    BallAlwaysStaysInRegion,
+    BallEventuallyEntersRegion,
+)
+from software.simulated_tests.robot_enters_region import RobotEventuallyExitsRegion
 from software.simulated_tests.simulated_test_fixture import (
     pytest_main,
 )
-from proto.message_translation.tbots_protobuf import create_world_state
-from proto.ssl_gc_common_pb2 import Team
-
-
-def ball_placement_play_setup(
-    ball_start_point, ball_placement_point, simulated_test_runner, blue_only
-):
-    """Set up ball placement test by initializing bot positions, ball placement targets, and test settings
-
-    :param ball_start_point: Initial point of the ball
-    :param ball_placement_point: Target point of the ball
-    :param simulated_test_runner: Simulated test runner
-    :param blue_only: If True, only the blue team is active; the yellow team is ignored.
-    """
-    # Setup blue robots
-    blue_bots = [
-        tbots_cpp.Point(-2.75, 1.5),
-        tbots_cpp.Point(-0.0, 0.0),
-        tbots_cpp.Point(-2.75, -0.5),
-        tbots_cpp.Field.createSSLDivisionBField().friendlyGoalCenter(),
-        tbots_cpp.Field.createSSLDivisionBField()
-        .friendlyDefenseArea()
-        .negXNegYCorner(),
-        tbots_cpp.Field.createSSLDivisionBField()
-        .friendlyDefenseArea()
-        .negXPosYCorner(),
-    ]
-
-    yellow_bots = []
-
-    # Optionally skip yellow robots entirely
-    if not blue_only:
-        yellow_bots = [
-            tbots_cpp.Point(1, 0),
-            tbots_cpp.Point(1, 2.5),
-            tbots_cpp.Point(1, -2.5),
-            tbots_cpp.Field.createSSLDivisionBField().enemyGoalCenter(),
-            tbots_cpp.Field.createSSLDivisionBField()
-            .enemyDefenseArea()
-            .negXNegYCorner(),
-            tbots_cpp.Field.createSSLDivisionBField()
-            .enemyDefenseArea()
-            .negXPosYCorner(),
-        ]
-
-    # Game Controller Setup
-    simulated_test_runner.gamecontroller.send_gc_command(
-        gc_command=Command.Type.STOP, team=Team.UNKNOWN
-    )
-    # Pass in placement point here - not required for all play tests
-    simulated_test_runner.gamecontroller.send_gc_command(
-        gc_command=Command.Type.BALL_PLACEMENT,
-        team=Team.BLUE,
-        final_ball_placement_point=ball_placement_point,
-    )
-
-    # Force play override here
-    blue_play = Play()
-    blue_play.name = PlayName.BallPlacementPlay
-
-    yellow_play = Play()
-    yellow_play.name = PlayName.HaltPlay
-
-    simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
-    if not blue_only:
-        simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-            Play, yellow_play
-        )
-
-    # Create world state
-    simulated_test_runner.simulator_proto_unix_io.send_proto(
-        WorldState,
-        create_world_state(
-            yellow_robot_locations=yellow_bots,
-            blue_robot_locations=blue_bots,
-            ball_location=ball_start_point,
-            ball_velocity=tbots_cpp.Vector(0, 0),
-        ),
-    )
 
 
 @pytest.mark.parametrize(
@@ -144,14 +69,88 @@ def test_robocup_technical_challenge_placement(
     )
 
 
+def ball_placement_play_setup(
+    ball_start_point, ball_placement_point, simulated_test_runner, blue_only
+):
+    """Set up ball placement test by initializing bot positions, ball placement targets, and test settings
+
+    :param ball_start_point: Initial point of the ball
+    :param ball_placement_point: Target point of the ball
+    :param simulated_test_runner: Simulated test runner
+    :param blue_only: If True, only the blue team is active; the yellow team is ignored.
+    """
+    # Setup blue robots
+    blue_bots = [
+        tbots_cpp.Point(-2.75, 1.5),
+        tbots_cpp.Point(-0.0, 0.0),
+        tbots_cpp.Point(-2.75, -0.5),
+        tbots_cpp.Field.createSSLDivisionBField().friendlyGoalCenter(),
+        tbots_cpp.Field.createSSLDivisionBField()
+        .friendlyDefenseArea()
+        .negXNegYCorner(),
+        tbots_cpp.Field.createSSLDivisionBField()
+        .friendlyDefenseArea()
+        .negXPosYCorner(),
+    ]
+
+    yellow_bots = []
+
+    # Optionally skip yellow robots entirely
+    if not blue_only:
+        yellow_bots = [
+            tbots_cpp.Point(1, 0),
+            tbots_cpp.Point(1, 2.5),
+            tbots_cpp.Point(1, -2.5),
+            tbots_cpp.Field.createSSLDivisionBField().enemyGoalCenter(),
+            tbots_cpp.Field.createSSLDivisionBField()
+            .enemyDefenseArea()
+            .negXNegYCorner(),
+            tbots_cpp.Field.createSSLDivisionBField()
+            .enemyDefenseArea()
+            .negXPosYCorner(),
+        ]
+
+    # Game Controller Setup
+    simulated_test_runner.send_gamecontroller_command(
+        gc_command=Command.Type.STOP, team=Team.UNKNOWN
+    )
+    # Pass in placement point here - not required for all play tests
+    simulated_test_runner.send_gamecontroller_command(
+        gc_command=Command.Type.BALL_PLACEMENT,
+        team=Team.BLUE,
+        final_ball_placement_point=ball_placement_point,
+    )
+
+    # Force play override here
+    blue_play = Play()
+    blue_play.name = PlayName.BallPlacementPlay
+
+    yellow_play = Play()
+    yellow_play.name = PlayName.HaltPlay
+
+    simulated_test_runner.set_play(blue_play, is_friendly=True)
+    if not blue_only:
+        simulated_test_runner.set_play(yellow_play, is_friendly=False)
+
+    # Create world state
+    simulated_test_runner.set_world_state(
+        create_world_state(
+            yellow_robot_locations=yellow_bots,
+            blue_robot_locations=blue_bots,
+            ball_location=ball_start_point,
+            ball_velocity=tbots_cpp.Vector(0, 0),
+        ),
+    )
+
+
 def run_ball_placement_scenario(
     simulated_test_runner, ball_start_point, ball_placement_point, blue_only=False
 ):
     """Runs a ball placement test scenario with the specified parameters.
 
     :param simulated_test_runner: The test runner used to simulate robot and ball behavior.
-    :param ball_start_point: The initial position of the ball (provided by pytest parameterization).
-    :param ball_placement_point: The target position where the ball should be placed (provided by pytest parameterization).
+    :param ball_start_point: The initial position of the ball.
+    :param ball_placement_point: The target position where the ball should be placed.
     :param blue_only: If True, only the blue team is active; the yellow team is ignored.
     """
     # Placement Eventually Validation

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_test.py
@@ -110,6 +110,16 @@ def ball_placement_play_setup(
             .negXPosYCorner(),
         ]
 
+    # Create world state
+    simulated_test_runner.set_world_state(
+        create_world_state(
+            yellow_robot_locations=yellow_bots,
+            blue_robot_locations=blue_bots,
+            ball_location=ball_start_point,
+            ball_velocity=tbots_cpp.Vector(0, 0),
+        ),
+    )
+
     # Game Controller Setup
     simulated_test_runner.send_gamecontroller_command(
         gc_command=Command.Type.STOP, team=Team.UNKNOWN
@@ -131,16 +141,6 @@ def ball_placement_play_setup(
     simulated_test_runner.set_play(blue_play, is_friendly=True)
     if not blue_only:
         simulated_test_runner.set_play(yellow_play, is_friendly=False)
-
-    # Create world state
-    simulated_test_runner.set_world_state(
-        create_world_state(
-            yellow_robot_locations=yellow_bots,
-            blue_robot_locations=blue_bots,
-            ball_location=ball_start_point,
-            ball_velocity=tbots_cpp.Vector(0, 0),
-        ),
-    )
 
 
 def run_ball_placement_scenario(

--- a/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_test.py
+++ b/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_test.py
@@ -9,68 +9,58 @@ from software.simulated_tests.simulated_test_fixture import (
 
 
 def test_crease_defense_play(simulated_test_runner):
-    # starting point must be Point
-    ball_initial_pos = tbots_cpp.Point(0.9, 2.85)
-    # placement point must be Vector2 to work with game controller
-    tbots_cpp.Point(-3, -2)
+    def setup(*args):
+        ball_initial_pos = tbots_cpp.Point(0.9, 2.85)
 
-    # Setup Bots
-    blue_bots = [
-        tbots_cpp.Point(-4.5, 0),
-        tbots_cpp.Point(-3, 1.5),
-        tbots_cpp.Point(-3, 0.5),
-        tbots_cpp.Point(-3, -0.5),
-        tbots_cpp.Point(-3, -1.5),
-        tbots_cpp.Point(-3, -3.0),
-    ]
+        blue_bots = [
+            tbots_cpp.Point(-4.5, 0),
+            tbots_cpp.Point(-3, 1.5),
+            tbots_cpp.Point(-3, 0.5),
+            tbots_cpp.Point(-3, -0.5),
+            tbots_cpp.Point(-3, -1.5),
+            tbots_cpp.Point(-3, -3.0),
+        ]
 
-    yellow_bots = [
-        tbots_cpp.Point(1, 3),
-        tbots_cpp.Point(1, -0.25),
-        tbots_cpp.Point(1, -1.25),
-        tbots_cpp.Field.createSSLDivisionBField().enemyGoalCenter(),
-        tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXNegYCorner(),
-        tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXPosYCorner(),
-    ]
+        yellow_bots = [
+            tbots_cpp.Point(1, 3),
+            tbots_cpp.Point(1, -0.25),
+            tbots_cpp.Point(1, -1.25),
+            tbots_cpp.Field.createSSLDivisionBField().enemyGoalCenter(),
+            tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXNegYCorner(),
+            tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXPosYCorner(),
+        ]
 
-    # Game Controller Setup
-    simulated_test_runner.gamecontroller.send_gc_command(
-        gc_command=Command.Type.STOP, team=Team.UNKNOWN
-    )
-    simulated_test_runner.gamecontroller.send_gc_command(
-        gc_command=Command.Type.FORCE_START, team=Team.BLUE
-    )
+        simulated_test_runner.send_gamecontroller_command(
+            gc_command=Command.Type.STOP, team=Team.UNKNOWN
+        )
+        simulated_test_runner.send_gamecontroller_command(
+            gc_command=Command.Type.FORCE_START, team=Team.BLUE
+        )
 
-    # Force play override here
-    blue_play = Play()
-    blue_play.name = PlayName.CreaseDefensePlay
+        blue_play = Play()
+        blue_play.name = PlayName.CreaseDefensePlay
 
-    yellow_play = Play()
-    yellow_play.name = PlayName.HaltPlay
+        yellow_play = Play()
+        yellow_play.name = PlayName.HaltPlay
 
-    simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
-    simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(Play, yellow_play)
+        simulated_test_runner.set_play(blue_play, is_friendly=True)
+        simulated_test_runner.set_play(yellow_play, is_friendly=False)
 
-    # Create world state
-    simulated_test_runner.simulator_proto_unix_io.send_proto(
-        WorldState,
-        create_world_state(
-            yellow_robot_locations=yellow_bots,
-            blue_robot_locations=blue_bots,
-            ball_location=ball_initial_pos,
-            ball_velocity=tbots_cpp.Vector(0, 0),
-        ),
-    )
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                yellow_robot_locations=yellow_bots,
+                blue_robot_locations=blue_bots,
+                ball_location=ball_initial_pos,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            ),
+        )
 
-    # Always Validation
-    # TODO- #2778 Validation
     always_validation_sequence_set = [[]]
 
-    # Eventually Validation
-    # TODO- #2778 Validation
     eventually_validation_sequence_set = [[]]
 
     simulated_test_runner.run_test(
+        setup=setup,
         inv_eventually_validation_sequence_set=eventually_validation_sequence_set,
         inv_always_validation_sequence_set=always_validation_sequence_set,
         test_timeout_s=25,

--- a/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_test.py
+++ b/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_test.py
@@ -59,8 +59,10 @@ def test_crease_defense_play(simulated_test_runner):
         simulated_test_runner.set_play(blue_play, is_friendly=True)
         simulated_test_runner.set_play(yellow_play, is_friendly=False)
 
+    # TODO (#2778): actually add validations
     always_validation_sequence_set = [[]]
 
+    # TODO (#2778): actually add validations
     eventually_validation_sequence_set = [[]]
 
     simulated_test_runner.run_test(

--- a/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_test.py
+++ b/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_test.py
@@ -26,8 +26,12 @@ def test_crease_defense_play(simulated_test_runner):
             tbots_cpp.Point(1, -0.25),
             tbots_cpp.Point(1, -1.25),
             tbots_cpp.Field.createSSLDivisionBField().enemyGoalCenter(),
-            tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXNegYCorner(),
-            tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXPosYCorner(),
+            tbots_cpp.Field.createSSLDivisionBField()
+            .enemyDefenseArea()
+            .negXNegYCorner(),
+            tbots_cpp.Field.createSSLDivisionBField()
+            .enemyDefenseArea()
+            .negXPosYCorner(),
         ]
 
         simulated_test_runner.send_gamecontroller_command(

--- a/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_test.py
+++ b/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_test.py
@@ -34,6 +34,15 @@ def test_crease_defense_play(simulated_test_runner):
             .negXPosYCorner(),
         ]
 
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                yellow_robot_locations=yellow_bots,
+                blue_robot_locations=blue_bots,
+                ball_location=ball_initial_pos,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            ),
+        )
+
         simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
@@ -49,15 +58,6 @@ def test_crease_defense_play(simulated_test_runner):
 
         simulated_test_runner.set_play(blue_play, is_friendly=True)
         simulated_test_runner.set_play(yellow_play, is_friendly=False)
-
-        simulated_test_runner.set_world_state(
-            create_world_state(
-                yellow_robot_locations=yellow_bots,
-                blue_robot_locations=blue_bots,
-                ball_location=ball_initial_pos,
-                ball_velocity=tbots_cpp.Vector(0, 0),
-            ),
-        )
 
     always_validation_sequence_set = [[]]
 

--- a/src/software/ai/hl/stp/play/defense/defense_play_test.py
+++ b/src/software/ai/hl/stp/play/defense/defense_play_test.py
@@ -37,33 +37,24 @@ from software.simulated_tests.simulated_test_fixture import (
 )
 def test_defense_play_ball_steal(simulated_test_runner, blue_bots, yellow_bots):
     def setup(*args):
-        # Starting point must be Point
         ball_initial_pos = tbots_cpp.Point(0.93, 0)
-        # Placement point must be Vector2 to work with game controller
-        tbots_cpp.Point(-3, -2)
 
-        # Game Controller Setup
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.FORCE_START, team=Team.BLUE
         )
 
-        # Force play override here
         blue_play = Play()
         blue_play.name = PlayName.DefensePlay
 
         params = AssignedTacticPlayControlParams()
 
-        simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
-        simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-            AssignedTacticPlayControlParams, params
-        )
+        simulated_test_runner.set_play(blue_play, is_friendly=True)
+        simulated_test_runner.set_tactics(params, is_friendly=False)
 
-        # Create world state
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState,
+        simulated_test_runner.set_world_state(
             create_world_state(
                 yellow_robot_locations=yellow_bots,
                 blue_robot_locations=blue_bots,
@@ -115,34 +106,25 @@ def test_defense_play_ball_steal(simulated_test_runner, blue_bots, yellow_bots):
 )
 def test_defense_play(simulated_test_runner, blue_bots, yellow_bots):
     def setup(*args):
-        # Starting point must be Point
         ball_initial_pos = tbots_cpp.Point(0.9, 2.85)
-        # Placement point must be Vector2 to work with game controller
-        tbots_cpp.Point(-3, -2)
 
-        # Game Controller Setup
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.FORCE_START, team=Team.BLUE
         )
 
-        # Force play override here
         blue_play = Play()
         blue_play.name = PlayName.DefensePlay
 
         yellow_play = Play()
         yellow_play.name = PlayName.ShootOrPassPlay
 
-        simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
-        simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-            Play, yellow_play
-        )
+        simulated_test_runner.set_play(blue_play, is_friendly=True)
+        simulated_test_runner.set_play(yellow_play, is_friendly=False)
 
-        # Create world state
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState,
+        simulated_test_runner.set_world_state(
             create_world_state(
                 yellow_robot_locations=yellow_bots,
                 blue_robot_locations=blue_bots,

--- a/src/software/ai/hl/stp/play/defense/defense_play_test.py
+++ b/src/software/ai/hl/stp/play/defense/defense_play_test.py
@@ -39,6 +39,15 @@ def test_defense_play_ball_steal(simulated_test_runner, blue_bots, yellow_bots):
     def setup(*args):
         ball_initial_pos = tbots_cpp.Point(0.93, 0)
 
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                yellow_robot_locations=yellow_bots,
+                blue_robot_locations=blue_bots,
+                ball_location=ball_initial_pos,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            ),
+        )
+
         simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
@@ -53,15 +62,6 @@ def test_defense_play_ball_steal(simulated_test_runner, blue_bots, yellow_bots):
 
         simulated_test_runner.set_play(blue_play, is_friendly=True)
         simulated_test_runner.set_tactics(params, is_friendly=False)
-
-        simulated_test_runner.set_world_state(
-            create_world_state(
-                yellow_robot_locations=yellow_bots,
-                blue_robot_locations=blue_bots,
-                ball_location=ball_initial_pos,
-                ball_velocity=tbots_cpp.Vector(0, 0),
-            ),
-        )
 
     simulated_test_runner.run_test(
         setup=setup,
@@ -108,6 +108,15 @@ def test_defense_play(simulated_test_runner, blue_bots, yellow_bots):
     def setup(*args):
         ball_initial_pos = tbots_cpp.Point(0.9, 2.85)
 
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                yellow_robot_locations=yellow_bots,
+                blue_robot_locations=blue_bots,
+                ball_location=ball_initial_pos,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            ),
+        )
+
         simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
@@ -123,15 +132,6 @@ def test_defense_play(simulated_test_runner, blue_bots, yellow_bots):
 
         simulated_test_runner.set_play(blue_play, is_friendly=True)
         simulated_test_runner.set_play(yellow_play, is_friendly=False)
-
-        simulated_test_runner.set_world_state(
-            create_world_state(
-                yellow_robot_locations=yellow_bots,
-                blue_robot_locations=blue_bots,
-                ball_location=ball_initial_pos,
-                ball_velocity=tbots_cpp.Vector(0, 0),
-            ),
-        )
 
     simulated_test_runner.run_test(
         setup=setup,

--- a/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_test.py
+++ b/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_test.py
@@ -23,7 +23,6 @@ def test_two_ai_ball_placement(
     simulated_test_runner, ball_start_point, ball_placement_point
 ):
     def setup(*args):
-        # Setup Bots
         blue_bots = [
             tbots_cpp.Point(-4.5, 0),
             tbots_cpp.Point(-4, 0.5),
@@ -46,33 +45,26 @@ def test_two_ai_ball_placement(
             .negXPosYCorner(),
         ]
 
-        # Game Controller Setup
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
-        # Pass in placement point here - not required for all play tests
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.BALL_PLACEMENT,
             team=Team.YELLOW,
             final_ball_placement_point=ball_placement_point,
         )
 
-        # Force play override here
         blue_play = Play()
         blue_play.name = PlayName.EnemyBallPlacementPlay
 
-        simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
+        simulated_test_runner.set_play(blue_play, is_friendly=True)
 
         yellow_play = Play()
         yellow_play.name = PlayName.BallPlacementPlay
 
-        simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-            Play, yellow_play
-        )
+        simulated_test_runner.set_play(yellow_play, is_friendly=False)
 
-        # Create world state
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState,
+        simulated_test_runner.set_world_state(
             create_world_state(
                 yellow_robot_locations=yellow_bots,
                 blue_robot_locations=blue_bots,

--- a/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_test.py
+++ b/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_test.py
@@ -45,6 +45,15 @@ def test_two_ai_ball_placement(
             .negXPosYCorner(),
         ]
 
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                yellow_robot_locations=yellow_bots,
+                blue_robot_locations=blue_bots,
+                ball_location=ball_start_point,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            ),
+        )
+
         simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
@@ -63,15 +72,6 @@ def test_two_ai_ball_placement(
         yellow_play.name = PlayName.BallPlacementPlay
 
         simulated_test_runner.set_play(yellow_play, is_friendly=False)
-
-        simulated_test_runner.set_world_state(
-            create_world_state(
-                yellow_robot_locations=yellow_bots,
-                blue_robot_locations=blue_bots,
-                ball_location=ball_start_point,
-                ball_velocity=tbots_cpp.Vector(0, 0),
-            ),
-        )
 
     always_validation_sequence_set = [
         [RobotNeverEntersPlacementRegion(ball_placement_point)]

--- a/src/software/ai/hl/stp/play/enemy_free_kick/enemy_free_kick_play_test.py
+++ b/src/software/ai/hl/stp/play/enemy_free_kick/enemy_free_kick_play_test.py
@@ -102,31 +102,24 @@ from software.simulated_tests.simulated_test_fixture import (
 def test_enemy_free_kick_play(
     simulated_test_runner, blue_bots, yellow_bots, ball_initial_pos
 ):
-    # Setup Bots
     def setup(*args):
-        # Game Controller Setup
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.DIRECT, team=Team.YELLOW
         )
 
-        # Force play override here
         blue_play = Play()
         blue_play.name = PlayName.EnemyFreeKickPlay
 
         yellow_play = Play()
         yellow_play.name = PlayName.FreeKickPlay
 
-        simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
-        simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-            Play, yellow_play
-        )
+        simulated_test_runner.set_play(blue_play, is_friendly=True)
+        simulated_test_runner.set_play(yellow_play, is_friendly=False)
 
-        # Create world state
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState,
+        simulated_test_runner.set_world_state(
             create_world_state(
                 yellow_robot_locations=yellow_bots,
                 blue_robot_locations=blue_bots,

--- a/src/software/ai/hl/stp/play/enemy_free_kick/enemy_free_kick_play_test.py
+++ b/src/software/ai/hl/stp/play/enemy_free_kick/enemy_free_kick_play_test.py
@@ -103,6 +103,15 @@ def test_enemy_free_kick_play(
     simulated_test_runner, blue_bots, yellow_bots, ball_initial_pos
 ):
     def setup(*args):
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                yellow_robot_locations=yellow_bots,
+                blue_robot_locations=blue_bots,
+                ball_location=ball_initial_pos,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            ),
+        )
+
         simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
@@ -118,15 +127,6 @@ def test_enemy_free_kick_play(
 
         simulated_test_runner.set_play(blue_play, is_friendly=True)
         simulated_test_runner.set_play(yellow_play, is_friendly=False)
-
-        simulated_test_runner.set_world_state(
-            create_world_state(
-                yellow_robot_locations=yellow_bots,
-                blue_robot_locations=blue_bots,
-                ball_location=ball_initial_pos,
-                ball_velocity=tbots_cpp.Vector(0, 0),
-            ),
-        )
 
     # Always Validation
     always_validation_sequence_set = [

--- a/src/software/ai/hl/stp/play/example/example_play_test.py
+++ b/src/software/ai/hl/stp/play/example/example_play_test.py
@@ -38,6 +38,15 @@ def test_example_play(simulated_test_runner):
             .negXPosYCorner(),
         ]
 
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                yellow_robot_locations=yellow_bots,
+                blue_robot_locations=blue_bots,
+                ball_location=ball_initial_pos,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            ),
+        )
+
         blue_play = Play()
         blue_play.name = PlayName.ExamplePlay
 
@@ -55,15 +64,6 @@ def test_example_play(simulated_test_runner):
         )
         simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.DIRECT, team=Team.BLUE
-        )
-
-        simulated_test_runner.set_world_state(
-            create_world_state(
-                yellow_robot_locations=yellow_bots,
-                blue_robot_locations=blue_bots,
-                ball_location=ball_initial_pos,
-                ball_velocity=tbots_cpp.Vector(0, 0),
-            ),
         )
 
     # params just have to be a list of length 1 to ensure the test runs at least once

--- a/src/software/ai/hl/stp/play/example/example_play_test.py
+++ b/src/software/ai/hl/stp/play/example/example_play_test.py
@@ -16,7 +16,6 @@ def test_example_play(simulated_test_runner):
     ball_initial_pos = tbots_cpp.Point(0, 0)
 
     def setup(*args):
-        # Setup Bots
         blue_bots = [
             tbots_cpp.Point(-3, 2.5),
             tbots_cpp.Point(-3, 1.5),
@@ -39,32 +38,26 @@ def test_example_play(simulated_test_runner):
             .negXPosYCorner(),
         ]
 
-        # Force play override here
         blue_play = Play()
         blue_play.name = PlayName.ExamplePlay
 
         yellow_play = Play()
         yellow_play.name = PlayName.HaltPlay
 
-        simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
-        simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-            Play, yellow_play
-        )
+        simulated_test_runner.set_play(blue_play, is_friendly=True)
+        simulated_test_runner.set_play(yellow_play, is_friendly=False)
 
-        # Game Controller Setup
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.NORMAL_START, team=Team.BLUE
         )
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.DIRECT, team=Team.BLUE
         )
 
-        # Create world state
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState,
+        simulated_test_runner.set_world_state(
             create_world_state(
                 yellow_robot_locations=yellow_bots,
                 blue_robot_locations=blue_bots,

--- a/src/software/ai/hl/stp/play/free_kick/free_kick_play_test.py
+++ b/src/software/ai/hl/stp/play/free_kick/free_kick_play_test.py
@@ -14,6 +14,15 @@ from software.simulated_tests.simulated_test_fixture import (
 def free_kick_play_setup(
     blue_bots, yellow_bots, ball_initial_pos, play_name, simulated_test_runner
 ):
+    simulated_test_runner.set_world_state(
+        create_world_state(
+            yellow_robot_locations=yellow_bots,
+            blue_robot_locations=blue_bots,
+            ball_location=ball_initial_pos,
+            ball_velocity=tbots_cpp.Vector(0, 0),
+        ),
+    )
+
     simulated_test_runner.send_gamecontroller_command(
         gc_command=Command.Type.STOP, team=Team.UNKNOWN
     )
@@ -32,15 +41,6 @@ def free_kick_play_setup(
 
     simulated_test_runner.set_play(blue_play, is_friendly=True)
     simulated_test_runner.set_play(yellow_play, is_friendly=False)
-
-    simulated_test_runner.set_world_state(
-        create_world_state(
-            yellow_robot_locations=yellow_bots,
-            blue_robot_locations=blue_bots,
-            ball_location=ball_initial_pos,
-            ball_velocity=tbots_cpp.Vector(0, 0),
-        ),
-    )
 
 
 # We want to test friendly half, enemy half, and at the border of the field

--- a/src/software/ai/hl/stp/play/free_kick/free_kick_play_test.py
+++ b/src/software/ai/hl/stp/play/free_kick/free_kick_play_test.py
@@ -14,38 +14,26 @@ from software.simulated_tests.simulated_test_fixture import (
 def free_kick_play_setup(
     blue_bots, yellow_bots, ball_initial_pos, play_name, simulated_test_runner
 ):
-    """Sets up the free kick play test
-
-    :param blue_bots: positions of blue robots
-    :param yellow_bots: positions of yellow robots
-    :param ball_initial_pos: initial position of the ball
-    :param play_name: current play being used for blue robots
-    :param simulated_test_runner: the current test runner
-    """
-    # Game Controller Setup
-    simulated_test_runner.gamecontroller.send_gc_command(
+    simulated_test_runner.send_gamecontroller_command(
         gc_command=Command.Type.STOP, team=Team.UNKNOWN
     )
-    simulated_test_runner.gamecontroller.send_gc_command(
+    simulated_test_runner.send_gamecontroller_command(
         gc_command=Command.Type.NORMAL_START, team=Team.BLUE
     )
-    simulated_test_runner.gamecontroller.send_gc_command(
+    simulated_test_runner.send_gamecontroller_command(
         gc_command=Command.Type.DIRECT, team=Team.BLUE
     )
 
-    # Force play override here
     blue_play = Play()
     blue_play.name = play_name
 
     yellow_play = Play()
     yellow_play.name = PlayName.HaltPlay
 
-    simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
-    simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(Play, yellow_play)
+    simulated_test_runner.set_play(blue_play, is_friendly=True)
+    simulated_test_runner.set_play(yellow_play, is_friendly=False)
 
-    # Create world state
-    simulated_test_runner.simulator_proto_unix_io.send_proto(
-        WorldState,
+    simulated_test_runner.set_world_state(
         create_world_state(
             yellow_robot_locations=yellow_bots,
             blue_robot_locations=blue_bots,

--- a/src/software/ai/hl/stp/play/halt_play/halt_play_test.py
+++ b/src/software/ai/hl/stp/play/halt_play/halt_play_test.py
@@ -11,10 +11,8 @@ from software.simulated_tests.simulated_test_fixture import (
 # @pytest.mark.parametrize("run_enemy_ai,test_duration", [(False, 20), (True, 20)])
 def test_halt_play(simulated_test_runner):
     def setup(*args):
-        # starting point must be Point
         ball_initial_pos = tbots_cpp.Point(0, 0)
 
-        # Setup Bots
         blue_bots = [
             tbots_cpp.Point(-3, 2.5),
             tbots_cpp.Point(-3, 1.5),
@@ -37,20 +35,14 @@ def test_halt_play(simulated_test_runner):
             .negXPosYCorner(),
         ]
 
-        # Game Controller Setup
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.FORCE_START, team=Team.UNKNOWN
         )
 
-        # No plays to override. AI does whatever for 3 seconds before HALT CMD
-        # is issued
-
-        # Create world state
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState,
+        simulated_test_runner.set_world_state(
             create_world_state(
                 yellow_robot_locations=yellow_bots,
                 blue_robot_locations=blue_bots,

--- a/src/software/ai/hl/stp/play/halt_play/halt_play_test.py
+++ b/src/software/ai/hl/stp/play/halt_play/halt_play_test.py
@@ -35,13 +35,6 @@ def test_halt_play(simulated_test_runner):
             .negXPosYCorner(),
         ]
 
-        simulated_test_runner.send_gamecontroller_command(
-            gc_command=Command.Type.STOP, team=Team.UNKNOWN
-        )
-        simulated_test_runner.send_gamecontroller_command(
-            gc_command=Command.Type.FORCE_START, team=Team.UNKNOWN
-        )
-
         simulated_test_runner.set_world_state(
             create_world_state(
                 yellow_robot_locations=yellow_bots,
@@ -49,6 +42,13 @@ def test_halt_play(simulated_test_runner):
                 ball_location=ball_initial_pos,
                 ball_velocity=tbots_cpp.Vector(0, 0),
             ),
+        )
+
+        simulated_test_runner.send_gamecontroller_command(
+            gc_command=Command.Type.STOP, team=Team.UNKNOWN
+        )
+        simulated_test_runner.send_gamecontroller_command(
+            gc_command=Command.Type.FORCE_START, team=Team.UNKNOWN
         )
 
     # params just have to be a list of length 1 to ensure the test runs at least once

--- a/src/software/ai/hl/stp/play/kickoff_play_test.py
+++ b/src/software/ai/hl/stp/play/kickoff_play_test.py
@@ -33,8 +33,12 @@ def test_kickoff_play(simulated_test_runner, is_friendly_test):
             tbots_cpp.Point(1, 2.5),
             tbots_cpp.Point(1, -2.5),
             tbots_cpp.Field.createSSLDivisionBField().enemyGoalCenter(),
-            tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXNegYCorner(),
-            tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXPosYCorner(),
+            tbots_cpp.Field.createSSLDivisionBField()
+            .enemyDefenseArea()
+            .negXNegYCorner(),
+            tbots_cpp.Field.createSSLDivisionBField()
+            .enemyDefenseArea()
+            .negXPosYCorner(),
         ]
 
         blue_play = Play()

--- a/src/software/ai/hl/stp/play/kickoff_play_test.py
+++ b/src/software/ai/hl/stp/play/kickoff_play_test.py
@@ -41,6 +41,15 @@ def test_kickoff_play(simulated_test_runner, is_friendly_test):
             .negXPosYCorner(),
         ]
 
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                yellow_robot_locations=yellow_bots,
+                blue_robot_locations=blue_bots,
+                ball_location=ball_initial_pos,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            ),
+        )
+
         blue_play = Play()
         yellow_play = Play()
 
@@ -67,15 +76,6 @@ def test_kickoff_play(simulated_test_runner, is_friendly_test):
 
         simulated_test_runner.set_play(blue_play, is_friendly=True)
         simulated_test_runner.set_play(yellow_play, is_friendly=False)
-
-        simulated_test_runner.set_world_state(
-            create_world_state(
-                yellow_robot_locations=yellow_bots,
-                blue_robot_locations=blue_bots,
-                ball_location=ball_initial_pos,
-                ball_velocity=tbots_cpp.Vector(0, 0),
-            ),
-        )
 
     # Always Validation
     always_validation_sequence_set = [[]]

--- a/src/software/ai/hl/stp/play/kickoff_play_test.py
+++ b/src/software/ai/hl/stp/play/kickoff_play_test.py
@@ -18,64 +18,60 @@ from software.simulated_tests.or_validation import OrValidation
 def test_kickoff_play(simulated_test_runner, is_friendly_test):
     ball_initial_pos = tbots_cpp.Point(0, 0)
 
-    # Setup Bots
-    blue_bots = [
-        tbots_cpp.Point(-3, 2.5),
-        tbots_cpp.Point(-3, 1.5),
-        tbots_cpp.Point(-3, 0.5),
-        tbots_cpp.Point(-3, -0.5),
-        tbots_cpp.Point(-3, -1.5),
-        tbots_cpp.Point(-3, -2.5),
-    ]
+    def setup(*args):
+        blue_bots = [
+            tbots_cpp.Point(-3, 2.5),
+            tbots_cpp.Point(-3, 1.5),
+            tbots_cpp.Point(-3, 0.5),
+            tbots_cpp.Point(-3, -0.5),
+            tbots_cpp.Point(-3, -1.5),
+            tbots_cpp.Point(-3, -2.5),
+        ]
 
-    yellow_bots = [
-        tbots_cpp.Point(1, 0),
-        tbots_cpp.Point(1, 2.5),
-        tbots_cpp.Point(1, -2.5),
-        tbots_cpp.Field.createSSLDivisionBField().enemyGoalCenter(),
-        tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXNegYCorner(),
-        tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXPosYCorner(),
-    ]
+        yellow_bots = [
+            tbots_cpp.Point(1, 0),
+            tbots_cpp.Point(1, 2.5),
+            tbots_cpp.Point(1, -2.5),
+            tbots_cpp.Field.createSSLDivisionBField().enemyGoalCenter(),
+            tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXNegYCorner(),
+            tbots_cpp.Field.createSSLDivisionBField().enemyDefenseArea().negXPosYCorner(),
+        ]
 
-    blue_play = Play()
-    yellow_play = Play()
+        blue_play = Play()
+        yellow_play = Play()
 
-    # Game Controller Setup
-    simulated_test_runner.gamecontroller.send_gc_command(
-        gc_command=Command.Type.STOP, team=Team.UNKNOWN
-    )
-
-    if is_friendly_test:
-        simulated_test_runner.gamecontroller.send_gc_command(
-            gc_command=Command.Type.KICKOFF, team=Team.BLUE
+        simulated_test_runner.send_gamecontroller_command(
+            gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
-        blue_play.name = PlayName.KickoffFriendlyPlay
-        yellow_play.name = PlayName.KickoffEnemyPlay
-    else:
-        simulated_test_runner.gamecontroller.send_gc_command(
-            gc_command=Command.Type.KICKOFF, team=Team.YELLOW
+
+        if is_friendly_test:
+            simulated_test_runner.send_gamecontroller_command(
+                gc_command=Command.Type.KICKOFF, team=Team.BLUE
+            )
+            blue_play.name = PlayName.KickoffFriendlyPlay
+            yellow_play.name = PlayName.KickoffEnemyPlay
+        else:
+            simulated_test_runner.send_gamecontroller_command(
+                gc_command=Command.Type.KICKOFF, team=Team.YELLOW
+            )
+            blue_play.name = PlayName.KickoffEnemyPlay
+            yellow_play.name = PlayName.KickoffFriendlyPlay
+
+        simulated_test_runner.send_gamecontroller_command(
+            gc_command=Command.Type.NORMAL_START, team=Team.BLUE
         )
-        blue_play.name = PlayName.KickoffEnemyPlay
-        yellow_play.name = PlayName.KickoffFriendlyPlay
 
-    simulated_test_runner.gamecontroller.send_gc_command(
-        gc_command=Command.Type.NORMAL_START, team=Team.BLUE
-    )
+        simulated_test_runner.set_play(blue_play, is_friendly=True)
+        simulated_test_runner.set_play(yellow_play, is_friendly=False)
 
-    # Force play override here
-    simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
-    simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(Play, yellow_play)
-
-    # Create world state
-    simulated_test_runner.simulator_proto_unix_io.send_proto(
-        WorldState,
-        create_world_state(
-            yellow_robot_locations=yellow_bots,
-            blue_robot_locations=blue_bots,
-            ball_location=ball_initial_pos,
-            ball_velocity=tbots_cpp.Vector(0, 0),
-        ),
-    )
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                yellow_robot_locations=yellow_bots,
+                blue_robot_locations=blue_bots,
+                ball_location=ball_initial_pos,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            ),
+        )
 
     # Always Validation
     always_validation_sequence_set = [[]]
@@ -138,6 +134,7 @@ def test_kickoff_play(simulated_test_runner, is_friendly_test):
         )
 
     simulated_test_runner.run_test(
+        setup=setup,
         inv_eventually_validation_sequence_set=eventually_validation_sequence_set,
         inv_always_validation_sequence_set=always_validation_sequence_set,
         test_timeout_s=10,

--- a/src/software/ai/hl/stp/play/offense/offense_play_test.py
+++ b/src/software/ai/hl/stp/play/offense/offense_play_test.py
@@ -12,13 +12,8 @@ from software.simulated_tests.simulated_test_fixture import (
 
 def test_offense_play(simulated_test_runner):
     def setup(start_point):
-        # starting point must be Point
         ball_initial_pos = start_point
-        # placement point must be Vector2 to work with game controller
-        tbots_cpp.Point(-3, -2)
-        tbots_cpp.Field.createSSLDivisionBField()
 
-        # Setup Bots
         blue_bots = [
             tbots_cpp.Point(-4.5, 3.0),
             tbots_cpp.Point(-2, 1.5),
@@ -41,29 +36,23 @@ def test_offense_play(simulated_test_runner):
             .negXPosYCorner(),
         ]
 
-        # Game Controller Setup
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.FORCE_START, team=Team.BLUE
         )
 
-        # Force play override here
         blue_play = Play()
         blue_play.name = PlayName.OffensePlay
 
         yellow_play = Play()
         yellow_play.name = PlayName.HaltPlay
 
-        simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
-        simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-            Play, yellow_play
-        )
+        simulated_test_runner.set_play(blue_play, is_friendly=True)
+        simulated_test_runner.set_play(yellow_play, is_friendly=False)
 
-        # Create world state
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState,
+        simulated_test_runner.set_world_state(
             create_world_state(
                 yellow_robot_locations=yellow_bots,
                 blue_robot_locations=blue_bots,

--- a/src/software/ai/hl/stp/play/offense/offense_play_test.py
+++ b/src/software/ai/hl/stp/play/offense/offense_play_test.py
@@ -36,6 +36,15 @@ def test_offense_play(simulated_test_runner):
             .negXPosYCorner(),
         ]
 
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                yellow_robot_locations=yellow_bots,
+                blue_robot_locations=blue_bots,
+                ball_location=ball_initial_pos,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            ),
+        )
+
         simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
@@ -51,15 +60,6 @@ def test_offense_play(simulated_test_runner):
 
         simulated_test_runner.set_play(blue_play, is_friendly=True)
         simulated_test_runner.set_play(yellow_play, is_friendly=False)
-
-        simulated_test_runner.set_world_state(
-            create_world_state(
-                yellow_robot_locations=yellow_bots,
-                blue_robot_locations=blue_bots,
-                ball_location=ball_initial_pos,
-                ball_velocity=tbots_cpp.Vector(0, 0),
-            ),
-        )
 
     field = tbots_cpp.Field.createSSLDivisionBField()
 

--- a/src/software/ai/hl/stp/play/passing_sim_test.py
+++ b/src/software/ai/hl/stp/play/passing_sim_test.py
@@ -45,7 +45,7 @@ def setup_pass_and_robots(
     blue_robot_locations = [attacker_robot_position, *receiver_robot_positions]
 
     # Setup the world state
-    simulated_test_runner.set_worldState(
+    simulated_test_runner.set_world_state(
         create_world_state(
             yellow_robot_locations=enemy_robot_positions,
             blue_robot_locations=blue_robot_locations,

--- a/src/software/ai/hl/stp/play/shoot_or_chip_play_test.py
+++ b/src/software/ai/hl/stp/play/shoot_or_chip_play_test.py
@@ -52,22 +52,19 @@ def test_shoot_or_chip_play(simulated_test_runner):
 
         world_state.yellow_robots[5].CopyFrom(last_robot)
 
-        # Game Controller Setup
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
-        simulated_test_runner.gamecontroller.send_gc_command(
+        simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.FORCE_START, team=Team.BLUE
         )
 
         blue_play = Play()
         blue_play.name = PlayName.ShootOrChipPlay
 
-        simulated_test_runner.blue_full_system_proto_unix_io.send_proto(Play, blue_play)
+        simulated_test_runner.set_play(blue_play, is_friendly=True)
 
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState, world_state
-        )
+        simulated_test_runner.set_world_state(world_state)
 
     simulated_test_runner.run_test(
         setup=setup,

--- a/src/software/ai/hl/stp/play/shoot_or_chip_play_test.py
+++ b/src/software/ai/hl/stp/play/shoot_or_chip_play_test.py
@@ -52,6 +52,8 @@ def test_shoot_or_chip_play(simulated_test_runner):
 
         world_state.yellow_robots[5].CopyFrom(last_robot)
 
+        simulated_test_runner.set_world_state(world_state)
+
         simulated_test_runner.send_gamecontroller_command(
             gc_command=Command.Type.STOP, team=Team.UNKNOWN
         )
@@ -61,10 +63,7 @@ def test_shoot_or_chip_play(simulated_test_runner):
 
         blue_play = Play()
         blue_play.name = PlayName.ShootOrChipPlay
-
         simulated_test_runner.set_play(blue_play, is_friendly=True)
-
-        simulated_test_runner.set_world_state(world_state)
 
     simulated_test_runner.run_test(
         setup=setup,

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_tactic_test.py
@@ -47,7 +47,7 @@ def test_crease_positioning(
     simulated_test_runner,
 ):
     def setup(*args):
-        simulated_test_runner.set_worldState(
+        simulated_test_runner.set_world_state(
             create_world_state(
                 blue_robot_locations=[blue_bots],
                 yellow_robot_locations=[yellow_bots],
@@ -160,7 +160,7 @@ def test_crease_autochip(
     simulated_test_runner,
 ):
     def setup(*args):
-        simulated_test_runner.set_worldState(
+        simulated_test_runner.set_world_state(
             create_world_state(
                 blue_robot_locations=[blue_bots],
                 yellow_robot_locations=[yellow_bots],
@@ -235,7 +235,7 @@ def test_crease_get_ball(
     simulated_test_runner,
 ):
     def setup(*args):
-        simulated_test_runner.set_worldState(
+        simulated_test_runner.set_world_state(
             create_world_state(
                 blue_robot_locations=[blue_bots],
                 yellow_robot_locations=[yellow_bots],

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_tactic_test.py
@@ -46,21 +46,17 @@ def test_crease_positioning(
     ball_initial_velocity,
     simulated_test_runner,
 ):
-    # Setup Robot
     def setup(*args):
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState,
+        simulated_test_runner.set_worldState(
             create_world_state(
                 blue_robot_locations=[blue_bots],
                 yellow_robot_locations=[yellow_bots],
                 ball_location=ball_initial_pos,
                 ball_velocity=ball_initial_velocity,
-            ),
+            )
         )
 
-        # Setup Tactic
         params = AssignedTacticPlayControlParams()
-
         params.assigned_tactics[0].crease_defender.CopyFrom(
             CreaseDefenderTactic(
                 enemy_threat_origin=tbots_cpp.createPointProto(ball_initial_pos),
@@ -69,18 +65,11 @@ def test_crease_positioning(
                 ball_steal_mode=BallStealMode.STEAL,
             )
         )
+        simulated_test_runner.set_tactics(params, is_friendly=True)
 
-        simulated_test_runner.blue_full_system_proto_unix_io.send_proto(
-            AssignedTacticPlayControlParams, params
-        )
-
-        # Setup no tactics on the enemy side
         params = AssignedTacticPlayControlParams()
-        simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-            AssignedTacticPlayControlParams, params
-        )
+        simulated_test_runner.set_tactics(params, is_friendly=False)
 
-    # Always Validation
     always_validation_sequence_set = [
         [
             RobotNeverEntersRegion(
@@ -94,10 +83,8 @@ def test_crease_positioning(
         ]
     ]
 
-    # Eventually Validation
     eventually_validation_sequence_set = [
         [
-            # Crease defender should be near the defense area
             RobotEventuallyEntersRegion(
                 regions=[
                     tbots_cpp.Field.createSSLDivisionBField()
@@ -172,21 +159,17 @@ def test_crease_autochip(
     should_chip,
     simulated_test_runner,
 ):
-    # Setup Robot
     def setup(*args):
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState,
+        simulated_test_runner.set_worldState(
             create_world_state(
                 blue_robot_locations=[blue_bots],
                 yellow_robot_locations=[yellow_bots],
                 ball_location=ball_initial_pos,
                 ball_velocity=ball_initial_velocity,
-            ),
+            )
         )
 
-        # Setup Tactic
         params = AssignedTacticPlayControlParams()
-
         params.assigned_tactics[0].crease_defender.CopyFrom(
             CreaseDefenderTactic(
                 enemy_threat_origin=tbots_cpp.createPointProto(ball_initial_pos),
@@ -195,31 +178,21 @@ def test_crease_autochip(
                 ball_steal_mode=BallStealMode.STEAL,
             )
         )
+        simulated_test_runner.set_tactics(params, is_friendly=True)
 
-        simulated_test_runner.blue_full_system_proto_unix_io.send_proto(
-            AssignedTacticPlayControlParams, params
-        )
-
-        # Setup no tactics on the enemy side
         params = AssignedTacticPlayControlParams()
-        simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-            AssignedTacticPlayControlParams, params
-        )
+        simulated_test_runner.set_tactics(params, is_friendly=False)
 
-    # Always Validation
     always_validation_sequence_set = [
         [
             BallIsAlwaysOnGround(),
             NeverExcessivelyDribbles(),
         ]
     ]
-    # Eventually Validation
     eventually_validation_sequence_set = [[]]
 
     if should_chip:
-        # Always Validation for chipping
         always_validation_sequence_set = [[]]
-        # Eventually Validation for chipping
         eventually_validation_sequence_set = [[BallIsEventuallyOffGround()]]
 
     simulated_test_runner.run_test(
@@ -261,21 +234,17 @@ def test_crease_get_ball(
     should_dribble,
     simulated_test_runner,
 ):
-    # Setup Robot
     def setup(*args):
-        simulated_test_runner.simulator_proto_unix_io.send_proto(
-            WorldState,
+        simulated_test_runner.set_worldState(
             create_world_state(
                 blue_robot_locations=[blue_bots],
                 yellow_robot_locations=[yellow_bots],
                 ball_location=ball_initial_pos,
                 ball_velocity=ball_initial_velocity,
-            ),
+            )
         )
 
-        # Setup Tactic
         params = AssignedTacticPlayControlParams()
-
         params.assigned_tactics[0].crease_defender.CopyFrom(
             CreaseDefenderTactic(
                 enemy_threat_origin=tbots_cpp.createPointProto(ball_initial_pos),
@@ -284,25 +253,17 @@ def test_crease_get_ball(
                 ball_steal_mode=BallStealMode.STEAL,
             )
         )
+        simulated_test_runner.set_tactics(params, is_friendly=True)
 
-        simulated_test_runner.blue_full_system_proto_unix_io.send_proto(
-            AssignedTacticPlayControlParams, params
-        )
-
-        # Setup no tactics on the enemy side
         params = AssignedTacticPlayControlParams()
-        simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-            AssignedTacticPlayControlParams, params
-        )
+        simulated_test_runner.set_tactics(params, is_friendly=False)
 
-    # Always Validation
     always_validation_sequence_set = [
         [
             BallIsAlwaysOnGround(),
             NeverExcessivelyDribbles(),
         ]
     ]
-    # Eventually Validation
     eventually_validation_sequence_set = [[]]
 
     if should_dribble:

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_tactic_test.py
@@ -12,7 +12,6 @@ from software.simulated_tests.simulated_test_fixture import (
     pytest_main,
 )
 from proto.message_translation.tbots_protobuf import create_world_state
-from proto.ssl_gc_common_pb2 import Team
 
 
 @pytest.mark.parametrize(
@@ -115,7 +114,7 @@ def test_goalie_blocks_shot(
     simulated_test_runner,
 ):
     def setup(*args):
-        simulated_test_runner.set_worldState(
+        simulated_test_runner.set_world_state(
             create_world_state(
                 [],
                 blue_robot_locations=[robot_initial_position],
@@ -193,7 +192,7 @@ def test_goalie_clears_from_dead_zone(
     simulated_test_runner,
 ):
     def setup(*args):
-        simulated_test_runner.set_worldState(
+        simulated_test_runner.set_world_state(
             create_world_state(
                 [],
                 blue_robot_locations=[

--- a/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_tactic_test.py
@@ -36,7 +36,7 @@ def test_ball_chipped_on_intercept(
     simulated_test_runner,
 ):
     def setup(*args):
-        simulated_test_runner.set_worldState(
+        simulated_test_runner.set_world_state(
             create_world_state(
                 [],
                 blue_robot_locations=[position_to_block_from],
@@ -48,7 +48,9 @@ def test_ball_chipped_on_intercept(
         params = AssignedTacticPlayControlParams()
         params.assigned_tactics[0].pass_defender.CopyFrom(
             PassDefenderTactic(
-                position_to_block_from=tbots_cpp.createPointProto(position_to_block_from),
+                position_to_block_from=tbots_cpp.createPointProto(
+                    position_to_block_from
+                ),
                 ball_steal_mode=BallStealMode.STEAL,
             )
         )
@@ -109,7 +111,7 @@ def test_avoid_intercept_scenario(
     simulated_test_runner,
 ):
     def setup(*args):
-        simulated_test_runner.set_worldState(
+        simulated_test_runner.set_world_state(
             create_world_state(
                 [],
                 blue_robot_locations=[position_to_block_from],
@@ -121,7 +123,9 @@ def test_avoid_intercept_scenario(
         params = AssignedTacticPlayControlParams()
         params.assigned_tactics[0].pass_defender.CopyFrom(
             PassDefenderTactic(
-                position_to_block_from=tbots_cpp.createPointProto(position_to_block_from),
+                position_to_block_from=tbots_cpp.createPointProto(
+                    position_to_block_from
+                ),
                 ball_steal_mode=BallStealMode.STEAL,
             )
         )
@@ -243,7 +247,7 @@ def test_steal_ball(
     simulated_test_runner,
 ):
     def setup(*args):
-        simulated_test_runner.set_worldState(
+        simulated_test_runner.set_world_state(
             create_world_state(
                 blue_robot_locations=[position_to_block_from],
                 yellow_robot_locations=[enemy_kicker_position],
@@ -255,7 +259,9 @@ def test_steal_ball(
         params = AssignedTacticPlayControlParams()
         params.assigned_tactics[0].pass_defender.CopyFrom(
             PassDefenderTactic(
-                position_to_block_from=tbots_cpp.createPointProto(position_to_block_from),
+                position_to_block_from=tbots_cpp.createPointProto(
+                    position_to_block_from
+                ),
                 ball_steal_mode=BallStealMode.STEAL,
             )
         )

--- a/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_tactic_test.py
@@ -66,6 +66,7 @@ def test_ball_chipped_on_intercept(
                     tbots_cpp.Field.createSSLDivisionBField().friendlyDefenseArea()
                 ]
             ),
+            # Defender should intercept ball and prevent it from entering the goal
             BallNeverEntersRegion(
                 regions=[tbots_cpp.Field.createSSLDivisionBField().friendlyGoal()]
             ),

--- a/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_tactic_test.py
@@ -35,36 +35,28 @@ def test_ball_chipped_on_intercept(
     position_to_block_from,
     simulated_test_runner,
 ):
-    # Setup Robot
-    simulated_test_runner.simulator_proto_unix_io.send_proto(
-        WorldState,
-        create_world_state(
-            [],
-            blue_robot_locations=[position_to_block_from],
-            ball_location=ball_initial_position,
-            ball_velocity=ball_initial_velocity,
-        ),
-    )
-
-    # Setup Tactic
-    params = AssignedTacticPlayControlParams()
-    params.assigned_tactics[0].pass_defender.CopyFrom(
-        PassDefenderTactic(
-            position_to_block_from=tbots_cpp.createPointProto(position_to_block_from),
-            ball_steal_mode=BallStealMode.STEAL,
+    def setup(*args):
+        simulated_test_runner.set_worldState(
+            create_world_state(
+                [],
+                blue_robot_locations=[position_to_block_from],
+                ball_location=ball_initial_position,
+                ball_velocity=ball_initial_velocity,
+            )
         )
-    )
-    simulated_test_runner.blue_full_system_proto_unix_io.send_proto(
-        AssignedTacticPlayControlParams, params
-    )
 
-    # Setup no tactics on the enemy side
-    params = AssignedTacticPlayControlParams()
-    simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-        AssignedTacticPlayControlParams, params
-    )
+        params = AssignedTacticPlayControlParams()
+        params.assigned_tactics[0].pass_defender.CopyFrom(
+            PassDefenderTactic(
+                position_to_block_from=tbots_cpp.createPointProto(position_to_block_from),
+                ball_steal_mode=BallStealMode.STEAL,
+            )
+        )
+        simulated_test_runner.set_tactics(params, is_friendly=True)
 
-    # Always Validation
+        params = AssignedTacticPlayControlParams()
+        simulated_test_runner.set_tactics(params, is_friendly=False)
+
     always_validation_sequence_set = [
         [
             RobotNeverEntersRegion(
@@ -72,17 +64,16 @@ def test_ball_chipped_on_intercept(
                     tbots_cpp.Field.createSSLDivisionBField().friendlyDefenseArea()
                 ]
             ),
-            # Defender should intercept ball and prevent it from entering the goal
             BallNeverEntersRegion(
                 regions=[tbots_cpp.Field.createSSLDivisionBField().friendlyGoal()]
             ),
         ]
     ]
 
-    # Eventually Validation
     eventually_validation_sequence_set = [[BallSpeedEventuallyBelowThreshold(0.4)]]
 
     simulated_test_runner.run_test(
+        setup=setup,
         inv_eventually_validation_sequence_set=eventually_validation_sequence_set,
         inv_always_validation_sequence_set=always_validation_sequence_set,
         ag_eventually_validation_sequence_set=eventually_validation_sequence_set,
@@ -117,36 +108,28 @@ def test_avoid_intercept_scenario(
     position_to_block_from,
     simulated_test_runner,
 ):
-    # Setup Robot
-    simulated_test_runner.simulator_proto_unix_io.send_proto(
-        WorldState,
-        create_world_state(
-            [],
-            blue_robot_locations=[position_to_block_from],
-            ball_location=ball_initial_position,
-            ball_velocity=ball_initial_velocity,
-        ),
-    )
-
-    # Setup Tactic
-    params = AssignedTacticPlayControlParams()
-    params.assigned_tactics[0].pass_defender.CopyFrom(
-        PassDefenderTactic(
-            position_to_block_from=tbots_cpp.createPointProto(position_to_block_from),
-            ball_steal_mode=BallStealMode.STEAL,
+    def setup(*args):
+        simulated_test_runner.set_worldState(
+            create_world_state(
+                [],
+                blue_robot_locations=[position_to_block_from],
+                ball_location=ball_initial_position,
+                ball_velocity=ball_initial_velocity,
+            )
         )
-    )
-    simulated_test_runner.blue_full_system_proto_unix_io.send_proto(
-        AssignedTacticPlayControlParams, params
-    )
 
-    # Setup no tactics on the enemy side
-    params = AssignedTacticPlayControlParams()
-    simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-        AssignedTacticPlayControlParams, params
-    )
+        params = AssignedTacticPlayControlParams()
+        params.assigned_tactics[0].pass_defender.CopyFrom(
+            PassDefenderTactic(
+                position_to_block_from=tbots_cpp.createPointProto(position_to_block_from),
+                ball_steal_mode=BallStealMode.STEAL,
+            )
+        )
+        simulated_test_runner.set_tactics(params, is_friendly=True)
 
-    # Always Validation
+        params = AssignedTacticPlayControlParams()
+        simulated_test_runner.set_tactics(params, is_friendly=False)
+
     always_validation_sequence_set = [
         [
             # Defender should remain near position_to_block_from
@@ -179,10 +162,10 @@ def test_avoid_intercept_scenario(
         ]
     ]
 
-    # Eventually Validation
     eventually_validation_sequence_set = [[BallSpeedEventuallyBelowThreshold(0.4)]]
 
     simulated_test_runner.run_test(
+        setup=setup,
         inv_eventually_validation_sequence_set=eventually_validation_sequence_set,
         inv_always_validation_sequence_set=always_validation_sequence_set,
         ag_eventually_validation_sequence_set=eventually_validation_sequence_set,
@@ -259,35 +242,28 @@ def test_steal_ball(
     should_steal,
     simulated_test_runner,
 ):
-    # Setup Robot
-    simulated_test_runner.simulator_proto_unix_io.send_proto(
-        WorldState,
-        create_world_state(
-            blue_robot_locations=[position_to_block_from],
-            yellow_robot_locations=[enemy_kicker_position],
-            ball_location=ball_initial_position,
-            ball_velocity=ball_initial_velocity,
-        ),
-    )
-
-    # Setup Tactic
-    params = AssignedTacticPlayControlParams()
-    params.assigned_tactics[0].pass_defender.CopyFrom(
-        PassDefenderTactic(
-            position_to_block_from=tbots_cpp.createPointProto(position_to_block_from),
-            ball_steal_mode=BallStealMode.STEAL,
+    def setup(*args):
+        simulated_test_runner.set_worldState(
+            create_world_state(
+                blue_robot_locations=[position_to_block_from],
+                yellow_robot_locations=[enemy_kicker_position],
+                ball_location=ball_initial_position,
+                ball_velocity=ball_initial_velocity,
+            )
         )
-    )
-    simulated_test_runner.blue_full_system_proto_unix_io.send_proto(
-        AssignedTacticPlayControlParams, params
-    )
 
-    # Setup no tactics on the enemy side
-    params = AssignedTacticPlayControlParams()
-    simulated_test_runner.yellow_full_system_proto_unix_io.send_proto(
-        AssignedTacticPlayControlParams, params
-    )
-    # Always Validation
+        params = AssignedTacticPlayControlParams()
+        params.assigned_tactics[0].pass_defender.CopyFrom(
+            PassDefenderTactic(
+                position_to_block_from=tbots_cpp.createPointProto(position_to_block_from),
+                ball_steal_mode=BallStealMode.STEAL,
+            )
+        )
+        simulated_test_runner.set_tactics(params, is_friendly=True)
+
+        params = AssignedTacticPlayControlParams()
+        simulated_test_runner.set_tactics(params, is_friendly=False)
+
     always_validation_sequence_set = [
         [
             RobotNeverEntersRegion(
@@ -297,7 +273,7 @@ def test_steal_ball(
             ),
             NeverExcessivelyDribbles(),
         ]
-    ]  # Eventually Validation
+    ]
     eventually_validation_sequence_set = [[BallSpeedEventuallyBelowThreshold(0.4)]]
 
     if should_steal:
@@ -311,6 +287,7 @@ def test_steal_ball(
         )
 
     simulated_test_runner.run_test(
+        setup=setup,
         inv_eventually_validation_sequence_set=eventually_validation_sequence_set,
         inv_always_validation_sequence_set=always_validation_sequence_set,
         ag_eventually_validation_sequence_set=eventually_validation_sequence_set,

--- a/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
+++ b/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
@@ -8,6 +8,7 @@ from software.py_constants import *
 from proto.message_translation.tbots_protobuf import create_world_state
 import math
 from proto.import_all_protos import *
+from proto.ssl_gc_common_pb2 import Team
 from software.simulated_tests.simulated_test_fixture import SimulatedTestRunner
 from software.simulated_tests.validation import (
     create_validation_types,
@@ -186,13 +187,13 @@ def hrvo_setup(
 
     # Game Controller Setup
     simulated_test_runner.send_gamecontroller_command(
-        gc_command=Command.Type.STOP, is_friendly=True
+        gc_command=Command.Type.STOP, team=Team.BLUE
     )
     simulated_test_runner.send_gamecontroller_command(
-        gc_command=Command.Type.STOP, is_friendly=False
+        gc_command=Command.Type.STOP, team=Team.YELLOW
     )
     simulated_test_runner.send_gamecontroller_command(
-        gc_command=Command.Type.FORCE_START, is_friendly=True
+        gc_command=Command.Type.FORCE_START, team=Team.BLUE
     )
 
     blue_params = AssignedTacticPlayControlParams()

--- a/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
+++ b/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
@@ -185,7 +185,15 @@ def hrvo_setup(
 
     ball_initial_vel = tbots.Point(0, 0)
 
-    # Game Controller Setup
+    simulated_test_runner.set_world_state(
+        create_world_state(
+            yellow_robot_locations=enemy_robots_positions,
+            blue_robot_locations=friendly_robots_positions,
+            ball_location=ball_initial_pos,
+            ball_velocity=ball_initial_vel,
+        )
+    )
+
     simulated_test_runner.send_gamecontroller_command(
         gc_command=Command.Type.STOP, team=Team.BLUE
     )
@@ -212,7 +220,6 @@ def hrvo_setup(
 
     simulated_test_runner.set_tactics(blue_params, True)
 
-    # Setup no tactics on the enemy side
     yellow_params = AssignedTacticPlayControlParams()
 
     for index, destination in enumerate(enemy_robots_destinations):
@@ -221,17 +228,6 @@ def hrvo_setup(
         )
 
     simulated_test_runner.set_tactics(yellow_params, False)
-
-    # Setup Robots
-    simulated_test_runner.simulator_proto_unix_io.send_proto(
-        WorldState,
-        create_world_state(
-            yellow_robot_locations=enemy_robots_positions,
-            blue_robot_locations=friendly_robots_positions,
-            ball_location=ball_initial_pos,
-            ball_velocity=ball_initial_vel,
-        ),
-    )
 
 
 @pytest.mark.parametrize(

--- a/src/software/field_tests/movement_robot_field_test.py
+++ b/src/software/field_tests/movement_robot_field_test.py
@@ -40,7 +40,7 @@ logger = create_logger(__name__)
 #         ball_location=tbots_cpp.Point(1, 1),
 #         ball_velocity=tbots_cpp.Point(0, 0),
 #     )
-#     simulated_test_runner.set_worldState(initial_worldstate)
+#     simulated_test_runner.set_world_state(initial_worldstate)
 #
 #     # Setup Tactic
 #     params = AssignedTacticPlayControlParams()

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -121,7 +121,7 @@ class SimulatedTestRunner(TbotsTestRunner):
         test_timeout_s=3,
         tick_duration_s=0.0166,  # Default to 60hz
         ci_cmd_with_delay=[],
-        run_till_end=True,
+        run_till_end=False,
     ):
         """Run a test
 

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -17,6 +17,7 @@ from software.thunderscope.binary_context_managers.full_system import FullSystem
 from software.thunderscope.binary_context_managers.simulator import Simulator
 from software.thunderscope.binary_context_managers.game_controller import Gamecontroller
 from software.thunderscope.thunderscope_config import configure_simulated_test_view
+from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
 
 from software.logger.logger import create_logger
 from typing import override
@@ -26,7 +27,6 @@ logger = create_logger(__name__)
 LAUNCH_DELAY_S = 0.1
 WORLD_BUFFER_TIMEOUT = 0.5
 PROCESS_BUFFER_DELAY_S = 0.01
-TEST_START_DELAY_S = 0.01
 PAUSE_AFTER_FAIL_DELAY_S = 3
 
 
@@ -89,6 +89,30 @@ class SimulatedTestRunner(TbotsTestRunner):
 
         if self.thunderscope:
             self.thunderscope.close()
+
+    def sync_setup(self, setup):
+        """Run setup until simulator has received game state
+
+        :param setup: Function that sets up the world state
+        """
+        world_state_received_buffer = ThreadSafeBuffer(1, WorldStateReceivedTrigger)
+        self.simulator_proto_unix_io.register_observer(
+            WorldStateReceivedTrigger, world_state_received_buffer
+        )
+
+        while True:
+            setup()
+
+            try:
+                world_state_received_buffer.get(
+                    block=True, timeout=WORLD_BUFFER_TIMEOUT
+                )
+            except queue.Empty:
+                # Did not receive a response within timeout period
+                continue
+            else:
+                # Received a response from the simulator
+                break
 
     def runner(
         self,
@@ -259,14 +283,6 @@ class SimulatedTestRunner(TbotsTestRunner):
             test_timeout_s[index] if type(test_timeout_s) == list else test_timeout_s
         )
 
-        # Start the test with a delay to allow the simulator to receive
-        # the initial world state. Without this delay, the SimulatorTick
-        # message may be received before the initial world state, causing
-        # the world to be empty, failing some AlwaysValidations
-        # TODO (#2858): Replace delay with an actual feedback from the simulator
-        #  for when it has received the initial world state
-        time.sleep(TEST_START_DELAY_S)
-
         # If thunderscope is enabled, run the test in a thread and show
         # thunderscope on this thread. The excepthook is setup to catch
         # any test failures and propagate them to the main thread
@@ -332,7 +348,7 @@ class InvariantTestRunner(SimulatedTestRunner):
         """
         threading.excepthook = self.excepthook
 
-        setup(params[0])
+        super().sync_setup(lambda: setup(params[0]))
 
         super().run_test(
             inv_always_validation_sequence_set,
@@ -377,7 +393,7 @@ class AggregateTestRunner(SimulatedTestRunner):
         # Catches Assertion Error thrown by failing test and increments counter
         # Calculates overall results and prints them
         for x in range(len(params)):
-            setup(params[x])
+            super().sync_setup(lambda: setup(params[x]))
 
             try:
                 super().run_test(

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -61,7 +61,7 @@ class SimulatedTestRunner(TbotsTestRunner):
         self.simulator_proto_unix_io = simulator_proto_unix_io
 
     @override
-    def set_worldState(self, worldstate: WorldState):
+    def set_world_state(self, worldstate: WorldState):
         """Sets the simulation worldstate
 
         :param worldstate: proto containing the desired worldstate

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -90,10 +90,11 @@ class SimulatedTestRunner(TbotsTestRunner):
         if self.thunderscope:
             self.thunderscope.close()
 
-    def sync_setup(self, setup):
+    def sync_setup(self, setup, param):
         """Run setup until simulator has received game state
 
         :param setup: Function that sets up the world state
+        :param param: Parameter passed into setup
         """
         world_state_received_buffer = ThreadSafeBuffer(1, WorldStateReceivedTrigger)
         self.simulator_proto_unix_io.register_observer(
@@ -101,7 +102,7 @@ class SimulatedTestRunner(TbotsTestRunner):
         )
 
         while True:
-            setup()
+            setup(param)
 
             try:
                 world_state_received_buffer.get(
@@ -348,7 +349,7 @@ class InvariantTestRunner(SimulatedTestRunner):
         """
         threading.excepthook = self.excepthook
 
-        super().sync_setup(lambda: setup(params[0]))
+        super().sync_setup(setup, params[0])
 
         super().run_test(
             inv_always_validation_sequence_set,
@@ -393,7 +394,7 @@ class AggregateTestRunner(SimulatedTestRunner):
         # Catches Assertion Error thrown by failing test and increments counter
         # Calculates overall results and prints them
         for x in range(len(params)):
-            super().sync_setup(lambda: setup(params[x]))
+            super().sync_setup(setup, params[x])
 
             try:
                 super().run_test(

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -117,12 +117,12 @@ class SimulatedTestRunner(TbotsTestRunner):
 
     def runner(
         self,
-        always_validation_sequence_set=[[]],
-        eventually_validation_sequence_set=[[]],
-        test_timeout_s=3,
-        tick_duration_s=0.0166,  # Default to 60hz
-        ci_cmd_with_delay=[],
-        run_till_end=False,
+        always_validation_sequence_set,
+        eventually_validation_sequence_set,
+        test_timeout_s,
+        tick_duration_s,
+        ci_cmd_with_delay,
+        run_till_end,
     ):
         """Run a test
 
@@ -257,7 +257,7 @@ class SimulatedTestRunner(TbotsTestRunner):
         always_validation_sequence_set,
         eventually_validation_sequence_set,
         test_timeout_s=3,
-        tick_duration_s=0.0166,
+        tick_duration_s=0.0166,  # Default to 60hz
         index=0,
         ci_cmd_with_delay=[],
         run_till_end=True,

--- a/src/software/simulated_tests/tbots_test_runner.py
+++ b/src/software/simulated_tests/tbots_test_runner.py
@@ -129,12 +129,12 @@ class TbotsTestRunner:
         fs_proto_unix_io.send_proto(Play, play)
 
     @abstractmethod
-    def set_worldState(self, worldstate: WorldState):
+    def set_world_state(self, worldstate: WorldState):
         """Sets the worldstate for the given team
 
         :param worldstate: the worldstate proto to use
         """
-        raise NotImplementedError("abstract class method called set_worldstate")
+        raise NotImplementedError("abstract class method called set_world_state")
 
     @abstractmethod
     def run_test(

--- a/src/software/simulated_tests/tbots_test_runner.py
+++ b/src/software/simulated_tests/tbots_test_runner.py
@@ -1,7 +1,6 @@
 from proto.import_all_protos import *
 from software.logger.logger import create_logger
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
-from proto.ssl_gc_common_pb2 import Team
 from abc import abstractmethod
 
 logger = create_logger(__name__)
@@ -72,7 +71,7 @@ class TbotsTestRunner:
     def send_gamecontroller_command(
         self,
         gc_command: proto.ssl_gc_state_pb2.Command,
-        is_friendly: bool,
+        team: proto.ssl_gc_common_pb2.Team,
         final_ball_placement_point=None,
     ):
         """Sends a gamecontroller command that is to be broadcasted to the given team
@@ -81,13 +80,6 @@ class TbotsTestRunner:
         :param is_friendly: whether the command should be sent to the friendly team
         :param final_ball_placement_point: where to place the ball in ball placement
         """
-        friendly_team, enemy_team = (
-            (Team.YELLOW, Team.BLUE)
-            if self.is_yellow_friendly
-            else (Team.BLUE, Team.YELLOW)
-        )
-        team = friendly_team if is_friendly else enemy_team
-
         self.gamecontroller.send_gc_command(
             gc_command=gc_command,
             team=team,

--- a/src/software/thunderscope/common/proto_configuration_widget.py
+++ b/src/software/thunderscope/common/proto_configuration_widget.py
@@ -16,6 +16,8 @@ class ProtoConfigurationWidget(QWidget):
     """Creates a searchable parameter widget that can take any protobuf,
     and convert it into a pyqtgraph ParameterTree. This will allow users
     to modify the values.
+
+    NOTE: If this widget is initialized, it will send a config proto with params
     """
 
     DELAYED_CONFIGURATION_TIMEOUT_S = 5

--- a/src/software/thunderscope/thunderscope_config.py
+++ b/src/software/thunderscope/thunderscope_config.py
@@ -1,20 +1,37 @@
+import os
+import signal
+from dataclasses import dataclass
+from typing import Sequence
+
+import pyqtgraph
+import qdarktheme
+
 from software.thunderscope.common.frametime_counter import FrameTimeCounter
-from software.thunderscope.widget_setup_functions import *
 from software.thunderscope.constants import ProtoUnixIOTypes
 from software.thunderscope.proto_unix_io import ProtoUnixIO
 from software.thunderscope.robot_communication import RobotCommunication
-from typing import Sequence
-from dataclasses import dataclass
 from software.thunderscope.thunderscope_types import (
     TScopeTab,
     TScopeWidget,
     WidgetPosition,
     WidgetStretchData,
 )
-import pyqtgraph
-import qdarktheme
-import signal
-import os
+from software.thunderscope.widget_setup_functions import (
+    IndividualRobotMode,
+    RobotView,
+    setup_ball_speed_plot,
+    setup_diagnostics_widget,
+    setup_estop_view,
+    setup_fps_widget,
+    setup_gl_widget,
+    setup_log_widget,
+    setup_parameter_widget,
+    setup_performance_plot,
+    setup_play_info,
+    setup_referee_info,
+    setup_robot_error_log_view_widget,
+    setup_robot_view,
+)
 
 
 @dataclass
@@ -37,7 +54,7 @@ def initialize_application() -> None:
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     # Setup MainApp and initialize DockArea
-    app = pyqtgraph.mkQApp("Thunderscope")
+    pyqtgraph.mkQApp("Thunderscope")
 
     # Setup stylesheet
     qdarktheme.setup_theme()
@@ -71,9 +88,10 @@ def connect_robot_view_to_robot_communication(
     :param robot_communication: the RobotCommunication instance to connect to
     """
     robot_view_widget.individual_robot_control_mode_signal.connect(
-        lambda robot_id,
-        robot_mode: robot_communication.toggle_individual_robot_control_mode(
-            robot_id, robot_mode
+        lambda robot_id, robot_mode: (
+            robot_communication.toggle_individual_robot_control_mode(
+                robot_id, robot_mode
+            )
         )
     )
 

--- a/src/software/thunderscope/thunderscope_config.py
+++ b/src/software/thunderscope/thunderscope_config.py
@@ -272,6 +272,51 @@ def configure_base_diagnostics(
     ] + extra_widgets
 
 
+def configure_base_simulated_test(
+    full_system_proto_unix_io: ProtoUnixIO,
+    sim_proto_unix_io: ProtoUnixIO,
+    friendly_colour_yellow: bool,
+) -> list:
+    """Returns a list of widget data for a FullSystem tab
+    along with any extra widgets passed in
+
+    :param full_system_proto_unix_io: the proto unix io to configure widgets with
+    :param sim_proto_unix_io: the proto unix io for the simulator
+    :param friendly_colour_yellow: if this is Yellow FullSystem (True) or Blue (False)
+    :param visualization_buffer_size: The size of the visualization buffer.
+            Increasing this will increase smoothness but will be less realtime.
+    :param frame_swap_counter: a FrameTimeCounter for the GLWidget to track
+                               the time between frame swaps
+    :param refresh_counter: a FrameTimeCounter for the refresh function
+    :return: list of widget data for FullSystem when running simulated tests
+    """
+    return [
+        TScopeWidget(
+            name="Field",
+            widget=setup_gl_widget(
+                sim_proto_unix_io=sim_proto_unix_io,
+                full_system_proto_unix_io=full_system_proto_unix_io,
+                friendly_colour_yellow=friendly_colour_yellow,
+                visualization_buffer_size=5,
+            ),
+        ),
+        TScopeWidget(
+            name="Logs",
+            widget=setup_log_widget(proto_unix_io=full_system_proto_unix_io),
+            anchor="Field",
+            position=WidgetPosition.LEFT,
+            stretch=WidgetStretchData(x=3),
+        ),
+        TScopeWidget(
+            name="Play Info",
+            widget=setup_play_info(proto_unix_io=full_system_proto_unix_io),
+            anchor="Field",
+            position=WidgetPosition.BOTTOM,
+            stretch=WidgetStretchData(y=3),
+        ),
+    ]
+
+
 def configure_two_ai_gamecontroller_view(
     visualization_buffer_size: int = 5,
 ) -> TScopeConfig:
@@ -339,7 +384,6 @@ def configure_simulated_test_view(
     simulator_proto_unix_io: ProtoUnixIO,
     blue_full_system_proto_unix_io: ProtoUnixIO,
     yellow_full_system_proto_unix_io: ProtoUnixIO,
-    visualization_buffer_size: int = 5,
 ) -> TScopeConfig:
     """Constructs the Thunderscope Config for simulated tests
     A view with 2 FullSystem tabs (Blue and Yellow)
@@ -366,24 +410,20 @@ def configure_simulated_test_view(
         tabs=[
             TScopeTab(
                 name="Blue FullSystem",
-                widgets=configure_base_fullsystem(
+                widgets=configure_base_simulated_test(
                     full_system_proto_unix_io=proto_unix_io_map[ProtoUnixIOTypes.BLUE],
                     sim_proto_unix_io=proto_unix_io_map[ProtoUnixIOTypes.SIM],
                     friendly_colour_yellow=False,
-                    visualization_buffer_size=visualization_buffer_size,
-                    extra_widgets=[],
                 ),
             ),
             TScopeTab(
                 name="Yellow FullSystem",
-                widgets=configure_base_fullsystem(
+                widgets=configure_base_simulated_test(
                     full_system_proto_unix_io=proto_unix_io_map[
                         ProtoUnixIOTypes.YELLOW
                     ],
                     sim_proto_unix_io=proto_unix_io_map[ProtoUnixIOTypes.SIM],
                     friendly_colour_yellow=True,
-                    visualization_buffer_size=visualization_buffer_size,
-                    extra_widgets=[],
                 ),
             ),
         ],


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

There are two bugs that are causing flaky/inconsistent simulated gameplay tests. Firstly, the issue where the WorldState is not initialized when a test starts, and the other when running thunderscope with the simulated tests the tactics get re-assigned automatically.

The first issue is fixed by running setup() repeatedly until WorldStateReceived proto is received. The second issue is fixed by removing the parameters tab (ProtoConfigurationWidget) which sends a ThunderbotsConfig proto that enables PlaySelectionFSM by default.

I've also done a lot of refactoring to existing tests to use the same functions provided by the simulated test runner and also to send the protos in correct order (world state, optionally game controller, then tactics/plays) since tests like kickoff_play_test would often be flaky due to the play being sent before world state.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Ran simulated tests repeatedly, especially the ball placement and HRVO tests which were particularly flaky, and HRVO passes consistently now. Ball placement still fails sometimes, but reviewing the replays, its because of the tactic reassignment oscillation.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

resolves #3621, resolves #2858, resolves #3562, resolves #3511

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

Did a lot of refactors to existing pytests to follow best practice and also use the setup parameter for simulated_test_runner.run_test so that the WorldStateReceived is checked.

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
