### PR TITLE
Explicitly assign halt tactic for play states without tactics

### DIFF
--- a/src/software/ai/hl/stp/play/play.cpp
+++ b/src/software/ai/hl/stp/play/play.cpp
@@ -115,6 +115,12 @@ std::unique_ptr<TbotsProto::PrimitiveSet> Play::get(
     {
         ZoneNamedN(_tracy_tactic_assignment, "Play: Assign tactics to robots", true);
 
+        if (priority_tactics.empty())
+        {
+            LOG(WARNING) << "Play has no tactics set. Defaulting to halt tactics.";
+            priority_tactics.push_back(TacticVector{});
+        }
+
         for (unsigned int i = 0; i < priority_tactics.size(); i++)
         {
             auto tactic_vector = priority_tactics[i];

--- a/src/software/ai/hl/stp/play/play.cpp
+++ b/src/software/ai/hl/stp/play/play.cpp
@@ -117,7 +117,6 @@ std::unique_ptr<TbotsProto::PrimitiveSet> Play::get(
 
         if (priority_tactics.empty())
         {
-            LOG(WARNING) << "Play has no tactics set. Defaulting to halt tactics.";
             priority_tactics.push_back(TacticVector{});
         }
 

--- a/src/software/ai/hl/stp/play/play.cpp
+++ b/src/software/ai/hl/stp/play/play.cpp
@@ -115,15 +115,13 @@ std::unique_ptr<TbotsProto::PrimitiveSet> Play::get(
     {
         ZoneNamedN(_tracy_tactic_assignment, "Play: Assign tactics to robots", true);
 
-        if (priority_tactics.empty())
-        {
-            priority_tactics.push_back(TacticVector{});
-        }
+        // Assigns halt tactic to robots if there are no more tactics in the play
+        priority_tactics.push_back(halt_tactics);
 
-        for (unsigned int i = 0; i < priority_tactics.size(); i++)
+        for (auto& tactic_vector : priority_tactics)
         {
-            auto tactic_vector = priority_tactics[i];
-            size_t num_tactics = tactic_vector.size();
+            if (robots.empty())
+                break;
 
             if (robots.size() < tactic_vector.size())
             {
@@ -131,15 +129,6 @@ std::unique_ptr<TbotsProto::PrimitiveSet> Play::get(
                 // (aka don't assign) the tactics at the end of the vector since they are
                 // considered lower priority
                 tactic_vector.resize(robots.size());
-            }
-            else if (i == (priority_tactics.size() - 1))
-            {
-                // If assigning the last tactic vector, then assign rest of robots with
-                // HaltTactics
-                for (unsigned int ii = 0; ii < (robots.size() - num_tactics); ii++)
-                {
-                    tactic_vector.push_back(halt_tactics[ii]);
-                }
             }
 
             auto [remaining_robots, new_primitives_to_assign,


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Whenever we have a state change in our play FSMs that do not have an associated action that explicitly sets the tactics of our robots, for example in ball placement play:

```
PlaceBallState_S + Update_E[!ballPlaced_G] / placeBall_A = PlaceBallState_S,
PlaceBallState_S + Update_E[ballPlaced_G] / startWait_A  = WaitState_S,
WaitState_S + Update_E[!waitDone_G]                      = WaitState_S,
```

placeBall_A sets tactics to have a robot place the ball. However, startWait_A does not set any tactics since robots are just waiting, and the last state also does not set any tactics since it does not have an associated action.

This previously looks like this:

<img width="905" height="238" alt="image" src="https://github.com/user-attachments/assets/d9d25406-697b-443e-80b6-173c9a239eb7" />

In play.cpp, we are supposed to set halt tactics for excess robots, but there is a off-by-one bug when the priority_tactics vector is empty. If a robot is currently driving when a state change happens with no tactics, the robot will keep driving and not stop !

```cpp
for (unsigned int i = 0; i < priority_tactics.size(); i++)
{
    // ...
    else if (i == (priority_tactics.size() - 1))
    {
        // If assigning the last tactic vector, then assign rest of robots with
        // HaltTactics
        for (unsigned int ii = 0; ii < (robots.size() - num_tactics); ii++)
        {
            tactic_vector.push_back(halt_tactics[ii]);
        }
    }
	// ...
}
```

This PR resolves this bug by rewriting this as a for-each loop and adding the halt_tactics vector to priority_tactics as a fallback.

<img width="785" height="211" alt="image" src="https://github.com/user-attachments/assets/d2e6debe-6232-4c8d-a692-94298bd16e96" />

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Previously, I thought priority_tactics being empty was an issue with the implementation of specific plays, but actually having no action associated with a state change is okay. I found this out by logging whenever it was empty, and found it was quite common. I watched the behaviour of robots playing an autoref'd game and it seems good, and fixes the issue when robots keep driving after its supposed to just wait.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
