### PR TITLE
Fix emergency stop logic for sending stop primitives

### DIFF
--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -58,9 +58,6 @@ class RobotCommunication:
         # dynamic map of robot id to the individual control mode
         self.robot_control_mode_map: dict[int, IndividualRobotMode] = {}
 
-        # static map of robot id to stop primitive
-        self.robot_stop_primitives_map: dict[int, StopPrimitive] = {}
-
         # links robot id to the number of times to send a stop primitive
         self.robot_stop_primitive_send_count: list[int] = [0] * MAX_ROBOT_IDS_PER_SIDE
 
@@ -76,9 +73,6 @@ class RobotCommunication:
             PowerControl, self.power_control_primitive_buffer
         )
 
-        # dynamic map of robot id to the individual control mode
-        self.robot_control_mode_map: dict[int, IndividualRobotMode] = {}
-
         self.send_estop_state_thread = threading.Thread(
             target=self.__send_estop_state, daemon=True
         )
@@ -86,10 +80,9 @@ class RobotCommunication:
             target=self.__run_primitive_set, daemon=True
         )
 
-        # load control mode and stop primitive maps with default values
+        # load control mode map with default values
         for robot_id in range(MAX_ROBOT_IDS_PER_SIDE):
             self.robot_control_mode_map[robot_id] = IndividualRobotMode.NONE
-            self.robot_stop_primitives_map[robot_id] = Primitive(stop=StopPrimitive())
 
         # TODO: (#3174): move estop state management out of robot_communication
         self.estop_mode = estop_mode

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -146,27 +146,27 @@ class RobotCommunication:
         )
 
     def __send_estop_state(self) -> None:
