### PR TITLE
Added test for World::updateGameStateBall(const Ball &ball) in software/world/world.cpp

### DIFF
--- a/src/software/world/world_test.cpp
+++ b/src/software/world/world_test.cpp
@@ -54,6 +54,17 @@ class WorldTest : public ::testing::Test
     World world;
 };
 
+TEST_F(WorldTest, update_game_state_ball)
+{
+    // updateGameStateBall should not throw or affect the world's own ball_
+    Ball new_ball = Ball(Point(3, 4), Vector(1.0, -0.5), current_time);
+    world.updateGameStateBall(new_ball);
+
+    // The world's ball_ member should be unchanged
+    Ball initial_ball = Ball(Point(1, 2), Vector(-0.3, 0), current_time);
+    EXPECT_EQ(world.ball(), initial_ball);
+}
+
 TEST_F(WorldTest, construction_with_parameters)
 {
     // Check that objects used for construction are returned by the accessors


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

    Added test TEST_F(WorldTest, update_game_state_ball) for World::updateGameStateBall(const Ball &ball) in software/world/world.cpp

### Testing Done

    Test TEST_F(WorldTest, update_game_state_ball) ran successfully.
<img width="570" height="232" alt="Screenshot from 2026-03-28 12-25-54" src="https://github.com/user-attachments/assets/0f2caec0-1656-4e59-9ea0-04f41861ef5b" />


### Resolved Issues

    resolves #1682 

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
