### PR TITLE
Fix SPI error logs

### DIFF
--- a/src/software/embedded/motor_controller/stspin_motor_controller.cpp
+++ b/src/software/embedded/motor_controller/stspin_motor_controller.cpp
@@ -287,7 +287,7 @@ void StSpinMotorController::sendAndReceiveMessage(const MotorIndex motor,
     }
 
     LOG(WARNING) << "Motor " << motor << " did not acknowledge message (seq_num "
-                 << motor_status_.at(motor).seq_num << ") after "
+                 << static_cast<int>(motor_status_.at(motor).seq_num) << ") after "
                  << MAX_SPI_TRANSFER_ATTEMPTS << " SPI attempts; giving up";
 }
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

SPI errors returned mysterious log message: [197B blob data]. It was because the seq_num variable being logged is a char which gets converted into a byte which caused the rest of the message to be interpreted as bytes. This is a very simple fix.

**Also this is quite important as this issue would crash _thunderscope_ on the computer because the robot log protobuf would contain the wrong type of data**

```
Jun 25 01:49:35 killit thunderloop_main[4554]:  2026/06/25 01:49:35 004157        WARNING [stspin_motor_controller.cpp->sendAndReceiveMessage:289]        Motor FRONT_LEFT did n
ot acknowledge message (seq_num {) after 100 SPI attempts; giving up                                                                                                            
Jun 25 01:49:35 killit thunderloop_main[4554]:  2026/06/25 01:49:35 026558        WARNING [stspin_motor_controller.cpp->sendAndReceiveMessage:289]        Motor FRONT_LEFT did n
ot acknowledge message (seq_num |) after 100 SPI attempts; giving up                                                                                                            
Jun 25 01:49:35 killit thunderloop_main[4554]:  2026/06/25 01:49:35 048974        WARNING [stspin_motor_controller.cpp->sendAndReceiveMessage:289]        Motor FRONT_LEFT did n
ot acknowledge message (seq_num }) after 100 SPI attempts; giving up                                                                                                            
Jun 25 01:49:35 killit thunderloop_main[4554]:  2026/06/25 01:49:35 071251        WARNING [stspin_motor_controller.cpp->sendAndReceiveMessage:289]        Motor FRONT_LEFT did n
ot acknowledge message (seq_num ~) after 100 SPI attempts; giving up                                                                                                            
Jun 25 01:49:35 killit thunderloop_main[4554]: [197B blob data]                                                                                                                 
Jun 25 01:49:35 killit thunderloop_main[4554]: WARNING: All log messages before absl::InitializeLog() is called are written to STDERR                                           
Jun 25 01:49:35 killit thunderloop_main[4554]: E0000 00:00:1782377375.116015    4557 wire_format_lite.cc:578] String field 'TbotsProto.RobotLog.log_msg' contains invalid UTF-8 
data when serializing a protocol buffer. Use the 'bytes' type if you intend to send raw bytes.                                                                                  
Jun 25 01:49:35 killit thunderloop_main[4554]: [197B blob data]                                                                                                                 
Jun 25 01:49:35 killit thunderloop_main[4554]: [197B blob data]                                                                                                                 
Jun 25 01:49:35 killit thunderloop_main[4554]: E0000 00:00:1782377375.138607    4557 wire_format_lite.cc:578] String field 'TbotsProto.RobotLog.log_msg' contains invalid UTF-8 
data when serializing a protocol buffer. Use the 'bytes' type if you intend to send raw bytes.                                                                                  
Jun 25 01:49:35 killit thunderloop_main[4554]: E0000 00:00:1782377375.160835    4557 wire_format_lite.cc:578] String field 'TbotsProto.RobotLog.log_msg' contains invalid UTF-8 
data when serializing a protocol buffer. Use the 'bytes' type if you intend to send raw bytes.                                                                                  
Jun 25 01:49:35 killit thunderloop_main[4554]: [197B blob data]                                                                                                                 
Jun 25 01:49:35 killit thunderloop_main[4554]: [197B blob data]                                   
```

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

No longer logs the weird message, its logging proper warning now.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
