### PR TITLE
Stat recording improvements for long durations

### DIFF
--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -275,11 +275,6 @@ class Gamecontroller:
 
         :param game_stage: The current game stage from the referee message
         """
-        # reset game state
-        self.simulator_proto_unix_io.send_proto(
-            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
-        )
-
         if game_stage == Referee.Stage.NORMAL_FIRST_HALF:
             ci_input = CiInput(timestamp=int(time.time_ns()))
             api_input = Input()
@@ -292,7 +287,19 @@ class Gamecontroller:
             ci_input.api_inputs.append(api_input)
             self.send_ci_input(ci_input)
         else:
-            self.reset_team_info(Division.DIV_B)
+            ci_input = CiInput(timestamp=int(time.time_ns()))
+            input_game_update = Input()
+            input_game_update.reset_match = True
+            input_game_update.change.update_config_change.CopyFrom(
+                self.reset_game(Division.DIV_B)
+            )
+            ci_input.api_inputs.append(input_game_update)
+            self.send_ci_input(ci_input)
+
+        # reset game state
+        self.simulator_proto_unix_io.send_proto(
+            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
+        )
 
         self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
 

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -276,24 +276,29 @@ class Gamecontroller:
         :param game_stage: The current game stage from the referee message
         """
         if game_stage == Referee.Stage.NORMAL_FIRST_HALF:
-            ci_input = CiInput(timestamp=int(time.time_ns()))
-            api_input = Input()
-            change = Change()
-
             # skip to pre second half
-            change.change_stage_change.new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE
-
-            api_input.change.CopyFrom(change)
-            ci_input.api_inputs.append(api_input)
-            self.send_ci_input(ci_input)
+            self.__set_game_stage(Referee.Stage.NORMAL_SECOND_HALF_PRE)
         else:
+            # end game
+            self.__set_game_stage(Referee.Stage.POST_GAME)
+
+            # reset match (start new game)
             ci_input = CiInput(timestamp=int(time.time_ns()))
-            input_game_update = Input()
-            input_game_update.reset_match = True
-            input_game_update.change.update_config_change.CopyFrom(
-                self.reset_game(Division.DIV_B)
-            )
-            ci_input.api_inputs.append(input_game_update)
+            input_reset_match = Input()
+            input_reset_match.reset_match = True
+            ci_input.api_inputs.append(input_reset_match)
+            self.send_ci_input(ci_input)
+
+            ci_input = CiInput(timestamp=int(time.time_ns()))
+            input_reset_match = Input()
+            input_reset_match.change.update_config_change.division = Division.DIV_B
+            ci_input.api_inputs.append(input_reset_match)
+            self.send_ci_input(ci_input)
+
+            ci_input = CiInput(timestamp=int(time.time_ns()))
+            input_reset_match = Input()
+            input_reset_match.change.update_config_change.match_type = MatchType.FRIENDLY
+            ci_input.api_inputs.append(input_reset_match)
             self.send_ci_input(ci_input)
 
         # reset game state
@@ -302,6 +307,15 @@ class Gamecontroller:
         )
 
         self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
+
+    def __set_game_stage(self, new_stage: Referee.Stage) -> None:
+        ci_input = CiInput(timestamp=int(time.time_ns()))
+        api_input = Input()
+        change = Change()
+        change.change_stage_change.new_stage = new_stage
+        api_input.change.CopyFrom(change)
+        ci_input.api_inputs.append(api_input)
+        self.send_ci_input(ci_input)
 
     def __find_unprocessed_events(
         self, referee: Referee, event_type: GameEvent.Type

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -277,28 +277,19 @@ class Gamecontroller:
             WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
         )
 
-        ci_input = CiInput(timestamp=int(time.time_ns()))
-        api_input = Input()
-
         if game_stage == Referee.Stage.NORMAL_FIRST_HALF:
-            # skip to pre second half
-            new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE
-            change = Change()
-            change.change_stage_change.new_stage = new_stage
-            api_input.change.CopyFrom(change)
-        else:
-            # reset game
-            api_input.reset_match = True
-            ci_input.api_inputs.append(api_input)
+            ci_input = CiInput(timestamp=int(time.time_ns()))
             api_input = Input()
             change = Change()
-            change.update_config_change.division = Division.DIV_B
-            change.update_config_change.match_type = MatchType.FRIENDLY
+
+            # skip to pre second half
+            change.change_stage_change.new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE
+
             api_input.change.CopyFrom(change)
-
-        ci_input.api_inputs.append(api_input)
-
-        self.send_ci_input(ci_input)
+            ci_input.api_inputs.append(api_input)
+            self.send_ci_input(ci_input)
+        else:
+            self.reset_team_info(Division.DIV_B)
 
         self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
 

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -23,17 +23,15 @@ from software.thunderscope.common.thread_safe_circular_buffer import (
     ThreadSafeCircularBuffer,
 )
 from software.thunderscope.util import is_current_platform_macos
-from software.py_constants import DIV_B_NUM_ROBOTS
-
-logger = logging.getLogger(__name__)
 
 
 class Gamecontroller:
     """Gamecontroller Context Manager"""
 
     CI_MODE_LAUNCH_DELAY_S = 0.3
-    REFEREE_IP = "224.5.23.1"
     CI_MODE_OUTPUT_RECEIVE_BUFFER_SIZE = 9000
+    REFEREE_IP = "224.5.23.1"
+    RESET_MATCH_DELAY_S = 1
 
     def __init__(
         self,
@@ -143,237 +141,6 @@ class Gamecontroller:
             )
             manual_command = self.command_override_buffer.get(return_cached=False)
 
