### PR TITLE
Allow no Estop for `tbots_cli`

### DIFF
--- a/src/software/embedded/robot_diagnostics_cli/embedded_communication.py
+++ b/src/software/embedded/robot_diagnostics_cli/embedded_communication.py
@@ -37,19 +37,29 @@ class EmbeddedCommunication:
             True,
         )
 
-        # initialising the estop
         self.estop_reader = None
         self.should_send_stop = False
-        self.estop_mode, self.estop_path = get_estop_config(
-            keyboard_estop=False, disable_communication=False
-        )
+        self.estop_mode = EstopMode.PHYSICAL_ESTOP
+        self.estop_path = None
 
-        # Always in PHYSICAL_ESTOP mode within CLI
+    def setup_estop(self) -> bool:
+        """Lazily sets up the physical estop reader the first time a command
+        that actuates the robot's electrical/mechanical components is run.
+
+        :return: True if a physical estop is connected and ready, False otherwise
+        """
+        if self.estop_reader is not None:
+            return True
+
         try:
+            self.estop_mode, self.estop_path = get_estop_config(
+                keyboard_estop=False, disable_communication=False
+            )
             self.estop_reader = tbots_cpp.ThreadedEstopReader(self.estop_path, 115200)
             self.__update_estop_state()
-        except Exception as e:
-            raise Exception(f"Invalid Estop found at location {self.estop_path} as {e}")
+            return True
+        except Exception:
+            return False
 
     def __receive_robot_status(self, robot_status: Message) -> None:
         """Updates the dynamic information with the new RobotStatus message.

--- a/src/software/embedded/robot_diagnostics_cli/embedded_data.py
+++ b/src/software/embedded/robot_diagnostics_cli/embedded_data.py
@@ -64,14 +64,9 @@ class EmbeddedData:
     def get_chip_pulse_width(self) -> str:
         return self._get_value(ROBOT_CHIP_PULSE_WIDTH_CONFIG_KEY)
 
-    def get_current_draw(self) -> str:
-        return self._get_value(ROBOT_CURRENT_DRAW_CONFIG_KEY)
-
-    def get_battery_volt(self) -> str:
-        return self._get_value(ROBOT_BATTERY_VOLTAGE_CONFIG_KEY)
-
-    def get_cap_volt(self) -> str:
-        return self._get_value(ROBOT_CAPACITOR_VOLTAGE_CONFIG_KEY)
+    # TODO: #3809
+    # def get_cap_volt(self) -> str:
+    #     return self._get_value(ROBOT_CAPACITOR_VOLTAGE_CONFIG_KEY)
 
     def __clamp(self, val: float, min_val: float, max_val: float) -> float:
         """Simple Math Clamp function (Faster than numpy & fewer dependencies)

--- a/src/software/embedded/robot_diagnostics_cli/robot_diagnostics_cli.py
+++ b/src/software/embedded/robot_diagnostics_cli/robot_diagnostics_cli.py
@@ -1,6 +1,7 @@
 import subprocess
 import logging
 import typer as Typer
+from typer.main import get_command
 from rich import print
 from rich.live import Live
 from rich.table import Table
@@ -52,7 +53,9 @@ class RobotDiagnosticsCLI:
         self.app.command(short_help="Shows TOML Config Values")(self.config)
         self.app.command(short_help="Prints Thunderloop Logs")(self.log)
         self.app.command(short_help="Prints Thunderloop Status")(self.status)
-        self.app.command(short_help="Restarts Thunderloop")(self.restart_thunderloop)
+        self.app.command(short_help="Restarts Thunderloop")(self.restart)
+        self.app.command(short_help="Starts Thunderloop")(self.start)
+        self.app.command(short_help="Stops Thunderloop")(self.stop)
         # Communication object responsible for proto execution/transmission
         self.embedded_communication = embedded_communication
         # Data handler responsible for disk information
@@ -100,6 +103,24 @@ class RobotDiagnosticsCLI:
             return wrapper
 
         return decorator
+
+    def requires_estop(func):
+        """Decorator that ensures a physical estop is plugged in before running a
+        command that actuates the robot's electrical/mechanical components.
+        """
+
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            if not self.embedded_communication.setup_estop():
+                logging.warning(
+                    "[bold yellow]No estop plugged in: this command controls the "
+                    "robot's electrical/mechanical components and requires an estop. "
+                    "Plug one in and try again. Command not executed.[/bold yellow]"
+                )
+                return
+            return func(self, *args, **kwargs)
+
+        return wrapper
 
     def __generate_stats_table(self) -> Table:
         """Make a new table with robot status information."""
