### PR TITLE
Physical e-stop support for MacOS

### DIFF
--- a/src/shared/constants.h
+++ b/src/shared/constants.h
@@ -213,11 +213,22 @@ static const unsigned int NUM_TIMES_SEND_STOP = 10;
 // disconnected
 static const double DISCONNECT_DURATION_MS = 1 * MILLISECONDS_PER_SECOND;
 
-// product and vendor id for Arduino Uno Rev3 (retrieved from
-// http://www.linux-usb.org/usb.ids )
-#define ARDUINO_ID_LENGTH 5
-static const char ARDUINO_VENDOR_ID[ARDUINO_ID_LENGTH]  = "2341";
-static const char ARDUINO_PRODUCT_ID[ARDUINO_ID_LENGTH] = "0043";
+// Vendor and product id pairs for the USB-to-serial adapters used by the
+// physical estop. Multiple pairs are supported since estop units may use
+// different adapters. IDs retrieved from http://www.linux-usb.org/usb.ids
+struct EstopUsbId
+{
+    const char* vendor_id;
+    const char* product_id;
+};
+
+constexpr EstopUsbId ESTOP_USB_DEVICE_IDS[] = {
+    {"2341", "0043"},  // Arduino Uno Rev3
+    {"1a86", "7523"},  // CH340-based Arduino clones
+};
+
+constexpr int NUM_ESTOP_USB_DEVICE_IDS =
+    sizeof(ESTOP_USB_DEVICE_IDS) / sizeof(ESTOP_USB_DEVICE_IDS[0]);
 
 // Number of times thunderloop should tick per second
 static const unsigned THUNDERLOOP_HZ = 300u;

--- a/src/software/estop/arduino_util.cpp
+++ b/src/software/estop/arduino_util.cpp
@@ -21,11 +21,15 @@ std::optional<std::string> ArduinoUtil::getArduinoPort()
         std::optional<HwInfo> hwInfo = getInfo(device);
         if (hwInfo.has_value())
         {
-            if (hwInfo.value().vendor == ARDUINO_VENDOR_ID &&
-                hwInfo.value().product == ARDUINO_PRODUCT_ID)
+            for (const auto& id : ESTOP_USB_DEVICE_IDS)
             {
-                std::string device_path = (boost::format("/dev/%1%") % device).str();
-                return device_path;
+                if (hwInfo.value().vendor == id.vendor_id &&
+                    hwInfo.value().product == id.product_id)
+                {
+                    std::string device_path =
+                        (boost::format("/dev/%1%") % device).str();
+                    return device_path;
+                }
             }
         }
     }

--- a/src/software/estop/arduino_util.cpp
+++ b/src/software/estop/arduino_util.cpp
@@ -26,8 +26,7 @@ std::optional<std::string> ArduinoUtil::getArduinoPort()
                 if (hwInfo.value().vendor == id.vendor_id &&
                     hwInfo.value().product == id.product_id)
                 {
-                    std::string device_path =
-                        (boost::format("/dev/%1%") % device).str();
+                    std::string device_path = (boost::format("/dev/%1%") % device).str();
                     return device_path;
                 }
             }

--- a/src/software/py_constants.cpp
+++ b/src/software/py_constants.cpp
@@ -169,4 +169,8 @@ PYBIND11_MODULE(py_constants, m)
     m.attr("AUTO_CHIP_DISTANCE_DEFAULT_M")     = AUTO_CHIP_DISTANCE_DEFAULT_M;
     m.attr("AUTO_KICK_SPEED_DEFAULT_M_PER_S")  = AUTO_KICK_SPEED_DEFAULT_M_PER_S;
     m.attr("WHEEL_ROTATION_MAX_SPEED_M_PER_S") = WHEEL_ROTATION_MAX_SPEED_M_PER_S;
+
+    // Estop Arduino USB identifiers
+    m.attr("ARDUINO_VENDOR_ID")  = std::string(ARDUINO_VENDOR_ID);
+    m.attr("ARDUINO_PRODUCT_ID") = std::string(ARDUINO_PRODUCT_ID);
 }

--- a/src/software/py_constants.cpp
+++ b/src/software/py_constants.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "shared/constants.h"
 #include "software/constants.h"
