### PR TITLE
Increase SPI message delimiter length and validate sequence number in received messages

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -219,7 +219,7 @@ git_repository(
     name = "mdv6_firmware",
     build_file = "@//extlibs:mdv6_firmware.bzl",
     # Pinning to the exact commit guarantees Bazel will rebuild when this commit SHA is updated
-    commit = "7657fb1c63bccd506196c42ff1720928314977c7",  # latest commit on master branch
+    commit = "4341d96e9be1cb01f10d52f7e80326b84dbfb4ea",  # latest commit on master branch
     remote = "https://github.com/UBC-Thunderbots/MDv6_Firmware.git",
 )
 

--- a/src/software/embedded/motor_controller/stspin_motor_controller.cpp
+++ b/src/software/embedded/motor_controller/stspin_motor_controller.cpp
@@ -2,6 +2,7 @@
 
 #include <linux/spi/spidev.h>
 
+#include <algorithm>
 #include <chrono>
 #include <iomanip>
 #include <thread>
@@ -240,18 +241,19 @@ void StSpinMotorController::sendAndReceiveMessage(const MotorIndex motor,
         received_data.insert(received_data.end(), rx.begin(), rx.end());
 
         auto delimiter_pos =
-            std::find(received_data.begin(), received_data.end(), MESSAGE_DELIMITER);
+            std::search(received_data.begin(), received_data.end(),
+                        MESSAGE_DELIMITER.begin(), MESSAGE_DELIMITER.end());
 
         if (delimiter_pos == received_data.end())
         {
-            // No delimiter byte found, discard everything
+            // No delimiter sequence found, discard everything
             received_data.clear();
             continue;
         }
 
         if (std::distance(delimiter_pos, received_data.end()) < MESSAGE_SIZE)
         {
-            // Not enough bytes after delimiter byte for a full message,
+            // Not enough bytes after delimiter sequence for a full message,
             // wait for more bytes
             continue;
         }
@@ -261,11 +263,17 @@ void StSpinMotorController::sendAndReceiveMessage(const MotorIndex motor,
         const uint8_t actual_crc = Crc8Autosar::calc(&(*delimiter_pos), MESSAGE_SIZE - 1);
         if (expected_crc == actual_crc)
         {
-            const uint8_t ack_seq_num = *std::next(delimiter_pos);
-            if (ack_seq_num == motor_status_.at(motor).seq_num)
+            const uint8_t ack_seq_num =
+                *std::next(delimiter_pos, MESSAGE_DELIMITER.size());
+
+            const uint8_t current_seq = motor_status_.at(motor).seq_num;
+            const uint8_t prev_seq    = current_seq - 1;
+
+            // Accept responses where the sequence number is either the current
+            // sequence number (ACK for the message we just sent) or the
+            // previous sequence number
+            if (ack_seq_num == current_seq || ack_seq_num == prev_seq)
             {
-                // The message we just sent was acknowledged, we can stop resending
-                // and waiting for a response
                 const auto now = std::chrono::steady_clock::now();
                 motor_status_.at(motor).last_message_ack_time = now;
 
@@ -278,7 +286,9 @@ void StSpinMotorController::sendAndReceiveMessage(const MotorIndex motor,
             }
         }
 
-        received_data.erase(received_data.begin(), std::next(delimiter_pos));
+        // Erase everything up to the start of the delimiter to look for the next
+        // potential message
+        received_data.erase(received_data.begin(), delimiter_pos);
     }
 
     LOG(WARNING) << "Motor " << motor << " did not acknowledge message (seq_num "
@@ -290,8 +300,12 @@ void StSpinMotorController::populateTx(const MotorIndex motor,
                                        const OutgoingMessage& outgoing_message,
                                        std::array<uint8_t, MESSAGE_SIZE>& tx)
 {
-    tx[0] = MESSAGE_DELIMITER;
-    tx[1] = motor_status_.at(motor).seq_num;
+    std::copy(MESSAGE_DELIMITER.begin(), MESSAGE_DELIMITER.end(), tx.begin());
+
+    constexpr size_t seq_index    = MESSAGE_DELIMITER.size();
+    constexpr size_t opcode_index = seq_index + 1;
+
+    tx[seq_index] = motor_status_.at(motor).seq_num;
 
     std::visit(
         [&]<typename TMessage>(TMessage&& message)
@@ -299,132 +313,155 @@ void StSpinMotorController::populateTx(const MotorIndex motor,
             using T = std::decay_t<TMessage>;
             if constexpr (std::is_same_v<T, NoOpMessage>)
             {
-                tx[2] = static_cast<uint8_t>(StSpinOpcode::NO_OP);
+                tx[opcode_index] = static_cast<uint8_t>(StSpinOpcode::NO_OP);
             }
             else if constexpr (std::is_same_v<T, SetTargetSpeedMessage>)
             {
-                tx[2] = static_cast<uint8_t>(StSpinOpcode::SET_TARGET_SPEED);
-                tx[3] = static_cast<uint8_t>(message.motor_enabled);
-                tx[4] =
+                tx[opcode_index] = static_cast<uint8_t>(StSpinOpcode::SET_TARGET_SPEED);
+                tx[opcode_index + 1] = static_cast<uint8_t>(message.motor_enabled);
+                tx[opcode_index + 2] =
                     static_cast<uint8_t>(0xFF & (message.motor_target_speed_rpm >> 8));
-                tx[5] = static_cast<uint8_t>(0xFF & message.motor_target_speed_rpm);
+                tx[opcode_index + 3] =
+                    static_cast<uint8_t>(0xFF & message.motor_target_speed_rpm);
             }
             else if constexpr (std::is_same_v<T, SetTargetTorqueMessage>)
             {
-                tx[2] = static_cast<uint8_t>(StSpinOpcode::SET_TARGET_TORQUE);
-                tx[3] = static_cast<uint8_t>(message.motor_enabled);
-                tx[4] = static_cast<uint8_t>(0xFF & (message.motor_target_torque >> 8));
-                tx[5] = static_cast<uint8_t>(0xFF & message.motor_target_torque);
+                tx[opcode_index] = static_cast<uint8_t>(StSpinOpcode::SET_TARGET_TORQUE);
+                tx[opcode_index + 1] = static_cast<uint8_t>(message.motor_enabled);
+                tx[opcode_index + 2] =
+                    static_cast<uint8_t>(0xFF & (message.motor_target_torque >> 8));
+                tx[opcode_index + 3] =
+                    static_cast<uint8_t>(0xFF & message.motor_target_torque);
             }
             else if constexpr (std::is_same_v<T, SetResponseTypeMessage>)
             {
-                tx[2] = static_cast<uint8_t>(StSpinOpcode::SET_RESPONSE_TYPE);
-                tx[3] = static_cast<uint8_t>(message.response_type);
+                tx[opcode_index] = static_cast<uint8_t>(StSpinOpcode::SET_RESPONSE_TYPE);
+                tx[opcode_index + 1] = static_cast<uint8_t>(message.response_type);
             }
             else if constexpr (std::is_same_v<T, SetPidTorqueKpKiMessage>)
             {
-                tx[2] = static_cast<uint8_t>(StSpinOpcode::SET_PID_TORQUE_KP_KI);
-                tx[3] = static_cast<uint8_t>(0xFF & (message.kp >> 8));
-                tx[4] = static_cast<uint8_t>(0xFF & message.kp);
-                tx[5] = static_cast<uint8_t>(0xFF & (message.ki >> 8));
-                tx[6] = static_cast<uint8_t>(0xFF & message.ki);
+                tx[opcode_index] =
+                    static_cast<uint8_t>(StSpinOpcode::SET_PID_TORQUE_KP_KI);
+                tx[opcode_index + 1] = static_cast<uint8_t>(0xFF & (message.kp >> 8));
+                tx[opcode_index + 2] = static_cast<uint8_t>(0xFF & message.kp);
+                tx[opcode_index + 3] = static_cast<uint8_t>(0xFF & (message.ki >> 8));
+                tx[opcode_index + 4] = static_cast<uint8_t>(0xFF & message.ki);
             }
             else if constexpr (std::is_same_v<T, SetPidFluxKpKiMessage>)
             {
-                tx[2] = static_cast<uint8_t>(StSpinOpcode::SET_PID_FLUX_KP_KI);
-                tx[3] = static_cast<uint8_t>(0xFF & (message.kp >> 8));
-                tx[4] = static_cast<uint8_t>(0xFF & message.kp);
-                tx[5] = static_cast<uint8_t>(0xFF & (message.ki >> 8));
-                tx[6] = static_cast<uint8_t>(0xFF & message.ki);
+                tx[opcode_index] = static_cast<uint8_t>(StSpinOpcode::SET_PID_FLUX_KP_KI);
+                tx[opcode_index + 1] = static_cast<uint8_t>(0xFF & (message.kp >> 8));
+                tx[opcode_index + 2] = static_cast<uint8_t>(0xFF & message.kp);
+                tx[opcode_index + 3] = static_cast<uint8_t>(0xFF & (message.ki >> 8));
+                tx[opcode_index + 4] = static_cast<uint8_t>(0xFF & message.ki);
             }
             else if constexpr (std::is_same_v<T, SetPidSpeedKpKiMessage>)
             {
-                tx[2] = static_cast<uint8_t>(StSpinOpcode::SET_PID_SPEED_KP_KI);
-                tx[3] = static_cast<uint8_t>(0xFF & (message.kp >> 8));
-                tx[4] = static_cast<uint8_t>(0xFF & message.kp);
-                tx[5] = static_cast<uint8_t>(0xFF & (message.ki >> 8));
-                tx[6] = static_cast<uint8_t>(0xFF & message.ki);
+                tx[opcode_index] =
+                    static_cast<uint8_t>(StSpinOpcode::SET_PID_SPEED_KP_KI);
+                tx[opcode_index + 1] = static_cast<uint8_t>(0xFF & (message.kp >> 8));
+                tx[opcode_index + 2] = static_cast<uint8_t>(0xFF & message.kp);
+                tx[opcode_index + 3] = static_cast<uint8_t>(0xFF & (message.ki >> 8));
+                tx[opcode_index + 4] = static_cast<uint8_t>(0xFF & message.ki);
             }
             else if constexpr (std::is_same_v<T, SetSpeedFeedForwardKaKvMessage>)
             {
-                tx[2] = static_cast<uint8_t>(StSpinOpcode::SET_SPEED_FEED_FORWARD_KA_KV);
-                tx[3] = static_cast<uint8_t>(0xFF & (message.ka >> 8));
-                tx[4] = static_cast<uint8_t>(0xFF & message.ka);
-                tx[5] = static_cast<uint8_t>(0xFF & (message.kv >> 8));
-                tx[6] = static_cast<uint8_t>(0xFF & message.kv);
+                tx[opcode_index] =
+                    static_cast<uint8_t>(StSpinOpcode::SET_SPEED_FEED_FORWARD_KA_KV);
+                tx[opcode_index + 1] = static_cast<uint8_t>(0xFF & (message.ka >> 8));
+                tx[opcode_index + 2] = static_cast<uint8_t>(0xFF & message.ka);
+                tx[opcode_index + 3] = static_cast<uint8_t>(0xFF & (message.kv >> 8));
+                tx[opcode_index + 4] = static_cast<uint8_t>(0xFF & message.kv);
             }
             else if constexpr (std::is_same_v<T, SetSpeedFeedForwardKsMessage>)
             {
-                tx[2] = static_cast<uint8_t>(StSpinOpcode::SET_SPEED_FEED_FORWARD_KS);
-                tx[3] = static_cast<uint8_t>(0xFF & (message.ks >> 8));
-                tx[4] = static_cast<uint8_t>(0xFF & message.ks);
+                tx[opcode_index] =
+                    static_cast<uint8_t>(StSpinOpcode::SET_SPEED_FEED_FORWARD_KS);
+                tx[opcode_index + 1] = static_cast<uint8_t>(0xFF & (message.ks >> 8));
+                tx[opcode_index + 2] = static_cast<uint8_t>(0xFF & message.ks);
             }
         },
         outgoing_message);
 
-    tx[7] = Crc8Autosar::calc(tx.data(), MESSAGE_SIZE - 1);
+    tx[MESSAGE_SIZE - 1] = Crc8Autosar::calc(tx.data(), MESSAGE_SIZE - 1);
 }
 
 void StSpinMotorController::processRx(const MotorIndex motor,
                                       const std::array<uint8_t, MESSAGE_SIZE>& rx)
 {
-    switch (static_cast<StSpinResponseType>(rx[2]))
+    const size_t opcode_index = MESSAGE_DELIMITER.size() + 1;
+
+    switch (static_cast<StSpinResponseType>(rx[opcode_index]))
     {
         case StSpinResponseType::SPEED_AND_FAULTS:
         {
             motor_status_[motor].speed =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[3]) << 8) | rx[4]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 1]) << 8) |
