### PR TITLE
Fix pre-commit bot deleting requirement lock files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,9 @@ repos:
         name: compile pip requirements
         language: system
         entry: scripts/compile_pip_requirements.sh
+        # Only run when a requirements.in actually changes
+        files: requirements\.in$
+        pass_filenames: false
 
     -   id: lint_and_format
         name: fix common trivial code errors

--- a/scripts/compile_pip_requirements.sh
+++ b/scripts/compile_pip_requirements.sh
@@ -14,12 +14,21 @@ CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # The root bazel directory
 BAZEL_ROOT_DIR="$CURR_DIR/../src"
 
+# The number of times to retry an update target before giving up
+MAX_ATTEMPTS=5
+
+retry() {
+    for _ in $(seq "$MAX_ATTEMPTS"); do
+        "$@" && return 0
+    done
+}
+
 cd $BAZEL_ROOT_DIR
-bazel run //software/thunderscope:requirements.update
-bazel run //software/embedded/ansible:requirements.update
-bazel run //software/gameplay_tests:requirements.update
-bazel run //software/embedded/robot_diagnostics_cli:requirements.update
-bazel run //starlark/nanopb:requirements.update
+retry bazel run //software/thunderscope:requirements.update
+retry bazel run //software/embedded/ansible:requirements.update
+retry bazel run //software/gameplay_tests:requirements.update
+retry bazel run //software/embedded/robot_diagnostics_cli:requirements.update
+retry bazel run //starlark/nanopb:requirements.update
 
 # Restore any lock file a failed update left empty so we don't commit a deleted lock file,
 # then exit non-zero so we know to re-run the failed script

--- a/scripts/compile_pip_requirements.sh
+++ b/scripts/compile_pip_requirements.sh
@@ -20,3 +20,15 @@ bazel run //software/embedded/ansible:requirements.update
 bazel run //software/gameplay_tests:requirements.update
 bazel run //software/embedded/robot_diagnostics_cli:requirements.update
 bazel run //starlark/nanopb:requirements.update
+
+# Restore any lock file a failed update left empty so we don't commit a deleted lock file,
+# then exit non-zero so we know to re-run the failed script
+exit_code=0
+for lock in $(git ls-files '*requirements_lock*.txt'); do
+    if [ ! -s "$lock" ]; then
+        git restore "$lock"
+        echo "Restored $lock: its requirements.update target failed, please re-run"
+        exit_code=1
+    fi
+done
+exit $exit_code


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

This PR adds a check in compile_pip_requirements.sh to see if any lock files have been deleted, and fails the pre-commit ci while restoring the lock file so that we know to re-run the workflow. While I'm not sure about the root cause of why lock files are sometimes deleted, my best guess is that the network connection cuts out so the new requirements_lock file cannot be generated. I've tested by simulating a network failure, deleting the requirements_lock.txt and 

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

While this is quite difficult to test because its non-deterministic, I simulated the behaviour of the update failure by deleting a requirements_lock.txt, then running compile_pip_requirements.sh with wifi off. The new script catches this failure and restores the original state with the old lock file.

<img width="2036" height="1271" alt="image" src="https://github.com/user-attachments/assets/248eb159-1f85-46a8-aa27-959b0d60e7a3" />

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

resolves #3564 

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

N/A

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