-    @staticmethod
-    def __update_robot_count(
-        robot_states,
-        team: Team,
-        max_robots: int,
-        removed_robot_ids: queue.Queue[int],
-        field_edge_y_meters: float,
-    ) -> None:
-        """Static method for updating the number of robots in the world state (i.e. robot_states) for a given Team.
-        This method is team & side agnostic.
-
-        :param robot_states: WorldState <Robot ID, RobotState> map protobuf to be updated.
-        :param team: the Team of robots currently in play
-        :param max_robots: The number of robots we should have on the field. Must be >= 0
-        :param removed_robot_ids: The robots (IDs) which have been removed already and can safely be re-added
-        :param field_edge_y_meters: Places new robots at this y position along the centerline
-        :return:
-        """
-        # build the robot state for placing robots at the edge of field
-        place_state = RobotState(
-            global_position=Point(x_meters=0, y_meters=field_edge_y_meters)
-        )
-        # Remove robots, as we have too many. Set robot velocities to zero to avoid any drift
-        for count, robot in enumerate(team.team_robots, start=1):
-            if count <= max_robots:
-                robot_states[robot.id].CopyFrom(robot.current_state)
-                velocity = robot_states[robot.id].global_velocity
-                velocity.x_component_meters = 0
-                velocity.y_component_meters = 0
-            else:
-                removed_robot_ids.put(robot.id)
-        # Add robots, since we are missing some
-        robots_diff: int = max_robots - len(team.team_robots)
-        if robots_diff <= 0:
-            return
-        for _ in range(robots_diff):
-            try:
-                robot_states[removed_robot_ids.get_nowait()].CopyFrom(place_state)
-            except queue.Empty:
-                return
-
-    def __automate_referee(self, referee: Referee) -> None:
-        """Automate referee events by handling possible goals, ball placement failures,
-        game stage changes, and starting new game.
-
-        :param referee: the referee protobuf message
-        """
-        if referee.stage_time_left < 0:
-            self.__handle_game_stage_change(referee.stage)
-
-        possible_goal_events = self.__find_unprocessed_events(
-            referee, GameEvent.Type.POSSIBLE_GOAL
-        )
-        placement_failed_events = self.__find_unprocessed_events(
-            referee, GameEvent.Type.PLACEMENT_FAILED
-        )
-
-        if len(possible_goal_events) >= 1:
-            self.__handle_possible_goal(possible_goal_events[0].possible_goal.by_team)
-            self.processed_event_ids.add(possible_goal_events[0].id)
-
-        if len(placement_failed_events) >= 2:
-            self.__handle_placement_failed()
-            self.processed_event_ids.add(placement_failed_events[0].id)
-            self.processed_event_ids.add(placement_failed_events[1].id)
-
-    def handle_referee(self, referee: Referee) -> None:
-        """Updates the world state based on the referee message
-        :param referee: the referee protobuf message
-        """
-        # Check that we are running with the simulator and have access to its
-        # proto unix io
-        if self.simulator_proto_unix_io is None:
-            return
-
-        # Convert the latest blue world into a WorldState we can send to the simulator and update the robots
-        self.latest_world = self.blue_team_world_buffer.get(
-            block=False, return_cached=True
-        )
-
-        if self.automate_referee:
-            self.__automate_referee(referee)
-
-        max_allowed_bots_yellow: int = referee.yellow.max_allowed_bots
-        max_allowed_bots_blue: int = referee.blue.max_allowed_bots
-        # Ignore if nothing needs to be updated
-        if (
-            len(self.latest_world.friendly_team.team_robots) == max_allowed_bots_blue
-            and len(self.latest_world.enemy_team.team_robots) == max_allowed_bots_yellow
-        ):
-            return
-
-        # Populate a blank WorldState with new updated robot information
-        world_state = WorldState()
-        field_edge_y_meters: Final[int] = (
-            self.latest_world.field.field_y_length
-            - self.latest_world.field.boundary_buffer_size
-        )
-
-        self.__update_robot_count(
-            world_state.blue_robots,
-            self.latest_world.friendly_team,
-            max_allowed_bots_blue,
-            self.blue_removed_robot_ids,
-            field_edge_y_meters,
-        )
-        self.__update_robot_count(
-            world_state.yellow_robots,
-            self.latest_world.enemy_team,
-            max_allowed_bots_yellow,
-            self.yellow_removed_robot_ids,
-            -field_edge_y_meters,
-        )
-
-        # Check if we need to invert the world state
-        if referee.blue_team_on_positive_half:
-            for robot in itertools.chain(
-                world_state.blue_robots, world_state.yellow_robots
-            ):
-                robot.current_state.global_position.x_meters *= -1
-                robot.current_state.global_position.y_meters *= -1
-                robot.current_state.global_orientation.radians += math.pi
-
-        # Send out updated world state
-        self.simulator_proto_unix_io.send_proto(WorldState, world_state)
-
-    def __handle_game_stage_change(self, game_stage: Referee.Stage) -> None:
-        """Handle game stage change by advancing to the next half once first half is over
-        and starting a new game once the second half is over.
-
-        :param game_stage: The current game stage from the referee message
-        """
-        if game_stage == Referee.Stage.NORMAL_FIRST_HALF:
-            # skip to pre second half
-            self.__set_game_stage(Referee.Stage.NORMAL_SECOND_HALF_PRE)
-        else:
-            # end game
-            self.__set_game_stage(Referee.Stage.POST_GAME)
-
-            # Race condition where events don't get resolved before setting new match settings
-            time.sleep(1)
-
-            # reset match (start new game)
-            ci_input = CiInput(timestamp=int(time.time_ns()))
-            input_reset_match = Input()
-            input_reset_match.reset_match = True
-            ci_input.api_inputs.append(input_reset_match)
-            self.send_ci_input(ci_input)
-
-            ci_input = CiInput(timestamp=int(time.time_ns()))
-            input_reset_match = Input()
-            input_reset_match.change.update_config_change.division = Division.DIV_B
-            ci_input.api_inputs.append(input_reset_match)
-            self.send_ci_input(ci_input)
-
-            ci_input = CiInput(timestamp=int(time.time_ns()))
-            input_reset_match = Input()
-            input_reset_match.change.update_config_change.match_type = (
-                MatchType.FRIENDLY
-            )
-            ci_input.api_inputs.append(input_reset_match)
-            self.send_ci_input(ci_input)
-
-        # reset game state
-        self.simulator_proto_unix_io.send_proto(
-            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
-        )
-
-        self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
-
-    def __set_game_stage(self, new_stage: Referee.Stage) -> None:
-        ci_input = CiInput(timestamp=int(time.time_ns()))
-        api_input = Input()
-        change = Change()
-        change.change_stage_change.new_stage = new_stage
-        api_input.change.CopyFrom(change)
-        ci_input.api_inputs.append(api_input)
-        self.send_ci_input(ci_input)
-
-    def __find_unprocessed_events(
-        self, referee: Referee, event_type: GameEvent.Type
-    ) -> list[GameEvent]:
-        """Find unprocessed game events of the specified type.
-
-        :param referee: the referee protobuf message
-        :param event_type: the type of game event to search for
-        :return: list of unprocessed events of the given type
-        """
-        return [
-            event
-            for event in referee.game_events
-            if event.type == event_type and event.id not in self.processed_event_ids
-        ]
-
-    def __handle_possible_goal(self, scoring_team: SslTeam) -> None:
-        """Handle a possible goal event by approving the goal and starting ball placement.
-
-        :param scoring_team: the team that scored the goal
-        """
-        ci_input = CiInput(timestamp=int(time.time_ns()))
-        api_input = Input()
-        change = Change()
-
-        # Send goal game event to resolve the possible goal
-        game_event = GameEvent(
-            type=GameEvent.Type.GOAL,
-            origin=[
-                "Majority"
-            ],  # Required or else ssl-gamecontroller will convert game event to proposal
-            goal=GameEvent.Goal(by_team=scoring_team),
-        )
-
-        change.add_game_event_change.game_event.CopyFrom(game_event)
-        api_input.change.CopyFrom(change)
-        ci_input.api_inputs.append(api_input)
-        self.send_ci_input(ci_input)
-
-        # reset the robot and ball positions
-        self.simulator_proto_unix_io.send_proto(
-            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
-        )
-        self.send_gc_command(Command.Type.STOP, SslTeam.UNKNOWN)
-
-    def __handle_placement_failed(self) -> None:
-        """Handle a placement failed event by moving the ball to the placement point."""
-        world_state = WorldState()
-        world_state.ball_state.global_position.CopyFrom(
-            self.latest_world.game_state.ball_placement_point
-        )
-        self.simulator_proto_unix_io.send_proto(WorldState, world_state)
-
     def is_valid_port(self, port):
         """Determine whether or not a given port is valid
 
@@ -425,7 +192,7 @@ class Gamecontroller:
 
             :param data: The referee command to send
             """