@@ -161,21 +182,12 @@ class RobotDiagnosticsCLI:
             f"{ROBOT_CHIP_PULSE_WIDTH_CONFIG_KEY}",
             self.embedded_data.get_chip_pulse_width(),
         )
-        table.add_row(
-            "Battery Voltage",
-            f"{ROBOT_BATTERY_VOLTAGE_CONFIG_KEY}",
-            self.embedded_data.get_battery_volt(),
-        )
-        table.add_row(
-            "Battery Current Draw",
-            f"{ROBOT_CURRENT_DRAW_CONFIG_KEY}",
-            self.embedded_data.get_current_draw(),
-        )
-        table.add_row(
-            "Capacitor Voltage",
-            f"{ROBOT_CAPACITOR_VOLTAGE_CONFIG_KEY}",
-            self.embedded_data.get_cap_volt(),
-        )
+        # TODO: #3809
+        # table.add_row(
+        #     "Capacitor Voltage",
+        #     f"{ROBOT_CAPACITOR_VOLTAGE_CONFIG_KEY}",
+        #     self.embedded_data.get_cap_volt(),
+        # )
         return table
 
     def stats(self) -> None:
@@ -193,9 +205,19 @@ class RobotDiagnosticsCLI:
         log = subprocess.call(["service", "thunderloop", "status"])
         print(log)
 
-    def restart_thunderloop(self):
+    def restart(self):
         """CLI Command to restart Thunderloop service and print status"""
-        subprocess.run(["service", "thunderloop", "restart"])
+        subprocess.run(["sudo", "service", "thunderloop", "restart"])
+        self.status()
+
+    def start(self):
+        """CLI Command to start Thunderloop service and print status"""
+        subprocess.run(["sudo", "service", "thunderloop", "start"])
+        self.status()
+
+    def stop(self):
+        """CLI Command to stop Thunderloop service and print status"""
+        subprocess.run(["sudo", "service", "thunderloop", "stop"])
         self.status()
 
     def log(self):
@@ -203,6 +225,7 @@ class RobotDiagnosticsCLI:
         log = subprocess.call(["sudo", "journalctl", "-f", "-n", "100"])
         print(log)
 
+    @requires_estop
     @catch_interrupt_exception()
     def rotate(
         self,
@@ -227,6 +250,7 @@ class RobotDiagnosticsCLI:
             description,
         )
 
+    @requires_estop
     @catch_interrupt_exception()
     def move(
         self,
@@ -256,6 +280,7 @@ class RobotDiagnosticsCLI:
             description,
         )
 
+    @requires_estop
     @catch_interrupt_exception()
     def chip(
         self,
@@ -289,6 +314,7 @@ class RobotDiagnosticsCLI:
             self.embedded_communication.run_primitive(primitive)
             print(description)
 
+    @requires_estop
     @catch_interrupt_exception()
     def kick(
         self,
@@ -331,6 +357,7 @@ class RobotDiagnosticsCLI:
                 "Recharging...",
             )
 
+    @requires_estop
     @catch_interrupt_exception()
     def dribble(
         self,
@@ -358,6 +385,7 @@ class RobotDiagnosticsCLI:
             description,
         )
 
+    @requires_estop
     @catch_interrupt_exception()
     def move_wheel(
         self,
@@ -395,7 +423,14 @@ class RobotDiagnosticsCLI:
         # TODO (#3434): Add an emote function!
         return
 
+    def run(self) -> None:
+        """Launch the interactive Diagnostics CLI shell."""
+        self.app._add_completion = False
+        command = get_command(self.app)
+        command.add_help_option = False
+        command()
+
 
 if __name__ == "__main__":
     with EmbeddedCommunication() as embedded_communication:
-        RobotDiagnosticsCLI(embedded_communication).app()
+        RobotDiagnosticsCLI(embedded_communication).run()


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->
Updates the onboard `tbots_cli` to omit values removed in #3537, and also relaxes the requirement for an EStop to be connected to use the CLI. Instead, we should allow non-invasive commands (e.g. logging, and reading data of the PI) and only request an estop be connected when motion-based commands are issued.  

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Works on the robots!

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
Resolves #3779

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