@@ -170,7 +171,12 @@ PYBIND11_MODULE(py_constants, m)
     m.attr("AUTO_KICK_SPEED_DEFAULT_M_PER_S")  = AUTO_KICK_SPEED_DEFAULT_M_PER_S;
     m.attr("WHEEL_ROTATION_MAX_SPEED_M_PER_S") = WHEEL_ROTATION_MAX_SPEED_M_PER_S;
 
-    // Estop Arduino USB identifiers
-    m.attr("ARDUINO_VENDOR_ID")  = std::string(ARDUINO_VENDOR_ID);
-    m.attr("ARDUINO_PRODUCT_ID") = std::string(ARDUINO_PRODUCT_ID);
+    // Estop USB-to-serial adapter identifiers, as a list of
+    // (vendor_id, product_id) pairs
+    std::vector<std::pair<std::string, std::string>> estop_usb_device_ids;
+    for (const auto& id : ESTOP_USB_DEVICE_IDS)
+    {
+        estop_usb_device_ids.emplace_back(id.vendor_id, id.product_id);
+    }
+    m.attr("ESTOP_USB_DEVICE_IDS") = estop_usb_device_ids;
 }

--- a/src/software/thunderscope/BUILD
+++ b/src/software/thunderscope/BUILD
@@ -190,7 +190,9 @@ py_library(
 py_library(
     name = "estop_helpers",
     srcs = ["estop_helpers.py"],
+    data = ["//software:py_constants.so"],
     deps = [
         "//software/thunderscope:constants",
+        requirement("pyserial"),
     ],
 )

--- a/src/software/thunderscope/constants.py
+++ b/src/software/thunderscope/constants.py
@@ -107,7 +107,7 @@ LOG_LEVEL_STR_MAP = {
     LogLevel.CONTRACT: "CONTRACT",
 }
 
-# Paths to check for estop when running diagnostics
+# Paths to check for estop when running diagnostics, used as a fallback for Linux.
 ESTOP_PATH_1 = "/dev/ttyACM0"
 ESTOP_PATH_2 = "/dev/ttyUSB0"
 

--- a/src/software/thunderscope/estop_helpers.py
+++ b/src/software/thunderscope/estop_helpers.py
@@ -1,10 +1,38 @@
 import os
+from serial.tools import list_ports
+
+from software.py_constants import ARDUINO_VENDOR_ID, ARDUINO_PRODUCT_ID
 from software.thunderscope.constants import EstopMode, ESTOP_PATH_1, ESTOP_PATH_2
+
+
+def get_estop_path() -> str | None:
+    """Find the serial port that the physical estop is connected to.
+
+    Falls back to the well-known Linux device paths if the estop cannot be
+    matched by its USB IDs.
+
+    :return: the estop's serial port path, or None if no estop was found
+    """
+    for port in list_ports.comports():
+        if port.vid is None or port.pid is None:
+            continue
+        if (
+            f"{port.vid:04x}".lower() == ARDUINO_VENDOR_ID.lower()
+            and f"{port.pid:04x}".lower() == ARDUINO_PRODUCT_ID.lower()
+        ):
+            return port.device
+
+    # Fall back to linux device paths
+    for path in (ESTOP_PATH_1, ESTOP_PATH_2):
+        if os.path.exists(path):
+            return path
+
+    return None
 
 
 def get_estop_config(
     keyboard_estop: bool, disable_communication: bool
-) -> tuple[EstopMode, os.PathLike]:
+) -> tuple[EstopMode, str | None]:
     """Based on the estop mode argument provided, gets the corresponding
     estop mode and estop path (defined for physical estop mode only)
     Defaults to Physical estop if the given args are both False
@@ -21,15 +49,9 @@ def get_estop_config(
     if disable_communication:
         mode = EstopMode.DISABLE_ESTOP
 
-    # use different estop based on what is plugged in for physical estop mode
+    # locate the physical estop's serial port when in physical estop mode
     if mode == EstopMode.PHYSICAL_ESTOP:
-        path = (
-            ESTOP_PATH_1
-            if os.path.exists(ESTOP_PATH_1)
-            else ESTOP_PATH_2
-            if os.path.exists(ESTOP_PATH_2)
-            else None
-        )
+        path = get_estop_path()
         if not path:
             raise Exception(
                 "Estop is not plugged into a valid port, plug one in or use a different estop mode"

--- a/src/software/thunderscope/estop_helpers.py
+++ b/src/software/thunderscope/estop_helpers.py
@@ -1,7 +1,7 @@
 import os
 from serial.tools import list_ports
 
-from software.py_constants import ARDUINO_VENDOR_ID, ARDUINO_PRODUCT_ID
+from software.py_constants import ESTOP_USB_DEVICE_IDS
 from software.thunderscope.constants import EstopMode, ESTOP_PATH_1, ESTOP_PATH_2
 
 
@@ -13,13 +13,13 @@ def get_estop_path() -> str | None:
 
     :return: the estop's serial port path, or None if no estop was found
     """
