### PR TITLE
Use RobotState instead of individual variables for prim exec

### DIFF
--- a/src/software/embedded/primitive_executor.cpp
+++ b/src/software/embedded/primitive_executor.cpp
@@ -12,7 +12,9 @@
 
 PrimitiveExecutor::PrimitiveExecutor(
     const robot_constants::RobotConstants& robot_constants)
-    : current_primitive_(), robot_constants_(robot_constants)
+    : state_(Point(), Vector(), Angle(), AngularVelocity()),
+      current_primitive_(),
+      robot_constants_(robot_constants)
 {
 }
 
@@ -22,12 +24,13 @@ void PrimitiveExecutor::updatePrimitive(const TbotsProto::Primitive& primitive_m
 
     if (current_primitive_.has_move())
     {
-        trajectory_path_ = createTrajectoryPathFromParams(
-            current_primitive_.move().xy_traj_params(), velocity_, robot_constants_);
+        trajectory_path_ =
+            createTrajectoryPathFromParams(current_primitive_.move().xy_traj_params(),
+                                           state_.velocity(), robot_constants_);
 
         angular_trajectory_ =
             createAngularTrajectoryFromParams(current_primitive_.move().w_traj_params(),
-                                              angular_velocity_, robot_constants_);
+                                              state_.angularVelocity(), robot_constants_);
 
         time_since_trajectory_creation_ = Duration::fromSeconds(VISION_TO_ROBOT_DELAY_S);
     }
@@ -36,16 +39,17 @@ void PrimitiveExecutor::updatePrimitive(const TbotsProto::Primitive& primitive_m
 void PrimitiveExecutor::updateVelocity(const Vector& local_velocity,
                                        const AngularVelocity& angular_velocity)
 {
-    Vector actual_global_velocity = localToGlobalVelocity(local_velocity, orientation_);
-    velocity_                     = actual_global_velocity;
-    angular_velocity_             = angular_velocity;
+    Vector actual_global_velocity =
+        localToGlobalVelocity(local_velocity, state_.orientation());
+    state_.setVelocity(actual_global_velocity);
+    state_.setAngularVelocity(angular_velocity);
 }
 
 Vector PrimitiveExecutor::getTargetLinearVelocity()
 {
     Vector local_velocity = globalToLocalVelocity(
         trajectory_path_->getVelocity(time_since_trajectory_creation_.toSeconds()),
-        orientation_);
+        state_.orientation());
     Point position =
         trajectory_path_->getPosition(time_since_trajectory_creation_.toSeconds());
     double distance_to_destination =
@@ -61,13 +65,13 @@ Vector PrimitiveExecutor::getTargetLinearVelocity()
 
 AngularVelocity PrimitiveExecutor::getTargetAngularVelocity()
 {
-    orientation_ =
-        angular_trajectory_->getPosition(time_since_trajectory_creation_.toSeconds());
+    state_.setOrientation(
+        angular_trajectory_->getPosition(time_since_trajectory_creation_.toSeconds()));
 
     AngularVelocity angular_velocity =
         angular_trajectory_->getVelocity(time_since_trajectory_creation_.toSeconds());
     Angle orientation_to_destination =
-        orientation_.minDiff(angular_trajectory_->getDestination());
+        state_.orientation().minDiff(angular_trajectory_->getDestination());
     if (orientation_to_destination.toDegrees() < 5)
     {
         angular_velocity *= orientation_to_destination.toDegrees() / 5;

--- a/src/software/embedded/primitive_executor.cpp
+++ b/src/software/embedded/primitive_executor.cpp
@@ -11,13 +11,8 @@
 #include "software/physics/velocity_conversion_util.h"
 
 PrimitiveExecutor::PrimitiveExecutor(
-    const Duration time_step, const robot_constants::RobotConstants& robot_constants,
-    const TeamColour friendly_team_colour, const RobotId robot_id)
-    : current_primitive_(),
-      friendly_team_colour_(friendly_team_colour),
-      robot_constants_(robot_constants),
-      time_step_(time_step),
-      robot_id_(robot_id)
+    const Duration time_step, const robot_constants::RobotConstants& robot_constants)
+    : current_primitive_(), robot_constants_(robot_constants), time_step_(time_step)
 {
 }
 
@@ -36,11 +31,6 @@ void PrimitiveExecutor::updatePrimitive(const TbotsProto::Primitive& primitive_m
 
         time_since_trajectory_creation_ = Duration::fromSeconds(VISION_TO_ROBOT_DELAY_S);
     }
-}
-
-void PrimitiveExecutor::setStopPrimitive()
-{
-    current_primitive_ = *createStopPrimitiveProto();
 }
 
 void PrimitiveExecutor::updateVelocity(const Vector& local_velocity,
@@ -144,9 +134,4 @@ std::unique_ptr<TbotsProto::DirectControlPrimitive> PrimitiveExecutor::stepPrimi
         }
     }
     return std::make_unique<TbotsProto::DirectControlPrimitive>();
