### PR TITLE
Automate handling referee game events

### DIFF
--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -181,28 +181,28 @@ class Gamecontroller:
 
     def __automate_stage_change(self, referee):
         if referee.stage_time_left < 0:
-            print("should move on")
-
             if referee.stage == Referee.Stage.NORMAL_FIRST_HALF:
-                new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE
-            elif referee.stage == Referee.Stage.NORMAL_SECOND_HALF:
-                return  # perhaps start a new game
+                # reset game state
+                self.simulator_proto_unix_io.send_proto(
+                    WorldState, create_default_world_state(num_robots=6)
+                )
+
+                ci_input = CiInput(timestamp=int(time.time_ns()))
+                api_input = Input()
+                change = Change()
+                # skip to pre second half
+                change.change_stage_change.new_stage = (
+                    Referee.Stage.NORMAL_SECOND_HALF_PRE
+                )
+                api_input.change.CopyFrom(change)
+                ci_input.api_inputs.append(api_input)
+
+                self.send_ci_input(ci_input)
+
+                self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
             else:
-                return  # idk what to do here
-
-            default_world_state = create_default_world_state(num_robots=6)
-            self.simulator_proto_unix_io.send_proto(WorldState, default_world_state)
-
-            ci_input = CiInput(timestamp=int(time.time_ns()))
-            api_input = Input()
-            change = Change()
-            change.change_stage_change.new_stage = new_stage
-            api_input.change.CopyFrom(change)
-            ci_input.api_inputs.append(api_input)
-
-            self.send_ci_input(ci_input)
-
-            self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
+                # start new game
+                return
 
     def handle_referee(self, referee: Referee) -> None:
         """Updates the world state based on the referee message

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -209,7 +209,8 @@ class Gamecontroller:
         if self.simulator_proto_unix_io is None:
             return
 
-        self.__automate_referee(referee)
+        # TODO (#3633): automate referee events in record_stats mode
+        # self.__automate_referee(referee)
 
         # Convert the latest blue world into a WorldState we can send to the simulator and update the robots
         self.latest_world = self.blue_team_world_buffer.get(
@@ -285,15 +286,22 @@ class Gamecontroller:
         ci_input = CiInput(timestamp=int(time.time_ns()))
         api_input = Input()
         change = Change()
+
+        # Send goal game event to resolve the possible goal
         game_event = GameEvent(
             type=GameEvent.Type.GOAL,
-            origin=["Majority"],
+            origin=[
+                "Majority"
+            ],  # Required or else ssl-gamecontroller will convert game event to proposal
             goal=GameEvent.Goal(by_team=scoring_team),
         )
+
         change.add_game_event_change.game_event.CopyFrom(game_event)
         api_input.change.CopyFrom(change)
         ci_input.api_inputs.append(api_input)
         self.send_ci_input(ci_input)
+
+        # Send ball placement to (0,0) to reset game
         self.send_gc_command(
             gc_command=Command.Type.BALL_PLACEMENT,
             team=scoring_team,

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -296,9 +296,11 @@ class Gamecontroller:
             )
 
         if placement_failed is not None:
-            default_world_state = create_default_world_state(num_robots=6)
-            self.simulator_proto_unix_io.send_proto(WorldState, default_world_state)
-            self.latest_world = default_world_state
+            world_state = WorldState()
+            world_state.ball_state.global_position.CopyFrom(
+                self.latest_world.game_state.ball_placement_point
+            )
+            self.simulator_proto_unix_io.send_proto(WorldState, world_state)
 
     def is_valid_port(self, port):
         """Determine whether or not a given port is valid

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -247,7 +247,12 @@ class Gamecontroller:
         # Send out updated world state
         self.simulator_proto_unix_io.send_proto(WorldState, world_state)
 
-    def __handle_game_stage_change(self, game_stage: Referee.Stage):
+    def __handle_game_stage_change(self, game_stage: Referee.Stage) -> None:
+        """Handle game stage change by advancing to the next half once first half is over
+        and starting a new game once the second half is over.
+
+        :param game_stage: The current game stage from the referee message
+        """
         if game_stage == Referee.Stage.NORMAL_FIRST_HALF:
             # skip to pre second half
             new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -179,7 +179,11 @@ class Gamecontroller:
             except queue.Empty:
                 return
 
