### PR TITLE
Pass in delta_time dynamically for prim exec

### DIFF
--- a/src/software/embedded/primitive_executor.cpp
+++ b/src/software/embedded/primitive_executor.cpp
@@ -11,13 +11,8 @@
 #include "software/physics/velocity_conversion_util.h"
 
 PrimitiveExecutor::PrimitiveExecutor(
-    const Duration time_step, const robot_constants::RobotConstants& robot_constants,
-    const TeamColour friendly_team_colour, const RobotId robot_id)
-    : current_primitive_(),
-      friendly_team_colour_(friendly_team_colour),
-      robot_constants_(robot_constants),
-      time_step_(time_step),
-      robot_id_(robot_id)
+    const Duration time_step, const robot_constants::RobotConstants& robot_constants)
+    : current_primitive_(), robot_constants_(robot_constants), time_step_(time_step)
 {
 }
 
@@ -36,11 +31,6 @@ void PrimitiveExecutor::updatePrimitive(const TbotsProto::Primitive& primitive_m
 
         time_since_trajectory_creation_ = Duration::fromSeconds(VISION_TO_ROBOT_DELAY_S);
     }
-}
-
-void PrimitiveExecutor::setStopPrimitive()
-{
-    current_primitive_ = *createStopPrimitiveProto();
 }
 
 void PrimitiveExecutor::updateVelocity(const Vector& local_velocity,
@@ -144,9 +134,4 @@ std::unique_ptr<TbotsProto::DirectControlPrimitive> PrimitiveExecutor::stepPrimi
         }
     }
     return std::make_unique<TbotsProto::DirectControlPrimitive>();
-}
-
-void PrimitiveExecutor::setRobotId(const RobotId robot_id)
-{
-    robot_id_ = robot_id;
 }

--- a/src/software/embedded/primitive_executor.cpp
+++ b/src/software/embedded/primitive_executor.cpp
@@ -11,8 +11,8 @@
 #include "software/physics/velocity_conversion_util.h"
 
 PrimitiveExecutor::PrimitiveExecutor(
-    const Duration time_step, const robot_constants::RobotConstants& robot_constants)
-    : current_primitive_(), robot_constants_(robot_constants), time_step_(time_step)
+    const robot_constants::RobotConstants& robot_constants)
+    : current_primitive_(), robot_constants_(robot_constants)
 {
 }
 
@@ -78,9 +78,9 @@ AngularVelocity PrimitiveExecutor::getTargetAngularVelocity()
 
 
 std::unique_ptr<TbotsProto::DirectControlPrimitive> PrimitiveExecutor::stepPrimitive(
-    TbotsProto::PrimitiveExecutorStatus& status)
+    TbotsProto::PrimitiveExecutorStatus& status, Duration delta_time)
 {
-    time_since_trajectory_creation_ += time_step_;
+    time_since_trajectory_creation_ += delta_time;
     status.set_running_primitive(true);
 
     switch (current_primitive_.primitive_case())

--- a/src/software/embedded/primitive_executor.h
+++ b/src/software/embedded/primitive_executor.h
@@ -17,24 +17,15 @@ class PrimitiveExecutor
      * @param time_step Time step which this primitive executor operates in
      * @param robot_constants The robot constants for the robot which uses this primitive
      * executor
-     * @param friendly_team_colour The colour of the friendly team
-     * @param robot_id The id of the robot which uses this primitive executor
      */
     explicit PrimitiveExecutor(const Duration time_step,
-                               const robot_constants::RobotConstants& robot_constants,
-                               const TeamColour friendly_team_colour,
-                               const RobotId robot_id);
+                               const robot_constants::RobotConstants& robot_constants);
 
     /**
      * Update primitive executor with a new Primitive
      * @param primitive_msg The primitive to start
      */
     void updatePrimitive(const TbotsProto::Primitive& primitive_msg);
-
-    /**
-     * Set the current primitive to the stop primitive
-     */
-    void setStopPrimitive();
 
     /**
      * Update primitive executor with the current velocity of the robot
@@ -44,12 +35,6 @@ class PrimitiveExecutor
      */
     void updateVelocity(const Vector& local_velocity,
                         const AngularVelocity& angular_velocity);