-}
-
-void PrimitiveExecutor::setRobotId(const RobotId robot_id)
-{
-    robot_id_ = robot_id;
 }

--- a/src/software/embedded/primitive_executor.cpp
+++ b/src/software/embedded/primitive_executor.cpp
@@ -34,13 +34,12 @@ void PrimitiveExecutor::updatePrimitive(const TbotsProto::Primitive& primitive_m
     }
 }
 
-void PrimitiveExecutor::updateVelocity(const Vector& local_velocity,
-                                       const AngularVelocity& angular_velocity)
+void PrimitiveExecutor::updateState(const RobotState& state)
 {
     Vector actual_global_velocity =
-        localToGlobalVelocity(local_velocity, state_.orientation());
+        localToGlobalVelocity(state.localVelocity(), state_.orientation());
     state_.setVelocity(actual_global_velocity);
-    state_.setAngularVelocity(angular_velocity);
+    state_.setAngularVelocity(state.angularVelocity());
 }
 
 Vector PrimitiveExecutor::getTargetLinearVelocity()

--- a/src/software/embedded/primitive_executor.cpp
+++ b/src/software/embedded/primitive_executor.cpp
@@ -12,9 +12,7 @@
 
 PrimitiveExecutor::PrimitiveExecutor(
     const robot_constants::RobotConstants& robot_constants)
-    : state_(Point(), Vector(), Angle(), AngularVelocity()),
-      current_primitive_(),
-      robot_constants_(robot_constants)
+    : current_primitive_(), robot_constants_(robot_constants)
 {
 }
 

--- a/src/software/embedded/primitive_executor.cpp
+++ b/src/software/embedded/primitive_executor.cpp
@@ -11,8 +11,8 @@
 #include "software/physics/velocity_conversion_util.h"
 
 PrimitiveExecutor::PrimitiveExecutor(
-    const Duration time_step, const robot_constants::RobotConstants& robot_constants)
-    : current_primitive_(), robot_constants_(robot_constants), time_step_(time_step)
+    const robot_constants::RobotConstants& robot_constants)
+    : current_primitive_(), robot_constants_(robot_constants)
 {
 }
 
@@ -78,9 +78,9 @@ AngularVelocity PrimitiveExecutor::getTargetAngularVelocity()
 
 
 std::unique_ptr<TbotsProto::DirectControlPrimitive> PrimitiveExecutor::stepPrimitive(
-    TbotsProto::PrimitiveExecutorStatus& status)
+    TbotsProto::PrimitiveExecutorStatus& status, Duration delta_time)
 {
-    time_since_trajectory_creation_ += time_step_;
+    time_since_trajectory_creation_ += delta_time;
     status.set_running_primitive(true);
 
     switch (current_primitive_.primitive_case())

--- a/src/software/embedded/primitive_executor.h
+++ b/src/software/embedded/primitive_executor.h
@@ -61,11 +61,9 @@ class PrimitiveExecutor
      */
     AngularVelocity getTargetAngularVelocity();
 
+    RobotState state_;
     TbotsProto::Primitive current_primitive_;
     Duration time_since_trajectory_creation_;
-    Vector velocity_;
-    AngularVelocity angular_velocity_;
-    Angle orientation_;
     robot_constants::RobotConstants robot_constants_;
     std::optional<TrajectoryPath> trajectory_path_;
     std::optional<BangBangTrajectory1DAngular> angular_trajectory_;

--- a/src/software/embedded/primitive_executor.h
+++ b/src/software/embedded/primitive_executor.h
@@ -26,13 +26,11 @@ class PrimitiveExecutor
     void updatePrimitive(const TbotsProto::Primitive& primitive_msg);
 
     /**
-     * Update primitive executor with the current velocity of the robot
+     * Update primitive executor with the state of the robot
      *
-     * @param local_velocity The current _local_ velocity
-     * @param angular_velocity The current angular velocity
+     * @param state The current robot state
      */
-    void updateVelocity(const Vector& local_velocity,
-                        const AngularVelocity& angular_velocity);
+    void updateState(const RobotState& state);
 
     /**
      * Steps the current primitive and returns a direct control primitive with the

--- a/src/software/embedded/primitive_executor.h
+++ b/src/software/embedded/primitive_executor.h
@@ -17,24 +17,15 @@ class PrimitiveExecutor
      * @param time_step Time step which this primitive executor operates in
      * @param robot_constants The robot constants for the robot which uses this primitive
      * executor
-     * @param friendly_team_colour The colour of the friendly team
-     * @param robot_id The id of the robot which uses this primitive executor
      */
     explicit PrimitiveExecutor(const Duration time_step,
-                               const robot_constants::RobotConstants& robot_constants,
-                               const TeamColour friendly_team_colour,
-                               const RobotId robot_id);
+                               const robot_constants::RobotConstants& robot_constants);
 
     /**
      * Update primitive executor with a new Primitive
      * @param primitive_msg The primitive to start
      */
     void updatePrimitive(const TbotsProto::Primitive& primitive_msg);
