### PR TITLE
Fix Goalie ID Assignment in Sensor Fusion

### DIFF
--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -63,20 +63,24 @@ void SensorFusion::processSensorProto(const SensorProto& sensor_msg)
 
     updateWorld(sensor_msg.robot_status_msgs());
 
-    friendly_team.assignGoalie(friendly_goalie_id);
-    enemy_team.assignGoalie(enemy_goalie_id);
+    unsigned int unresolved_friendly_goalie_id = friendly_goalie_id;
+    unsigned int unresolved_enemy_goalie_id    = enemy_goalie_id;
 
     if (sensor_fusion_config.override_game_controller_friendly_goalie_id())
     {
         RobotId friendly_goalie_id_override = sensor_fusion_config.friendly_goalie_id();
-        friendly_team.assignGoalie(friendly_goalie_id_override);
+        unresolved_friendly_goalie_id       = friendly_goalie_id_override;
     }
 
     if (sensor_fusion_config.override_game_controller_enemy_goalie_id())
     {
         RobotId enemy_goalie_id_override = sensor_fusion_config.enemy_goalie_id();
-        enemy_team.assignGoalie(enemy_goalie_id_override);
+        unresolved_enemy_goalie_id       = enemy_goalie_id_override;
     }
+
+    friendly_team.assignGoalie(
+        resolveGoalieId(friendly_team, unresolved_friendly_goalie_id));
+    enemy_team.assignGoalie(resolveGoalieId(enemy_team, unresolved_enemy_goalie_id));
 }
 
 
@@ -468,6 +472,33 @@ BallDetection SensorFusion::invert(BallDetection ball_detection) const
     ball_detection.position =
         Point(-ball_detection.position.x(), -ball_detection.position.y());
     return ball_detection;
+}
+
+unsigned int SensorFusion::resolveGoalieId(const Team& team, unsigned int goalie_id)
+{
+    // If the desired goalie exists on the team, use it
+    if (team.getRobotById(goalie_id).has_value())
+    {
+        return goalie_id;
+    }
+
+    // Otherwise, find the lowest robot ID present on the team
+    const auto& all_robots = team.getAllRobots();
+    if (!all_robots.empty())
+    {
+        RobotId lowest_id = all_robots.front().id();
+        for (const auto& robot : all_robots)
+        {
+            if (robot.id() < lowest_id)
+            {
+                lowest_id = robot.id();
+            }
+        }
+        return lowest_id;
+    }
+
+    // If there are no robots on the team yet, fall back to the desired goalie ID
+    return goalie_id;
 }
 
 bool SensorFusion::teamHasBall(const Team& team, const Ball& ball)

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -476,13 +476,11 @@ BallDetection SensorFusion::invert(BallDetection ball_detection) const
 
 unsigned int SensorFusion::resolveGoalieId(const Team& team, unsigned int goalie_id)
 {
-    // If the desired goalie exists on the team, use it
     if (team.getRobotById(goalie_id).has_value())
     {
         return goalie_id;
     }
 
-    // Otherwise, find the lowest robot ID present on the team
     const auto& all_robots = team.getAllRobots();
     if (!all_robots.empty())
     {
@@ -494,10 +492,10 @@ unsigned int SensorFusion::resolveGoalieId(const Team& team, unsigned int goalie
                 lowest_id = robot.id();
             }
         }
+		LOG(WARNING) << "Assigned goalie robot" << goalie_id << "not found! Falling back goalie to next available robot:" << lowest_id <<std::endl;
         return lowest_id;
     }
 
-    // If there are no robots on the team yet, fall back to the desired goalie ID
     return goalie_id;
 }
 

--- a/src/software/sensor_fusion/sensor_fusion.cpp
+++ b/src/software/sensor_fusion/sensor_fusion.cpp
@@ -492,7 +492,9 @@ unsigned int SensorFusion::resolveGoalieId(const Team& team, unsigned int goalie
                 lowest_id = robot.id();
             }
         }
-		LOG(WARNING) << "Assigned goalie robot" << goalie_id << "not found! Falling back goalie to next available robot:" << lowest_id <<std::endl;
+        LOG(WARNING) << "Assigned goalie robot" << goalie_id
+                     << "not found! Falling back goalie to next available robot:"
+                     << lowest_id << std::endl;
         return lowest_id;
     }
 

