### PR TITLE
[DRAFT] Dry run powerboard flashing in pi setup script

### DIFF
--- a/src/software/embedded/setup_robot_software_deps.sh
+++ b/src/software/embedded/setup_robot_software_deps.sh
@@ -38,6 +38,9 @@ cd /tmp/tbots_download_cache/Python-3.12.0
 make -j$(nproc)
 sudo make altinstall
 
+# Remove outdated /opt/tbotspython
+sudo rm -rf /opt/tbotspython
+
 sudo mkdir -p /opt/tbotspython
 sudo chown -R $USER:$USER /opt/tbotspython
 
@@ -53,8 +56,6 @@ if ! /usr/local/bin/python3.12 /tmp/tbots_download_cache/get-platformio.py; then
     exit 1
 fi
 
-# delete existing symlink and link platformio to /opt/tbotspython/bin so that bazel can find it
-rm -f /opt/tbotspython/bin/platformio
 ln -s $HOME/.platformio/penv/bin/platformio /opt/tbotspython/bin/platformio
 
 # Install the espressif32 platform for powerboard flashing

--- a/src/software/embedded/setup_robot_software_deps.sh
+++ b/src/software/embedded/setup_robot_software_deps.sh
@@ -57,6 +57,9 @@ fi
 rm -f /opt/tbotspython/bin/platformio
 ln -s $HOME/.platformio/penv/bin/platformio /opt/tbotspython/bin/platformio
 
+# Install the espressif32 platform for powerboard flashing
+/opt/tbotspython/bin/platformio platform install espressif32
+
 # Programmatically enable serial communication for UART
 sudo raspi-config nonint do_serial_hw 0
 sudo raspi-config nonint do_serial_cons 1

--- a/src/software/embedded/setup_robot_software_deps.sh
+++ b/src/software/embedded/setup_robot_software_deps.sh
@@ -58,8 +58,31 @@ fi
 
 ln -s $HOME/.platformio/penv/bin/platformio /opt/tbotspython/bin/platformio
 
-# Install the espressif32 platform for powerboard flashing
-/opt/tbotspython/bin/platformio platform install espressif32
+# Pre-install everything PlatformIO needs to flash the powerboard so that
+# flashing works even when the Pi has no internet access.
+#
+# deploy_powerboard.yml flashes with `platformio run -t nobuild -t upload`.
+# `pio run` re-resolves and installs the project environment's packages on every
+# invocation. The prebuilt firmware and project libraries travel inside
+# powerloop.tar.gz, but the espressif32 platform, the xtensa toolchain, the
+# esptool uploader and the Arduino framework live in the *global* ~/.platformio
+# cache and are NOT shipped. framework-arduinoespressif32 is an *optional*
+# espressif32 package, so a bare `platform install espressif32` does not fetch
+# it and the first offline flash would fail trying to download it.
+#
+# Warm the global cache here (setup runs with verified internet) by resolving the
+# exact same packages `pio run` needs from a platformio.ini that mirrors the
+# powerloop project environment (keep in sync with src/software/power/BUILD).
+# Installing via a project dir (not `-p`) is what pulls the optional framework.
+POWERLOOP_PIO_WARMUP="$(mktemp -d)"
+cat > "$POWERLOOP_PIO_WARMUP/platformio.ini" <<'EOF'
+[env:pico32]
+platform = espressif32
+board = pico32
+framework = arduino
+EOF
+/opt/tbotspython/bin/platformio pkg install -d "$POWERLOOP_PIO_WARMUP"
+rm -rf "$POWERLOOP_PIO_WARMUP"
 
 # Programmatically enable serial communication for UART
 sudo raspi-config nonint do_serial_hw 0


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

We get this error message when running the powerboard deploy script:

```
platformio:

fatal: [robert.local]: FAILED! => {"changed": true, "cmd": ["/opt/tbotspython/bin/platformio", "run", "--disable-auto-clean", "-t", "nobuild", "-t", "upload", "-d", "/home/robot/powerloop/powerloop_main_workdir"], "delta": "0:02:06.458360", "end": "2026-06-12 23:54:18.310095", "msg": "non-zero return code", "rc": 1, "start": "2026-06-12 23:52:11.851735", "stderr": "HTTPClientError: ", "stderr_lines": ["HTTPClientError: "], "stdout": "Processing pico32 (platform: espressif32; board: pico32; framework: arduino)\n--------------------------------------------------------------------------------\nPlatform Manager: Installing espressif32", "stdout_lines": ["Processing pico32 (platform: espressif32; board: pico32; framework: arduino)", "--------------------------------------------------------------------------------", "Platform Manager: Installing espressif32"]} 
```

Platformio attempts to install the espressif32 platform, but the robot usually doesn't have internet access. This PR adds a dry-run of the powerboard flashing in the setup script of the pi while it has internet access so that it installs all the necessary dependencies ahead of time.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

NOT TESTED YET

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

(didn't write issue for this)

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

N/A

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
