### PR TITLE
Fix enemy free kick play test validations

### DIFF
--- a/src/software/ai/hl/stp/play/enemy_free_kick/enemy_free_kick_play_test.py
+++ b/src/software/ai/hl/stp/play/enemy_free_kick/enemy_free_kick_play_test.py
@@ -92,10 +92,6 @@ from software.gameplay_tests.simulated_test_fixture import (
         ),
     ],
 )
-# TODO: #3503
-@pytest.mark.skip(
-    "Disabling this test because OrValidation is passed both an always validation and eventually validation"
-)
 def test_enemy_free_kick_play(
     simulated_test_runner, blue_bots, yellow_bots, ball_initial_pos
 ):
@@ -120,15 +116,15 @@ def test_enemy_free_kick_play(
             blue_play=PlayName.EnemyFreeKickPlay, yellow_play=PlayName.FreeKickPlay
         )
 
-    # Always Validation
+    # Validation RoboCup SSL rules: can't be within 0.5m of ball before its kicked
     always_validation_sequence_set = [
         [
             OrValidation(
                 [
                     RobotNeverEntersRegion(
-                        regions=[tbots_cpp.Circle(ball_initial_pos, 0.05)]
+                        regions=[tbots_cpp.Circle(ball_initial_pos, 0.5)]
                     ),
-                    BallEventuallyExitsRegion(
+                    BallNeverEntersRegion(
                         regions=[tbots_cpp.Circle(ball_initial_pos, 0.05)]
                     ),
                 ]


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Rewrites the enemy free kick play test validations in a similar way as the enemy kickoff play test, avoiding mixing eventual and always validations in the OrValidation. The logic makes sense, and I also fixed a typo of 0.05m away from ball when its actually supposed to be 0.5m according to the ssl robocup rules pdf.

The image below shows the range where friendly robots can't enter:

<img width="297" height="187" alt="image" src="https://github.com/user-attachments/assets/7148f54f-fc14-48ce-b1c2-61f04ec4276b" />

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Ran `./tbots.py test enemy_free_kick_play_test -t` and looked at the validation visualizations; everything looks good and the test passes.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

resolves #3503 

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
