### PR TITLE
Fix bazel refresh_compile_commands

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -137,6 +137,7 @@ use_repo(
     "boost",
 )
 
+# Temporary workaround while https://github.com/hedronvision/bazel-compile-commands-extractor/pull/219 is not merged
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 archive_override(
     module_name = "hedron_compile_commands",

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -137,12 +137,12 @@ use_repo(
     "boost",
 )
 
-bazel_dep(name = "hedron_compile_commands", version = "1.0.5", dev_dependency = True)
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 archive_override(
     module_name = "hedron_compile_commands",
-    sha256 = "658122cfb1f25be76ea212b00f5eb047d8e2adc8bcf923b918461f2b1e37cdf2",
-    strip_prefix = "bazel-compile-commands-extractor-4f28899228fb3ad0126897876f147ca15026151e",
-    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/4f28899228fb3ad0126897876f147ca15026151e.tar.gz",
+    sha256 = "ba3feefdf57b6d4c749e3c4abfa86f3673e7db364cb13acfc3496dce6ea801a3",
+    strip_prefix = "bazel-compile-commands-extractor-f5fbd4cee671d8d908f37c83abaf70fba5928fc7",
+    url = "https://github.com/mikael-s-persson/bazel-compile-commands-extractor/archive/f5fbd4cee671d8d908f37c83abaf70fba5928fc7.tar.gz",
 )
 
 bazel_dep(name = "platformio_rules", repo_name = "platformio_rules")


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

The `bazel run //:refresh_compile_commands` command is currently not working on MacOS due to a bug https://github.com/hedronvision/bazel-compile-commands-extractor/issues/199 that doesn't allow targets with only header files. https://github.com/hedronvision/bazel-compile-commands-extractor/pull/219 fixes that issue but has not been merged because of some stability reason for hedronvision's internal usage of the tool. So, this PR just changes the source of the hedron_compile_commands dependency in MODULE.bazel to a fork which contains the fix for this bug. **NOTE: I have no idea why it is only an issue on MacOS; it seems like it should be an issue on Ubuntu as well.**

LOGS BEFORE FIX:

```
❯ bazel run //:refresh_compile_commands
INFO: Invocation ID: 928cc7fd-2406-476a-9a3b-6dae020205e5
INFO: Analyzed target //:refresh_compile_commands (105 packages loaded, 1483 targets configured).
INFO: Found 1 target...
Target //:refresh_compile_commands up-to-date:
  bazel-bin/refresh_compile_commands
  bazel-bin/refresh_compile_commands.check_python_version.py
  bazel-bin/refresh_compile_commands.py
INFO: Elapsed time: 0.503s, Critical Path: 0.01s
INFO: 12 processes: 2 disk cache hit, 10 internal.
INFO: Build completed successfully, 12 total actions
INFO: Running command line: bazel-bin/refresh_compile_commands
>>> Analyzing commands used in //software/...
WARNING: Build options --features and --host_features have changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
>>> A source file you compile doesn't (yet) exist: software/embedded/velocity_controller/pid_controller_test.cpp
    It's probably a generated file, and you haven't yet run a build to generate it.
    That's OK; your code doesn't even have to compile for this tool to work.
    If you can, though, you might want to run a build of your code with --keep_going.
        That way everything possible is generated, browsable and indexed for autocomplete.
    However, if you have *already* built your code, and generated the missing file...
        Please make sure you're supplying this tool with the same flags you use to build.
        You can either use a refresh_compile_commands rule or the special -- syntax. Please see the README.
        [Supplying flags normally won't work. That just causes this tool to be built with those flags.]
    Continuing gracefully...
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_avah/e8ab241f4ad621b3c5fd12a59f9a954c/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.runfiles/_main/refresh_compile_commands.check_python_version.py", line 15, in <module>
    refresh_compile_commands.main()
  File "/private/var/tmp/_bazel_avah/e8ab241f4ad621b3c5fd12a59f9a954c/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.runfiles/_main/refresh_compile_commands.py", line 1420, in main
    compile_command_entries.extend(_get_commands(target, flags))
  File "/private/var/tmp/_bazel_avah/e8ab241f4ad621b3c5fd12a59f9a954c/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.runfiles/_main/refresh_compile_commands.py", line 1279, in _get_commands
    yield from _convert_compile_commands(parsed_aquery_output)
  File "/private/var/tmp/_bazel_avah/e8ab241f4ad621b3c5fd12a59f9a954c/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.runfiles/_main/refresh_compile_commands.py", line 1159, in _convert_compile_commands
    for source_files, header_files, compile_command_args in outputs:
                                                            ^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.13/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 619, in result_iterator
    yield _result_or_cancel(fs.pop())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.13/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 317, in _result_or_cancel
    return fut.result(timeout)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.13/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.13/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/opt/homebrew/Cellar/python@3.12/3.12.13/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_avah/e8ab241f4ad621b3c5fd12a59f9a954c/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.runfiles/_main/refresh_compile_commands.py", line 1123, in _get_cpp_command_for_files
    source_files, header_files = _get_files(compile_action)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_avah/e8ab241f4ad621b3c5fd12a59f9a954c/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.runfiles/_main/refresh_compile_commands.py", line 627, in _get_files
    assert source_file_candidates, f"No source files found in compile args: {compile_action.arguments}.\nPlease file an issue with this information!"
           ^^^^^^^^^^^^^^^^^^^^^^
AssertionError: No source files found in compile args: ['external/rules_cc++cc_configure_extension+local_config_cc/cc_wrapper.sh', '-xc++-header', '-fsyntax-only', '-U_FORTIFY_SOURCE', '-fstack-protector', '-Wall', '-Wthread-safety', '-Wself-assign', '-Wunused-but-set-parameter', '-Wno-free-nonheap-object', '-fcolor-diagnostics', '-fno-omit-frame-pointer', '-std=c++17', '-mmacosx-version-min=14.5', '-MD', '-MF', 'bazel-out/darwin_arm64-fastbuild/bin/external/abseil-cpp+/absl/strings/_objs/string_view/string_view.h.d', '-iquote', 'external/abseil-cpp+', '-iquote', 'bazel-out/darwin_arm64-fastbuild/bin/external/abseil-cpp+', '-isystem', 'external/abseil-cpp+', '-isystem', 'bazel-out/darwin_arm64-fastbuild/bin/external/abseil-cpp+', '-DCURRENT_ROBOT_VERSION=2026', '-std=c++2a', '-DG3_DYNAMIC_LOGGING', '-Wall', '-Wextra', '-Wc++98-compat-extra-semi', '-Wcast-qual', '-Wconversion', '-Wdeprecated-pragma', '-Wfloat-overflow-conversion', '-Wfloat-zero-conversion', '-Wfor-loop-analysis', '-Wformat-security', '-Wgnu-redeclared-enum', '-Winfinite-recursion', '-Winvalid-constexpr', '-Wliteral-conversion', '-Wmissing-declarations', '-Woverlength-strings', '-Wpointer-arith', '-Wself-assign', '-Wshadow-all', '-Wshorten-64-to-32', '-Wsign-conversion', '-Wstring-conversion', '-Wtautological-overlap-compare', '-Wtautological-unsigned-zero-compare', '-Wundef', '-Wuninitialized', '-Wunreachable-code', '-Wunused-comparison', '-Wunused-local-typedefs', '-Wunused-result', '-Wvla', '-Wwrite-strings', '-Wno-float-conversion', '-Wno-implicit-float-conversion', '-Wno-implicit-int-float-conversion', '-Wno-unknown-warning-option', '-DNOMINMAX', '-Wvla', '-c', 'external/abseil-cpp+/absl/strings/string_view.h', '-o', 'bazel-out/darwin_arm64-fastbuild/bin/external/abseil-cpp+/absl/strings/_objs/string_view/string_view.h.processed', '-no-canonical-prefixes', '-Wno-builtin-macro-redefined', '-D__DATE__="redacted"', '-D__TIMESTAMP__="redacted"', '-D__TIME__="redacted"'].
```

LOGS AFTER FIX:

```
❯ bazel run //:refresh_compile_commands
INFO: Invocation ID: 10e12b0a-c453-43c0-8f05-9b7503945653
WARNING: Build options --features and --host_features have changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
INFO: Analyzed target //:refresh_compile_commands (105 packages loaded, 1483 targets configured).
INFO: Found 1 target...
Target //:refresh_compile_commands up-to-date:
  bazel-bin/refresh_compile_commands
  bazel-bin/refresh_compile_commands.check_python_version.py
  bazel-bin/refresh_compile_commands.py
INFO: Elapsed time: 1.188s, Critical Path: 0.00s
INFO: 2 processes: 10 action cache hit, 2 internal.
INFO: Build completed successfully, 2 total actions
INFO: Running command line: bazel-bin/refresh_compile_commands
>>> Analyzing commands used in //software/...
WARNING: Build options --features and --host_features have changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
>>> Finished extracting commands for //software/...
>>> Analyzing commands used in //proto/...
>>> Finished extracting commands for //proto/...
>>> Analyzing commands used in //extlibs/...
>>> Finished extracting commands for //extlibs/...
>>> Analyzing commands used in //shared/...
>>> Finished extracting commands for //shared/...
```

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

- On master, ran `bazel run //:refresh_compile_commands` and compile_commands.json was generated successfully Ubuntu but not MacOS.
- After change, ran `bazel run //:refresh_compile_commands` and compile_commands.json was generated successfully on both MacOS and Ubuntu.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

(didn't make an issue for this small fix)

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

N/A

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
