### PR TITLE
Add missing required tactic proto fields in tests

### DIFF
--- a/src/software/ai/hl/stp/tactic/attacker/attacker_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/attacker/attacker_tactic_test.py
@@ -370,6 +370,7 @@ def test_attacker_shoot_goal(
                     chip_target=tbots_cpp.createPointProto(
                         tbots_cpp.Point(0, field.fieldLines().yMin())
                     ),
+                    pass_committed=False,
                 )
             }
         )

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_tactic_test.py
@@ -46,6 +46,8 @@ def test_not_bumping_ball_towards_net(simulated_test_runner):
                 0: CreaseDefenderTactic(
                     enemy_threat_origin=tbots_cpp.createPointProto(enemy_threat_point),
                     crease_defender_alignment=CreaseDefenderAlignment.CENTRE,
+                    max_allowed_speed_mode=MaxAllowedSpeedMode.PHYSICAL_LIMIT,
+                    ball_steal_mode=BallStealMode.STEAL,
                 )
             }
         )
@@ -105,6 +107,8 @@ def test_crease_region_positioning(
                 0: CreaseDefenderTactic(
                     enemy_threat_origin=tbots_cpp.createPointProto(enemy_threat_point),
                     crease_defender_alignment=crease_alignment,
+                    max_allowed_speed_mode=MaxAllowedSpeedMode.PHYSICAL_LIMIT,
+                    ball_steal_mode=BallStealMode.STEAL,
                 )
             }
         )

--- a/src/software/ai/hl/stp/tactic/dribble/dribble_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/dribble/dribble_tactic_test.py
@@ -460,7 +460,7 @@ def test_robot_not_bumping_ball_when_turning(
             )
         )
 
-        dribble_params = DribbleTactic()
+        dribble_params = DribbleTactic(allow_excessive_dribbling=False)
         simulated_test_runner.set_tactics(blue_tactics={1: dribble_params})
 
     eventually_validations = [

--- a/src/software/ai/hl/stp/tactic/move/move_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/move/move_tactic_test.py
@@ -56,6 +56,11 @@ def test_move_across_field(simulated_test_runner):
                     final_orientation=tbots_cpp.createAngleProto(
                         tbots_cpp.Angle.zero()
                     ),
+                    dribbler_mode=DribblerMode.OFF,
+                    ball_collision_type=BallCollisionType.AVOID,
+                    auto_chip_or_kick=AutoChipOrKick(),
+                    max_allowed_speed_mode=MaxAllowedSpeedMode.PHYSICAL_LIMIT,
+                    obstacle_avoidance_mode=ObstacleAvoidanceMode.AGGRESSIVE,
                 )
             }
         )
@@ -321,6 +326,11 @@ def test_move_across_x_axis(simulated_test_runner):
                     final_orientation=tbots_cpp.createAngleProto(
                         tbots_cpp.Angle.zero()
                     ),
+                    dribbler_mode=DribblerMode.OFF,
+                    ball_collision_type=BallCollisionType.AVOID,
+                    auto_chip_or_kick=AutoChipOrKick(),
+                    max_allowed_speed_mode=MaxAllowedSpeedMode.PHYSICAL_LIMIT,
+                    obstacle_avoidance_mode=ObstacleAvoidanceMode.AGGRESSIVE,
                 )
             }
         )


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

In a few simulated test files, the tactic protos created do not have all the required fields. While the tests still run in most instances, this is technically not correct since we want all the required fields to be explicitly set when creating. This has caused issues when I was working on #3540, where it would crash the test: `2026-06-21 15:58:52,751 - [ERROR] - [Thread-32 (__send_protobuf)] - root - (threaded_unix_sender.py).__send_protobuf(60) - Received an invalid proto of type TbotsProto.AssignedTacticPlayControlParams`

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Ran sim test suite, everything passes still.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

N/A

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

N/A

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