-
-    /**
-     * Set the robot id
-     * @param robot_id The id of the robot which uses this primitive executor
-     */
-    void setRobotId(RobotId robot_id);
 
     /**
      * Steps the current primitive and returns a direct control primitive with the
@@ -81,7 +66,6 @@ class PrimitiveExecutor
     Vector velocity_;
     AngularVelocity angular_velocity_;
     Angle orientation_;
-    TeamColour friendly_team_colour_;
     robot_constants::RobotConstants robot_constants_;
     std::optional<TrajectoryPath> trajectory_path_;
     std::optional<BangBangTrajectory1DAngular> angular_trajectory_;
@@ -89,7 +73,6 @@ class PrimitiveExecutor
     // TODO (#2855): Add dynamic time_step to `stepPrimitive` and remove this constant
     // time step to be used, in Seconds
     Duration time_step_;
-    RobotId robot_id_;
 
     // Estimated delay between a vision frame to AI processing to robot executing
     static constexpr double VISION_TO_ROBOT_DELAY_S = 0.03;

--- a/src/software/embedded/primitive_executor.h
+++ b/src/software/embedded/primitive_executor.h
@@ -14,12 +14,10 @@ class PrimitiveExecutor
    public:
     /**
      * Constructor
-     * @param time_step Time step which this primitive executor operates in
      * @param robot_constants The robot constants for the robot which uses this primitive
      * executor
      */
