### PR TITLE
Fix lint_and_format.sh compatibility issues for MacOS

### DIFF
--- a/environment_setup/macos_requirements.txt
+++ b/environment_setup/macos_requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint==24.12.2
+ansible-lint==26.4.0
 pyqtgraph==0.13.7
 thefuzz==0.19.0
 iterfzf==0.5.0.20.0
@@ -10,4 +10,3 @@ pyqt-toast-notification==1.3.2
 grpcio-tools==1.71.0
 platformio==6.1.18
 pyqt6==6.9.1
-

--- a/environment_setup/setup_software_mac.sh
+++ b/environment_setup/setup_software_mac.sh
@@ -68,6 +68,10 @@ sudo chmod +x "$CURR_DIR/../src/software/autoref/run_autoref.sh"
 sudo cp "$CURR_DIR/../src/software/autoref/DIV_B.txt" "/opt/tbotspython/autoReferee/config/geometry/DIV_B.txt"
 print_status_msg "Finished setting up AutoRef"
 
+print_status_msg "Install clang-format"
+install_clang_format $sys
+print_status_msg "Done installing clang-format"
+
 print_status_msg "Setting up cross compiler for robot software"
 install_cross_compiler $sys
 print_status_msg "Done setting up cross compiler for robot software"

--- a/environment_setup/setup_software_mac.sh
+++ b/environment_setup/setup_software_mac.sh
@@ -51,7 +51,6 @@ print_status_msg "Setting Up Python Environment"
 
 # Create virtual environment
 sudo python3.12 -m venv /opt/tbotspython
-chmod
 source /opt/tbotspython/bin/activate
 
 # Install Python dependencies

--- a/environment_setup/ubuntu24_requirements.txt
+++ b/environment_setup/ubuntu24_requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint==25.8.1
+ansible-lint==26.4.0
 pyqtgraph==0.13.7
 thefuzz==0.19.0
 iterfzf==0.5.0.20.0

--- a/environment_setup/util.sh
+++ b/environment_setup/util.sh
@@ -29,7 +29,11 @@ install_bazel() {
 }
 
 install_clang_format() {
-    ln -s /usr/bin/clang-format-14 /opt/tbotspython/bin/clang-format
+    if is_darwin $1; then
+        ln -s /opt/homebrew/bin/clang-format /opt/tbotspython/bin/clang-format
+    else
+        ln -s /usr/bin/clang-format-14 /opt/tbotspython/bin/clang-format
+    fi
 }
 
 install_cross_compiler() {

--- a/scripts/lint_and_format.sh
+++ b/scripts/lint_and_format.sh
@@ -25,7 +25,7 @@ function run_clang_format () {
     cd $BAZEL_ROOT_DIR
 
     # Generate extension string
-    # Formatted as -iname *.EXTENSION -o
+    # Formatted as -name *.EXTENSION -o
     EXTENSION_STRING=""
     for value in "${CLANG_FORMAT_EXTENSIONS[@]}"
     do
@@ -35,8 +35,8 @@ function run_clang_format () {
     # Find all the files that we want to format, and pass them to
     # clang-format as arguments
     # We remove the last -o flag from the extension string
-    find $CURR_DIR/../src/ ${EXTENSION_STRING::-2}  \
-        | xargs -I{} -n1000 $CLANG_BIN -i -style=file:$CURR_DIR/../.clang-format
+    find $CURR_DIR/../src ${EXTENSION_STRING% -o} \
+        | xargs $CLANG_BIN -i -style=file:$CURR_DIR/../.clang-format
 
     if [[ "$?" != 0 ]]; then
         printf "\n***Failed to run clang-format over all files!***\n\n"


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

On MacOS, lint_and_format.sh does not work as a result of many issues:

1. MacOS has bash 3.2 by default, and the syntax used on line 38 does not work on this version.
2. Xargs flags are not used properly on line 39, somehow this works on ubuntu but it really shouldn't
3. The clang-format binary is not sym linked to /opt/tbotspython/bin/clang-format in the mac setup script
4. The version of ansible-lint is outdated in macos_requirements.txt, which causes an error

This PR resolves these issues so that lint_and_format.sh works on MacOS.

Here is the output of lint_and_format.sh before the changes on macos.

```
❯ ./scripts/lint_and_format.sh
Fixing spelling...

./thunderscope/thunderscope_main.py:483: withs ==> with, widths
./thunderscope/wifi_communication_manager.py:158: iff ==> if  | disabled due to valid mathematical concept
./thunderscope/gl/graphics/gl_heatmap.py:80: uint ==> unit  | disabled due to being a data type
./thunderscope/gl/graphics/gl_heatmap.py:85: uint ==> unit  | disabled due to being a data type
Running clang-format over all files...

./scripts/lint_and_format.sh: line 38: -2: substring expression < 0
Running bazel buildifier to format all bazel BUILD files...

INFO: Invocation ID: f96c04a9-4acb-48fb-9906-e3eb4fe28951
INFO: Analyzed target //starlark/buildifier:buildifier.fix (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //starlark/buildifier:buildifier.fix up-to-date:
  bazel-bin/starlark/buildifier/buildifier.fix.bash
INFO: Elapsed time: 0.058s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/starlark/buildifier/buildifier.fix.bash

Running ruff to lint and format Python files...

warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`.
warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`.
No errors fixed (1510 fixes available with `--unsafe-fixes`).
169 files left unchanged
Adding table of contents to Markdown files...

Adding missing new lines to end of files...

Checking for merge conflict markers...

Running ansible-lint...

[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
[DEPRECATION WARNING]: Importing 'to_bytes' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.
Traceback (most recent call last):
  File "/opt/tbotspython/bin/ansible-lint", line 3, in <module>
    from ansiblelint.__main__ import _run_cli_entrypoint
  File "/opt/tbotspython/lib/python3.12/site-packages/ansiblelint/__main__.py", line 49, in <module>
    from ansiblelint import cli
  File "/opt/tbotspython/lib/python3.12/site-packages/ansiblelint/cli.py", line 30, in <module>
    from ansiblelint.yaml_utils import clean_json
  File "/opt/tbotspython/lib/python3.12/site-packages/ansiblelint/yaml_utils.py", line 33, in <module>
    from ansiblelint.utils import Task
  File "/opt/tbotspython/lib/python3.12/site-packages/ansiblelint/utils.py", line 49, in <module>
    from ansible.parsing.yaml.constructor import AnsibleConstructor, AnsibleMapping
ModuleNotFoundError: No module named 'ansible.parsing.yaml.constructor'

***Failed to lint and format Ansible files!***
```

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Messed up the formatting on some files and ran lint_and_format.sh on mac, they were fixed. **Note: formatting on c++ files may be different since there is different defaults for clang-format 20 vs 14. This will be resolved in #3678**

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