-
-    /**
-     * Set the current primitive to the stop primitive
-     */
-    void setStopPrimitive();
 
     /**
      * Update primitive executor with the current velocity of the robot
@@ -44,12 +35,6 @@ class PrimitiveExecutor
      */
     void updateVelocity(const Vector& local_velocity,
                         const AngularVelocity& angular_velocity);
-
-    /**
-     * Set the robot id
-     * @param robot_id The id of the robot which uses this primitive executor
-     */
-    void setRobotId(RobotId robot_id);
 
     /**
      * Steps the current primitive and returns a direct control primitive with the
@@ -81,7 +66,6 @@ class PrimitiveExecutor
     Vector velocity_;
     AngularVelocity angular_velocity_;
     Angle orientation_;
-    TeamColour friendly_team_colour_;
     robot_constants::RobotConstants robot_constants_;
     std::optional<TrajectoryPath> trajectory_path_;
     std::optional<BangBangTrajectory1DAngular> angular_trajectory_;
@@ -89,7 +73,6 @@ class PrimitiveExecutor
     // TODO (#2855): Add dynamic time_step to `stepPrimitive` and remove this constant
     // time step to be used, in Seconds
     Duration time_step_;
-    RobotId robot_id_;
 
     // Estimated delay between a vision frame to AI processing to robot executing
     static constexpr double VISION_TO_ROBOT_DELAY_S = 0.03;

--- a/src/software/embedded/primitive_executor.h
+++ b/src/software/embedded/primitive_executor.h
@@ -14,12 +14,10 @@ class PrimitiveExecutor
    public:
     /**
      * Constructor
-     * @param time_step Time step which this primitive executor operates in
      * @param robot_constants The robot constants for the robot which uses this primitive
      * executor
      */