--- a/src/software/sensor_fusion/sensor_fusion.h
+++ b/src/software/sensor_fusion/sensor_fusion.h
@@ -158,6 +158,18 @@ class SensorFusion
     static bool teamHasBall(const Team& team, const Ball& ball);
 
     /**
+     * Given a team and a desired goalie ID, returns the desired ID if a robot with
+     * that ID exists on the team. Otherwise, returns the lowest robot ID present on
+     * the team. If the team has no robots, returns the desired goalie ID as a fallback.
+     *
+     * @param team The team to check
+     * @param goalie_id The desired goalie ID
+     *
+     * @return The goalie ID to use
+     */
+    static unsigned int resolveGoalieId(const Team& team, unsigned int goalie_id);
+
+    /**
      * This function controls the behavior of how the ball is being updated. If this
      * returns True, we use the position of the robot that triggers the breakbeam instead
      * of the one given by the ssl vision system.

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -175,7 +175,8 @@ class SensorFusionTest : public ::testing::Test
         }
         friendly_team.updateRobots(friendly_robots);
         // This must be a robot ID that actually exists on the team, since
-        // SensorFusion::resolveGoalieId validates the goalie ID exists before assigning it
+        // SensorFusion::resolveGoalieId validates the goalie ID exists before assigning
+        // it
         friendly_team.assignGoalie(1);
         Team enemy_team;
         std::vector<Robot> enemy_robots;
@@ -185,7 +186,8 @@ class SensorFusionTest : public ::testing::Test
         }
         enemy_team.updateRobots(enemy_robots);
         // This must be a robot ID that actually exists on the team, since
-        // SensorFusion::resolveGoalieId validates the goalie ID exists before assigning it
+        // SensorFusion::resolveGoalieId validates the goalie ID exists before assigning
+        // it
         enemy_team.assignGoalie(1);
         return World(field, ball, friendly_team, enemy_team);
     }

--- a/src/software/sensor_fusion/sensor_fusion_test.cpp
+++ b/src/software/sensor_fusion/sensor_fusion_test.cpp
@@ -174,7 +174,9 @@ class SensorFusionTest : public ::testing::Test
             friendly_robots.emplace_back(state.id, state.robot_state, current_time);
         }
         friendly_team.updateRobots(friendly_robots);
-        friendly_team.assignGoalie(0);
+        // This must be a robot ID that actually exists on the team, since
+        // SensorFusion::resolveGoalieId validates the goalie ID exists before assigning it
+        friendly_team.assignGoalie(1);
         Team enemy_team;
         std::vector<Robot> enemy_robots;
         for (const auto& state : initBlueRobotStates())
@@ -182,7 +184,9 @@ class SensorFusionTest : public ::testing::Test
             enemy_robots.emplace_back(state.id, state.robot_state, current_time);
         }
         enemy_team.updateRobots(enemy_robots);
-        enemy_team.assignGoalie(0);
+        // This must be a robot ID that actually exists on the team, since
+        // SensorFusion::resolveGoalieId validates the goalie ID exists before assigning it
+        enemy_team.assignGoalie(1);
         return World(field, ball, friendly_team, enemy_team);
     }
 
@@ -197,7 +201,9 @@ class SensorFusionTest : public ::testing::Test
             friendly_robots.emplace_back(state.id, state.robot_state, current_time);
         }
         friendly_team.updateRobots(friendly_robots);
-        friendly_team.assignGoalie(0);
+        // This must be a robot ID that actually exists on the team, since
+        // SensorFusion::resolveGoalieId validates the goalie ID before assigning it
+        friendly_team.assignGoalie(1);
         Team enemy_team;
         std::vector<Robot> enemy_robots;
         for (const auto& state : initInvertedBlueRobotStates())
@@ -205,7 +211,9 @@ class SensorFusionTest : public ::testing::Test
             enemy_robots.emplace_back(state.id, state.robot_state, current_time);
         }
         enemy_team.updateRobots(enemy_robots);
-        enemy_team.assignGoalie(0);
+        // This must be a robot ID that actually exists on the team, since
+        // SensorFusion::resolveGoalieId validates the goalie ID before assigning it
+        enemy_team.assignGoalie(1);
         return World(field, ball, friendly_team, enemy_team);
     }
 
@@ -787,8 +795,9 @@ TEST_F(SensorFusionTest, test_sensor_fusion_reset_behaviour_trigger_reset)
 {
     config.set_override_game_controller_friendly_goalie_id(true);
     config.set_override_game_controller_enemy_goalie_id(true);
-    config.set_friendly_goalie_id(0);
-    config.set_enemy_goalie_id(0);
+    // Must use a robot ID that exists on both teams (1 is the lowest ID in our test data)
+    config.set_friendly_goalie_id(1);
+    config.set_enemy_goalie_id(1);
     sensor_fusion = SensorFusion(config);
 
     SensorProto sensor_msg;


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

In Sensor Fusion, we process the data we get from the SSL Camera into a World proto with Robots on each team.

Currently, we assign an ID to be the goalie based on either the SensorFusionConfig or a default of 0. 

However, we can run into the case where the assigned goalie is not present in the game, which causes a **"Robot with ID <id> not found"** error.

This PR adds an extra check to make sure the assigned goalie exists in game. If not, it assigns the next lowest ID to be the goalie.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Tested in sim, especially in sandbox mode by removing robots. When active goalie was removed, the next lowest ID was automatically made goalie.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
