### PR TITLE
Fix inconsistent tick speeds

### DIFF
--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -153,7 +153,7 @@ static const double SECONDS_PER_MINUTE           = 60.0;
 static const double DEFAULT_SIMULATOR_TICK_RATE_SECONDS_PER_TICK =
     1.0 / 60.0;  // corresponds to 60 Hz
 static const double DEFAULT_SIMULATOR_TICK_RATE_MILLISECONDS_PER_TICK =
-    DEFAULT_SIMULATOR_TICK_RATE_SECONDS_PER_TICK * 1000;
+    DEFAULT_SIMULATOR_TICK_RATE_SECONDS_PER_TICK * MILLISECONDS_PER_SECOND;
 
 // The total number of robot ids on one team
 static const unsigned int MAX_ROBOT_IDS_PER_SIDE = 8;

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -456,7 +456,6 @@ ErForceSimulator::getRampedVelocityPrimitive(
 void ErForceSimulator::stepSimulation(const Duration& time_step)
 {
     current_time = current_time + time_step;
-    LOG(INFO) << static_cast<int>(current_time.toSeconds());
 
     SSLSimulationProto::RobotControl yellow_robot_control =
         updateSimulatorRobots(yellow_primitive_executor_map, *yellow_team_world_msg,

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -456,6 +456,7 @@ ErForceSimulator::getRampedVelocityPrimitive(
 void ErForceSimulator::stepSimulation(const Duration& time_step)
 {
     current_time = current_time + time_step;
+    LOG(INFO) << static_cast<int>(current_time.toSeconds());
 
     SSLSimulationProto::RobotControl yellow_robot_control =
         updateSimulatorRobots(yellow_primitive_executor_map, *yellow_team_world_msg,

--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -212,10 +212,6 @@ class TigersAutoref:
                 self.initial_timestamp + time_provider_instance.elapsed_time_ns()
             )
         )
-        print(
-            "autoref timestamp:",
-            int(time_provider_instance.elapsed_time_ns() * SECONDS_PER_NANOSECOND),
-        )
 
         ci_input.api_inputs.append(Input())
         ci_input.tracker_packet.CopyFrom(tracker_wrapper)

--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -73,6 +73,7 @@ class TigersAutoref:
         self.suppress_logs = suppress_logs
         self.tick_rate_ms = tick_rate_ms
         self.show_gui = show_gui
+        self.initial_timestamp = time.time_ns()
 
     def __enter__(self) -> TigersAutoref:
         if not os.path.exists("/opt/tbotspython/autoReferee/bin/autoReferee"):
@@ -206,7 +207,11 @@ class TigersAutoref:
 
         :return: a list of CiOutput protos received from the Gamecontroller
         """
-        ci_input = CiInput(timestamp=time_provider_instance.time_provider_ns())
+        ci_input = CiInput(
+            timestamp=int(
+                self.initial_timestamp + time_provider_instance.elapsed_time_ns()
+            )
+        )
         print(
             "autoref timestamp:",
             int(time_provider_instance.elapsed_time_ns() * SECONDS_PER_NANOSECOND),

--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -6,7 +6,6 @@ from software.networking.ssl_proto_communication import (
     SslSocketProtoParseException,
     SslSocket,
 )
-from software.py_constants import SECONDS_PER_NANOSECOND
 import software.python_bindings as tbots_cpp
 from software.thunderscope.binary_context_managers.game_controller import Gamecontroller
 from software.thunderscope.binary_context_managers.util import *

--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -75,6 +75,7 @@ class TigersAutoref(TimeProvider):
         self.tick_rate_ms = tick_rate_ms
         self.show_gui = show_gui
 
+        self.initial_timestamp = int(time.time_ns())
         self.current_timestamp = int(time.time_ns())
         self.timestamp_mutex = threading.Lock()
 
@@ -218,6 +219,13 @@ class TigersAutoref(TimeProvider):
         """
         with self.timestamp_mutex:
             ci_input = CiInput(timestamp=self.current_timestamp)
+            print(
+                "autoref timestamp:",
+                int(
+                    (self.current_timestamp - self.initial_timestamp)
+                    * SECONDS_PER_NANOSECOND
+                ),
+            )
 
         ci_input.api_inputs.append(Input())
         ci_input.tracker_packet.CopyFrom(tracker_wrapper)

--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -12,7 +12,7 @@ from software.thunderscope.binary_context_managers.game_controller import Gameco
 from software.thunderscope.binary_context_managers.util import *
 from software.thunderscope.proto_unix_io import ProtoUnixIO
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
-from software.thunderscope.time_provider import TimeProvider
+from software.thunderscope.time_provider import time_provider_instance
 from subprocess import Popen
 
 import queue
@@ -20,10 +20,9 @@ import logging
 import os
 import threading
 import time
-from typing import override
 
 
-class TigersAutoref(TimeProvider):
+class TigersAutoref:
     """A wrapper over the TigersAutoref binary. It coordinates communication between the
     Simulator, TigersAutoref and Gamecontroller.
 
@@ -75,10 +74,6 @@ class TigersAutoref(TimeProvider):
         self.tick_rate_ms = tick_rate_ms
         self.show_gui = show_gui
 
-        self.initial_timestamp = int(time.time_ns())
-        self.current_timestamp = int(time.time_ns())
-        self.timestamp_mutex = threading.Lock()
-
     def __enter__(self) -> TigersAutoref:
         if not os.path.exists("/opt/tbotspython/autoReferee/bin/autoReferee"):
             logging.warning(
@@ -97,11 +92,6 @@ class TigersAutoref(TimeProvider):
         self.auto_ref_wrapper_thread.start()
 
         return self
-
-    @override
-    def time_provider(self):
-        with self.timestamp_mutex:
-            return self.current_timestamp * SECONDS_PER_NANOSECOND
 
     def _force_gamecontroller_to_accept_all_events(self) -> list[CiOutput]:
         """Force the Gamecontroller to accept all game events proposed by the Autoref
@@ -202,10 +192,9 @@ class TigersAutoref(TimeProvider):
                     )
                 )
 
-            with self.timestamp_mutex:
-                self.current_timestamp += int(
-                    self.tick_rate_ms * NANOSECONDS_PER_MILLISECOND
-                )
+            time_provider_instance.tick_ns(
+                self.tick_rate_ms * NANOSECONDS_PER_MILLISECOND
+            )
 
     def _forward_to_gamecontroller(
         self, tracker_wrapper: proto.ssl_vision_wrapper_tracked_pb2.TrackerWrapperPacket
@@ -217,15 +206,11 @@ class TigersAutoref(TimeProvider):
 
         :return: a list of CiOutput protos received from the Gamecontroller
         """
-        with self.timestamp_mutex:
-            ci_input = CiInput(timestamp=self.current_timestamp)
-            print(
-                "autoref timestamp:",
-                int(
-                    (self.current_timestamp - self.initial_timestamp)
-                    * SECONDS_PER_NANOSECOND
-                ),
-            )
+        ci_input = CiInput(timestamp=time_provider_instance.time_provider_ns())
+        print(
+            "autoref timestamp:",
+            int(time_provider_instance.elapsed_time_ns() * SECONDS_PER_NANOSECOND),
+        )
 
         ci_input.api_inputs.append(Input())
         ci_input.tracker_packet.CopyFrom(tracker_wrapper)

--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -193,10 +193,6 @@ class TigersAutoref:
                     )
                 )
 
-            # time_provider_instance.tick_ns(
-            #     self.tick_rate_ms * NANOSECONDS_PER_MILLISECOND
-            # )
-
     def _forward_to_gamecontroller(
         self, tracker_wrapper: proto.ssl_vision_wrapper_tracked_pb2.TrackerWrapperPacket
     ) -> list[CiOutput]:

--- a/src/software/thunderscope/binary_context_managers/tigers_autoref.py
+++ b/src/software/thunderscope/binary_context_managers/tigers_autoref.py
@@ -6,7 +6,7 @@ from software.networking.ssl_proto_communication import (
     SslSocketProtoParseException,
     SslSocket,
 )
-from software.py_constants import NANOSECONDS_PER_MILLISECOND, SECONDS_PER_NANOSECOND
+from software.py_constants import SECONDS_PER_NANOSECOND
 import software.python_bindings as tbots_cpp
 from software.thunderscope.binary_context_managers.game_controller import Gamecontroller
 from software.thunderscope.binary_context_managers.util import *
@@ -192,9 +192,9 @@ class TigersAutoref:
                     )
                 )
 
-            time_provider_instance.tick_ns(
-                self.tick_rate_ms * NANOSECONDS_PER_MILLISECOND
-            )
+            # time_provider_instance.tick_ns(
+            #     self.tick_rate_ms * NANOSECONDS_PER_MILLISECOND
+            # )
 
     def _forward_to_gamecontroller(
         self, tracker_wrapper: proto.ssl_vision_wrapper_tracked_pb2.TrackerWrapperPacket

--- a/src/software/thunderscope/thunderscope_main.py
+++ b/src/software/thunderscope/thunderscope_main.py
@@ -546,7 +546,7 @@ if __name__ == "__main__":
                 # call so we need to somehow close it before doing our resource cleanup
                 exiter_thread = threading.Thread(
                     target=exit_poller,
-                    args=(autoref, CI_DURATION_S, lambda: tscope.close()),
+                    args=(CI_DURATION_S, lambda: tscope.close()),
                     daemon=True,
                 )
 

--- a/src/software/thunderscope/time_provider.py
+++ b/src/software/thunderscope/time_provider.py
@@ -1,12 +1,29 @@
-from abc import abstractmethod
+import threading
+import time
 
 
 class TimeProvider:
-    """An interface for an object that can provide time information"""
+    """A singleton class that can provide time information"""
 
-    @abstractmethod
-    def time_provider(self) -> float:
-        """Provide the current time in seconds since the epoch"""
-        raise NotImplementedError(
-            "abstract method time_provider called from base class"
-        )
+    def __init__(self) -> None:
+        """Constructs time provider with initial timestamp at nanoseconds since epoch"""
+        self._initial_timestamp = time.time_ns()
+        self._current_timestamp = self._initial_timestamp
+        self._timestamp_mutex = threading.Lock()
+
+    def time_provider_ns(self) -> int:
+        """... kind of a weird function"""
+        with self._timestamp_mutex:
+            return int(self._current_timestamp)
+
+    def elapsed_time_ns(self) -> int:
+        """Returns elapsed time since time provider was constructed in nanoseconds"""
+        return int(self.time_provider_ns() - self._initial_timestamp)
+
+    def tick_ns(self, delta_time_ns: float) -> None:
+        """Advances time provider by a delta time in nanoseconds"""
+        with self._timestamp_mutex:
+            self._current_timestamp += delta_time_ns
+
+
+time_provider_instance = TimeProvider()

--- a/src/software/thunderscope/time_provider.py
+++ b/src/software/thunderscope/time_provider.py
@@ -1,29 +1,23 @@
 import threading
-import time
 
 
 class TimeProvider:
     """A singleton class that can provide time information"""
 
     def __init__(self) -> None:
-        """Constructs time provider with initial timestamp at nanoseconds since epoch"""
-        self._initial_timestamp = time.time_ns()
-        self._current_timestamp = self._initial_timestamp
-        self._timestamp_mutex = threading.Lock()
+        """Constructs time provider with no elapsed time"""
+        self._elapsed_time = 0.0
+        self._mutex = threading.Lock()
 
-    def time_provider_ns(self) -> int:
-        """... kind of a weird function"""
-        with self._timestamp_mutex:
-            return int(self._current_timestamp)
-
-    def elapsed_time_ns(self) -> int:
-        """Returns elapsed time since time provider was constructed in nanoseconds"""
-        return int(self.time_provider_ns() - self._initial_timestamp)
+    def elapsed_time_ns(self) -> float:
+        """Returns elapsed time in nanoseconds since time provider was constructed"""
+        with self._mutex:
+            return self._elapsed_time
 
     def tick_ns(self, delta_time_ns: float) -> None:
-        """Advances time provider by a delta time in nanoseconds"""
-        with self._timestamp_mutex:
-            self._current_timestamp += delta_time_ns
+        """Advances elapsed time by a delta time in nanoseconds"""
+        with self._mutex:
+            self._elapsed_time += delta_time_ns
 
 
 time_provider_instance = TimeProvider()

--- a/src/software/thunderscope/time_provider.py
+++ b/src/software/thunderscope/time_provider.py
@@ -1,23 +1,17 @@
-import threading
-
-
 class TimeProvider:
     """A singleton class that can provide time information"""
 
     def __init__(self) -> None:
         """Constructs time provider with no elapsed time"""
         self._elapsed_time = 0.0
-        self._mutex = threading.Lock()
 
     def elapsed_time_ns(self) -> float:
         """Returns elapsed time in nanoseconds since time provider was constructed"""
-        with self._mutex:
-            return self._elapsed_time
+        return self._elapsed_time
 
     def tick_ns(self, delta_time_ns: float) -> None:
         """Advances elapsed time by a delta time in nanoseconds"""
-        with self._mutex:
-            self._elapsed_time += delta_time_ns
+        self._elapsed_time += delta_time_ns
 
 
 time_provider_instance = TimeProvider()

--- a/src/software/thunderscope/util.py
+++ b/src/software/thunderscope/util.py
@@ -6,12 +6,12 @@ if TYPE_CHECKING:
 
 from proto.import_all_protos import *
 from proto.message_translation import tbots_protobuf
-from software.py_constants import SECONDS_PER_MILLISECOND
+from software.py_constants import SECONDS_PER_MILLISECOND, SECONDS_PER_NANOSECOND
 from software.thunderscope.constants import ProtoUnixIOTypes
 from software.thunderscope.proto_unix_io import ProtoUnixIO
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
 
-from software.thunderscope.time_provider import TimeProvider
+from software.thunderscope.time_provider import time_provider_instance
 
 import queue
 import time
@@ -21,7 +21,6 @@ import software.python_bindings as tbots_cpp
 
 
 def exit_poller(
-    time_provider: TimeProvider,
     exit_duration_s: float,
     on_exit: Callable[[], None],
     poll_duration_s: float = 0.5,
@@ -29,13 +28,14 @@ def exit_poller(
     """Calls the on_exit callback once the elapsed exit_duration has passed from the start of this function call,
     polling every poll_duration using system time
 
-    :param time_provider:   used to compare all timestamps
     :param exit_duration_s: how long to poll from the start of this program before exiting
     :param on_exit:         callback once the exit_duration time has elapsed
     :param poll_duration_s: interval between polling the time_provider for the current timestamp
     """
-    time_now_s = time_provider.time_provider()
-    while time_provider.time_provider() <= (time_now_s + exit_duration_s):
+    while (
+        time_provider_instance.elapsed_time_ns() * SECONDS_PER_NANOSECOND
+        <= exit_duration_s
+    ):
         time.sleep(poll_duration_s)
 
     on_exit()

--- a/src/software/thunderscope/util.py
+++ b/src/software/thunderscope/util.py
@@ -6,7 +6,11 @@ if TYPE_CHECKING:
 
 from proto.import_all_protos import *
 from proto.message_translation import tbots_protobuf
-from software.py_constants import SECONDS_PER_MILLISECOND, SECONDS_PER_NANOSECOND
+from software.py_constants import (
+    SECONDS_PER_MILLISECOND,
+    SECONDS_PER_NANOSECOND,
+    NANOSECONDS_PER_MILLISECOND,
+)
 from software.thunderscope.constants import ProtoUnixIOTypes
 from software.thunderscope.proto_unix_io import ProtoUnixIO
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
@@ -69,7 +73,7 @@ def async_sim_ticker(
     blue_proto_unix_io.register_observer(PrimitiveSet, blue_primitive_set_buffer)
     yellow_proto_unix_io.register_observer(PrimitiveSet, yellow_primitive_set_buffer)
 
-    current_timestamp = 0
+    current_timestamp = time_provider_instance.time_provider_ns()
 
     while tscope.is_open():
         # flush primitive set buffers before sending the next tick
@@ -84,8 +88,11 @@ def async_sim_ticker(
         tick = SimulatorTick(milliseconds=tick_rate_ms)
         sim_proto_unix_io.send_proto(SimulatorTick, tick)
 
-        current_timestamp += tick_rate_ms
-        print("simulator timestamp:", int(current_timestamp / 1000))
+        time_provider_instance.tick_ns(tick_rate_ms * NANOSECONDS_PER_MILLISECOND)
+        print(
+            "simulator timestamp:",
+            int(time_provider_instance.elapsed_time_ns() * SECONDS_PER_NANOSECOND),
+        )
 
         while True:
             try:
@@ -93,6 +100,9 @@ def async_sim_ticker(
                 break
             except queue.Empty:
                 sim_proto_unix_io.send_proto(SimulatorTick, tick)
+                time_provider_instance.tick_ns(
+                    tick_rate_ms * NANOSECONDS_PER_MILLISECOND
+                )
 
         while True:
             try:
@@ -100,6 +110,9 @@ def async_sim_ticker(
                 break
             except queue.Empty:
                 sim_proto_unix_io.send_proto(SimulatorTick, tick)
+                time_provider_instance.tick_ns(
+                    tick_rate_ms * NANOSECONDS_PER_MILLISECOND
+                )
 
 
 def realtime_sim_ticker(
@@ -122,6 +135,7 @@ def realtime_sim_ticker(
         if simulation_state_message.is_playing:
             tick = SimulatorTick(milliseconds=tick_rate_ms)
             sim_proto_unix_io.send_proto(SimulatorTick, tick)
+            time_provider_instance.tick_ns(tick_rate_ms * NANOSECONDS_PER_MILLISECOND)
 
         time.sleep(per_tick_delay_s / simulation_state_message.simulation_speed)
 

--- a/src/software/thunderscope/util.py
+++ b/src/software/thunderscope/util.py
@@ -73,8 +73,6 @@ def async_sim_ticker(
     blue_proto_unix_io.register_observer(PrimitiveSet, blue_primitive_set_buffer)
     yellow_proto_unix_io.register_observer(PrimitiveSet, yellow_primitive_set_buffer)
 
-    current_timestamp = time_provider_instance.time_provider_ns()
-
     while tscope.is_open():
         # flush primitive set buffers before sending the next tick
         while (

--- a/src/software/thunderscope/util.py
+++ b/src/software/thunderscope/util.py
@@ -69,6 +69,8 @@ def async_sim_ticker(
     blue_proto_unix_io.register_observer(PrimitiveSet, blue_primitive_set_buffer)
     yellow_proto_unix_io.register_observer(PrimitiveSet, yellow_primitive_set_buffer)
 
+    current_timestamp = 0
+
     while tscope.is_open():
         # flush primitive set buffers before sending the next tick
         while (
@@ -81,6 +83,9 @@ def async_sim_ticker(
         # Tick simulation
         tick = SimulatorTick(milliseconds=tick_rate_ms)
         sim_proto_unix_io.send_proto(SimulatorTick, tick)
+
+        current_timestamp += tick_rate_ms
+        print("simulator timestamp:", int(current_timestamp / 1000))
 
         while True:
             try:

--- a/src/software/thunderscope/util.py
+++ b/src/software/thunderscope/util.py
@@ -85,12 +85,7 @@ def async_sim_ticker(
         # Tick simulation
         tick = SimulatorTick(milliseconds=tick_rate_ms)
         sim_proto_unix_io.send_proto(SimulatorTick, tick)
-
         time_provider_instance.tick_ns(tick_rate_ms * NANOSECONDS_PER_MILLISECOND)
-        print(
-            "simulator timestamp:",
-            int(time_provider_instance.elapsed_time_ns() * SECONDS_PER_NANOSECOND),
-        )
 
         while True:
             try:


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Issue was that both the simulator and autoref are being ticked at the same time step of `DEFAULT_SIMULATOR_TICK_RATE_MILLISECONDS_PER_TICK`, however, they tick at different rates and the timestamp variable to keep track of each are incremented at different rates.

**This solution refactors the TimeProvider class into a singleton class so that there is a single source for the current timestamp.**

[Screencast from 2026-03-21 12-38-43.webm](https://github.com/user-attachments/assets/f0d217fd-e050-44aa-9e43-f2daba6c2b7f)

Debug logs from before, simulator runs about 6x faster compared to autoref.

```
simulator timestamp: 316
simulator timestamp: 316
simulator timestamp: 316
simulator timestamp: 316
autoref timestamp: 53
simulator timestamp: 316
simulator timestamp: 316
simulator timestamp: 316
simulator timestamp: 316
simulator timestamp: 316
simulator timestamp: 316
simulator timestamp: 316
simulator timestamp: 317
autoref timestamp: 53
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
autoref timestamp: 53
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
simulator timestamp: 317
autoref timestamp: 53
simulator timestamp: 317
simulator timestamp: 317
```

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Ran thunderscope_main with all 4 combinations of ci_mode on/off and enable_autoref on/off. The time seems to be consistent when checking the CiInput messages sent to autoref and also the current_time in er_force_simulator.cpp which gets updated with each SimulatorTick message.

### Note about referee message timestamps

<img width="1539" height="51" alt="image" src="https://github.com/user-attachments/assets/a934858e-388a-4ba5-bf71-f27a2a3f12c4" />

The packet_timestamp in the Referee messages sent in the CiOutput messages to thunderscope are determined by ssl gamecontroller and it just uses unix epoch timestamp. This is why the match duration and also packet timestamp is still real time. This should have no effect on gameplay.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

resolves #3653 

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

N/A

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