+    estop_usb_ids = {
+        (vendor.lower(), product.lower()) for vendor, product in ESTOP_USB_DEVICE_IDS
+    }
     for port in list_ports.comports():
         if port.vid is None or port.pid is None:
             continue
-        if (
-            f"{port.vid:04x}".lower() == ARDUINO_VENDOR_ID.lower()
-            and f"{port.pid:04x}".lower() == ARDUINO_PRODUCT_ID.lower()
-        ):
+        if (f"{port.vid:04x}".lower(), f"{port.pid:04x}".lower()) in estop_usb_ids:
             return port.device
 
     # Fall back to linux device paths

--- a/src/software/thunderscope/requirements.in
+++ b/src/software/thunderscope/requirements.in
@@ -3,6 +3,7 @@ netifaces==0.11.0
 evdev==1.7.0; sys_platform == "linux"
 numpy==1.26.4
 protobuf==6.31.1
+pyserial==3.5
 pyqtgraph==0.13.7
 pyqtdarktheme-fork==2.3.2
 PyQt6-Qt6==6.8.1

--- a/src/software/thunderscope/requirements_lock.darwin.txt
+++ b/src/software/thunderscope/requirements_lock.darwin.txt
@@ -120,6 +120,10 @@ pyqtgraph==0.13.7 \
     --hash=sha256:64f84f1935c6996d0e09b1ee66fe478a7771e3ca6f3aaa05f00f6e068321d9e3 \
     --hash=sha256:7754edbefb6c367fa0dfb176e2d0610da3ada20aa7a5318516c74af5fb72bf7a
     # via -r software/thunderscope/requirements.in
+pyserial==3.5 \
+    --hash=sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb \
+    --hash=sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0
+    # via -r software/thunderscope/requirements.in
 qtawesome==1.4.0 \
     --hash=sha256:783e414d1317f3e978bf67ea8e8a1b1498bad9dbd305dec814027e3b50521be6 \
     --hash=sha256:a4d689fa071c595aa6184171ce1f0f847677cb8d2db45382c43129f1d72a3d93

--- a/src/software/thunderscope/requirements_lock.txt
+++ b/src/software/thunderscope/requirements_lock.txt
@@ -123,6 +123,10 @@ pyqtgraph==0.13.7 \
     --hash=sha256:64f84f1935c6996d0e09b1ee66fe478a7771e3ca6f3aaa05f00f6e068321d9e3 \
     --hash=sha256:7754edbefb6c367fa0dfb176e2d0610da3ada20aa7a5318516c74af5fb72bf7a
     # via -r software/thunderscope/requirements.in
+pyserial==3.5 \
+    --hash=sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb \
+    --hash=sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0
+    # via -r software/thunderscope/requirements.in
 qtawesome==1.4.0 \
     --hash=sha256:783e414d1317f3e978bf67ea8e8a1b1498bad9dbd305dec814027e3b50521be6 \
     --hash=sha256:a4d689fa071c595aa6184171ce1f0f847677cb8d2db45382c43129f1d72a3d93


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

**This is a stacked PR: #3800 #3802**

Instead of relying on hardcoded linux device paths for the physical estop, uses pyserial and checks the vendor id and product id of the arduino used for the estop to locate the path of the estop. This is necessary since the macos serial ports are dynamic.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Ran diagnostics and estop was detected and works like expected.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
