### PR TITLE
Avah/macos fix gamecontroller interface

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Tbots CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, robocup_* ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, robocup_* ]
   schedule:
     - cron: '0 8 * * *'  # 12 AM PST / 8 AM UTC
   workflow_dispatch:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,9 +2,9 @@ name: auto-fixes with pre-commit
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, robocup_* ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, robocup_* ]
     types: [ opened, reopened, synchronize, ready_for_review ]
 
 concurrency:

--- a/src/software/gameplay_tests/simulated_test_fixture.py
+++ b/src/software/gameplay_tests/simulated_test_fixture.py
@@ -591,7 +591,8 @@ def simulated_test_runner():
         running_in_realtime=args.enable_thunderscope and not args.ci_mode,
     ) as yellow_fs:
         with Gamecontroller(
-            suppress_logs=(not args.show_gamecontroller_logs)
+            suppress_logs=(not args.show_gamecontroller_logs),
+            parallelized=True,
         ) as gamecontroller:
             blue_fs.setup_proto_unix_io(blue_full_system_proto_unix_io)
             yellow_fs.setup_proto_unix_io(yellow_full_system_proto_unix_io)

--- a/src/software/thunderscope/binary_context_managers/BUILD
+++ b/src/software/thunderscope/binary_context_managers/BUILD
@@ -24,6 +24,7 @@ py_library(
         "//software/networking:ssl_proto_communication",
         "//software/thunderscope:util",
         "//software/thunderscope/common:thread_safe_circular_buffer",
+        requirement("netifaces"),
     ],
 )
 

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -46,15 +46,18 @@ class Gamecontroller:
         suppress_logs: bool = False,
         use_conventional_port: bool = False,
         automate_referee: bool = False,
+        parallelized: bool = False,
     ) -> None:
         """Run Gamecontroller
 
         :param suppress_logs: True if logs should be suppressed
         :param use_conventional_port: True when using static referee port. False for dynamic port assignments.
-        :param automate_referee: True if referee commands should be automated
+        :param automate_referee: True if referee commands should be automated.
+        :param parallelized: True when this is one of many Gamecontrollers running at once.
         """
         self.suppress_logs = suppress_logs
         self.automate_referee = automate_referee
+        self.parallelized = parallelized
 
         self.use_conventional_port = use_conventional_port
         self.referee_port = None
@@ -111,17 +114,20 @@ class Gamecontroller:
 
             command += ["-publishAddress", f"{self.REFEREE_IP}:{self.referee_port}"]
             command += ["-ciAddress", f"localhost:{self.ci_port}"]
-            command += [
-                "-address",
-                "localhost:0",
-                "-autorefAddress",
-                "localhost:0",
-                "-remoteControlAddress",
-                "localhost:0",
-                "-teamAddress",
-                "localhost:0",
-                "-backendOnly",
-            ]
+            if self.parallelized:
+                # One of many GCs running at once: no web UI and all-dynamic ports so
+                # instances don't collide on the fixed UI / autoref ports.
+                command += [
+                    "-address",
+                    "localhost:0",
+                    "-autorefAddress",
+                    "localhost:0",
+                    "-remoteControlAddress",
+                    "localhost:0",
+                    "-teamAddress",
+                    "localhost:0",
+                    "-backendOnly",
+                ]
 
             if self.suppress_logs:
                 with open(os.devnull, "w") as fp:

--- a/src/software/thunderscope/binary_context_managers/game_controller.py
+++ b/src/software/thunderscope/binary_context_managers/game_controller.py
@@ -7,6 +7,8 @@ import random
 import logging
 import os
 import time
+import netifaces
+
 from subprocess import Popen
 from typing import Any
 
@@ -245,15 +247,10 @@ class Gamecontroller:
             if autoref_proto_unix_io is not None:
                 autoref_proto_unix_io.send_proto(Referee, data)
 
-        if is_current_platform_macos():
-            loopback_iface = "en0"
-        else:
-            loopback_iface = "lo"
-
         self.receive_referee_command = tbots_cpp.SSLRefereeProtoListener(
             Gamecontroller.REFEREE_IP,
             self.referee_port,
-            loopback_iface,
+            self.__get_referee_multicast_interface(),
             __send_referee_command,
             True,
         )
@@ -630,3 +627,19 @@ class Gamecontroller:
                 robot_states[removed_robot_ids.get_nowait()].CopyFrom(place_state)
             except queue.Empty:
                 return
+
+    @staticmethod
+    def __get_referee_multicast_interface() -> str:
+        """Determine the network interface to join the referee multicast group on.
+
+        :return: the name of the interface to receive referee multicast on
+        """
+        if not is_current_platform_macos():
+            return "lo"
+
+        default = netifaces.gateways().get("default", {}).get(netifaces.AF_INET)
+        if default:
+            # default is a (gateway_ip, interface_name) tuple
+            return default[1]
+
+        raise RuntimeError("Could not determine the default network interface on macOS")


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Original PR merged into `robocup_2026`: #3819

Discovered this cause we don't have good wifi here at robocup, found out by turning off wifi macos can't use the en0 interface which is referenced in gamecontroller binary context manager. This PR uses netifaces to get primary interface instead of relying on en0 for macos, this does not need to be changed on linux since the multicast messages get sent to the loopback interface.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Without the changes, running `./tbots.py run thunderscope --enable_autoref` with wifi turned off results in this error:

```
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_avah/c66e7f3b6f9fffee22646d89d33fc0ae/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/software/thunderscope/thunderscope_main.runfiles/_main/software/thunderscope/thunderscope_main.py", line 483, in <module>
    gamecontroller.setup_proto_unix_io(
  File "/private/var/tmp/_bazel_avah/c66e7f3b6f9fffee22646d89d33fc0ae/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/software/thunderscope/thunderscope_main.runfiles/_main/software/thunderscope/binary_context_managers/game_controller.py", line 253, in setup_proto_unix_io
    self.receive_referee_command = tbots_cpp.SSLRefereeProtoListener(
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
software.python_bindings.TbotsNetworkException: Could not find the local ip address for the given interface: en0
```

After the changes, everything works including gamecontroller.

**NOTE: there is an additional bug fix for a bug introduced in #3766 about gamecontroller ports**

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