-    def __automate_stage_change(self, referee):
+    def __automate_referee(self, referee: Referee) -> None:
+        """Automate referee events by handling game stage changes and starting new game.
+
+        :param referee: the referee protobuf message
+        """
         if referee.stage_time_left < 0:
             if referee.stage == Referee.Stage.NORMAL_FIRST_HALF:
                 # skip to pre second half
@@ -218,8 +222,8 @@ class Gamecontroller:
             block=False, return_cached=True
         )
 
-        # TODO (#3633): only call when using record stats
-        self.__automate_stage_change(referee)
+        # TODO (#3633): only automate referee events in record_stats mode
+        self.__automate_referee(referee)
 
         max_allowed_bots_yellow: int = referee.yellow.max_allowed_bots
         max_allowed_bots_blue: int = referee.blue.max_allowed_bots

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -185,28 +185,7 @@ class Gamecontroller:
         :param referee: the referee protobuf message
         """
         if referee.stage_time_left < 0:
-            if referee.stage == Referee.Stage.NORMAL_FIRST_HALF:
-                # skip to pre second half
-                new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE
-            else:
-                # reset game
-                new_stage = Referee.Stage.NORMAL_FIRST_HALF_PRE
-
-            # reset game state
-            self.simulator_proto_unix_io.send_proto(
-                WorldState, create_default_world_state(num_robots=6)
-            )
-
-            ci_input = CiInput(timestamp=int(time.time_ns()))
-            api_input = Input()
-            change = Change()
-            change.change_stage_change.new_stage = new_stage
-            api_input.change.CopyFrom(change)
-            ci_input.api_inputs.append(api_input)
-
-            self.send_ci_input(ci_input)
-
-            self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
+            self.__handle_game_stage_change(referee.stage)
 
     def handle_referee(self, referee: Referee) -> None:
         """Updates the world state based on the referee message
@@ -267,6 +246,30 @@ class Gamecontroller:
 
         # Send out updated world state
         self.simulator_proto_unix_io.send_proto(WorldState, world_state)
+
+    def __handle_game_stage_change(self, game_stage: Referee.Stage):
+        if game_stage == Referee.Stage.NORMAL_FIRST_HALF:
+            # skip to pre second half
+            new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE
+        else:
+            # reset game
+            new_stage = Referee.Stage.NORMAL_FIRST_HALF_PRE
+
+        # reset game state
+        self.simulator_proto_unix_io.send_proto(
+            WorldState, create_default_world_state(num_robots=6)
+        )
+
+        ci_input = CiInput(timestamp=int(time.time_ns()))
+        api_input = Input()
+        change = Change()
+        change.change_stage_change.new_stage = new_stage
+        api_input.change.CopyFrom(change)
+        ci_input.api_inputs.append(api_input)
+
+        self.send_ci_input(ci_input)
+
+        self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
 
     def is_valid_port(self, port):
         """Determine whether or not a given port is valid

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -68,7 +68,7 @@ class Gamecontroller:
         self.latest_world = None
         self.blue_removed_robot_ids = queue.Queue()
         self.yellow_removed_robot_ids = queue.Queue()
-        self.processed_events = set()
+        self.processed_event_ids = set()
 
     def get_referee_port(self) -> int:
         """Sometimes, the port that we are using changes depending on context.
@@ -239,19 +239,22 @@ class Gamecontroller:
         self.simulator_proto_unix_io.send_proto(WorldState, world_state)
 
     def __automate_referee(self, referee: Referee):
-        possible_goal = False
+        possible_goal = next(
+            (
+                event.possible_goal
+                for event in referee.game_events
+                if event.type == GameEvent.Type.POSSIBLE_GOAL
+                and event.id not in self.processed_event_ids
+            ),
+            None,
+        )
 
-        for game_event in referee.game_events:
-            if (
-                game_event.type == GameEvent.Type.POSSIBLE_GOAL
-                and game_event.id not in self.processed_events
-            ):
-                possible_goal = True
-                self.processed_events.add(game_event.id)
+        for event in referee.game_events:
+            self.processed_event_ids.add(event.id)
 