-            self.handle_referee(data)
+            self.__handle_referee(data)
             blue_full_system_proto_unix_io.send_proto(Referee, data)
             yellow_full_system_proto_unix_io.send_proto(Referee, data)
             if autoref_proto_unix_io is not None:
@@ -533,46 +300,8 @@ class Gamecontroller:
 
         return ci_output_list
 
-    def reset_team(self, name: str, team: str) -> Change.UpdateTeamState:
-        """Returns an UpdateTeamState proto for the gamecontroller to reset team info.
-
-        :param name name of the new team
-        :param team yellow or blue team to update
-
-        :return: corresponding UpdateTeamState proto
-        """
-        update_team_state = Change.UpdateTeamState()
-        update_team_state.for_team = team
-        update_team_state.team_name.value = name
-        update_team_state.goals.value = 0
-        update_team_state.timeouts_left.value = 4
-        update_team_state.timeout_time_left.value = "05:00"
-        update_team_state.can_place_ball.value = True
-
-        return update_team_state
-
-    def reset_game(
-        self, division: proto.ssl_gc_common_pb2.Division
-    ) -> Change.UpdateConfig:
-        """Returns an UpdateConfig proto for the Gamecontroller to reset game info.
-
-        :param division the Division proto corresponding to the game division to set up the Gamecontroller for
-
-        :return: corresponding UpdateConfig proto
-        """
-        game_update = Change.UpdateConfig()
-        game_update.division = division
-        game_update.first_kickoff_team = SslTeam.BLUE
-        game_update.match_type = MatchType.FRIENDLY
-
-        return game_update
-
-    def reset_team_info(
-        self, division: proto.ssl_gc_common_pb2.Division
-    ) -> list[CiOutput]:
-        """Sends a message to the Gamecontroller to reset Team information.
-
-        :param division: the Division proto corresponding to the game division to set up the Gamecontroller for
+    def reset_match(self) -> list[CiOutput]:
+        """Sends a message to the Gamecontroller to reset match information to our defaults.
 
         :return: a list of CiOutput protos from the Gamecontroller
         """
@@ -581,25 +310,14 @@ class Gamecontroller:
         input_reset_match = Input()
         input_reset_match.reset_match = True
 
-        input_blue_update = Input()
-        input_blue_update.change.update_team_state_change.CopyFrom(
-            self.reset_team("BLUE", SslTeam.BLUE)
-        )
-
-        input_yellow_update = Input()
-        input_yellow_update.change.update_team_state_change.CopyFrom(
-            self.reset_team("YELLOW", SslTeam.YELLOW)
-        )
-
-        input_game_update = Input()
-        input_game_update.change.update_config_change.CopyFrom(
-            self.reset_game(division)
+        input_set_match_config = Input()
+        input_set_match_config.change.update_config_change.division = Division.DIV_B
+        input_set_match_config.change.update_config_change.match_type = (
+            MatchType.FRIENDLY
         )
 
         ci_input.api_inputs.append(input_reset_match)
-        ci_input.api_inputs.append(input_blue_update)
-        ci_input.api_inputs.append(input_yellow_update)
-        ci_input.api_inputs.append(input_game_update)
+        ci_input.api_inputs.append(input_set_match_config)
 
         return self.send_ci_input(ci_input)
 
@@ -620,3 +338,220 @@ class Gamecontroller:
         ci_input.api_inputs.append(game_config_input)
 
         return self.send_ci_input(ci_input)
+
+    def __handle_referee(self, referee: Referee) -> None:
+        """Updates the world state based on the referee message
+        :param referee: the referee protobuf message
+        """
+        # Check that we are running with the simulator and have access to its
+        # proto unix io
+        if self.simulator_proto_unix_io is None:
+            return
+
+        # Convert the latest blue world into a WorldState we can send to the simulator and update the robots
+        self.latest_world = self.blue_team_world_buffer.get(
+            block=False, return_cached=True
+        )
+
+        if self.automate_referee:
+            self.__automate_referee(referee)
+
+        if (
+            len(self.latest_world.friendly_team.team_robots)
+            != referee.blue.max_allowed_bots
+            or len(self.latest_world.enemy_team.team_robots)
+            != referee.yellow.max_allowed_bots
+        ):
+            self.__update_max_allowed_robots(referee)
+
+    def __automate_referee(self, referee: Referee) -> None:
+        """Automate referee events by handling possible goals, ball placement failures,
+        game stage changes, and starting new game.
+
+        :param referee: the referee protobuf message
+        """
+        if referee.stage_time_left < 0:
+            self.__handle_game_stage_change(referee.stage)
+
+        possible_goal_events = self.__find_unprocessed_events(
+            referee, GameEvent.Type.POSSIBLE_GOAL
+        )
+        placement_failed_events = self.__find_unprocessed_events(
+            referee, GameEvent.Type.PLACEMENT_FAILED
+        )
+
+        if len(possible_goal_events) >= 1:
+            self.__handle_possible_goal(possible_goal_events[0].possible_goal.by_team)
+            self.processed_event_ids.add(possible_goal_events[0].id)
+
+        if len(placement_failed_events) >= 2:
+            self.__handle_placement_failed()
+            self.processed_event_ids.add(placement_failed_events[0].id)
+            self.processed_event_ids.add(placement_failed_events[1].id)
+
+    def __handle_game_stage_change(self, game_stage: Referee.Stage) -> None:
+        """Handle game stage change by advancing to the next half once first half is over
+        and starting a new game once the second half is over.
+
+        :param game_stage: The current game stage from the referee message
+        """
+        if game_stage == Referee.Stage.NORMAL_FIRST_HALF:
+            # skip to pre second half
+            self.__set_game_stage(Referee.Stage.NORMAL_SECOND_HALF_PRE)
+        else:
+            # end game
+            self.__set_game_stage(Referee.Stage.POST_GAME)
+
+            # Race condition where events don't get resolved before setting new match settings
+            time.sleep(self.RESET_MATCH_DELAY_S)
+
+            # start new game
+            self.reset_match()
+
+        # reset game state
+        self.simulator_proto_unix_io.send_proto(
+            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
+        )
+
+        self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
+
+    def __set_game_stage(self, new_stage: Referee.Stage) -> None:
+        ci_input = CiInput(timestamp=int(time.time_ns()))
+        api_input = Input()
+        change = Change()
+        change.change_stage_change.new_stage = new_stage
+        api_input.change.CopyFrom(change)
+        ci_input.api_inputs.append(api_input)
+        self.send_ci_input(ci_input)
+
+    def __find_unprocessed_events(
+        self, referee: Referee, event_type: GameEvent.Type
+    ) -> list[GameEvent]:
+        """Find unprocessed game events of the specified type.
+
+        :param referee: the referee protobuf message
+        :param event_type: the type of game event to search for
+        :return: list of unprocessed events of the given type
+        """
+        return [
+            event
+            for event in referee.game_events
+            if event.type == event_type and event.id not in self.processed_event_ids
+        ]
+
+    def __handle_possible_goal(self, scoring_team: SslTeam) -> None:
+        """Handle a possible goal event by approving the goal and resetting world state.
+
+        :param scoring_team: the team that scored the goal
+        """
+        ci_input = CiInput(timestamp=int(time.time_ns()))
+        api_input = Input()
+        change = Change()
+
+        # Send goal game event to resolve the possible goal
+        game_event = GameEvent(
+            type=GameEvent.Type.GOAL,
+            origin=[
+                "Majority"
+            ],  # Required or else ssl-gamecontroller will convert game event to proposal
+            goal=GameEvent.Goal(by_team=scoring_team),
+        )
+
+        change.add_game_event_change.game_event.CopyFrom(game_event)
+        api_input.change.CopyFrom(change)
+        ci_input.api_inputs.append(api_input)
+        self.send_ci_input(ci_input)
+
+        # reset the robot and ball positions
+        self.simulator_proto_unix_io.send_proto(
+            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
+        )
+        self.send_gc_command(Command.Type.STOP, SslTeam.UNKNOWN)
+
+    def __handle_placement_failed(self) -> None:
+        """Handle a placement failed event by moving the ball to the placement point."""
+        world_state = WorldState()
+        world_state.ball_state.global_position.CopyFrom(
+            self.latest_world.game_state.ball_placement_point
+        )
+        self.simulator_proto_unix_io.send_proto(WorldState, world_state)
+
+    def __update_max_allowed_robots(self, referee: Referee) -> None:
+        """Update the world state by adding or removing robots for each team to match
+        their maximum allowed number of robots.
+
+        :param referee: the referee protobuf message
+        """
+        world_state = WorldState()
+        field_edge_y_meters: Final[int] = (
+            self.latest_world.field.field_y_length
+            - self.latest_world.field.boundary_buffer_size
+        )
+
+        self.__update_robot_count(
+            world_state.blue_robots,
+            self.latest_world.friendly_team,
+            referee.blue.max_allowed_bots,
+            self.blue_removed_robot_ids,
+            field_edge_y_meters,
+        )
+        self.__update_robot_count(
+            world_state.yellow_robots,
+            self.latest_world.enemy_team,
+            referee.yellow.max_allowed_bots,
+            self.yellow_removed_robot_ids,
+            -field_edge_y_meters,
+        )
+
+        # Check if we need to invert the world state
+        if referee.blue_team_on_positive_half:
+            for robot in itertools.chain(
+                world_state.blue_robots, world_state.yellow_robots
+            ):
+                robot.current_state.global_position.x_meters *= -1
+                robot.current_state.global_position.y_meters *= -1
+                robot.current_state.global_orientation.radians += math.pi
+
+        # Send out updated world state
+        self.simulator_proto_unix_io.send_proto(WorldState, world_state)
+
+    @staticmethod
+    def __update_robot_count(
+        robot_states,
+        team: Team,
+        max_robots: int,
+        removed_robot_ids: queue.Queue[int],
+        field_edge_y_meters: float,
+    ) -> None:
+        """Static method for updating the number of robots in the world state (i.e. robot_states) for a given Team.
+        This method is team & side agnostic.
+
+        :param robot_states: WorldState <Robot ID, RobotState> map protobuf to be updated.
+        :param team: the Team of robots currently in play
+        :param max_robots: The number of robots we should have on the field. Must be >= 0
+        :param removed_robot_ids: The robots (IDs) which have been removed already and can safely be re-added
+        :param field_edge_y_meters: Places new robots at this y position along the centerline
+        :return:
+        """
+        # build the robot state for placing robots at the edge of field
+        place_state = RobotState(
+            global_position=Point(x_meters=0, y_meters=field_edge_y_meters)
+        )
+        # Remove robots, as we have too many. Set robot velocities to zero to avoid any drift
+        for count, robot in enumerate(team.team_robots, start=1):
+            if count <= max_robots:
+                robot_states[robot.id].CopyFrom(robot.current_state)
+                velocity = robot_states[robot.id].global_velocity
+                velocity.x_component_meters = 0
+                velocity.y_component_meters = 0
+            else:
+                removed_robot_ids.put(robot.id)
+        # Add robots, since we are missing some
+        robots_diff: int = max_robots - len(team.team_robots)
+        if robots_diff <= 0:
+            return
+        for _ in range(robots_diff):
+            try:
+                robot_states[removed_robot_ids.get_nowait()].CopyFrom(place_state)
+            except queue.Empty:
+                return

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -39,13 +39,16 @@ class Gamecontroller:
         self,
         suppress_logs: bool = False,
         use_conventional_port: bool = False,
+        automate_referee: bool = False,
     ) -> None:
         """Run Gamecontroller
 
         :param suppress_logs: Whether to suppress the logs
         :param use_conventional_port: whether or not to use the conventional port!