-        """Constant loop which sends the current estop status proto if estop is not disabled
-        Uses the keyboard estop value for keyboard estop mode
-        If we're in physical estop mode, uses the physical estop value
-        If estop has just changed from playing to stop, set flag to send stop primitive once to connected robots
+        """Constant loop which sends the current estop status proto.
+
+        If estop is set to stop, set flag to send stop primitives to connected robots
         """
-        previous_estop_is_playing = True
-        if self.estop_mode != EstopMode.DISABLE_ESTOP:
-            while True:
-                if self.estop_mode == EstopMode.PHYSICAL_ESTOP:
-                    self.estop_is_playing = self.estop_reader.isEstopPlay()
+        if self.estop_mode == EstopMode.DISABLE_ESTOP:
+            return
 
-                if not self.estop_is_playing:
-                    self.robot_stop_primitive_send_count = [
-                        NUM_TIMES_SEND_STOP
-                        for robot_id in range(MAX_ROBOT_IDS_PER_SIDE)
-                    ]
+        while True:
+            if self.estop_mode == EstopMode.PHYSICAL_ESTOP:
+                self.estop_is_playing = self.estop_reader.isEstopPlay()
 
-                self.current_proto_unix_io.send_proto(
-                    EstopState, EstopState(is_playing=self.estop_is_playing)
-                )
-                time.sleep(0.1)
+            if not self.estop_is_playing:
+                self.robot_stop_primitive_send_count = [
+                    NUM_TIMES_SEND_STOP
+                    for robot_id in range(MAX_ROBOT_IDS_PER_SIDE)
+                ]
+
+            self.current_proto_unix_io.send_proto(
+                EstopState, EstopState(is_playing=self.estop_is_playing)
+            )
+            time.sleep(0.1)
 
     def __should_send_packet(self, robot_id) -> bool:
         """Returns True if the proto should be sent to the robot with the given id

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -159,8 +159,7 @@ class RobotCommunication:
 
             if not self.estop_is_playing:
                 self.robot_stop_primitive_send_count = [
-                    NUM_TIMES_SEND_STOP
-                    for robot_id in range(MAX_ROBOT_IDS_PER_SIDE)
+                    NUM_TIMES_SEND_STOP for robot_id in range(MAX_ROBOT_IDS_PER_SIDE)
                 ]
 
             self.current_proto_unix_io.send_proto(

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -190,8 +190,8 @@ class RobotCommunication:
         For Diagnostics protos, does not block and returns cached message if none available
         Sleeps for 10ms for diagnostics
 
-        If the emergency stop is tripped, the PrimitiveSet will not be sent so
-        that the robots timeout and stop.
+        If the emergency stop is tripped, regular primitives are withheld and a
+        stop primitive is sent to every robot instead, so the robots stop immediately.
         """
         while self.running:
             self.communication_manager.poll()
@@ -239,8 +239,10 @@ class RobotCommunication:
                     fullsystem_primitive_set.robot_primitives[robot_id]
                 )
 
-            # sends a final stop primitive to all disconnected robots and removes them from list
-            # in order to prevent robots acting on cached old primitives
+            # send a final stop primitive to all disconnected/estopped robots so
+            # they don't act on cached old primitives;
+
+            force_stop_robot_ids = set()
             for robot_id, num_times_to_send_stop in enumerate(
                 self.robot_stop_primitive_send_count
             ):
@@ -249,9 +251,13 @@ class RobotCommunication:
                     self.robot_stop_primitive_send_count[robot_id] = (
                         num_times_to_send_stop - 1
                     )
+                    force_stop_robot_ids.add(robot_id)
 
             for robot_id, primitive in robot_primitives_map.items():
-                if not self.__should_send_packet(robot_id=robot_id):
+                if (
+                    robot_id not in force_stop_robot_ids
+                    and not self.__should_send_packet(robot_id=robot_id)
+                ):
                     continue
                 primitive.sequence_number = self.sequence_number
                 primitive.time_sent.CopyFrom(

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -41,10 +41,6 @@ class RobotCommunication:
         """
         self.sequence_number = 0
         self.current_proto_unix_io = current_proto_unix_io
-        self.estop_mode = estop_mode
-
-        self.estop_path = estop_path
-        self.estop_baudrate = estop_baudrate
 
         self.communication_manager = communication_manager
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -120,6 +120,9 @@ class RobotCommunication:
         And sends a message to the console
         """
         if self.estop_mode == EstopMode.KEYBOARD_ESTOP:
+            self.robot_stop_primitive_send_count = [
+                NUM_TIMES_SEND_STOP for robot_id in range(MAX_ROBOT_IDS_PER_SIDE)
+            ]
             self.estop_is_playing = not self.estop_is_playing
             logger.debug(
                 "Keyboard Estop changed to "
@@ -154,10 +157,11 @@ class RobotCommunication:
             return
 
         while True:
+            prev_estop_playing = self.estop_is_playing
             if self.estop_mode == EstopMode.PHYSICAL_ESTOP:
                 self.estop_is_playing = self.estop_reader.isEstopPlay()
 
-            if not self.estop_is_playing:
+            if prev_estop_playing and not self.estop_is_playing:
                 self.robot_stop_primitive_send_count = [
                     NUM_TIMES_SEND_STOP for robot_id in range(MAX_ROBOT_IDS_PER_SIDE)
                 ]
@@ -265,6 +269,7 @@ class RobotCommunication:
                 self.communication_manager.send_primitive(
                     robot_id=robot_id, primitive=primitive
                 )
+                print(f"{primitive}: {self.estop_is_playing}")
 
             self.sequence_number += 1
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -44,7 +44,7 @@ class RobotCommunication:
         self.estop_mode = estop_mode
 
         self.estop_path = estop_path
-        self.estop_buadrate = estop_baudrate
+        self.estop_baudrate = estop_baudrate
 
         self.communication_manager = communication_manager
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -116,13 +116,11 @@ class RobotCommunication:
         }
 
     def toggle_keyboard_estop(self) -> None:
-        """If keyboard estop is being used, toggles the estop state
-        And sends a message to the console
+        """Toggle the keyboard estop state, queue stop primitives for all robots,
+        and log the new state. No-op unless in keyboard estop mode.
         """
         if self.estop_mode == EstopMode.KEYBOARD_ESTOP:
-            self.robot_stop_primitive_send_count = [
-                NUM_TIMES_SEND_STOP for robot_id in range(MAX_ROBOT_IDS_PER_SIDE)
-            ]
+            self.__queue_stop_for_all_robots()
             self.estop_is_playing = not self.estop_is_playing
             logger.debug(
                 "Keyboard Estop changed to "
@@ -136,22 +134,29 @@ class RobotCommunication:
     def toggle_individual_robot_control_mode(
         self, robot_id: int, mode: IndividualRobotMode
     ):
-        """Changes the input mode for a robot between NONE, MANUAL, or AI
-        If changing from MANUAL OR AI to NONE, add robot id to stop primitive
-        map so that multiple stop primitives are sent - safety number one priority
+        """Change a robot's input mode (NONE, MANUAL, or AI).
 
-        :param mode: the mode of input for this robot's primitives
+        Switching to NONE queues stop primitives for the robot so it stops
+        instead of acting on cached primitives.
+
         :param robot_id: the id of the robot whose mode we're changing
+        :param mode: the mode of input for this robot's primitives
         """
         self.robot_control_mode_map[robot_id] = mode
         self.robot_stop_primitive_send_count[robot_id] = (
             NUM_TIMES_SEND_STOP if mode == IndividualRobotMode.NONE else 0
         )
 
-    def __send_estop_state(self) -> None:
-        """Constant loop which sends the current estop status proto.
+    def __queue_stop_for_all_robots(self) -> None:
+        """Queue NUM_TIMES_SEND_STOP stop primitives for every robot."""
+        self.robot_stop_primitive_send_count = [
+            NUM_TIMES_SEND_STOP for _ in range(MAX_ROBOT_IDS_PER_SIDE)
+        ]
 
-        If estop is set to stop, set flag to send stop primitives to connected robots
+    def __send_estop_state(self) -> None:
+        """Continuously broadcast the estop state, refreshing the physical estop
+        reading each iteration. On a play->stop transition, queue stop primitives
+        for all robots. No-op when estop is disabled.
         """
         if self.estop_mode == EstopMode.DISABLE_ESTOP:
             return
@@ -162,9 +167,7 @@ class RobotCommunication:
                 self.estop_is_playing = self.estop_reader.isEstopPlay()
 
             if prev_estop_playing and not self.estop_is_playing:
-                self.robot_stop_primitive_send_count = [
-                    NUM_TIMES_SEND_STOP for robot_id in range(MAX_ROBOT_IDS_PER_SIDE)
-                ]
+                self.__queue_stop_for_all_robots()
 
             self.current_proto_unix_io.send_proto(
                 EstopState, EstopState(is_playing=self.estop_is_playing)
@@ -185,16 +188,14 @@ class RobotCommunication:
         )
 
     def __run_primitive_set(self) -> None:
-        """Forward PrimitiveSet protos from Fullsystem and MotorControl/PowerControl
-        protos from Robot Diagnostics to the robots.
+        """Forward AI primitives (PrimitiveSet) and diagnostics MotorControl/
+        PowerControl protos to the robots.
 
-        For AI protos, blocks for 10ms if no proto is available, and then returns a cached proto
+        Blocks up to ROBOT_COMMUNICATIONS_TIMEOUT_S for an AI proto, falling back
+        to the cached one; diagnostics protos are read non-blocking.
 
-        For Diagnostics protos, does not block and returns cached message if none available
-        Sleeps for 10ms for diagnostics
-
-        If the emergency stop is tripped, regular primitives are withheld and a
-        stop primitive is sent to every robot instead, so the robots stop immediately.
+        While the estop is tripped, regular primitives are withheld and a stop
+        primitive is sent to every robot instead so they stop immediately.
         """
         while self.running:
             self.communication_manager.poll()
@@ -242,9 +243,8 @@ class RobotCommunication:
                     fullsystem_primitive_set.robot_primitives[robot_id]
                 )
 
-            # send a final stop primitive to all disconnected/estopped robots so
-            # they don't act on cached old primitives;
-
+            # force a stop primitive to estopped/uncontrolled robots so they
+            # don't keep acting on their last primitive
             force_stop_robot_ids = set()
             for robot_id, num_times_to_send_stop in enumerate(
                 self.robot_stop_primitive_send_count
@@ -269,7 +269,6 @@ class RobotCommunication:
                 self.communication_manager.send_primitive(
                     robot_id=robot_id, primitive=primitive
                 )
-                print(f"{primitive}: {self.estop_is_playing}")
 
             self.sequence_number += 1
 

--- a/src/software/thunderscope/robot_communication.py
+++ b/src/software/thunderscope/robot_communication.py
@@ -90,6 +90,7 @@ class RobotCommunication:
         # if using keyboard estop, skips this step
         self.estop_reader = None
         self.estop_is_playing = False
+        self.prev_estop_is_playing = False
 
         # only checks for estop if we are in physical estop mode
         if self.estop_mode == EstopMode.PHYSICAL_ESTOP:
@@ -109,7 +110,7 @@ class RobotCommunication:
         and log the new state. No-op unless in keyboard estop mode.
         """
         if self.estop_mode == EstopMode.KEYBOARD_ESTOP:
-            self.__queue_stop_for_all_robots()
+            self.prev_estop_is_playing = self.estop_is_playing
             self.estop_is_playing = not self.estop_is_playing
             logger.debug(
                 "Keyboard Estop changed to "
@@ -151,11 +152,11 @@ class RobotCommunication:
             return
 
         while True:
-            prev_estop_playing = self.estop_is_playing
             if self.estop_mode == EstopMode.PHYSICAL_ESTOP:
+                self.prev_estop_is_playing = self.estop_is_playing
                 self.estop_is_playing = self.estop_reader.isEstopPlay()
 
-            if prev_estop_playing and not self.estop_is_playing:
+            if self.prev_estop_is_playing and not self.estop_is_playing:
                 self.__queue_stop_for_all_robots()
 
             self.current_proto_unix_io.send_proto(


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

This PR fixes the estop logic so that stop primitives are actually sent to all robots when the estop is set to stop. Previously, there was a method that guarded against primitives being sent when estop is stopped, however, this logic also prevented stop primitives from being sent. I have observed the robot speeding up for half a second after the estop was pressed, and that was because stop primitives weren't being sent and the robot only stops as a result of the time-out on thunderloop. This PR fixes this.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

https://github.com/user-attachments/assets/8a00899d-c247-49dc-a804-c4a34241e8e1

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

N/A

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