+                                     rx[opcode_index + 2]);
             const uint16_t fault_flags =
-                static_cast<uint16_t>((static_cast<uint16_t>(rx[5]) << 8) | rx[6]);
+                static_cast<uint16_t>((static_cast<uint16_t>(rx[opcode_index + 3]) << 8) |
+                                      rx[opcode_index + 4]);
             updateFaults(motor, fault_flags);
             break;
         }
         case StSpinResponseType::IQ_AND_ID:
         {
             motor_status_[motor].iq =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[3]) << 8) | rx[4]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 1]) << 8) |
+                                     rx[opcode_index + 2]);
             motor_status_[motor].id =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[5]) << 8) | rx[6]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 3]) << 8) |
+                                     rx[opcode_index + 4]);
             break;
         }
         case StSpinResponseType::VQ_AND_VD:
         {
             motor_status_[motor].vq =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[3]) << 8) | rx[4]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 1]) << 8) |
+                                     rx[opcode_index + 2]);
             motor_status_[motor].vd =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[5]) << 8) | rx[6]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 3]) << 8) |
+                                     rx[opcode_index + 4]);
             break;
         }
         case StSpinResponseType::PHASE_CURRENT_AND_VOLTAGE:
         {
             motor_status_[motor].phase_current =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[3]) << 8) | rx[4]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 1]) << 8) |
