### PR TITLE
Fix test replay log being automatically deleted

### DIFF
--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -204,10 +204,11 @@ class FieldTestRunner(TbotsTestRunner):
 
 def get_runtime_dir():
     """Gets the base runtime directory for the test execution.
+
     TODO: Refactor #3744
 
-    Uses a persistent directory so that UNIX socket paths stay short
-    and replay logs survive after the test ends.
+    Creates a new persistent directory for each test so that tests
+    running in parallel do not interfere with each other.
 
     :return: The path to the runtime directory.
     """

--- a/src/software/field_tests/field_test_fixture.py
+++ b/src/software/field_tests/field_test_fixture.py
@@ -206,23 +206,16 @@ def get_runtime_dir():
     """Gets the base runtime directory for the test execution.
     TODO: Refactor #3744
 
-    If running under Bazel, it uses TEST_TMPDIR to keep tests isolated. To prevent UNIX
-    socket path length limits from being exceeded by Bazel's long paths, it creates a short
-    symlink in /tmp to the TEST_TMPDIR.
+    Uses a persistent directory so that UNIX socket paths stay short
+    and replay logs survive after the test ends.
 
     :return: The path to the runtime directory.
     """
-    test_tmpdir = os.environ.get("TEST_TMPDIR")
-    if not test_tmpdir:
-        return "/tmp/tbots"
     import uuid
 
-    symlink_path = os.path.join("/tmp", f"tbt_{uuid.uuid4().hex[:8]}")
-    try:
-        os.symlink(test_tmpdir, symlink_path)
-    except OSError:
-        pass
-    return symlink_path
+    runtime_dir = os.path.join("/tmp", f"tbots_{uuid.uuid4().hex[:8]}")
+    os.makedirs(runtime_dir, exist_ok=True)
+    return runtime_dir
 
 
 RUNTIME_DIR = get_runtime_dir()

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -423,23 +423,16 @@ def get_runtime_dir():
     """Gets the base runtime directory for the test execution.
     TODO: Refactor #3744
 
-    If running under Bazel, it uses TEST_TMPDIR to keep tests isolated. To prevent UNIX
-    socket path length limits from being exceeded by Bazel's long paths, it creates a short
-    symlink in /tmp to the TEST_TMPDIR.
+    Uses a persistent directory so that UNIX socket paths stay short
+    and replay logs survive after the test ends.
 
     :return: The path to the runtime directory.
     """
-    test_tmpdir = os.environ.get("TEST_TMPDIR")
-    if not test_tmpdir:
-        return "/tmp/tbots"
     import uuid
 
-    symlink_path = os.path.join("/tmp", f"tbt_{uuid.uuid4().hex[:8]}")
-    try:
-        os.symlink(test_tmpdir, symlink_path)
-    except OSError:
-        pass
-    return symlink_path
+    runtime_dir = os.path.join("/tmp", f"tbots_{uuid.uuid4().hex[:8]}")
+    os.makedirs(runtime_dir, exist_ok=True)
+    return runtime_dir
 
 
 RUNTIME_DIR = get_runtime_dir()

--- a/src/software/simulated_tests/simulated_test_fixture.py
+++ b/src/software/simulated_tests/simulated_test_fixture.py
@@ -421,10 +421,11 @@ class AggregateTestRunner(SimulatedTestRunner):
 
 def get_runtime_dir():
     """Gets the base runtime directory for the test execution.
+
     TODO: Refactor #3744
 
-    Uses a persistent directory so that UNIX socket paths stay short
-    and replay logs survive after the test ends.
+    Creates a new persistent directory for each test so that tests
+    running in parallel do not interfere with each other.
 
     :return: The path to the runtime directory.
     """


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

In #3766, we created symlinks to the bazel sandbox directory so that simulated tests won't interfere while running at the same time. However, this bazel directory is deleted automatically after the test ends so test replays are not saved. This PR simply turns these symlinks into persistent directories instead.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Ran a sim test, the replay is there after the test ends.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

#3768 

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