-        if possible_goal:
+        if possible_goal is not None:
             print("goal scored")
-            scoring_team = game_event.possible_goal.by_team
+            scoring_team = possible_goal.by_team
 
             ci_input = CiInput(timestamp=int(time.time_ns()))
             api_input = Input()

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -179,6 +179,27 @@ class Gamecontroller:
             except queue.Empty:
                 return
 
+    def __automate_referee(self, referee: Referee) -> None:
+        """Automate referee events by handling possible goals and ball placement failures.
+
+        :param referee: the referee protobuf message
+        """
+        possible_goal_event = self.__find_unprocessed_event(
+            referee, GameEvent.Type.POSSIBLE_GOAL
+        )
+        placement_failed_event = self.__find_unprocessed_event(
+            referee, GameEvent.Type.PLACEMENT_FAILED
+        )
+
+        if possible_goal_event:
+            self.__handle_possible_goal(possible_goal_event.possible_goal.by_team)
+
+        if placement_failed_event:
+            self.__handle_placement_failed()
+
+        for event in referee.game_events:
+            self.processed_event_ids.add(event.id)
+
     def handle_referee(self, referee: Referee) -> None:
         """Updates the world state based on the referee message
         :param referee: the referee protobuf message
@@ -238,68 +259,54 @@ class Gamecontroller:
         # Send out updated world state
         self.simulator_proto_unix_io.send_proto(WorldState, world_state)
 
-    def __automate_referee(self, referee: Referee):
-        possible_goal = next(
+    def __find_unprocessed_event(
+        self, referee: Referee, event_type: GameEvent.Type
+    ) -> GameEvent:
+        """Find an unprocessed game event of the specified type.
+
+        :param referee: the referee protobuf message
+        :param event_type: the type of game event to search for
+        :return: the first unprocessed event of the given type, or None if not found
+        """
+        return next(
             (
-                event.possible_goal
+                event
                 for event in referee.game_events
-                if event.type == GameEvent.Type.POSSIBLE_GOAL
-                and event.id not in self.processed_event_ids
+                if event.type == event_type and event.id not in self.processed_event_ids
             ),
             None,
         )
 
-        placement_failed = next(
-            (
-                event.placement_failed
-                for event in referee.game_events
-                if event.type == GameEvent.Type.PLACEMENT_FAILED
-                and event.id not in self.processed_event_ids
-            ),
-            None,
+    def __handle_possible_goal(self, scoring_team: SslTeam) -> None:
+        """Handle a possible goal event by approving the goal and starting ball placement.
+
+        :param scoring_team: the team that scored the goal
+        """
+        ci_input = CiInput(timestamp=int(time.time_ns()))
+        api_input = Input()
+        change = Change()
+        game_event = GameEvent(
+            type=GameEvent.Type.GOAL,
+            origin=["Majority"],
+            goal=GameEvent.Goal(by_team=scoring_team),
+        )
+        change.add_game_event_change.game_event.CopyFrom(game_event)
+        api_input.change.CopyFrom(change)
+        ci_input.api_inputs.append(api_input)
+        self.send_ci_input(ci_input)
+        self.send_gc_command(
+            gc_command=Command.Type.BALL_PLACEMENT,
+            team=scoring_team,
+            final_ball_placement_point=tbots_cpp.Point(0, 0),
         )
 
-        for event in referee.game_events:
-            self.processed_event_ids.add(event.id)
-
-        if possible_goal is not None:
-            print("goal scored")
-            scoring_team = possible_goal.by_team
-
-            ci_input = CiInput(timestamp=int(time.time_ns()))
-            api_input = Input()
-            change = Change()
-
-            add_game_event = Change.AddGameEvent()
-            game_event = GameEvent(
-                type=GameEvent.Type.GOAL,
-                origin=[
-                    "Majority"
-                ],  # Required or else ssl gamecontroller will convert game event to proposal
-                goal=GameEvent.Goal(by_team=scoring_team),
-            )
-            add_game_event.game_event.CopyFrom(game_event)
-            change.add_game_event_change.CopyFrom(add_game_event)
-
-            api_input.change.CopyFrom(change)
-            ci_input.api_inputs.append(api_input)
-
-            # Send game event where team actually scores goal
-            self.send_ci_input(ci_input)
-
-            # Then, start ball placement since robots are halted after possible goal
-            self.send_gc_command(
-                gc_command=Command.Type.BALL_PLACEMENT,
-                team=scoring_team,
-                final_ball_placement_point=tbots_cpp.Point(0, 0),
-            )
-
-        if placement_failed is not None:
-            world_state = WorldState()
-            world_state.ball_state.global_position.CopyFrom(
-                self.latest_world.game_state.ball_placement_point
-            )
-            self.simulator_proto_unix_io.send_proto(WorldState, world_state)
+    def __handle_placement_failed(self) -> None:
+        """Handle a placement failed event by moving the ball to the placement point."""
+        world_state = WorldState()
+        world_state.ball_state.global_position.CopyFrom(
+            self.latest_world.game_state.ball_placement_point
+        )
+        self.simulator_proto_unix_io.send_proto(WorldState, world_state)
 
     def is_valid_port(self, port):
         """Determine whether or not a given port is valid

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -182,27 +182,27 @@ class Gamecontroller:
     def __automate_stage_change(self, referee):
         if referee.stage_time_left < 0:
             if referee.stage == Referee.Stage.NORMAL_FIRST_HALF:
-                # reset game state
-                self.simulator_proto_unix_io.send_proto(
-                    WorldState, create_default_world_state(num_robots=6)
-                )
-
-                ci_input = CiInput(timestamp=int(time.time_ns()))
-                api_input = Input()
-                change = Change()
                 # skip to pre second half
-                change.change_stage_change.new_stage = (
-                    Referee.Stage.NORMAL_SECOND_HALF_PRE
-                )
-                api_input.change.CopyFrom(change)
-                ci_input.api_inputs.append(api_input)
-
-                self.send_ci_input(ci_input)
-
-                self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
+                new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE
             else:
-                # start new game
-                return
+                # reset game
+                new_stage = Referee.Stage.NORMAL_FIRST_HALF_PRE
+
+            # reset game state
+            self.simulator_proto_unix_io.send_proto(
+                WorldState, create_default_world_state(num_robots=6)
+            )
+
+            ci_input = CiInput(timestamp=int(time.time_ns()))
+            api_input = Input()
+            change = Change()
+            change.change_stage_change.new_stage = new_stage
+            api_input.change.CopyFrom(change)
+            ci_input.api_inputs.append(api_input)
+
+            self.send_ci_input(ci_input)
+
+            self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
 
     def handle_referee(self, referee: Referee) -> None:
         """Updates the world state based on the referee message

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -296,10 +296,9 @@ class Gamecontroller:
             )
 
         if placement_failed is not None:
-            # TODO: make sure team with yellow/red cards have less robots
-            self.simulator_proto_unix_io.send_proto(
-                WorldState, create_default_world_state(num_robots=6)
-            )
+            default_world_state = create_default_world_state(num_robots=6)
+            self.simulator_proto_unix_io.send_proto(WorldState, default_world_state)
+            self.latest_world = default_world_state
 
     def is_valid_port(self, port):
         """Determine whether or not a given port is valid

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -10,6 +10,7 @@ from subprocess import Popen
 from typing import Any
 
 from proto.import_all_protos import *
+from proto.message_translation.tbots_protobuf import create_default_world_state
 from proto.ssl_gc_common_pb2 import Team as SslTeam
 from software.networking.ssl_proto_communication import *
 import software.python_bindings as tbots_cpp
@@ -22,6 +23,7 @@ from software.thunderscope.common.thread_safe_circular_buffer import (
     ThreadSafeCircularBuffer,
 )
 from software.thunderscope.util import is_current_platform_macos
+from software.py_constants import DIV_B_NUM_ROBOTS
 
 logger = logging.getLogger(__name__)
 