+        :param automate_referee: whether or not referee commands should be automated
         """
         self.suppress_logs = suppress_logs
+        self.automate_referee = automate_referee
 
         # We default to using a non-conventional port to avoid emitting
         # on the same port as what other teams may be listening on.
@@ -220,8 +223,8 @@ class Gamecontroller:
             block=False, return_cached=True
         )
 
-        # TODO (#3633): only automate referee events in record_stats mode
-        self.__automate_referee(referee)
+        if self.automate_referee:
+            self.__automate_referee(referee)
 
         max_allowed_bots_yellow: int = referee.yellow.max_allowed_bots
         max_allowed_bots_blue: int = referee.blue.max_allowed_bots

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -23,6 +23,7 @@ from software.thunderscope.common.thread_safe_circular_buffer import (
     ThreadSafeCircularBuffer,
 )
 from software.thunderscope.util import is_current_platform_macos
+from software.thunderscope.time_provider import time_provider_instance
 
 
 class Gamecontroller:
@@ -32,6 +33,7 @@ class Gamecontroller:
     CI_MODE_OUTPUT_RECEIVE_BUFFER_SIZE = 9000
     REFEREE_IP = "224.5.23.1"
     RESET_MATCH_DELAY_S = 1
+    NO_GAME_PROGRESS_DURATION_S = 120
 
     def __init__(
         self,
@@ -72,6 +74,8 @@ class Gamecontroller:
         self.blue_removed_robot_ids = queue.Queue()
         self.yellow_removed_robot_ids = queue.Queue()
         self.processed_event_ids = set()
+        self.last_stage_time_left = None
+        self.pause_start_timestamp = None
 
     def get_referee_port(self) -> int:
         """Sometimes, the port that we are using changes depending on context.
