### PR TITLE
Stat recording improvements

### DIFF
--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -37,6 +37,7 @@ class Gamecontroller:
         self,
         suppress_logs: bool = False,
         use_conventional_port: bool = False,
+        is_recording_stats: bool = False
     ) -> None:
         """Run Gamecontroller
 
@@ -44,6 +45,7 @@ class Gamecontroller:
         :param use_conventional_port: whether or not to use the conventional port!
         """
         self.suppress_logs = suppress_logs
+        self.is_recording_stats = is_recording_stats
 
         # We default to using a non-conventional port to avoid emitting
         # on the same port as what other teams may be listening on.
@@ -192,8 +194,8 @@ class Gamecontroller:
             block=False, return_cached=True
         )
 
-        max_allowed_bots_yellow: int = referee.yellow.max_allowed_bots
-        max_allowed_bots_blue: int = referee.blue.max_allowed_bots
+        max_allowed_bots_yellow: int = 6 if self.is_recording_stats else referee.yellow.max_allowed_bots
+        max_allowed_bots_blue: int = 6 if self.is_recording_stats else referee.blue.max_allowed_bots
         # Ignore if nothing needs to be updated
         if (
             len(self.latest_world.friendly_team.team_robots) == max_allowed_bots_blue

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -37,7 +37,7 @@ class Gamecontroller:
         self,
         suppress_logs: bool = False,
         use_conventional_port: bool = False,
-        is_recording_stats: bool = False
+        record_stats: bool = False
     ) -> None:
         """Run Gamecontroller
 
@@ -45,7 +45,7 @@ class Gamecontroller:
         :param use_conventional_port: whether or not to use the conventional port!
         """
         self.suppress_logs = suppress_logs
-        self.is_recording_stats = is_recording_stats
+        self.record_stats = record_stats
 
         # We default to using a non-conventional port to avoid emitting
         # on the same port as what other teams may be listening on.
@@ -70,6 +70,7 @@ class Gamecontroller:
         self.latest_world = None
         self.blue_removed_robot_ids = queue.Queue()
         self.yellow_removed_robot_ids = queue.Queue()
+        self._max_robots_per_team = 6  # Tracks current max sent to SSL GC (for record_stats red card compensation)
 
     def get_referee_port(self) -> int:
         """Sometimes, the port that we are using changes depending on context.
@@ -194,8 +195,17 @@ class Gamecontroller:
             block=False, return_cached=True
         )
 
-        max_allowed_bots_yellow: int = 6 if self.is_recording_stats else referee.yellow.max_allowed_bots
-        max_allowed_bots_blue: int = 6 if self.is_recording_stats else referee.blue.max_allowed_bots
+        max_allowed_bots_yellow: int = 6 if self.record_stats else referee.yellow.max_allowed_bots
+        max_allowed_bots_blue: int = 6 if self.record_stats else referee.blue.max_allowed_bots
+
+        if self.record_stats:
+            # The SSL GC computes effective_max = max_robots_per_team - red_cards.
+            # Compensate so the GC's effective limit stays at 6 and it doesn't force halt.
+            max_red_cards = max(referee.blue.red_cards, referee.yellow.red_cards)
+            needed = 6 + max_red_cards
+            if needed != self._max_robots_per_team:
+                self._send_max_robots_update(needed)
+                self._max_robots_per_team = needed
         # Ignore if nothing needs to be updated
         if (
             len(self.latest_world.friendly_team.team_robots) == max_allowed_bots_blue
@@ -317,6 +327,20 @@ class Gamecontroller:
             World, self.blue_team_world_buffer
         )
         self.simulator_proto_unix_io = simulator_proto_unix_io
+
+    def _send_max_robots_update(self, max_robots: int) -> None:
+        """Send UpdateConfig to the SSL GC to set max_robots_per_team.
+        Used in record_stats mode to compensate for red cards so the GC doesn't force halt.
+
+        :param max_robots: the new max_robots_per_team value to send
+        """
+        ci_input = CiInput(timestamp=int(time.time_ns()))
+        update_config = Change.UpdateConfig()
+        update_config.max_robots_per_team.value = max_robots
+        api_input = Input()
+        api_input.change.update_config_change.CopyFrom(update_config)
+        ci_input.api_inputs.append(api_input)
+        self.send_ci_input(ci_input)
 
     def send_gc_command(
         self,

--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -52,6 +52,7 @@ class TigersAutoref(TimeProvider):
         buffer_size: int = 5,
         suppress_logs: bool = True,
         show_gui: bool = False,
+        record_stats: bool = False,
     ) -> None:
         """Constructor
 