-    explicit PrimitiveExecutor(const Duration time_step,
-                               const robot_constants::RobotConstants& robot_constants);
+    explicit PrimitiveExecutor(const robot_constants::RobotConstants& robot_constants);
 
     /**
      * Update primitive executor with a new Primitive
@@ -39,13 +37,15 @@ class PrimitiveExecutor
     /**
      * Steps the current primitive and returns a direct control primitive with the
      * target wheel velocities
+     *
      * @param status The status of the primitive executor, set to false if current
      * primitive is a Stop primitive
+     * @param delta_time The elapsed time since the last primitive step
      *
      * @returns DirectControlPrimitive The direct control primitive msg
      */
     std::unique_ptr<TbotsProto::DirectControlPrimitive> stepPrimitive(
-        TbotsProto::PrimitiveExecutorStatus& status);
+        TbotsProto::PrimitiveExecutorStatus& status, Duration delta_time);
 
    private:
     /*
@@ -69,10 +69,6 @@ class PrimitiveExecutor
     robot_constants::RobotConstants robot_constants_;
     std::optional<TrajectoryPath> trajectory_path_;
     std::optional<BangBangTrajectory1DAngular> angular_trajectory_;
-
-    // TODO (#2855): Add dynamic time_step to `stepPrimitive` and remove this constant
-    // time step to be used, in Seconds
-    Duration time_step_;
 
     // Estimated delay between a vision frame to AI processing to robot executing
     static constexpr double VISION_TO_ROBOT_DELAY_S = 0.03;

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -84,7 +84,7 @@ Thunderloop::Thunderloop(const robot_constants::RobotConstants& robot_constants,
       kick_constant_(std::stoi(toml_config_client_->get(ROBOT_KICK_CONSTANT_CONFIG_KEY))),
       chip_pulse_width_(
           std::stoi(toml_config_client_->get(ROBOT_CHIP_PULSE_WIDTH_CONFIG_KEY))),
-      primitive_executor_(Duration::fromSeconds(1.0 / loop_hz), robot_constants)
+      primitive_executor_(robot_constants)
 {
     waitForNetworkUp();
 
@@ -287,7 +287,7 @@ void Thunderloop::runLoop()
                 }
 
                 direct_control_ =
-                    *primitive_executor_.stepPrimitive(primitive_executor_status_);
+                    *primitive_executor_.stepPrimitive(primitive_executor_status_, Duration::fromSeconds(1.0 / loop_hz_));
             }
 
             thunderloop_status_.set_primitive_executor_step_time_ms(

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -286,8 +286,8 @@ void Thunderloop::runLoop()
                     primitive_executor_.updatePrimitive(*createStopPrimitiveProto());
                 }
 
-                direct_control_ =
-                    *primitive_executor_.stepPrimitive(primitive_executor_status_, Duration::fromSeconds(1.0 / loop_hz_));
+                direct_control_ = *primitive_executor_.stepPrimitive(
+                    primitive_executor_status_, Duration::fromSeconds(1.0 / loop_hz_));
             }
 
             thunderloop_status_.set_primitive_executor_step_time_ms(

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -71,7 +71,6 @@ extern "C"
 
 Thunderloop::Thunderloop(const robot_constants::RobotConstants& robot_constants,
                          bool enable_log_merging, const int loop_hz)
-    // TODO (#2495): Set the friendly team colour
     : toml_config_client_(std::make_unique<TomlConfigClient>(TOML_CONFIG_FILE_PATH)),
       motor_status_(std::nullopt),
       robot_constants_(robot_constants),
@@ -84,8 +83,7 @@ Thunderloop::Thunderloop(const robot_constants::RobotConstants& robot_constants,
       kick_constant_(std::stoi(toml_config_client_->get(ROBOT_KICK_CONSTANT_CONFIG_KEY))),
       chip_pulse_width_(
           std::stoi(toml_config_client_->get(ROBOT_CHIP_PULSE_WIDTH_CONFIG_KEY))),
-      primitive_executor_(Duration::fromSeconds(1.0 / loop_hz), robot_constants,
-                          TeamColour::YELLOW, robot_id_)
+      primitive_executor_(Duration::fromSeconds(1.0 / loop_hz), robot_constants)
 {
     waitForNetworkUp();
 

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 
 #include "proto/message_translation/tbots_protobuf.h"
+#include "proto/primitive/primitive_msg_factory.h"
 #include "proto/robot_crash_msg.pb.h"
 #include "proto/robot_status_msg.pb.h"
 #include "proto/tbots_software_msgs.pb.h"
@@ -282,7 +283,7 @@ void Thunderloop::runLoop()
 
                 if (nanoseconds_elapsed_since_last_primitive > PACKET_TIMEOUT_NS)
                 {
-                    primitive_executor_.setStopPrimitive();
+                    primitive_executor_.updatePrimitive(*createStopPrimitiveProto());
                 }
 
                 direct_control_ =

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -281,15 +281,13 @@ void ErForceSimulator::setRobots(
         if (side == gameController::Team::BLUE)
         {
             auto robot_primitive_executor = std::make_shared<PrimitiveExecutor>(
-                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants,
-                TeamColour::BLUE, id);
+                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants);
             blue_primitive_executor_map.insert({id, robot_primitive_executor});
         }
         else
         {
             auto robot_primitive_executor = std::make_shared<PrimitiveExecutor>(
-                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants,
-                TeamColour::YELLOW, id);
+                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants);
             yellow_primitive_executor_map.insert({id, robot_primitive_executor});
         }
     }

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -20,10 +20,10 @@ ErForceSimulator::ErForceSimulator(const TbotsProto::FieldType& field_type,
                                    const robot_constants::RobotConstants& robot_constants,
                                    std::unique_ptr<RealismConfigErForce>& realism_config,
                                    const bool ramping,
-                                   double primitive_executor_time_step)
+                                   Duration primitive_executor_time_step)
     : yellow_team_world_msg(std::make_unique<TbotsProto::World>()),
       blue_team_world_msg(std::make_unique<TbotsProto::World>()),
-      primitive_executor_time_step_s(primitive_executor_time_step),
+      primitive_executor_time_step(primitive_executor_time_step),
       frame_number(0),
       euclidean_to_four_wheel(robot_constants),
       robot_constants(robot_constants),
@@ -280,14 +280,14 @@ void ErForceSimulator::setRobots(
     {
         if (side == gameController::Team::BLUE)
         {
-            auto robot_primitive_executor = std::make_shared<PrimitiveExecutor>(
-                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants);
+            auto robot_primitive_executor =
+                std::make_shared<PrimitiveExecutor>(robot_constants);
             blue_primitive_executor_map.insert({id, robot_primitive_executor});
         }
         else
         {
-            auto robot_primitive_executor = std::make_shared<PrimitiveExecutor>(
-                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants);
+            auto robot_primitive_executor =
+                std::make_shared<PrimitiveExecutor>(robot_constants);
             yellow_primitive_executor_map.insert({id, robot_primitive_executor});
         }
     }
@@ -389,15 +389,17 @@ SSLSimulationProto::RobotControl ErForceSimulator::updateSimulatorRobots(
         TbotsProto::PrimitiveExecutorStatus status;  // Added for compilation
         if (ramping)
         {
-            auto direct_control_no_ramp = primitive_executor->stepPrimitive(status);
-            direct_control              = getRampedVelocityPrimitive(
-                             current_velocity_map.at(robot_id).first,
-                             current_velocity_map.at(robot_id).second, *direct_control_no_ramp,
-                             primitive_executor_time_step_s);
+            auto direct_control_no_ramp =
+                primitive_executor->stepPrimitive(status, primitive_executor_time_step);
+            direct_control = getRampedVelocityPrimitive(
+                current_velocity_map.at(robot_id).first,
+                current_velocity_map.at(robot_id).second, *direct_control_no_ramp,
+                primitive_executor_time_step);
         }
         else
         {
-            direct_control = primitive_executor->stepPrimitive(status);
+            direct_control =
+                primitive_executor->stepPrimitive(status, primitive_executor_time_step);
         }
 
         auto command = *getRobotCommandFromDirectControl(
@@ -411,8 +413,7 @@ std::unique_ptr<TbotsProto::DirectControlPrimitive>
 ErForceSimulator::getRampedVelocityPrimitive(
     const Vector current_local_velocity,
     const AngularVelocity current_local_angular_velocity,
-    TbotsProto::DirectControlPrimitive& target_velocity_primitive,
-    const double& time_to_ramp)
+    TbotsProto::DirectControlPrimitive& target_velocity_primitive, Duration time_to_ramp)
 {
     TbotsProto::MotorControl_DirectVelocityControl direct_velocity =
         target_velocity_primitive.motor_control().direct_velocity_control();
@@ -435,7 +436,7 @@ ErForceSimulator::getRampedVelocityPrimitive(
         euclidean_to_four_wheel.getWheelVelocity(current_euclidean_velocity);
 
     WheelSpace_t ramped_four_wheel = euclidean_to_four_wheel.rampWheelVelocity(
-        current_wheel_velocity, target_wheel_velocity, time_to_ramp);
+        current_wheel_velocity, target_wheel_velocity, time_to_ramp.toSeconds());
 
     EuclideanSpace_t ramped_euclidean =
         euclidean_to_four_wheel.getEuclideanVelocity(ramped_four_wheel);

--- a/src/software/simulation/er_force_simulator.h
+++ b/src/software/simulation/er_force_simulator.h
@@ -27,12 +27,12 @@ class ErForceSimulator
      * @param robot_constants The robot constants
      * @param realism_config realism configuration
      */