@@ -366,10 +370,28 @@ class Gamecontroller:
 
     def __automate_referee(self, referee: Referee) -> None:
         """Automate referee events by handling possible goals, ball placement failures,
-        game stage changes, and starting new game.
+        game stage changes, starting new game, and resetting when there is no game progress.
 
         :param referee: the referee protobuf message
         """
+        if referee.stage_time_left == self.last_stage_time_left:
+            if (
+                self.pause_start_timestamp
+                and (
+                    time_provider_instance.elapsed_time_ns()
+                    - self.pause_start_timestamp
+                )
+                * SECONDS_PER_NANOSECOND
+                >= self.NO_GAME_PROGRESS_DURATION_S
+            ):
+                logging.warning(f"Gamecontroller: Ending game early due unknown issue stopping game progress for {
+                    self.NO_GAME_PROGRESS_DURATION_S} seconds")
+                self.__handle_game_stage_change(Referee.Stage.NORMAL_SECOND_HALF)
+                self.pause_start_timestamp = None
+        else:
+            self.last_stage_time_left = referee.stage_time_left
+            self.pause_start_timestamp = time_provider_instance.elapsed_time_ns()
+
         if referee.stage_time_left < 0:
             self.__handle_game_stage_change(referee.stage)
 
@@ -408,12 +430,7 @@ class Gamecontroller:
             # start new game
             self.reset_match()
 