-    explicit PrimitiveExecutor(const Duration time_step,
-                               const robot_constants::RobotConstants& robot_constants);
+    explicit PrimitiveExecutor(const robot_constants::RobotConstants& robot_constants);
 
     /**
      * Update primitive executor with a new Primitive
@@ -39,13 +37,15 @@ class PrimitiveExecutor
     /**
      * Steps the current primitive and returns a direct control primitive with the
      * target wheel velocities
+     *
      * @param status The status of the primitive executor, set to false if current
      * primitive is a Stop primitive
+     * @param delta_time The elapsed time since the last primitive step
      *
      * @returns DirectControlPrimitive The direct control primitive msg
      */
     std::unique_ptr<TbotsProto::DirectControlPrimitive> stepPrimitive(
-        TbotsProto::PrimitiveExecutorStatus& status);
+        TbotsProto::PrimitiveExecutorStatus& status, Duration delta_time);
 
    private:
     /*
@@ -69,10 +69,6 @@ class PrimitiveExecutor
     robot_constants::RobotConstants robot_constants_;
     std::optional<TrajectoryPath> trajectory_path_;
     std::optional<BangBangTrajectory1DAngular> angular_trajectory_;
-
-    // TODO (#2855): Add dynamic time_step to `stepPrimitive` and remove this constant
-    // time step to be used, in Seconds
-    Duration time_step_;
 
     // Estimated delay between a vision frame to AI processing to robot executing
     static constexpr double VISION_TO_ROBOT_DELAY_S = 0.03;

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -84,7 +84,7 @@ Thunderloop::Thunderloop(const robot_constants::RobotConstants& robot_constants,
       kick_constant_(std::stoi(toml_config_client_->get(ROBOT_KICK_CONSTANT_CONFIG_KEY))),
       chip_pulse_width_(
           std::stoi(toml_config_client_->get(ROBOT_CHIP_PULSE_WIDTH_CONFIG_KEY))),
-      primitive_executor_(Duration::fromSeconds(1.0 / loop_hz), robot_constants)
+      primitive_executor_(robot_constants)
 {
     waitForNetworkUp();
 
@@ -287,7 +287,7 @@ void Thunderloop::runLoop()
                 }
 
                 direct_control_ =
-                    *primitive_executor_.stepPrimitive(primitive_executor_status_);
+                    *primitive_executor_.stepPrimitive(primitive_executor_status_, Duration::fromSeconds(1.0 / loop_hz_));
             }
 
             thunderloop_status_.set_primitive_executor_step_time_ms(

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -71,7 +71,6 @@ extern "C"
 
 Thunderloop::Thunderloop(const robot_constants::RobotConstants& robot_constants,
                          bool enable_log_merging, const int loop_hz)
-    // TODO (#2495): Set the friendly team colour
     : toml_config_client_(std::make_unique<TomlConfigClient>(TOML_CONFIG_FILE_PATH)),
       motor_status_(std::nullopt),
       robot_constants_(robot_constants),
@@ -84,8 +83,7 @@ Thunderloop::Thunderloop(const robot_constants::RobotConstants& robot_constants,
       kick_constant_(std::stoi(toml_config_client_->get(ROBOT_KICK_CONSTANT_CONFIG_KEY))),
       chip_pulse_width_(
           std::stoi(toml_config_client_->get(ROBOT_CHIP_PULSE_WIDTH_CONFIG_KEY))),
-      primitive_executor_(Duration::fromSeconds(1.0 / loop_hz), robot_constants,
-                          TeamColour::YELLOW, robot_id_)
+      primitive_executor_(Duration::fromSeconds(1.0 / loop_hz), robot_constants)
 {
     waitForNetworkUp();
 

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 
 #include "proto/message_translation/tbots_protobuf.h"
+#include "proto/primitive/primitive_msg_factory.h"
 #include "proto/robot_crash_msg.pb.h"
 #include "proto/robot_status_msg.pb.h"
 #include "proto/tbots_software_msgs.pb.h"
@@ -282,7 +283,7 @@ void Thunderloop::runLoop()
 
                 if (nanoseconds_elapsed_since_last_primitive > PACKET_TIMEOUT_NS)
                 {
-                    primitive_executor_.setStopPrimitive();
+                    primitive_executor_.updatePrimitive(*createStopPrimitiveProto());
                 }
 
                 direct_control_ =

--- a/src/software/embedded/thunderloop.cpp
+++ b/src/software/embedded/thunderloop.cpp
@@ -18,6 +18,7 @@
 #include "software/networking/tbots_network_exception.h"
 #include "software/tracy/tracy_constants.h"
 #include "software/util/scoped_timespec_timer/scoped_timespec_timer.h"
+#include "software/world/robot_state.h"
 
 /**
  * https://web.archive.org/web/20210308013218/https://rt.wiki.kernel.org/index.php/Squarewave-example
@@ -262,9 +263,9 @@ void Thunderloop::runLoop()
             if (motor_status_.has_value())
             {
                 auto status = motor_status_.value();
-                primitive_executor_.updateVelocity(
-                    createVector(status.local_velocity()),
-                    createAngularVelocity(status.angular_velocity()));
+                primitive_executor_.updateState(
+                    RobotState(Point(), createVector(status.local_velocity()), Angle(),
+                               createAngularVelocity(status.angular_velocity())));
             }
 
             // Timeout Overrides for Primitives

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -297,19 +297,19 @@ void ErForceSimulator::setYellowRobotPrimitiveSet(
     const TbotsProto::PrimitiveSet& primitive_set_msg,
     std::unique_ptr<TbotsProto::World> world_msg)
 {
-    auto sim_state                   = getSimulatorState();
-    const auto& sim_robots           = sim_state.yellow_robots();
-    const auto robot_to_vel_pair_map = getRobotIdToLocalVelocityMap(sim_robots);
+    auto sim_state         = getSimulatorState();
+    const auto& sim_robots = sim_state.yellow_robots();
+    const auto robot_map   = getRobotIdToRobotStateMap(sim_robots);
 
     yellow_team_world_msg               = std::move(world_msg);
     const TbotsProto::World world_proto = *yellow_team_world_msg;
     for (auto& [robot_id, primitive] : primitive_set_msg.robot_primitives())
     {
-        if (robot_to_vel_pair_map.contains(robot_id))
+        if (robot_map.contains(robot_id))
         {
-            auto& [local_vel, angular_vel] = robot_to_vel_pair_map.at(robot_id);
+            const auto& robot_state = robot_map.at(robot_id);
             setRobotPrimitive(robot_id, primitive_set_msg, yellow_primitive_executor_map,
-                              world_proto, local_vel, angular_vel);
+                              world_proto, robot_state);
         }
     }
 }
@@ -318,20 +318,20 @@ void ErForceSimulator::setBlueRobotPrimitiveSet(
     const TbotsProto::PrimitiveSet& primitive_set_msg,
     std::unique_ptr<TbotsProto::World> world_msg)
 {
-    auto sim_state                   = getSimulatorState();
-    const auto& sim_robots           = sim_state.blue_robots();
-    const auto robot_to_vel_pair_map = getRobotIdToLocalVelocityMap(sim_robots);
+    auto sim_state         = getSimulatorState();
+    const auto& sim_robots = sim_state.blue_robots();
+    const auto robot_map   = getRobotIdToRobotStateMap(sim_robots);
 
     blue_team_world_msg                 = std::move(world_msg);
     const TbotsProto::World world_proto = *blue_team_world_msg;
 
     for (auto& [robot_id, primitive] : primitive_set_msg.robot_primitives())
     {
-        if (robot_to_vel_pair_map.contains(robot_id))
+        if (robot_map.contains(robot_id))
         {
-            auto& [local_vel, angular_vel] = robot_to_vel_pair_map.at(robot_id);
+            const auto& robot_state = robot_map.at(robot_id);
             setRobotPrimitive(robot_id, primitive_set_msg, blue_primitive_executor_map,
-                              world_proto, local_vel, angular_vel);
+                              world_proto, robot_state);
         }
     }
 }
@@ -340,8 +340,7 @@ void ErForceSimulator::setRobotPrimitive(
     RobotId id, const TbotsProto::PrimitiveSet& primitive_set_msg,
     std::unordered_map<unsigned int, std::shared_ptr<PrimitiveExecutor>>&
         robot_primitive_executor_map,
-    const TbotsProto::World& world_msg, const Vector& local_velocity,
-    const AngularVelocity angular_velocity)
+    const TbotsProto::World& world_msg, const RobotState& robot_state)
 {
     // Set to NEG_X because the world msg in this simulator is normalized
     // correctly
@@ -351,7 +350,8 @@ void ErForceSimulator::setRobotPrimitive(
     {
         auto primitive_executor = robot_primitive_executor_iter->second;
         primitive_executor->updatePrimitive(primitive_set_msg.robot_primitives().at(id));
-        primitive_executor->updateVelocity(local_velocity, angular_velocity);
+        primitive_executor->updateVelocity(robot_state.localVelocity(),
+                                           robot_state.angularVelocity());
     }
     else
     {
@@ -367,23 +367,14 @@ SSLSimulationProto::RobotControl ErForceSimulator::updateSimulatorRobots(
 {
     SSLSimulationProto::RobotControl robot_control;
 
-    auto sim_state = getSimulatorState();
-    std::map<RobotId, std::pair<Vector, Angle>> current_velocity_map;
-    if (side == gameController::Team::BLUE)
-    {
-        const auto& sim_robots = sim_state.blue_robots();
-        current_velocity_map   = getRobotIdToLocalVelocityMap(sim_robots);
-    }
-    else
-    {
-        const auto& sim_robots = sim_state.yellow_robots();
-        current_velocity_map   = getRobotIdToLocalVelocityMap(sim_robots);
-    }
+    auto sim_state         = getSimulatorState();
+    const auto& sim_robots = (side == gameController::Team::BLUE)
+                                 ? sim_state.blue_robots()
+                                 : sim_state.yellow_robots();
+    const auto robot_map   = getRobotIdToRobotStateMap(sim_robots);
 
-    for (auto& primitive_executor_with_id : robot_primitive_executor_map)
+    for (auto& [robot_id, primitive_executor] : robot_primitive_executor_map)
     {
-        unsigned int robot_id    = primitive_executor_with_id.first;
-        auto& primitive_executor = primitive_executor_with_id.second;
         std::unique_ptr<TbotsProto::DirectControlPrimitive> direct_control;
 
         TbotsProto::PrimitiveExecutorStatus status;  // Added for compilation
@@ -391,10 +382,10 @@ SSLSimulationProto::RobotControl ErForceSimulator::updateSimulatorRobots(
         {
             auto direct_control_no_ramp =
                 primitive_executor->stepPrimitive(status, primitive_executor_time_step);
-            direct_control = getRampedVelocityPrimitive(
-                current_velocity_map.at(robot_id).first,
-                current_velocity_map.at(robot_id).second, *direct_control_no_ramp,
-                primitive_executor_time_step);
+            const auto& robot_state = robot_map.at(robot_id);
+            direct_control          = getRampedVelocityPrimitive(
+                robot_state.localVelocity(), robot_state.angularVelocity(),
+                *direct_control_no_ramp, primitive_executor_time_step);
         }
         else
         {
@@ -563,18 +554,18 @@ void ErForceSimulator::resetCurrentTime()
     current_time = Timestamp::fromSeconds(0);
 }
 
-std::map<RobotId, std::pair<Vector, AngularVelocity>>
-ErForceSimulator::getRobotIdToLocalVelocityMap(
+std::map<RobotId, RobotState> ErForceSimulator::getRobotIdToRobotStateMap(
     const google::protobuf::RepeatedPtrField<world::SimRobot>& sim_robots)
 {
-    std::map<RobotId, std::pair<Vector, AngularVelocity>> robot_to_local_velocity;
+    std::map<RobotId, RobotState> robot_map;
     for (const auto& sim_robot : sim_robots)
     {
-        const Vector local_vel =
-            globalToLocalVelocity(Vector(sim_robot.v_x(), sim_robot.v_y()),
-                                  Angle::fromRadians(sim_robot.angle()));
-        const AngularVelocity angular_vel       = Angle::fromRadians(sim_robot.r_z());
-        robot_to_local_velocity[sim_robot.id()] = {local_vel, angular_vel};
+        const Point position                   = Point(sim_robot.p_x(), sim_robot.p_y());
+        const Vector velocity                  = Vector(sim_robot.v_x(), sim_robot.v_y());
+        const Angle orientation                = Angle::fromRadians(sim_robot.angle());
+        const AngularVelocity angular_velocity = Angle::fromRadians(sim_robot.r_z());
+        robot_map[sim_robot.id()] =
+            RobotState(position, velocity, orientation, angular_velocity);
     }
-    return robot_to_local_velocity;
+    return robot_map;
 }

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -559,10 +559,10 @@ std::map<RobotId, RobotState> ErForceSimulator::getRobotIdToRobotStateMap(
     std::map<RobotId, RobotState> robot_map;
     for (const auto& sim_robot : sim_robots)
     {
-        const Point position                   = Point(sim_robot.p_x(), sim_robot.p_y());
-        const Vector velocity                  = Vector(sim_robot.v_x(), sim_robot.v_y());
-        const Angle orientation                = Angle::fromRadians(sim_robot.angle());
-        const AngularVelocity angular_velocity = Angle::fromRadians(sim_robot.r_z());
+        const auto position         = Point(sim_robot.p_x(), sim_robot.p_y());
+        const auto velocity         = Vector(sim_robot.v_x(), sim_robot.v_y());
+        const auto orientation      = Angle::fromRadians(sim_robot.angle());
+        const auto angular_velocity = AngularVelocity::fromRadians(sim_robot.r_z());
         robot_map[sim_robot.id()] =
             RobotState(position, velocity, orientation, angular_velocity);
     }

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -350,8 +350,7 @@ void ErForceSimulator::setRobotPrimitive(
     {
         auto primitive_executor = robot_primitive_executor_iter->second;
         primitive_executor->updatePrimitive(primitive_set_msg.robot_primitives().at(id));
-        primitive_executor->updateVelocity(robot_state.localVelocity(),
-                                           robot_state.angularVelocity());
+        primitive_executor->updateState(robot_state);
     }
     else
     {

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -281,15 +281,13 @@ void ErForceSimulator::setRobots(
         if (side == gameController::Team::BLUE)
         {
             auto robot_primitive_executor = std::make_shared<PrimitiveExecutor>(
-                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants,
-                TeamColour::BLUE, id);
+                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants);
             blue_primitive_executor_map.insert({id, robot_primitive_executor});
         }
         else
         {
             auto robot_primitive_executor = std::make_shared<PrimitiveExecutor>(
-                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants,
-                TeamColour::YELLOW, id);
+                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants);
             yellow_primitive_executor_map.insert({id, robot_primitive_executor});
         }
     }

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -20,10 +20,10 @@ ErForceSimulator::ErForceSimulator(const TbotsProto::FieldType& field_type,
                                    const robot_constants::RobotConstants& robot_constants,
                                    std::unique_ptr<RealismConfigErForce>& realism_config,
                                    const bool ramping,
-                                   double primitive_executor_time_step)
+                                   Duration primitive_executor_time_step)
     : yellow_team_world_msg(std::make_unique<TbotsProto::World>()),
       blue_team_world_msg(std::make_unique<TbotsProto::World>()),
-      primitive_executor_time_step_s(primitive_executor_time_step),
+      primitive_executor_time_step(primitive_executor_time_step),
       frame_number(0),
       euclidean_to_four_wheel(robot_constants),
       robot_constants(robot_constants),
@@ -280,14 +280,14 @@ void ErForceSimulator::setRobots(
     {
         if (side == gameController::Team::BLUE)
         {
-            auto robot_primitive_executor = std::make_shared<PrimitiveExecutor>(
-                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants);
+            auto robot_primitive_executor =
+                std::make_shared<PrimitiveExecutor>(robot_constants);
             blue_primitive_executor_map.insert({id, robot_primitive_executor});
         }
         else
         {
-            auto robot_primitive_executor = std::make_shared<PrimitiveExecutor>(
-                Duration::fromSeconds(primitive_executor_time_step_s), robot_constants);
+            auto robot_primitive_executor =
+                std::make_shared<PrimitiveExecutor>(robot_constants);
             yellow_primitive_executor_map.insert({id, robot_primitive_executor});
         }
     }
@@ -389,15 +389,17 @@ SSLSimulationProto::RobotControl ErForceSimulator::updateSimulatorRobots(
         TbotsProto::PrimitiveExecutorStatus status;  // Added for compilation
         if (ramping)
         {
-            auto direct_control_no_ramp = primitive_executor->stepPrimitive(status);
-            direct_control              = getRampedVelocityPrimitive(
-                             current_velocity_map.at(robot_id).first,
-                             current_velocity_map.at(robot_id).second, *direct_control_no_ramp,
-                             primitive_executor_time_step_s);
+            auto direct_control_no_ramp =
+                primitive_executor->stepPrimitive(status, primitive_executor_time_step);
+            direct_control = getRampedVelocityPrimitive(
+                current_velocity_map.at(robot_id).first,
+                current_velocity_map.at(robot_id).second, *direct_control_no_ramp,
+                primitive_executor_time_step);
         }
         else
         {
-            direct_control = primitive_executor->stepPrimitive(status);
+            direct_control =
+                primitive_executor->stepPrimitive(status, primitive_executor_time_step);
         }
 
         auto command = *getRobotCommandFromDirectControl(
@@ -411,8 +413,7 @@ std::unique_ptr<TbotsProto::DirectControlPrimitive>
 ErForceSimulator::getRampedVelocityPrimitive(
     const Vector current_local_velocity,
     const AngularVelocity current_local_angular_velocity,
-    TbotsProto::DirectControlPrimitive& target_velocity_primitive,
-    const double& time_to_ramp)
+    TbotsProto::DirectControlPrimitive& target_velocity_primitive, Duration time_to_ramp)
 {
     TbotsProto::MotorControl_DirectVelocityControl direct_velocity =
         target_velocity_primitive.motor_control().direct_velocity_control();
@@ -435,7 +436,7 @@ ErForceSimulator::getRampedVelocityPrimitive(
         euclidean_to_four_wheel.getWheelVelocity(current_euclidean_velocity);
 
     WheelSpace_t ramped_four_wheel = euclidean_to_four_wheel.rampWheelVelocity(
-        current_wheel_velocity, target_wheel_velocity, time_to_ramp);
+        current_wheel_velocity, target_wheel_velocity, time_to_ramp.toSeconds());
 
     EuclideanSpace_t ramped_euclidean =
         euclidean_to_four_wheel.getEuclideanVelocity(ramped_four_wheel);

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -383,8 +383,8 @@ SSLSimulationProto::RobotControl ErForceSimulator::updateSimulatorRobots(
                 primitive_executor->stepPrimitive(status, primitive_executor_time_step);
             const auto& robot_state = robot_map.at(robot_id);
             direct_control          = getRampedVelocityPrimitive(
-                robot_state.localVelocity(), robot_state.angularVelocity(),
-                *direct_control_no_ramp, primitive_executor_time_step);
+                         robot_state.localVelocity(), robot_state.angularVelocity(),
+                         *direct_control_no_ramp, primitive_executor_time_step);
         }
         else
         {

--- a/src/software/simulation/er_force_simulator.h
+++ b/src/software/simulation/er_force_simulator.h
@@ -27,12 +27,12 @@ class ErForceSimulator
      * @param robot_constants The robot constants
      * @param realism_config realism configuration
      */