+                                     rx[opcode_index + 2]);
             motor_status_[motor].phase_voltage =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[5]) << 8) | rx[6]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 3]) << 8) |
+                                     rx[opcode_index + 4]);
             break;
         }
         case StSpinResponseType::IQ_AND_IQ_REF:
         {
             motor_status_[motor].iq =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[3]) << 8) | rx[4]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 1]) << 8) |
+                                     rx[opcode_index + 2]);
             motor_status_[motor].iq_ref =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[5]) << 8) | rx[6]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 3]) << 8) |
+                                     rx[opcode_index + 4]);
             break;
         }
         case StSpinResponseType::ID_AND_ID_REF:
         {
             motor_status_[motor].id =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[3]) << 8) | rx[4]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 1]) << 8) |
+                                     rx[opcode_index + 2]);
             motor_status_[motor].id_ref =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[5]) << 8) | rx[6]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 3]) << 8) |
+                                     rx[opcode_index + 4]);
             break;
         }
         case StSpinResponseType::SPEED_AND_SPEED_REF:
         {
             motor_status_[motor].speed =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[3]) << 8) | rx[4]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 1]) << 8) |
+                                     rx[opcode_index + 2]);
             motor_status_[motor].speed_ref =
-                static_cast<int16_t>((static_cast<uint16_t>(rx[5]) << 8) | rx[6]);
+                static_cast<int16_t>((static_cast<uint16_t>(rx[opcode_index + 3]) << 8) |
+                                     rx[opcode_index + 4]);
             break;
         }
     }