@@ -184,21 +186,21 @@ class Gamecontroller:
 
         :param referee: the referee protobuf message
         """
-        possible_goal_event = self.__find_unprocessed_event(
+        possible_goal_events = self.__find_unprocessed_events(
             referee, GameEvent.Type.POSSIBLE_GOAL
         )
-        placement_failed_event = self.__find_unprocessed_event(
+        placement_failed_events = self.__find_unprocessed_events(
             referee, GameEvent.Type.PLACEMENT_FAILED
         )
 
-        if possible_goal_event:
-            self.__handle_possible_goal(possible_goal_event.possible_goal.by_team)
+        if len(possible_goal_events) >= 1:
+            self.__handle_possible_goal(possible_goal_events[0].possible_goal.by_team)
+            self.processed_event_ids.add(possible_goal_events[0].id)
 
-        if placement_failed_event:
+        if len(placement_failed_events) >= 2:
             self.__handle_placement_failed()
-
-        for event in referee.game_events:
-            self.processed_event_ids.add(event.id)
+            self.processed_event_ids.add(placement_failed_events[0].id)
+            self.processed_event_ids.add(placement_failed_events[1].id)
 
     def handle_referee(self, referee: Referee) -> None:
         """Updates the world state based on the referee message
@@ -260,23 +262,20 @@ class Gamecontroller:
         # Send out updated world state
         self.simulator_proto_unix_io.send_proto(WorldState, world_state)
 