-    explicit ErForceSimulator(const TbotsProto::FieldType& field_type,
-                              const robot_constants::RobotConstants& robot_constants,
-                              std::unique_ptr<RealismConfigErForce>& realism_config,
-                              const bool ramping = false,
-                              double primitive_executor_time_step_s =
-                                  DEFAULT_SIMULATOR_TICK_RATE_SECONDS_PER_TICK);
+    explicit ErForceSimulator(
+        const TbotsProto::FieldType& field_type,
+        const robot_constants::RobotConstants& robot_constants,
+        std::unique_ptr<RealismConfigErForce>& realism_config, const bool ramping = false,
+        Duration primitive_executor_time_step_s =
+            Duration::fromSeconds(DEFAULT_SIMULATOR_TICK_RATE_SECONDS_PER_TICK));
     ErForceSimulator()  = delete;
     ~ErForceSimulator() = default;
 
@@ -202,7 +202,7 @@ class ErForceSimulator
         const Vector current_local_velocity,
         const AngularVelocity current_local_angular_velocity,
         TbotsProto::DirectControlPrimitive& target_velocity_primitive,
-        const double& time_to_ramp);
+        Duration time_to_ramp);
 
     // Map of Robot id to Primitive Executor
     std::unordered_map<unsigned int, std::shared_ptr<PrimitiveExecutor>>