-    explicit ErForceSimulator(const TbotsProto::FieldType& field_type,
-                              const robot_constants::RobotConstants& robot_constants,
-                              std::unique_ptr<RealismConfigErForce>& realism_config,
-                              const bool ramping = false,
-                              double primitive_executor_time_step_s =
-                                  DEFAULT_SIMULATOR_TICK_RATE_SECONDS_PER_TICK);
+    explicit ErForceSimulator(
+        const TbotsProto::FieldType& field_type,
+        const robot_constants::RobotConstants& robot_constants,
+        std::unique_ptr<RealismConfigErForce>& realism_config, const bool ramping = false,
+        Duration primitive_executor_time_step_s =
+            Duration::fromSeconds(DEFAULT_SIMULATOR_TICK_RATE_SECONDS_PER_TICK));
     ErForceSimulator()  = delete;
     ~ErForceSimulator() = default;
 
@@ -202,7 +202,7 @@ class ErForceSimulator
         const Vector current_local_velocity,
         const AngularVelocity current_local_angular_velocity,
         TbotsProto::DirectControlPrimitive& target_velocity_primitive,
-        const double& time_to_ramp);
+        Duration time_to_ramp);
 
     // Map of Robot id to Primitive Executor
     std::unordered_map<unsigned int, std::shared_ptr<PrimitiveExecutor>>
@@ -212,7 +212,7 @@ class ErForceSimulator
     std::unique_ptr<TbotsProto::World> yellow_team_world_msg;
     std::unique_ptr<TbotsProto::World> blue_team_world_msg;
 
-    double primitive_executor_time_step_s;
+    Duration primitive_executor_time_step;
     unsigned int frame_number;
 
     // The current time.


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

**This is a stacked PR: #3756 #3758 #3759 #3760.**

This PR removes the time_step field in PrimitiveExecutor and instead adds an extra delta_time argument to stepPrimitive() so that we allow for a dynamic time step.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

resolves #2855

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