-        # reset game state
-        self.simulator_proto_unix_io.send_proto(
-            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
-        )
-
-        self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
+        self.__reset_world_state()
 
     def __set_game_stage(self, new_stage: Referee.Stage) -> None:
         ci_input = CiInput(timestamp=int(time.time_ns()))
@@ -462,11 +479,7 @@ class Gamecontroller:
         ci_input.api_inputs.append(api_input)
         self.send_ci_input(ci_input)
 
-        # reset the robot and ball positions
-        self.simulator_proto_unix_io.send_proto(
-            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
-        )
-        self.send_gc_command(Command.Type.STOP, SslTeam.UNKNOWN)
+        self.__reset_world_state()
 
     def __handle_placement_failed(self) -> None:
         """Handle a placement failed event by moving the ball to the placement point."""
@@ -475,6 +488,13 @@ class Gamecontroller:
             self.latest_world.game_state.ball_placement_point
         )
         self.simulator_proto_unix_io.send_proto(WorldState, world_state)
+
+    def __reset_world_state(self) -> None:
+        """Resets the robot and ball positions"""
+        self.simulator_proto_unix_io.send_proto(
+            WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
+        )
+        self.send_gc_command(gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN)
 
     def __update_max_allowed_robots(self, referee: Referee) -> None:
         """Update the world state by adding or removing robots for each team to match

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -272,13 +272,6 @@ class Gamecontroller:
 
         :param game_stage: The current game stage from the referee message
         """