@@ -212,7 +212,7 @@ class ErForceSimulator
     std::unique_ptr<TbotsProto::World> yellow_team_world_msg;
     std::unique_ptr<TbotsProto::World> blue_team_world_msg;
 
-    double primitive_executor_time_step_s;
+    Duration primitive_executor_time_step;
     unsigned int frame_number;
 
     // The current time.

--- a/src/software/simulation/er_force_simulator.h
+++ b/src/software/simulation/er_force_simulator.h
@@ -7,6 +7,7 @@
 #include "software/embedded/primitive_executor.h"
 #include "software/physics/euclidean_to_wheel.h"
 #include "software/world/field.h"
+#include "software/world/robot_state.h"
 #include "software/world/team_types.h"
 #include "software/world/world.h"
 
@@ -158,8 +159,7 @@ class ErForceSimulator
         RobotId id, const TbotsProto::PrimitiveSet& primitive_set_msg,
         std::unordered_map<unsigned int, std::shared_ptr<PrimitiveExecutor>>&
             robot_primitive_executor_map,
-        const TbotsProto::World& world_msg, const Vector& local_velocity,
-        const AngularVelocity angular_velocity);
+        const TbotsProto::World& world_msg, const RobotState& robot_state);
 
     /**
      * Gets a map from robot id to local and angular velocity from repeated sim robots
@@ -168,8 +168,7 @@ class ErForceSimulator
      *
      * @return a map from robot id to local velocity and angular velocity
      */