--- a/src/software/embedded/motor_controller/stspin_motor_controller.cpp
+++ b/src/software/embedded/motor_controller/stspin_motor_controller.cpp
@@ -288,7 +288,7 @@ void StSpinMotorController::sendAndReceiveMessage(const MotorIndex motor,
 
         // Erase everything up to the start of the delimiter to look for the next
         // potential message
-        received_data.erase(received_data.begin(), delimiter_pos);
+        received_data.erase(received_data.begin(), std::next(delimiter_pos));
     }
 
     LOG(WARNING) << "Motor " << motor << " did not acknowledge message (seq_num "

--- a/src/software/embedded/motor_controller/stspin_motor_controller.h
+++ b/src/software/embedded/motor_controller/stspin_motor_controller.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <chrono>
 
 #include "software/embedded/gpio/gpio.h"
@@ -40,10 +41,10 @@ class StSpinMotorController : public MotorController
                      SetSpeedFeedForwardKaKvMessage, SetSpeedFeedForwardKsMessage>;
 
     // Length of message (in number of bytes)
-    static constexpr unsigned int MESSAGE_SIZE = 8;
+    static constexpr unsigned int MESSAGE_SIZE = 10;
 
-    // Delimiter byte used to indicate start of a message
-    static constexpr uint8_t MESSAGE_DELIMITER = 0xAA;
+    // Delimiter sequence used to indicate start of a message
+    static constexpr std::array<uint8_t, 3> MESSAGE_DELIMITER = {0xAA, 0xBB, 0xCC};
 
     // Maximum number of SPI transfer attempts to wait for an acknowledgement
     // before giving up. Prevents unresponsive MD (e.g. firmware crash or


### PR DESCRIPTION
### Description

We were using `0xAA` to delimit messages, but this byte can occasionally appear within the payload data, causing the receiver to misalign and interpret a data byte as the start of a new message. The incorrectly aligned 8-byte sequence can rarely still produce a valid CRC, resulting in acceptance of a corrupted or false frame.

To reduce the chance of this happening, I've increased the delimiter sequence to 3 bytes `0xAA 0xBB 0xCC` and now also check that the sequence number in the received message is correct (either the current seq num in case of ACK or one less)  

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
