### PR TITLE
Use er force simulator position data for pytest validations

### DIFF
--- a/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
+++ b/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
@@ -49,7 +49,7 @@ class HRVORobotEntersRegionAndStops:
 
         self.is_stationary = True
 
-    def get_validation_status(self, world: tbots.World) -> ValidationStatus:
+    def get_validation_status(self, world: tbots.World, simulator_state=None) -> ValidationStatus:
         """Checks if a specific robot id is in the provided region
         Then checks if that robot is stationary within a threshold for the provided number of ticks
 

--- a/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
+++ b/src/software/ai/navigator/trajectory/simulated_hrvo_test.py
@@ -49,7 +49,9 @@ class HRVORobotEntersRegionAndStops:
 
         self.is_stationary = True
 
-    def get_validation_status(self, world: tbots.World, simulator_state=None) -> ValidationStatus:
+    def get_validation_status(
+        self, world: tbots.World, simulator_state=None
+    ) -> ValidationStatus:
         """Checks if a specific robot id is in the provided region
         Then checks if that robot is stationary within a threshold for the provided number of ticks
 

--- a/src/software/simulated_tests/BUILD
+++ b/src/software/simulated_tests/BUILD
@@ -18,6 +18,7 @@ py_library(
         "//software:py_constants.so",
     ],
     deps = [
+        "//extlibs/er_force_sim/src/protobuf:erforce_py_proto",
         "//proto:import_all_protos",
         "//software/logger:py_logger",
         "//software/networking/unix:threaded_unix_listener_py",

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -200,6 +200,11 @@ class SimulatedTestRunner(TbotsTestRunner):
             if self.thunderscope and tick_duration_s > processing_time:
                 time.sleep(tick_duration_s - processing_time)
 
+            # Fetch the latest true simulator state (non-blocking; None if not yet available)
+            simulator_state = self.simulator_state_buffer.get(
+                block=False, return_cached=False
+            )
+
             # Validate
             (
                 eventually_validation_proto_set,
@@ -208,6 +213,7 @@ class SimulatedTestRunner(TbotsTestRunner):
                 world,
                 eventually_validation_sequence_set,
                 always_validation_sequence_set,
+                simulator_state=simulator_state,
             )
 
             # Set the test name

--- a/src/software/simulated_tests/tbots_test_runner.py
+++ b/src/software/simulated_tests/tbots_test_runner.py
@@ -1,4 +1,5 @@
 from proto.import_all_protos import *
+from extlibs.er_force_sim.src.protobuf.world_pb2 import SimulatorState
 from software.logger.logger import create_logger
 from software.thunderscope.thread_safe_buffer import ThreadSafeBuffer
 from abc import abstractmethod
@@ -46,12 +47,18 @@ class TbotsTestRunner:
         self.robot_status_buffer = ThreadSafeBuffer(
             buffer_size=1, protobuf_type=RobotStatus
         )
+        self.simulator_state_buffer = ThreadSafeBuffer(
+            buffer_size=20, protobuf_type=SimulatorState
+        )
 
         self.blue_full_system_proto_unix_io.register_observer(
             SSL_WrapperPacket, self.ssl_wrapper_buffer
         )
         self.blue_full_system_proto_unix_io.register_observer(
             RobotStatus, self.robot_status_buffer
+        )
+        self.blue_full_system_proto_unix_io.register_observer(
+            SimulatorState, self.simulator_state_buffer
         )
         if self.is_yellow_friendly:
             self.yellow_full_system_proto_unix_io.register_observer(

--- a/src/software/simulated_tests/validation/BUILD
+++ b/src/software/simulated_tests/validation/BUILD
@@ -33,6 +33,7 @@ py_library(
         "//software:python_bindings.so",
     ],
     deps = [
+        "//extlibs/er_force_sim/src/protobuf:erforce_py_proto",
         "//proto:software_py_proto",
         "//proto:tbots_py_proto",
         "//software/logger:py_logger",

--- a/src/software/simulated_tests/validation/avoid_collisions.py
+++ b/src/software/simulated_tests/validation/avoid_collisions.py
@@ -21,7 +21,9 @@ class RobotsDoNotCollide(Validation):
         self.fouled_robots = []
 
     @override
-    def get_validation_status(self, world: World, simulator_state=None) -> ValidationStatus:
+    def get_validation_status(
+        self, world: World, simulator_state=None
+    ) -> ValidationStatus:
         """Checks if any 2 robots in the world have collided
 
         :param world: the World message to validate

--- a/src/software/simulated_tests/validation/avoid_collisions.py
+++ b/src/software/simulated_tests/validation/avoid_collisions.py
@@ -21,7 +21,7 @@ class RobotsDoNotCollide(Validation):
         self.fouled_robots = []
 
     @override
-    def get_validation_status(self, world: World) -> ValidationStatus:
+    def get_validation_status(self, world: World, simulator_state=None) -> ValidationStatus:
         """Checks if any 2 robots in the world have collided
 
         :param world: the World message to validate

--- a/src/software/simulated_tests/validation/ball_enters_region.py
+++ b/src/software/simulated_tests/validation/ball_enters_region.py
@@ -17,7 +17,7 @@ class BallEntersRegion(Validation):
         self.ball_position = None
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the ball enters the provided regions
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/ball_enters_region.py
+++ b/src/software/simulated_tests/validation/ball_enters_region.py
@@ -5,6 +5,7 @@ from software.simulated_tests.validation.validation import (
     Validation,
     create_validation_geometry,
     create_validation_types,
+    get_ball_pos,
 )
 from typing import override
 
@@ -24,11 +25,9 @@ class BallEntersRegion(Validation):
         :return: FAILING until a ball enters any of the regions
                  PASSING when a ball enters
         """
-        self.ball_position = world.ball.current_state.global_position
+        self.ball_position = get_ball_pos(world, simulator_state)
         for region in self.regions:
-            if tbots_cpp.contains(
-                region, tbots_cpp.createPoint(world.ball.current_state.global_position)
-            ):
+            if tbots_cpp.contains(region, self.ball_position):
                 return ValidationStatus.PASSING
         return ValidationStatus.FAILING
 

--- a/src/software/simulated_tests/validation/ball_is_off_ground.py
+++ b/src/software/simulated_tests/validation/ball_is_off_ground.py
@@ -21,7 +21,7 @@ class BallIsOffGround(Validation):
         self.threshold = threshold
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the ball has is threshold meters off the ground
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/ball_kicked_in_direction.py
+++ b/src/software/simulated_tests/validation/ball_kicked_in_direction.py
@@ -33,7 +33,7 @@ class BallKickedInDirection(Validation):
         )
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the ball has been kicked in the expected direction
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/ball_kicked_in_direction.py
+++ b/src/software/simulated_tests/validation/ball_kicked_in_direction.py
@@ -5,6 +5,8 @@ from software.simulated_tests.validation.validation import (
     Validation,
     create_validation_geometry,
     create_validation_types,
+    get_ball_pos,
+    get_ball_vel,
 )
 from typing import override
 
@@ -40,13 +42,8 @@ class BallKickedInDirection(Validation):
         :return: FAILING if the ball has not been kicked in the expected direction
                  PASSING if the ball has been kicked in the expected direction
         """
-        ball_pos = world.ball.current_state.global_position
-        ball_vel = world.ball.current_state.global_velocity
-
-        point = tbots_cpp.Point(ball_pos.x_meters, ball_pos.y_meters)
-        vector = tbots_cpp.Vector(
-            ball_vel.x_component_meters, ball_vel.y_component_meters
-        )
+        point = get_ball_pos(world, simulator_state)
+        vector = get_ball_vel(world, simulator_state)
 
         ball = tbots_cpp.Ball(point, vector, tbots_cpp.Timestamp())
 

--- a/src/software/simulated_tests/validation/ball_moves_in_direction.py
+++ b/src/software/simulated_tests/validation/ball_moves_in_direction.py
@@ -24,7 +24,7 @@ class BallMovesForward(Validation):
         self.tolerance = tolerance
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if ball is moving forward
 
         :param world: The world msg to validate
@@ -84,7 +84,7 @@ class BallMovesForwardInRegions(BallMovesForward):
         self.regions = regions
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         for region in self.regions:
             if tbots.contains(
                 region, tbots.createPoint(world.ball.current_state.global_position)

--- a/src/software/simulated_tests/validation/ball_moves_in_direction.py
+++ b/src/software/simulated_tests/validation/ball_moves_in_direction.py
@@ -88,7 +88,9 @@ class BallMovesForwardInRegions(BallMovesForward):
     def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         for region in self.regions:
             if tbots.contains(region, get_ball_pos(world, simulator_state)):
-                return super().get_validation_status(world, simulator_state=simulator_state)
+                return super().get_validation_status(
+                    world, simulator_state=simulator_state
+                )
 
         return ValidationStatus.PASSING
 

--- a/src/software/simulated_tests/validation/ball_moves_in_direction.py
+++ b/src/software/simulated_tests/validation/ball_moves_in_direction.py
@@ -5,6 +5,7 @@ from software.simulated_tests.validation.validation import (
     Validation,
     create_validation_geometry,
     create_validation_types,
+    get_ball_pos,
 )
 from typing import override
 
@@ -31,7 +32,7 @@ class BallMovesForward(Validation):
         :return: FAILING if ball doesn't move in the direction
                  PASSING if ball moves in the direction
         """
-        current_ball_position = world.ball.current_state.global_position.x_meters
+        current_ball_position = get_ball_pos(world, simulator_state).x()
 
         # if max displacement is not set or current ball is moving in the right direction
         # set it and return PASSING
@@ -86,10 +87,8 @@ class BallMovesForwardInRegions(BallMovesForward):
     @override
     def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         for region in self.regions:
-            if tbots.contains(
-                region, tbots.createPoint(world.ball.current_state.global_position)
-            ):
-                return super().get_validation_status(world)
+            if tbots.contains(region, get_ball_pos(world, simulator_state)):
+                return super().get_validation_status(world, simulator_state=simulator_state)
 
         return ValidationStatus.PASSING
 

--- a/src/software/simulated_tests/validation/ball_speed_threshold.py
+++ b/src/software/simulated_tests/validation/ball_speed_threshold.py
@@ -22,7 +22,7 @@ class BallSpeedThreshold(Validation):
         self.speed_threshold = speed_threshold
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the ball speed is at or above some threshold
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/ball_speed_threshold.py
+++ b/src/software/simulated_tests/validation/ball_speed_threshold.py
@@ -7,6 +7,7 @@ from software.simulated_tests.validation.validation import (
     Validation,
     create_validation_geometry,
     create_validation_types,
+    get_ball_vel,
 )
 from typing import override
 
@@ -29,10 +30,7 @@ class BallSpeedThreshold(Validation):
         :return: FAILING if the ball speed is below some threshold
                  PASSING if the ball speed is at or above some threshold
         """
-        if (
-            tbots_cpp.createVector(world.ball.current_state.global_velocity).length()
-            >= self.speed_threshold
-        ):
+        if get_ball_vel(world, simulator_state).length() >= self.speed_threshold:
             return ValidationStatus.PASSING
 
         return ValidationStatus.FAILING

--- a/src/software/simulated_tests/validation/ball_stops_in_region.py
+++ b/src/software/simulated_tests/validation/ball_stops_in_region.py
@@ -16,7 +16,7 @@ class BallStopsInRegion(Validation):
         self.regions = regions if regions else []
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the ball stops in the provided regions
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/ball_stops_in_region.py
+++ b/src/software/simulated_tests/validation/ball_stops_in_region.py
@@ -26,9 +26,10 @@ class BallStopsInRegion(Validation):
                  PASSING when a ball stops in a region
         """
         for region in self.regions:
-            if tbots_cpp.contains(
-                region, get_ball_pos(world, simulator_state)
-            ) and get_ball_vel(world, simulator_state).length() <= 0.01:
+            if (
+                tbots_cpp.contains(region, get_ball_pos(world, simulator_state))
+                and get_ball_vel(world, simulator_state).length() <= 0.01
+            ):
                 return ValidationStatus.PASSING
 
         return ValidationStatus.FAILING

--- a/src/software/simulated_tests/validation/ball_stops_in_region.py
+++ b/src/software/simulated_tests/validation/ball_stops_in_region.py
@@ -5,6 +5,8 @@ from software.simulated_tests.validation.validation import (
     Validation,
     create_validation_geometry,
     create_validation_types,
+    get_ball_pos,
+    get_ball_vel,
 )
 from typing import override
 
@@ -25,13 +27,8 @@ class BallStopsInRegion(Validation):
         """
         for region in self.regions:
             if tbots_cpp.contains(
-                region, tbots_cpp.createPoint(world.ball.current_state.global_position)
-            ) and (
-                tbots_cpp.createVector(
-                    world.ball.current_state.global_velocity
-                ).length()
-                <= 0.01
-            ):
+                region, get_ball_pos(world, simulator_state)
+            ) and get_ball_vel(world, simulator_state).length() <= 0.01:
                 return ValidationStatus.PASSING
 
         return ValidationStatus.FAILING

--- a/src/software/simulated_tests/validation/delay_validation.py
+++ b/src/software/simulated_tests/validation/delay_validation.py
@@ -16,7 +16,7 @@ class DelayValidation(Validation):
         self.validation = validation
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks validation after delay finished. If during delay, returns default validation status.
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/duration_validation.py
+++ b/src/software/simulated_tests/validation/duration_validation.py
@@ -23,7 +23,7 @@ class DurationValidation(Validation):
         self.validation = validation
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if validation has been consecutively PASSING for a duration.
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/excessive_dribbling.py
+++ b/src/software/simulated_tests/validation/excessive_dribbling.py
@@ -19,7 +19,7 @@ class ExcessivelyDribbling(Validation):
         self.dribbling_error_margin = 0.05
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if any friendly robot is excessively dribbling the ball past the max dribble displacement
         minus the dribbling error margin
 

--- a/src/software/simulated_tests/validation/excessive_dribbling.py
+++ b/src/software/simulated_tests/validation/excessive_dribbling.py
@@ -5,6 +5,7 @@ from software.simulated_tests.validation.validation import (
     Validation,
     create_validation_geometry,
     create_validation_types,
+    get_ball_pos,
 )
 from typing import override
 
@@ -27,7 +28,7 @@ class ExcessivelyDribbling(Validation):
         :return: FAILING when the robot is excessively dribbling
                  PASSING when the robot is not excessively dribbling
         """
-        ball_position = tbots_cpp.createPoint(world.ball.current_state.global_position)
+        ball_position = get_ball_pos(world, simulator_state)
         for robot in world.friendly_team.team_robots:
             if tbots_cpp.Robot(robot).isNearDribbler(
                 ball_position, self.dribbler_tolerance

--- a/src/software/simulated_tests/validation/friendly_has_ball_possession.py
+++ b/src/software/simulated_tests/validation/friendly_has_ball_possession.py
@@ -22,7 +22,7 @@ class FriendlyHasBallPossession(Validation):
         self.tolerance = tolerance
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if friendly robot has possession of the ball
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/friendly_has_ball_possession.py
+++ b/src/software/simulated_tests/validation/friendly_has_ball_possession.py
@@ -5,6 +5,7 @@ from software.simulated_tests.validation.validation import (
     Validation,
     create_validation_geometry,
     create_validation_types,
+    get_ball_pos,
 )
 from typing import override
 
@@ -29,7 +30,7 @@ class FriendlyHasBallPossession(Validation):
         :return: FAILING when friendly robot does not have possession of the ball
                  PASSING when friendly robot has possession of the ball
         """
-        ball_position = tbots_cpp.createPoint(world.ball.current_state.global_position)
+        ball_position = get_ball_pos(world, simulator_state)
         for robot in world.friendly_team.team_robots:
             if self.robot_id is not None and robot.id != self.robot_id:
                 continue

--- a/src/software/simulated_tests/validation/friendly_receives_ball_slow.py
+++ b/src/software/simulated_tests/validation/friendly_receives_ball_slow.py
@@ -24,7 +24,7 @@ class FriendlyReceivesBallSlow(FriendlyHasBallPossession):
         self.max_receive_speed = max_receive_speed
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the specified robot receives the ball too fast
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/friendly_receives_ball_slow.py
+++ b/src/software/simulated_tests/validation/friendly_receives_ball_slow.py
@@ -1,4 +1,3 @@
-import software.python_bindings as tbots_cpp
 from proto.import_all_protos import *
 
 from software.simulated_tests.validation.validation import (
@@ -34,7 +33,10 @@ class FriendlyReceivesBallSlow(FriendlyHasBallPossession):
                  PASSING if the ball is not near the dribbler, or if it is near
                          the dribbler at a speed slower than the max
         """
-        if super().get_validation_status(world, simulator_state=simulator_state) == ValidationStatus.PASSING:
+        if (
+            super().get_validation_status(world, simulator_state=simulator_state)
+            == ValidationStatus.PASSING
+        ):
             ball_velocity = get_ball_vel(world, simulator_state)
             if ball_velocity.length() - self.max_receive_speed > 0.2:
                 return ValidationStatus.FAILING

--- a/src/software/simulated_tests/validation/friendly_receives_ball_slow.py
+++ b/src/software/simulated_tests/validation/friendly_receives_ball_slow.py
@@ -3,6 +3,7 @@ from proto.import_all_protos import *
 
 from software.simulated_tests.validation.validation import (
     create_validation_types,
+    get_ball_vel,
 )
 from software.simulated_tests.validation.friendly_has_ball_possession import (
     FriendlyHasBallPossession,
@@ -33,10 +34,8 @@ class FriendlyReceivesBallSlow(FriendlyHasBallPossession):
                  PASSING if the ball is not near the dribbler, or if it is near
                          the dribbler at a speed slower than the max
         """
-        if super().get_validation_status(world) == ValidationStatus.PASSING:
-            ball_velocity = tbots_cpp.createVector(
-                world.ball.current_state.global_velocity
-            )
+        if super().get_validation_status(world, simulator_state=simulator_state) == ValidationStatus.PASSING:
+            ball_velocity = get_ball_vel(world, simulator_state)
             if ball_velocity.length() - self.max_receive_speed > 0.2:
                 return ValidationStatus.FAILING
         return ValidationStatus.PASSING

--- a/src/software/simulated_tests/validation/friendly_team_scored.py
+++ b/src/software/simulated_tests/validation/friendly_team_scored.py
@@ -16,7 +16,7 @@ class FriendlyTeamScored(Validation):
         self.region = tbots_cpp.Field.createSSLDivisionBField().enemyGoal()
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the ball enters the provided regions
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/or_validation.py
+++ b/src/software/simulated_tests/validation/or_validation.py
@@ -17,9 +17,12 @@ class OrValidation(Validation):
         self.validations = validations
 
     @override
-    def get_validation_status(self, world):
+    def get_validation_status(self, world, simulator_state=None):
         for validation in self.validations:
-            if validation.get_validation_status(world) == ValidationStatus.PASSING:
+            if (
+                validation.get_validation_status(world, simulator_state=simulator_state)
+                == ValidationStatus.PASSING
+            ):
                 return ValidationStatus.PASSING
         return ValidationStatus.FAILING
 

--- a/src/software/simulated_tests/validation/robot_at_angular_velocity.py
+++ b/src/software/simulated_tests/validation/robot_at_angular_velocity.py
@@ -24,7 +24,7 @@ class RobotAtAngularVelocity(Validation):
         self.threshold = threshold
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the robot is at the expected angular velocity
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/robot_at_orientation.py
+++ b/src/software/simulated_tests/validation/robot_at_orientation.py
@@ -26,7 +26,7 @@ class RobotAtOrientation(Validation):
         self.threshold = threshold
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the robot is at the expected orientation
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/robot_at_position.py
+++ b/src/software/simulated_tests/validation/robot_at_position.py
@@ -27,7 +27,7 @@ class RobotAtPosition(Validation):
         self.threshold = threshold
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the robot is at the target position
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/robot_enters_placement_region.py
+++ b/src/software/simulated_tests/validation/robot_enters_placement_region.py
@@ -26,7 +26,7 @@ class RobotEntersPlacementRegion(Validation):
         )
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if robots enter the ball placement region
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/robot_enters_region.py
+++ b/src/software/simulated_tests/validation/robot_enters_region.py
@@ -24,7 +24,7 @@ class MinNumberOfRobotsEntersRegion(Validation):
         self.robot_in_zone = {}
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if a specific number of robots enter the provided set of regions
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/robot_enters_region_and_stops.py
+++ b/src/software/simulated_tests/validation/robot_enters_region_and_stops.py
@@ -32,7 +32,7 @@ class RobotEntersRegionAndStops(RobotEntersRegion):
         self.passing_robot_id = None
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if a robot is in the provided region
         Then checks if that robot is stationary within a threshold for the provided number of ticks
 

--- a/src/software/simulated_tests/validation/robot_received_ball.py
+++ b/src/software/simulated_tests/validation/robot_received_ball.py
@@ -22,7 +22,7 @@ class RobotReceivedBall(Validation):
         self.tolerance = tolerance
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the specific robot has received the ball
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/robot_received_ball.py
+++ b/src/software/simulated_tests/validation/robot_received_ball.py
@@ -5,6 +5,7 @@ from software.simulated_tests.validation.validation import (
     Validation,
     create_validation_geometry,
     create_validation_types,
+    get_ball_pos,
 )
 from typing import override
 
@@ -29,7 +30,7 @@ class RobotReceivedBall(Validation):
         :return: FAILING when the robot does not have the ball
                  PASSING when the robot has the ball
         """
-        ball_position = tbots_cpp.createPoint(world.ball.current_state.global_position)
+        ball_position = get_ball_pos(world, simulator_state)
         for robot in world.friendly_team.team_robots:
             if robot.id == self.robot_id:
                 if tbots_cpp.Robot(robot).isNearDribbler(ball_position, self.tolerance):

--- a/src/software/simulated_tests/validation/robot_speed_threshold.py
+++ b/src/software/simulated_tests/validation/robot_speed_threshold.py
@@ -23,7 +23,7 @@ class RobotSpeedThreshold(Validation):
         self.speed_threshold = speed_threshold
 
     @override
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         """Checks if the friendly robots' speed is at or above some threshold
 
         :param world: The world msg to validate

--- a/src/software/simulated_tests/validation/validation.py
+++ b/src/software/simulated_tests/validation/validation.py
@@ -8,7 +8,7 @@ class Validation:
     """A validation function"""
 
     @abstractmethod
-    def get_validation_status(self, world) -> ValidationStatus:
+    def get_validation_status(self, world, simulator_state=None) -> ValidationStatus:
         raise NotImplementedError("get_validation_status is not implemented")
 
     @abstractmethod
@@ -66,15 +66,16 @@ def create_validation_types(validation_class):
         """
         self.validation = validation_class(*args, **kwargs)
 
-    def flip_validation(self, world):
+    def flip_validation(self, world, simulator_state=None):
         """Flip the validation status
 
         :param world: The world msg to validate on
+        :param simulator_state: The simulator state with true positions, or None
         """
         return {
             ValidationStatus.FAILING: ValidationStatus.PASSING,
             ValidationStatus.PASSING: ValidationStatus.FAILING,
-        }[self.validation.get_validation_status(world)]
+        }[self.validation.get_validation_status(world, simulator_state=simulator_state)]
 
     # Generate the types: specifically, all Eventually validations will return
     # EVENTUALLY when get_validation_type is called, and all Always validations
@@ -95,7 +96,10 @@ def create_validation_types(validation_class):
             + repr(self.validation),
             "get_validation_type": lambda self: ValidationType.EVENTUALLY,
             "get_validation_status": lambda self,
-            world: self.validation.get_validation_status(world),
+            world,
+            simulator_state=None: self.validation.get_validation_status(
+                world, simulator_state=simulator_state
+            ),
         },
     )
 
@@ -107,7 +111,11 @@ def create_validation_types(validation_class):
             "__repr__": lambda self: "EventuallyFalseValidation: "
             + repr(self.validation),
             "get_validation_type": lambda self: ValidationType.EVENTUALLY,
-            "get_validation_status": lambda self, world: flip_validation(self, world),
+            "get_validation_status": lambda self,
+            world,
+            simulator_state=None: flip_validation(
+                self, world, simulator_state=simulator_state
+            ),
         },
     )
 
@@ -119,7 +127,10 @@ def create_validation_types(validation_class):
             "__repr__": lambda self: "AlwaysTrueValidation: " + repr(self.validation),
             "get_validation_type": lambda self: ValidationType.ALWAYS,
             "get_validation_status": lambda self,
-            world: self.validation.get_validation_status(world),
+            world,
+            simulator_state=None: self.validation.get_validation_status(
+                world, simulator_state=simulator_state
+            ),
         },
     )
 
@@ -130,7 +141,11 @@ def create_validation_types(validation_class):
             **common,
             "__repr__": lambda self: "AlwaysFalseValidation: " + repr(self.validation),
             "get_validation_type": lambda self: ValidationType.ALWAYS,
-            "get_validation_status": lambda self, world: flip_validation(self, world),
+            "get_validation_status": lambda self,
+            world,
+            simulator_state=None: flip_validation(
+                self, world, simulator_state=simulator_state
+            ),
         },
     )
 
@@ -138,7 +153,10 @@ def create_validation_types(validation_class):
 
 
 def run_validation_sequence_sets(
-    world, eventually_validation_sequence_set, always_validation_sequence_set
+    world,
+    eventually_validation_sequence_set,
+    always_validation_sequence_set,
+    simulator_state=None,
 ):
     """Given both eventually and always validation sequence sets, (and world)
     run validation and aggregate the results in a validation proto set.
@@ -170,7 +188,7 @@ def run_validation_sequence_sets(
         validation_proto = ValidationProto()
 
         # Get status
-        status = validation.get_validation_status(world)
+        status = validation.get_validation_status(world, simulator_state=simulator_state)
 
         # Create validation proto
         validation_proto.status = status

--- a/src/software/simulated_tests/validation/validation.py
+++ b/src/software/simulated_tests/validation/validation.py
@@ -188,7 +188,9 @@ def run_validation_sequence_sets(
         validation_proto = ValidationProto()
 
         # Get status
-        status = validation.get_validation_status(world, simulator_state=simulator_state)
+        status = validation.get_validation_status(
+            world, simulator_state=simulator_state
+        )
 
         # Create validation proto
         validation_proto.status = status

--- a/src/software/simulated_tests/validation/validation.py
+++ b/src/software/simulated_tests/validation/validation.py
@@ -4,6 +4,20 @@ from proto.validation_pb2 import *
 from abc import abstractmethod
 
 
+def get_ball_pos(world, simulator_state=None):
+    """Return true ball position from simulator if available, else from world."""
+    if simulator_state is not None and simulator_state.HasField("ball"):
+        return tbots_cpp.Point(simulator_state.ball.p_x, simulator_state.ball.p_y)
+    return tbots_cpp.createPoint(world.ball.current_state.global_position)
+
+
+def get_ball_vel(world, simulator_state=None):
+    """Return true ball velocity from simulator if available, else from world."""
+    if simulator_state is not None and simulator_state.HasField("ball"):
+        return tbots_cpp.Vector(simulator_state.ball.v_x, simulator_state.ball.v_y)
+    return tbots_cpp.createVector(world.ball.current_state.global_velocity)
+
+
 class Validation:
     """A validation function"""
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description
Resolves:
#3684 

Previously, our validations checks the ball/robot locations with the sensor fused data. That is not ideal, because we should be testing against the ground truth, which is the positional data generated directly from the er-force simulator.

This ticket accomplishes this by passing in a simulator state in validations and using its locations. When nothing is passed, validation falls back to using sensor fused data.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Works locally.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues
#3684 
<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