-    static std::map<RobotId, std::pair<Vector, AngularVelocity>>
-    getRobotIdToLocalVelocityMap(
+    static std::map<RobotId, RobotState> getRobotIdToRobotStateMap(
         const google::protobuf::RepeatedPtrField<world::SimRobot>& sim_robots);
 
     /**

--- a/src/software/world/BUILD
+++ b/src/software/world/BUILD
@@ -139,6 +139,7 @@ cc_library(
         "//software/geom:angular_velocity",
         "//software/geom:point",
         "//software/geom:vector",
+        "//software/physics:velocity_conversion_util",
         "//software/time:duration",
     ],
 )

--- a/src/software/world/robot_state.cpp
+++ b/src/software/world/robot_state.cpp
@@ -1,5 +1,7 @@
 #include "software/world/robot_state.h"
 
+#include "software/physics/velocity_conversion_util.h"
+
 RobotState::RobotState(const Point& position, const Vector& velocity,
                        const Angle& orientation, const AngularVelocity& angular_velocity,
                        const bool breakbeam_tripped)
@@ -31,6 +33,11 @@ Point RobotState::position() const
 Vector RobotState::velocity() const
 {
     return velocity_;
+}
+
+Vector RobotState::localVelocity() const
+{
+    return globalToLocalVelocity(velocity_, orientation_);
 }
 
 Angle RobotState::orientation() const

--- a/src/software/world/robot_state.cpp
+++ b/src/software/world/robot_state.cpp
@@ -48,6 +48,26 @@ bool RobotState::breakbeamTripped() const
     return breakbeam_tripped_;
 }
 
+void RobotState::setPosition(const Point& position)
+{
+    position_ = position;
+}
+
+void RobotState::setVelocity(const Vector& velocity)
+{
+    velocity_ = velocity;
+}
+
+void RobotState::setOrientation(const Angle& orientation)
+{
+    orientation_ = orientation;
+}
+
+void RobotState::setAngularVelocity(const AngularVelocity& angular_velocity)
+{
+    angular_velocity_ = angular_velocity;
+}
+
 bool RobotState::operator==(const RobotState& other) const
 {
     return this->position() == other.position() && this->velocity() == other.velocity() &&

--- a/src/software/world/robot_state.h
+++ b/src/software/world/robot_state.h
@@ -18,6 +18,11 @@ class RobotState
 {
    public:
     /**
+     * Creates a robot state with default values
+     */
+    RobotState() = default;
+
+    /**
      * Creates a new robot state with the given position, velocity, orientation, angular
      * velocity, and timestamp
      *

--- a/src/software/world/robot_state.h
+++ b/src/software/world/robot_state.h
@@ -60,6 +60,13 @@ class RobotState
     Vector velocity() const;
 
     /**
+     * Returns the local velocity of the robot represented by this state
+     *
+     * @return the local velocity of the robot represented by this state
+     */
+    Vector localVelocity() const;
+
+    /**
      * Returns the orientation of the robot represented by this state
      *
      * @return the orientation of the robot represented by this state

--- a/src/software/world/robot_state.h
+++ b/src/software/world/robot_state.h
@@ -76,6 +76,34 @@ class RobotState
     bool breakbeamTripped() const;
 
     /**
+     * Sets the position of the robot, with coordinates in metres
+     *
+     * @param position The new position of the robot
+     */
+    void setPosition(const Point& position);
+
+    /**
+     * Sets the velocity of the robot, in metres per second
+     *
+     * @param velocity The new velocity of the robot
+     */
+    void setVelocity(const Vector& velocity);
+
+    /**
+     * Sets the orientation of the robot
+     *
+     * @param orientation The new orientation of the robot
+     */
+    void setOrientation(const Angle& orientation);
+
+    /**
+     * Sets the angular velocity of the robot
+     *
+     * @param angular_velocity The new angular velocity of the robot
+     */
+    void setAngularVelocity(const AngularVelocity& angular_velocity);
+
+    /**
      * Defines the equality operator for a RobotState. RobotStates are equal if
      * all their members are equal
      *


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

**This is a stacked PR: #3756 #3758 #3759 #3760.**

In ErForceSimulator and PrimitiveExecutor, we originally passed robot velocities and angular velocities as an std::pair or as separate function arguments. Since we will need the robot position and orientations as well for the updated primitive executor, this data should be encapsulated into a RobotState struct. However, since there is already a RobotState class, I just reused this class and added setters since originally it was read-only.

Also see: https://github.com/UBC-Thunderbots/Software/pull/3716#discussion_r3276643789

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