-        if game_stage == Referee.Stage.NORMAL_FIRST_HALF:
-            # skip to pre second half
-            new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE
-        else:
-            # reset game
-            new_stage = Referee.Stage.NORMAL_FIRST_HALF_PRE
-
         # reset game state
         self.simulator_proto_unix_io.send_proto(
             WorldState, create_default_world_state(num_robots=DIV_B_NUM_ROBOTS)
@@ -286,9 +279,23 @@ class Gamecontroller:
 
         ci_input = CiInput(timestamp=int(time.time_ns()))
         api_input = Input()
-        change = Change()
-        change.change_stage_change.new_stage = new_stage
-        api_input.change.CopyFrom(change)
+
+        if game_stage == Referee.Stage.NORMAL_FIRST_HALF:
+            # skip to pre second half
+            new_stage = Referee.Stage.NORMAL_SECOND_HALF_PRE
+            change = Change()
+            change.change_stage_change.new_stage = new_stage
+            api_input.change.CopyFrom(change)
+        else:
+            # reset game
+            api_input.reset_match = True
+            ci_input.api_inputs.append(api_input)
+            api_input = Input()
+            change = Change()
+            change.update_config_change.division = Division.DIV_B
+            change.update_config_change.match_type = MatchType.FRIENDLY
+            api_input.change.CopyFrom(change)
+
         ci_input.api_inputs.append(api_input)
 
         self.send_ci_input(ci_input)

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -282,6 +282,9 @@ class Gamecontroller:
             # end game
             self.__set_game_stage(Referee.Stage.POST_GAME)
 
+            # Race condition where events don't get resolved before setting new match settings
+            time.sleep(1)
+
             # reset match (start new game)
             ci_input = CiInput(timestamp=int(time.time_ns()))
             input_reset_match = Input()
@@ -297,7 +300,9 @@ class Gamecontroller:
 
             ci_input = CiInput(timestamp=int(time.time_ns()))
             input_reset_match = Input()
-            input_reset_match.change.update_config_change.match_type = MatchType.FRIENDLY
+            input_reset_match.change.update_config_change.match_type = (
+                MatchType.FRIENDLY
+            )
             ci_input.api_inputs.append(input_reset_match)
             self.send_ci_input(ci_input)
 
@@ -572,24 +577,26 @@ class Gamecontroller:
         :return: a list of CiOutput protos from the Gamecontroller
         """
         ci_input = CiInput(timestamp=int(time.time_ns()))
+
+        input_reset_match = Input()
+        input_reset_match.reset_match = True
+
         input_blue_update = Input()
-        input_blue_update.reset_match = True
         input_blue_update.change.update_team_state_change.CopyFrom(
             self.reset_team("BLUE", SslTeam.BLUE)
         )
 
         input_yellow_update = Input()
-        input_yellow_update.reset_match = True
         input_yellow_update.change.update_team_state_change.CopyFrom(
             self.reset_team("YELLOW", SslTeam.YELLOW)
         )
 
         input_game_update = Input()
-        input_game_update.reset_match = True
         input_game_update.change.update_config_change.CopyFrom(
             self.reset_game(division)
         )
 
+        ci_input.api_inputs.append(input_reset_match)
         ci_input.api_inputs.append(input_blue_update)
         ci_input.api_inputs.append(input_yellow_update)
         ci_input.api_inputs.append(input_game_update)

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -374,23 +374,7 @@ class Gamecontroller:
 
         :param referee: the referee protobuf message
         """
-        if referee.stage_time_left == self.last_stage_time_left:
-            if (
-                self.pause_start_timestamp
-                and (
-                    time_provider_instance.elapsed_time_ns()
-                    - self.pause_start_timestamp
-                )
-                * SECONDS_PER_NANOSECOND
-                >= self.NO_GAME_PROGRESS_DURATION_S
-            ):
-                logging.warning(f"Gamecontroller: Ending game early due unknown issue stopping game progress for {
-                    self.NO_GAME_PROGRESS_DURATION_S} seconds")
-                self.__handle_game_stage_change(Referee.Stage.NORMAL_SECOND_HALF)
-                self.pause_start_timestamp = None
-        else:
-            self.last_stage_time_left = referee.stage_time_left
-            self.pause_start_timestamp = time_provider_instance.elapsed_time_ns()
+        self.__handle_game_no_progress(referee)
 
         if referee.stage_time_left < 0:
             self.__handle_game_stage_change(referee.stage)
@@ -410,6 +394,34 @@ class Gamecontroller:
             self.__handle_placement_failed()
             self.processed_event_ids.add(placement_failed_events[0].id)
             self.processed_event_ids.add(placement_failed_events[1].id)
+
+    def __handle_game_no_progress(self, referee: Referee) -> None:
+        """Handle game stalling by ending early if there is no progress in game stage time for too long.
+
+        :param referee: the referee protobuf message
+        """
+        is_game_progressing = referee.stage_time_left != self.last_stage_time_left
+        self.last_stage_time_left = referee.stage_time_left
+
+        if is_game_progressing:
+            self.pause_start_timestamp = None
+            return
+
+        # First referee message after being paused
+        if self.pause_start_timestamp is None:
+            self.pause_start_timestamp = time_provider_instance.elapsed_time_ns()
+
+        pause_duration_s = (
+            time_provider_instance.elapsed_time_ns() - self.pause_start_timestamp
+        ) * SECONDS_PER_NANOSECOND
+
+        if pause_duration_s >= self.NO_GAME_PROGRESS_DURATION_S:
+            logging.warning(
+                f"Gamecontroller: Ending game early due unknown issue halting "
+                f"game progress for {self.NO_GAME_PROGRESS_DURATION_S} seconds"
+            )
+            self.__handle_game_stage_change(Referee.Stage.NORMAL_SECOND_HALF)
+            self.pause_start_timestamp = None
 
     def __handle_game_stage_change(self, game_stage: Referee.Stage) -> None:
         """Handle game stage change by advancing to the next half once first half is over

--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -158,7 +158,7 @@ class TigersAutoref:
 
         self._force_gamecontroller_to_accept_all_events()
         self._send_geometry()
-        self.gamecontroller.reset_team_info(Division.DIV_B)
+        self.gamecontroller.reset_match()
 
         self.gamecontroller.send_gc_command(
             gc_command=Command.Type.STOP, team=SslTeam.UNKNOWN

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -345,7 +345,6 @@ if __name__ == "__main__":
             Gamecontroller(
                 suppress_logs=(not args.verbose),
                 use_conventional_port=False,
-                automate_referee=args.ci_mode,
             )
             if args.launch_gc
             else contextlib.nullcontext()
@@ -478,6 +477,7 @@ if __name__ == "__main__":
             log_level=args.log_level,
         ) as yellow_fs, Gamecontroller(
             suppress_logs=(not args.verbose),
+            automate_referee=args.ci_mode,
         ) as gamecontroller, (
             # Here we only initialize autoref if the --enable_autoref flag is requested.
             # To avoid nested Python withs, the autoref is initialized as None when this flag doesn't exist.

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -343,7 +343,9 @@ if __name__ == "__main__":
 
         with (
             Gamecontroller(
-                suppress_logs=(not args.verbose), use_conventional_port=False
+                suppress_logs=(not args.verbose),
+                use_conventional_port=False,
+                automate_referee=args.ci_mode,
             )
             if args.launch_gc
             else contextlib.nullcontext()

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -13,13 +13,6 @@ from software.thunderscope.binary_context_managers.runtime_manager import (
 )
 from software.thunderscope.log.stats.stats import Stats
 
-protobuf_impl_type = api_implementation.Type()
-assert protobuf_impl_type == "upb", (
-    f"Trying to use the {protobuf_impl_type} protobuf implementation. "
-    "Please use the upb implementation, available in python protobuf version 4.21.0 and above."
-    f"The current version of protobuf is {google.protobuf.__version__}"
-)
-
 from software.thunderscope.thunderscope import Thunderscope
 from software.thunderscope.constants import LogLevels
 from software.thunderscope.binary_context_managers import *
@@ -40,8 +33,14 @@ from software.thunderscope.util import *
 from software.thunderscope.binary_context_managers.full_system import FullSystem
 from software.thunderscope.binary_context_managers.simulator import Simulator
 from software.thunderscope.binary_context_managers.game_controller import Gamecontroller
-
 from software.thunderscope.binary_context_managers.tigers_autoref import TigersAutoref
+
+protobuf_impl_type = api_implementation.Type()
+assert protobuf_impl_type == "upb", (
+    f"Trying to use the {protobuf_impl_type} protobuf implementation. "
+    "Please use the upb implementation, available in python protobuf version 4.21.0 and above."
+    f"The current version of protobuf is {google.protobuf.__version__}"
+)
 
 ###########################################################################
 #                         Thunderscope Main                               #

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -239,9 +239,10 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--record_stats",
-        action="store_true",
-        default=False,
-        help="Whether to record stats about fullsystem performance (during AI vs AI)",
+        action="store",
+        type=int,
+        default=0,
+        help="Record stats about fullsystem performance (during AI vs AI) for a set amount of time in minutes",
     )
 
     args = parser.parse_args()
@@ -421,6 +422,10 @@ if __name__ == "__main__":
             layout_path=args.layout,
         )
 
+        if args.record_stats:
+            args.ci_mode = True
+            args.enable_autoref = True
+
         def __ticker(tick_rate_ms: int) -> None:
             """Setup the world and tick simulation forever
 
@@ -545,7 +550,10 @@ if __name__ == "__main__":
                 # call so we need to somehow close it before doing our resource cleanup
                 exiter_thread = threading.Thread(
                     target=exit_poller,
-                    args=(CI_DURATION_S, lambda: tscope.close()),
+                    args=(
+                        args.record_stats if args.record_stats else CI_DURATION_S,
+                        lambda: tscope.close(),
+                    ),
                     daemon=True,
                 )
 

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -551,7 +551,9 @@ if __name__ == "__main__":
                 exiter_thread = threading.Thread(
                     target=exit_poller,
                     args=(
-                        args.record_stats if args.record_stats else CI_DURATION_S,
+                        (args.record_stats * SECONDS_PER_MINUTE)
+                        if args.record_stats
+                        else CI_DURATION_S,
                         lambda: tscope.close(),
                     ),
                     daemon=True,

--- a/src/software/thunderscope/util.py
+++ b/src/software/thunderscope/util.py
@@ -8,7 +8,6 @@ from proto.import_all_protos import *
 from proto.message_translation import tbots_protobuf
 from software.py_constants import (
     SECONDS_PER_MILLISECOND,
-    SECONDS_PER_NANOSECOND,
     NANOSECONDS_PER_MILLISECOND,
 )
 from software.thunderscope.constants import ProtoUnixIOTypes
@@ -36,10 +35,8 @@ def exit_poller(
     :param on_exit:         callback once the exit_duration time has elapsed
     :param poll_duration_s: interval between polling the time_provider for the current timestamp
     """
-    while (
-        time_provider_instance.elapsed_time_ns() * SECONDS_PER_NANOSECOND
-        <= exit_duration_s
-    ):
+    start_time_s = time.time()
+    while time.time() <= start_time_s + exit_duration_s:
         time.sleep(poll_duration_s)
 
     on_exit()


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

Implements the following improvements to stat recording:

1. Can run stat recording for a specific time (eg. 40 minutes) by running: 
`./tbots.py run thunderscope_main --record_stats 40` (this is real time / system time, not the sped up ci_mode time)
2. Starts a new match once a match's second half has ended
3. Implements a safeguard to check if match is not progressing to make sure stat recording for long periods of time is possible without human supervision

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Ran `./tbots.py run thunderscope_main --record_stats 40` and multiple games played out without any human input. Repeated this test for 30 minutes and 50 minutes as well, no human input was required.

Ran the same command, this time purposefully placing ball outside of play area after failed ball placement so that the game stops progressing. The safeguard restarts the game as expected and logs a warning.

The recorded stats in the `/tmp/tbots/stats/` directory have weird behavior; the goals, red cards, and yellow cards are taken straight from the referee messages so they reflect the current game, but the shots on net and shots blocked stats are carried over since we track those using our own code. This interaction will need to be addressed when implementing proper stat recording results for multiple games.

eg.

```
cat /tmp/tbots/stats/blue.toml

goals = "0"
red_cards = "0"
yellow_cards = "0"
shots_on_net = "56"
shots_blocked = "39"
```

~~Tested by running for 660 minutes, might have issue since there are only like 100 shots on net recorded which is pretty low for over 40 hours of simulated playtime. Did see a weird bug where robot was outside of the bounds of the field and the rest of the robots started moving very slow for a few seconds, perhaps this happened but for longer period of time.~~ **Nevermind, my computer just went to sleep. It gets up to like 1000+ on the stats after a few hours**

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e4558374-6099-4c75-a30e-95e72d82b976" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f5689894-c4cf-4834-9860-25d5d5dcc472" />

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

resolves #3633

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

There is a lot of refactoring of methods in the game_controller file that is not important for functionality but just makes code better to read. I understand this makes the code much more difficult to review so the key changes are noted below:

- Changes for automatically starting new games are in the `__handle_game_stage_change` method in the gamecontroller file. 
- Changes for record_stats for amount of minutes is in `thunderscope_main.py`. 
- Changes for the safeguard are in the `__automate_referee` method in the gamecontroller file.

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