-    def __find_unprocessed_event(
+    def __find_unprocessed_events(
         self, referee: Referee, event_type: GameEvent.Type
-    ) -> GameEvent:
-        """Find an unprocessed game event of the specified type.
+    ) -> list[GameEvent]:
+        """Find unprocessed game events of the specified type.
 
         :param referee: the referee protobuf message
         :param event_type: the type of game event to search for
-        :return: the first unprocessed event of the given type, or None if not found
+        :return: list of unprocessed events of the given type
         """
-        return next(
-            (
-                event
-                for event in referee.game_events
-                if event.type == event_type and event.id not in self.processed_event_ids
-            ),
-            None,
-        )
+        return [
+            event
+            for event in referee.game_events
+            if event.type == event_type and event.id not in self.processed_event_ids
+        ]
 
     def __handle_possible_goal(self, scoring_team: SslTeam) -> None:
         """Handle a possible goal event by approving the goal and starting ball placement.
@@ -301,12 +300,11 @@ class Gamecontroller:
         ci_input.api_inputs.append(api_input)
         self.send_ci_input(ci_input)
 
-        # Send ball placement to (0,0) to reset game
-        self.send_gc_command(
-            gc_command=Command.Type.BALL_PLACEMENT,
-            team=scoring_team,
-            final_ball_placement_point=tbots_cpp.Point(0, 0),
+        # reset the robot and ball positions
+        self.simulator_proto_unix_io.send_proto(
+            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
         )
+        self.send_gc_command(Command.Type.STOP, SslTeam.UNKNOWN)
 
     def __handle_placement_failed(self) -> None:
         """Handle a placement failed event by moving the ball to the placement point."""

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import itertools
 
 import queue
 import random
@@ -10,6 +11,7 @@ from typing import Any
 
 from proto.import_all_protos import *
 from proto.ssl_gc_common_pb2 import Team as SslTeam
+from proto.message_translation.tbots_protobuf import create_default_world_state
 from software.networking.ssl_proto_communication import *
 import software.python_bindings as tbots_cpp
 from software.thunderscope.proto_unix_io import ProtoUnixIO
@@ -23,7 +25,6 @@ from software.thunderscope.common.thread_safe_circular_buffer import (
 from software.thunderscope.util import is_current_platform_macos
 
 logger = logging.getLogger(__name__)
-import itertools
 
 
 class Gamecontroller:
@@ -177,6 +178,31 @@ class Gamecontroller:
                 robot_states[removed_robot_ids.get_nowait()].CopyFrom(place_state)
             except queue.Empty:
                 return
+
+    def __automate_stage_change(self, referee):
+        if referee.stage_time_left < 0:
+            print("should move on")
+
+            if referee.stage == Referee.Stage.NORMAL_FIRST_HALF:
+                new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE
+            elif referee.stage == Referee.Stage.NORMAL_SECOND_HALF:
+                return  # perhaps start a new game
+            else:
+                return  # idk what to do here
+
+            default_world_state = create_default_world_state(num_robots=6)
+            self.simulator_proto_unix_io.send_proto(WorldState, default_world_state)
+
+            ci_input = CiInput(timestamp=int(time.time_ns()))
+            api_input = Input()
+            change = Change()
+            change.change_stage_change.new_stage.CopyFrom(new_stage)
+            api_input.change.CopyFrom(change)
+            ci_input.api_inputs.append(api_input)
+
+            self.send_ci_input(ci_input)
+
+            self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
 
     def handle_referee(self, referee: Referee) -> None:
         """Updates the world state based on the referee message

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import itertools
 
 import queue
 import random
@@ -23,7 +24,6 @@ from software.thunderscope.common.thread_safe_circular_buffer import (
 from software.thunderscope.util import is_current_platform_macos
 
 logger = logging.getLogger(__name__)
-import itertools
 
 
 class Gamecontroller:
@@ -68,6 +68,7 @@ class Gamecontroller:
         self.latest_world = None
         self.blue_removed_robot_ids = queue.Queue()
         self.yellow_removed_robot_ids = queue.Queue()
+        self.processed_events = set()
 
     def get_referee_port(self) -> int:
         """Sometimes, the port that we are using changes depending on context.
@@ -187,6 +188,8 @@ class Gamecontroller:
         if self.simulator_proto_unix_io is None:
             return
 
+        self.__automate_referee(referee)
+
         # Convert the latest blue world into a WorldState we can send to the simulator and update the robots
         self.latest_world = self.blue_team_world_buffer.get(
             block=False, return_cached=True
@@ -234,6 +237,49 @@ class Gamecontroller:
 
         # Send out updated world state
         self.simulator_proto_unix_io.send_proto(WorldState, world_state)
+
+    def __automate_referee(self, referee: Referee):
+        possible_goal = False
+
+        for game_event in referee.game_events:
+            if (
+                game_event.type == GameEvent.Type.POSSIBLE_GOAL
+                and game_event.id not in self.processed_events
+            ):
+                possible_goal = True
+                self.processed_events.add(game_event.id)
+
+        if possible_goal:
+            print("goal scored")
+            scoring_team = game_event.possible_goal.by_team
+
+            ci_input = CiInput(timestamp=int(time.time_ns()))
+            api_input = Input()
+            change = Change()
+
+            add_game_event = Change.AddGameEvent()
+            game_event = GameEvent(
+                type=GameEvent.Type.GOAL,
+                origin=[
+                    "Majority"
+                ],  # Required or else ssl gamecontroller will convert game event to proposal
+                goal=GameEvent.Goal(by_team=scoring_team),
+            )
+            add_game_event.game_event.CopyFrom(game_event)
+            change.add_game_event_change.CopyFrom(add_game_event)
+
+            api_input.change.CopyFrom(change)
+            ci_input.api_inputs.append(api_input)
+
+            # Send game event where team actually scores goal
+            self.send_ci_input(ci_input)
+
+            # Then, start ball placement since robots are halted after possible goal
+            self.send_gc_command(
+                gc_command=Command.Type.BALL_PLACEMENT,
+                team=scoring_team,
+                final_ball_placement_point=tbots_cpp.Point(0, 0),
+            )
 
     def is_valid_port(self, port):
         """Determine whether or not a given port is valid

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -209,13 +209,13 @@ class Gamecontroller:
         if self.simulator_proto_unix_io is None:
             return
 
-        # TODO (#3633): automate referee events in record_stats mode
-        # self.__automate_referee(referee)
-
         # Convert the latest blue world into a WorldState we can send to the simulator and update the robots
         self.latest_world = self.blue_team_world_buffer.get(
             block=False, return_cached=True
         )
+
+        # TODO (#3633): only automate referee events in record_stats mode
+        self.__automate_referee(referee)
 
         max_allowed_bots_yellow: int = referee.yellow.max_allowed_bots
         max_allowed_bots_blue: int = referee.blue.max_allowed_bots

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -22,6 +22,7 @@ from software.thunderscope.common.thread_safe_circular_buffer import (
     ThreadSafeCircularBuffer,
 )
 from software.thunderscope.util import is_current_platform_macos
+from proto.message_translation.tbots_protobuf import create_default_world_state
 
 logger = logging.getLogger(__name__)
 
@@ -249,6 +250,16 @@ class Gamecontroller:
             None,
         )
 
+        placement_failed = next(
+            (
+                event.placement_failed
+                for event in referee.game_events
+                if event.type == GameEvent.Type.PLACEMENT_FAILED
+                and event.id not in self.processed_event_ids
+            ),
+            None,
+        )
+
         for event in referee.game_events:
             self.processed_event_ids.add(event.id)
 
@@ -282,6 +293,12 @@ class Gamecontroller:
                 gc_command=Command.Type.BALL_PLACEMENT,
                 team=scoring_team,
                 final_ball_placement_point=tbots_cpp.Point(0, 0),
+            )
+
+        if placement_failed is not None:
+            # TODO: make sure team with yellow/red cards have less robots
+            self.simulator_proto_unix_io.send_proto(
+                WorldState, create_default_world_state(num_robots=6)
             )
 
     def is_valid_port(self, port):

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -218,6 +218,9 @@ class Gamecontroller:
             block=False, return_cached=True
         )
 
+        # TODO (#3633): only call when using record stats
+        self.__automate_stage_change(referee)
+
         max_allowed_bots_yellow: int = referee.yellow.max_allowed_bots
         max_allowed_bots_blue: int = referee.blue.max_allowed_bots
         # Ignore if nothing needs to be updated

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -23,6 +23,7 @@ from software.thunderscope.common.thread_safe_circular_buffer import (
     ThreadSafeCircularBuffer,
 )
 from software.thunderscope.util import is_current_platform_macos
+from software.py_constants import DIV_B_NUM_ROBOTS
 
 logger = logging.getLogger(__name__)
 
@@ -262,7 +263,7 @@ class Gamecontroller:
 
         # reset game state
         self.simulator_proto_unix_io.send_proto(
-            WorldState, create_default_world_state(num_robots=6)
+            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
         )
 
         ci_input = CiInput(timestamp=int(time.time_ns()))

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -22,7 +22,6 @@ from software.thunderscope.common.thread_safe_circular_buffer import (
     ThreadSafeCircularBuffer,
 )
 from software.thunderscope.util import is_current_platform_macos
-from proto.message_translation.tbots_protobuf import create_default_world_state
 
 logger = logging.getLogger(__name__)
 

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -196,7 +196,7 @@ class Gamecontroller:
             ci_input = CiInput(timestamp=int(time.time_ns()))
             api_input = Input()
             change = Change()
-            change.change_stage_change.new_stage.CopyFrom(new_stage)
+            change.change_stage_change.new_stage = new_stage
             api_input.change.CopyFrom(change)
             ci_input.api_inputs.append(api_input)
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Adds an `__automate_referee` method to the gamecontroller binary context manager class that handles referee game events for POSSIBLE_GOAL and FAILED_PLACEMENT. This automates two common human referee interventions so that the game will continue by itself.

- For a possible goal, automatically approves it and start ball placement to (0,0)
- For a failed placement, send a world state message with the ball teleported to the placement point

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Ran `./tbots.py run thunderscope_main --enable_autoref` (uncommented `__automate_referee` method call) and:

- Triggered possible goal event manually using gamecontroller UI, the goal was approved and ball placement started, the robots continued playing
- Waited until a goal was naturally scored, it was approved and same behaviour... robots kept playing
- Triggered ball placement with gamecontroller UI, then placed ball in corner with thunderscope, the team failed to place ball, then it was moved automatically to the placement position
- Waited for ball placement from the autoref, then placed ball in corner, same behaviour... still works


https://github.com/user-attachments/assets/96a14495-68a2-45ae-9def-c840fa5624db

https://github.com/user-attachments/assets/c5c27b2e-6aa7-4be5-a94e-c04c2041a7b1


### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

Part of #3633, resolves #3625 

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

N/A

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