@@ -62,6 +63,7 @@ class TigersAutoref(TimeProvider):
         :param buffer_size:     buffer size for the SSL wrapper and referee packets
         :param suppress_logs:   true silences logs from the Autoref binary, otherwise shows them (its very verbose)
         :param show_gui:        true shows the Tigers' autoref GUI, false runs it in headless mode
+        :param record_stats:    true if stats recording mode is enabled
         """
         self.tigers_autoref_proc = None
         self.auto_ref_proc_thread = None
@@ -74,6 +76,7 @@ class TigersAutoref(TimeProvider):
         self.suppress_logs = suppress_logs
         self.tick_rate_ms = tick_rate_ms
         self.show_gui = show_gui
+        self.record_stats = record_stats
 
         self.current_timestamp = int(time.time_ns())
         self.timestamp_mutex = threading.Lock()
@@ -236,7 +239,7 @@ class TigersAutoref(TimeProvider):
         if not self.show_gui:
             autoref_cmd += " -hl"
 
-        if self.ci_mode:
+        if self.ci_mode or self.record_stats:
             autoref_cmd += " --ci"
 
         if self.suppress_logs:

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
         help="Run unix_full_system under sudo",
     )
     parser.add_argument(
-        "--record_stats_duration",
+        "--record_stats_duration_s",
         type=int, 
         default = 60,
         help="Run unix_full_system under sudo",
@@ -479,7 +479,7 @@ if __name__ == "__main__":
         ) as yellow_fs, Gamecontroller(
             suppress_logs=(not args.verbose), record_stats=args.record_stats
         ) as gamecontroller, (
-            # Here we only initialize autoref if the --enable_autoref flag is requested.
+            # Here we only initialize autoref if the --enable_autoref flag is requested, or when we are recording stats.
             # To avoid nested Python withs, the autoref is initialized as None when this flag doesn't exist.
             # All calls to autoref should be guarded with args.enable_autoref
             TigersAutoref(
@@ -568,13 +568,13 @@ if __name__ == "__main__":
 
                 sys.exit(0)
             elif args.record_stats:
-                # In CI mode, we want AI vs AI to end automatically after a given time (CI_DURATION_S). The exiter
+                # In record stats mode mode, we want AI vs AI to end automatically after a given time (args.record_stats_duration_s). The exiter
                 # thread is passed an exit handler that will close the Thunderscope window
                 # This exit handler is necessary because Qt runs on the main thread, so tscope.show() is a blocking
                 # call so we need to somehow close it before doing our resource cleanup
                 exiter_thread = threading.Thread(
                     target=exit_poller,
-                    args=(autoref, args.record_stats_duration, lambda: tscope.close()),
+                    args=(autoref, args.record_stats_duration_s, lambda: tscope.close()),
                     daemon=True,
                 )
 

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -349,7 +349,7 @@ if __name__ == "__main__":
 
         with (
             Gamecontroller(
-                suppress_logs=(not args.verbose), use_conventional_port=False, is_recording_stats=args.record_stats
+                suppress_logs=(not args.verbose), use_conventional_port=False, record_stats=args.record_stats
             )
             if args.launch_gc
             else contextlib.nullcontext()
@@ -477,7 +477,7 @@ if __name__ == "__main__":
             running_in_realtime=(not args.ci_mode and not args.record_stats),
             log_level=args.log_level,
         ) as yellow_fs, Gamecontroller(
-            suppress_logs=(not args.verbose), is_recording_stats=args.record_stats
+            suppress_logs=(not args.verbose), record_stats=args.record_stats
         ) as gamecontroller, (
             # Here we only initialize autoref if the --enable_autoref flag is requested.
             # To avoid nested Python withs, the autoref is initialized as None when this flag doesn't exist.

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -209,6 +209,12 @@ if __name__ == "__main__":
         default=False,
         help="Run unix_full_system under sudo",
     )
+    parser.add_argument(
+        "--record_stats_duration",
+        type=int, 
+        default = 60,
+        help="Run unix_full_system under sudo",
+    )
 
     estop_group = parser.add_mutually_exclusive_group()
     estop_group.add_argument(
@@ -343,7 +349,7 @@ if __name__ == "__main__":
 
         with (
             Gamecontroller(
-                suppress_logs=(not args.verbose), use_conventional_port=False
+                suppress_logs=(not args.verbose), use_conventional_port=False, is_recording_stats=args.record_stats
             )
             if args.launch_gc
             else contextlib.nullcontext()
@@ -433,7 +439,7 @@ if __name__ == "__main__":
                 0 if args.empty else DIV_B_NUM_ROBOTS,
             )
 
-            if args.ci_mode:
+            if args.ci_mode or args.record_stats:
                 async_sim_ticker(
                     tick_rate_ms,
                     tscope.proto_unix_io_map[ProtoUnixIOTypes.BLUE],
@@ -459,7 +465,7 @@ if __name__ == "__main__":
             friendly_colour_yellow=False,
             should_restart_on_crash=False,
             run_sudo=args.sudo,
-            running_in_realtime=(not args.ci_mode),
+            running_in_realtime=(not args.ci_mode and not args.record_stats),
             log_level=args.log_level,
         ) as blue_fs, FullSystem(
             path_to_binary=runtime_config.get_yellow_runtime_path(),
@@ -468,10 +474,10 @@ if __name__ == "__main__":
             friendly_colour_yellow=True,
             should_restart_on_crash=False,
             run_sudo=args.sudo,
-            running_in_realtime=(not args.ci_mode),
+            running_in_realtime=(not args.ci_mode and not args.record_stats),
             log_level=args.log_level,
         ) as yellow_fs, Gamecontroller(
-            suppress_logs=(not args.verbose),
+            suppress_logs=(not args.verbose), is_recording_stats=args.record_stats
         ) as gamecontroller, (
             # Here we only initialize autoref if the --enable_autoref flag is requested.
             # To avoid nested Python withs, the autoref is initialized as None when this flag doesn't exist.
@@ -482,8 +488,9 @@ if __name__ == "__main__":
                 suppress_logs=(not args.verbose),
                 tick_rate_ms=DEFAULT_SIMULATOR_TICK_RATE_MILLISECONDS_PER_TICK,
                 show_gui=args.show_autoref_gui,
+                record_stats=args.record_stats
             )
-            if args.enable_autoref
+            if args.enable_autoref or args.record_stats
             else contextlib.nullcontext()
         ) as autoref, (
             Stats(
@@ -527,7 +534,7 @@ if __name__ == "__main__":
                 autoref_proto_unix_io=autoref_proto_unix_io,
                 simulator_proto_unix_io=tscope.proto_unix_io_map[ProtoUnixIOTypes.SIM],
             )
-            if args.enable_autoref:
+            if args.enable_autoref or args.record_stats:
                 autoref.setup_ssl_wrapper_packets(
                     autoref_proto_unix_io,
                 )
@@ -547,6 +554,27 @@ if __name__ == "__main__":
                 exiter_thread = threading.Thread(
                     target=exit_poller,
                     args=(autoref, CI_DURATION_S, lambda: tscope.close()),
+                    daemon=True,
+                )
+
+                exiter_thread.start()  # start the exit countdown
+                sim_ticker_thread.start()  # start the simulation ticking
+
+                tscope.show()  # blocking!
+
+                # these resource cleanups occur after tscope.close() is called by the exiter_thread
+                exiter_thread.join()
+                sim_ticker_thread.join()
+
+                sys.exit(0)
+            elif args.record_stats:
+                # In CI mode, we want AI vs AI to end automatically after a given time (CI_DURATION_S). The exiter
+                # thread is passed an exit handler that will close the Thunderscope window
+                # This exit handler is necessary because Qt runs on the main thread, so tscope.show() is a blocking
+                # call so we need to somehow close it before doing our resource cleanup
+                exiter_thread = threading.Thread(
+                    target=exit_poller,
+                    args=(autoref, args.record_stats_duration, lambda: tscope.close()),
                     daemon=True,
                 )
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description
This PR resolves https://github.com/UBC-Thunderbots/Software/issues/3633.
It is currently partially completed.
- [x] --record stats can trigger stat recording without needing other flags
		On top of record_stats, record_stats_durationn_s is also introduced so we can specify how long we collect data
- [x] red cards disabled in --record_stats
		Done by fixing number of robots, and sending UpdateConfig proto to update `max robot on team x` on ssl gamecontroller. If UpdateConfig is not sent, play will halt due to `too many robots`

- [ ] automatically approve goals and restart game after goal
- [ ] automatically place ball
- [ ] run autoref at ci_mode speeds

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
1.  --record_stats. Works basically like with --enable_autoref, --ci_mode, and --record_stats enabled before. 
2.  Red cards (and yellow cards too) no longer affect number of robots in the game:
	
Before: Number of blue robots reduced
[Screencast from 2026-03-01 16-19-59.webm](https://github.com/user-attachments/assets/75f493af-2d3f-4317-aff2-7152a60099a1)

After: Giving red cards doens't reduce robots
[Screencast from 2026-03-01 16-45-44.webm](https://github.com/user-attachments/assets/1bea38ec-295c-4ef7-9c99-c7c13bb9ae5b)

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
https://github.com/UBC-Thunderbots/Software/issues/3633.
https://github.com/UBC-Thunderbots/Software/issues/3625.
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
