### PR TITLE
control ball before chipping in GoalieFSM

### DIFF
--- a/docs/fsm-diagrams.md
+++ b/docs/fsm-diagrams.md
@@ -381,14 +381,16 @@ direction LR
 PositionToBlock --> MoveToGoalLine : [shouldMoveToGoalLine]\n<i>moveToGoalLine</i>
 PositionToBlock --> DribbleFSM : [shouldEvacuateCrease]\n<i>retrieveFromDeadZone</i>
 PositionToBlock --> Panic : [shouldPanic]\n<i>panic</i>
-PositionToBlock --> PivotKickFSM : [shouldPivotChip]\n<i>updatePivotKick</i>
+PositionToBlock --> DribbleFSM : [shouldPivotChip]\n<i>controlBallForChip</i>
 PositionToBlock --> PositionToBlock : <i>positionToBlock</i>
 DribbleFSM --> PivotKickFSM : [retrieveDone]\n<i>updatePivotKick</i>
+DribbleFSM --> PivotKickFSM : [ballControlled && shouldPivotChip]\n<i>updatePivotKick</i>
 DribbleFSM --> MoveToGoalLine : [shouldMoveToGoalLine]\n<i>moveToGoalLine</i>
-DribbleFSM --> DribbleFSM : [ballInInflatedDefenseArea]\n<i>retrieveFromDeadZone</i>
+DribbleFSM --> DribbleFSM : [shouldEvacuateCrease]\n<i>retrieveFromDeadZone</i>
+DribbleFSM --> DribbleFSM : [shouldPivotChip]\n<i>controlBallForChip</i>
 DribbleFSM --> PositionToBlock : [!ballInInflatedDefenseArea]\n<i>positionToBlock</i>
 Panic --> MoveToGoalLine : [shouldMoveToGoalLine]\n<i>moveToGoalLine</i>
-Panic --> PivotKickFSM : [shouldPivotChip]\n<i>updatePivotKick</i>
+Panic --> DribbleFSM : [shouldPivotChip]\n<i>controlBallForChip</i>
 Panic --> PositionToBlock : [panicDone]\n<i>positionToBlock</i>
 Panic --> Panic : <i>panic</i>
 PivotKickFSM --> MoveToGoalLine : [shouldMoveToGoalLine]\n<i>moveToGoalLine</i>

--- a/docs/fsm-diagrams.md
+++ b/docs/fsm-diagrams.md
@@ -388,6 +388,7 @@ DribbleFSM --> PivotKickFSM : [ballControlled && shouldPivotChip]\n<i>updatePivo
 DribbleFSM --> MoveToGoalLine : [shouldMoveToGoalLine]\n<i>moveToGoalLine</i>
 DribbleFSM --> DribbleFSM : [shouldEvacuateCrease]\n<i>retrieveFromDeadZone</i>
 DribbleFSM --> DribbleFSM : [shouldPivotChip]\n<i>controlBallForChip</i>
+DribbleFSM --> DribbleFSM : [ballInInflatedDefenseArea]\n<i>controlBallForChip</i>
 DribbleFSM --> PositionToBlock : [!ballInInflatedDefenseArea]\n<i>positionToBlock</i>
 Panic --> MoveToGoalLine : [shouldMoveToGoalLine]\n<i>moveToGoalLine</i>
 Panic --> DribbleFSM : [shouldPivotChip]\n<i>controlBallForChip</i>

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.cpp
@@ -307,3 +307,34 @@ void GoalieFSM::retrieveFromDeadZone(
     // update the dribble fsm
     processEvent(DribbleFSM::Update(control_params, event.common));
 }
+
+bool GoalieFSM::ballControlled(const Update& event)
+{
+    return event.common.robot.isNearDribbler(
+        event.common.world_ptr->ball().position());
+}
+
+void GoalieFSM::controlBallForChip(
+    const Update& event, boost::sml::back::process<DribbleFSM::Update> processEvent)
+{
+    // Ensure that we start our chip away from the no chip zone in front of
+    // the goal (prevents accidentally scoring an own goal)
+    double clear_origin_x = getNoChipRectangle(event.common.world_ptr->field()).xMax() +
+                            ROBOT_MAX_RADIUS_METERS;
+    double chip_origin_x =
+        std::max(clear_origin_x, event.common.world_ptr->ball().position().x());
+    Point chip_origin =
+        Point(chip_origin_x, event.common.world_ptr->ball().position().y());
+
+    Point chip_target  = findGoodChipTarget(*event.common.world_ptr,
+                                            ai_config_ptr->goalie_tactic_config());
+    Vector chip_vector = chip_target - chip_origin;
+
+    DribbleFSM::ControlParams control_params{
+        .dribble_destination       = chip_origin,
+        .final_dribble_orientation = chip_vector.orientation(),
+        .allow_excessive_dribbling = false,
+    };
+
+    processEvent(DribbleFSM::Update(control_params, event.common));
+}

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.cpp
@@ -317,8 +317,7 @@ bool GoalieFSM::ballControlled(const Update& event)
         return false;
     }
 
-    Point chip_origin =
-        getChipOrigin(event.common.world_ptr->field(), ball_position);
+    Point chip_origin = getChipOrigin(event.common.world_ptr->field(), ball_position);
     return comparePoints(ball_position, chip_origin, BALL_RETRIEVED_THRESHOLD);
 }
 

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.cpp
@@ -95,6 +95,13 @@ Rectangle GoalieFSM::getNoChipRectangle(const Field& field)
         field.friendlyGoalpostPos() + Vector(2 * ROBOT_MAX_RADIUS_METERS, 0));
 }
 
+Point GoalieFSM::getChipOrigin(const Field& field, const Point& ball_position)
+{
+    double clear_origin_x = getNoChipRectangle(field).xMax() + ROBOT_MAX_RADIUS_METERS;
+    double chip_origin_x  = std::max(clear_origin_x, ball_position.x());
+    return Point(chip_origin_x, ball_position.y());
+}
+
 Point GoalieFSM::findGoodChipTarget(
     const World& world, const TbotsProto::GoalieTacticConfig& goalie_tactic_config)
 {
@@ -219,14 +226,8 @@ void GoalieFSM::panic(const Update& event)
 void GoalieFSM::updatePivotKick(
     const Update& event, boost::sml::back::process<PivotKickFSM::Update> processEvent)
 {
-    // Ensure that we start our chip away from the no chip zone in front of
-    // the goal (prevents accidentally scoring an own goal)
-    double clear_origin_x = getNoChipRectangle(event.common.world_ptr->field()).xMax() +
-                            ROBOT_MAX_RADIUS_METERS;
-    double chip_origin_x =
-        std::max(clear_origin_x, event.common.world_ptr->ball().position().x());
-    Point chip_origin =
-        Point(chip_origin_x, event.common.world_ptr->ball().position().y());
+    Point chip_origin = getChipOrigin(event.common.world_ptr->field(),
+                                      event.common.world_ptr->ball().position());
 
     Point chip_target  = findGoodChipTarget(*event.common.world_ptr,
                                             ai_config_ptr->goalie_tactic_config());
@@ -310,20 +311,22 @@ void GoalieFSM::retrieveFromDeadZone(
 
 bool GoalieFSM::ballControlled(const Update& event)
 {
-    return event.common.robot.isNearDribbler(event.common.world_ptr->ball().position());
+    Point ball_position = event.common.world_ptr->ball().position();
+    if (!event.common.robot.isNearDribbler(ball_position))
+    {
+        return false;
+    }
+
+    Point chip_origin =
+        getChipOrigin(event.common.world_ptr->field(), ball_position);
+    return comparePoints(ball_position, chip_origin, BALL_RETRIEVED_THRESHOLD);
 }
 
 void GoalieFSM::controlBallForChip(
     const Update& event, boost::sml::back::process<DribbleFSM::Update> processEvent)
 {
-    // Ensure that we start our chip away from the no chip zone in front of
-    // the goal (prevents accidentally scoring an own goal)
-    double clear_origin_x = getNoChipRectangle(event.common.world_ptr->field()).xMax() +
-                            ROBOT_MAX_RADIUS_METERS;
-    double chip_origin_x =
-        std::max(clear_origin_x, event.common.world_ptr->ball().position().x());
-    Point chip_origin =
-        Point(chip_origin_x, event.common.world_ptr->ball().position().y());
+    Point chip_origin = getChipOrigin(event.common.world_ptr->field(),
+                                      event.common.world_ptr->ball().position());
 
     Point chip_target  = findGoodChipTarget(*event.common.world_ptr,
                                             ai_config_ptr->goalie_tactic_config());

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.cpp
@@ -310,8 +310,7 @@ void GoalieFSM::retrieveFromDeadZone(
 
 bool GoalieFSM::ballControlled(const Update& event)
 {
-    return event.common.robot.isNearDribbler(
-        event.common.world_ptr->ball().position());
+    return event.common.robot.isNearDribbler(event.common.world_ptr->ball().position());
 }
 
 void GoalieFSM::controlBallForChip(

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
@@ -242,9 +242,8 @@ struct GoalieFSM : TacticFSM<GoalieFSM>
                 DribbleFSM_S,
             PositionToBlock_S + Update_E / positionToBlock_A,
             DribbleFSM_S + Update_E[retrieveDone_G] / updatePivotKick_A = PivotKickFSM_S,
-            DribbleFSM_S +
-                Update_E[ballControlled_G && shouldPivotChip_G] / updatePivotKick_A =
-                PivotKickFSM_S,
+            DribbleFSM_S + Update_E[ballControlled_G && shouldPivotChip_G] /
+                               updatePivotKick_A = PivotKickFSM_S,
             DribbleFSM_S + Update_E[shouldMoveToGoalLine_G] / moveToGoalLine_A =
                 MoveToGoalLine_S,
             DribbleFSM_S + Update_E[shouldEvacuateCrease_G] / retrieveFromDeadZone_A,

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
@@ -75,6 +75,16 @@ struct GoalieFSM : TacticFSM<GoalieFSM>
     static Rectangle getNoChipRectangle(const Field& field);
 
     /**
+     * Gets the point the goalie should dribble to before chipping the ball
+     *
+     * @param field the field
+     * @param ball_position the current ball position
+     *
+     * @return the point the goalie should chip from
+     */
+    static Point getChipOrigin(const Field& field, const Point& ball_position);
+
+    /**
      * Finds a good point to chip the ball to from its current position
      *
      * @param world the world

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
@@ -248,6 +248,7 @@ struct GoalieFSM : TacticFSM<GoalieFSM>
                 MoveToGoalLine_S,
             DribbleFSM_S + Update_E[shouldEvacuateCrease_G] / retrieveFromDeadZone_A,
             DribbleFSM_S + Update_E[shouldPivotChip_G] / controlBallForChip_A,
+            DribbleFSM_S + Update_E[ballInInflatedDefenseArea_G] / controlBallForChip_A,
             DribbleFSM_S + Update_E[!ballInInflatedDefenseArea_G] / positionToBlock_A =
                 PositionToBlock_S,
             Panic_S + Update_E[shouldMoveToGoalLine_G] / moveToGoalLine_A =

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
@@ -184,6 +184,25 @@ struct GoalieFSM : TacticFSM<GoalieFSM>
      */
     bool ballInInflatedDefenseArea(const Update& event);
 
+    /**
+     * Guard to check if goalie has control of ball (ready to chip)
+     *
+     * @param event GoalieFSM::Update event
+     *
+     * @return if the goalie has control of the ball
+     */
+    bool ballControlled(const Update& event);
+
+    /**
+     * Action that dribbles to get the ball and face the direction we want to chip in
+     * before we enter PivotKickFSM
+     *
+     * @param event GoalieFSM::Update event
+     * @param processEvent processes the DribbleFSM::Update
+     */
+    void controlBallForChip(const Update& event,
+                            boost::sml::back::process<DribbleFSM::Update> processEvent);
+
     auto operator()()
     {
         using namespace boost::sml;
@@ -203,12 +222,14 @@ struct GoalieFSM : TacticFSM<GoalieFSM>
         DEFINE_SML_GUARD(shouldPanic)
         DEFINE_SML_GUARD(shouldMoveToGoalLine)
         DEFINE_SML_GUARD(retrieveDone)
+        DEFINE_SML_GUARD(ballControlled)
 
         DEFINE_SML_ACTION(panic)
         DEFINE_SML_ACTION(positionToBlock)
         DEFINE_SML_ACTION(moveToGoalLine)
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(updatePivotKick, PivotKickFSM)
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(retrieveFromDeadZone, DribbleFSM)
+        DEFINE_SML_SUB_FSM_UPDATE_ACTION(controlBallForChip, DribbleFSM)
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state
@@ -217,19 +238,23 @@ struct GoalieFSM : TacticFSM<GoalieFSM>
             PositionToBlock_S +
                 Update_E[shouldEvacuateCrease_G] / retrieveFromDeadZone_A = DribbleFSM_S,
             PositionToBlock_S + Update_E[shouldPanic_G] / panic_A         = Panic_S,
-            PositionToBlock_S + Update_E[shouldPivotChip_G] / updatePivotKick_A =
-                PivotKickFSM_S,
+            PositionToBlock_S + Update_E[shouldPivotChip_G] / controlBallForChip_A =
+                DribbleFSM_S,
             PositionToBlock_S + Update_E / positionToBlock_A,
             DribbleFSM_S + Update_E[retrieveDone_G] / updatePivotKick_A = PivotKickFSM_S,
+            DribbleFSM_S +
+                Update_E[ballControlled_G && shouldPivotChip_G] / updatePivotKick_A =
+                PivotKickFSM_S,
             DribbleFSM_S + Update_E[shouldMoveToGoalLine_G] / moveToGoalLine_A =
                 MoveToGoalLine_S,
-            DribbleFSM_S + Update_E[ballInInflatedDefenseArea_G] / retrieveFromDeadZone_A,
+            DribbleFSM_S + Update_E[shouldEvacuateCrease_G] / retrieveFromDeadZone_A,
+            DribbleFSM_S + Update_E[shouldPivotChip_G] / controlBallForChip_A,
             DribbleFSM_S + Update_E[!ballInInflatedDefenseArea_G] / positionToBlock_A =
                 PositionToBlock_S,
             Panic_S + Update_E[shouldMoveToGoalLine_G] / moveToGoalLine_A =
                 MoveToGoalLine_S,
-            Panic_S + Update_E[shouldPivotChip_G] / updatePivotKick_A = PivotKickFSM_S,
-            Panic_S + Update_E[panicDone_G] / positionToBlock_A       = PositionToBlock_S,
+            Panic_S + Update_E[shouldPivotChip_G] / controlBallForChip_A = DribbleFSM_S,
+            Panic_S + Update_E[panicDone_G] / positionToBlock_A = PositionToBlock_S,
             Panic_S + Update_E / panic_A,
             PivotKickFSM_S + Update_E[shouldMoveToGoalLine_G] / moveToGoalLine_A =
                 MoveToGoalLine_S,

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm_test.cpp
@@ -130,7 +130,8 @@ TEST(GoalieFSMTest, test_transitions)
     EXPECT_TRUE(fsm.is(boost::sml::state<DribbleFSM>));
 
     // possession alone in the no-chip rectangle should not transition to PivotKickFSM
-    ::TestUtil::setBallPosition(world_ptr, goalie.position(), Timestamp::fromSeconds(123));
+    ::TestUtil::setBallPosition(world_ptr, goalie.position(),
+                                Timestamp::fromSeconds(123));
     fsm.process_event(GoalieFSM::Update(
         {}, TacticUpdate(goalie, world_ptr, [](std::shared_ptr<Primitive>) {})));
     EXPECT_TRUE(fsm.is(boost::sml::state<DribbleFSM>));
@@ -138,7 +139,7 @@ TEST(GoalieFSMTest, test_transitions)
     // give possession at the safe chip origin (outside the no-chip rectangle)
     Point chip_origin = GoalieFSM::getChipOrigin(world_ptr->field(),
                                                  world_ptr->field().friendlyGoalCenter());
-    goalie = ::TestUtil::createRobotAtPos(chip_origin);
+    goalie            = ::TestUtil::createRobotAtPos(chip_origin);
     ::TestUtil::setBallPosition(world_ptr, chip_origin, Timestamp::fromSeconds(123));
 
     // goalie should transition to PivotKickFSM once the ball is controlled and positioned

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm_test.cpp
@@ -129,11 +129,19 @@ TEST(GoalieFSMTest, test_transitions)
         {}, TacticUpdate(goalie, world_ptr, [](std::shared_ptr<Primitive>) {})));
     EXPECT_TRUE(fsm.is(boost::sml::state<DribbleFSM>));
 
-    // give possession (ball is near dribbler)
-    ::TestUtil::setBallPosition(world_ptr, goalie.position(),
-                                Timestamp::fromSeconds(123));
+    // possession alone in the no-chip rectangle should not transition to PivotKickFSM
+    ::TestUtil::setBallPosition(world_ptr, goalie.position(), Timestamp::fromSeconds(123));
+    fsm.process_event(GoalieFSM::Update(
+        {}, TacticUpdate(goalie, world_ptr, [](std::shared_ptr<Primitive>) {})));
+    EXPECT_TRUE(fsm.is(boost::sml::state<DribbleFSM>));
 
-    // goalie should transition to PivotKickFSM once the ball is controlled
+    // give possession at the safe chip origin (outside the no-chip rectangle)
+    Point chip_origin = GoalieFSM::getChipOrigin(world_ptr->field(),
+                                                 world_ptr->field().friendlyGoalCenter());
+    goalie = ::TestUtil::createRobotAtPos(chip_origin);
+    ::TestUtil::setBallPosition(world_ptr, chip_origin, Timestamp::fromSeconds(123));
+
+    // goalie should transition to PivotKickFSM once the ball is controlled and positioned
     fsm.process_event(GoalieFSM::Update(
         {}, TacticUpdate(goalie, world_ptr, [](std::shared_ptr<Primitive>) {})));
     EXPECT_TRUE(fsm.is(boost::sml::state<PivotKickFSM>));

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm_test.cpp
@@ -127,16 +127,13 @@ TEST(GoalieFSMTest, test_transitions)
     // goalie should transition to DribbleFSM
     fsm.process_event(GoalieFSM::Update(
         {}, TacticUpdate(goalie, world_ptr, [](std::shared_ptr<Primitive>) {})));
-    EXPECT_TRUE(fsm.is(boost::sml::state<PivotKickFSM>));
+    EXPECT_TRUE(fsm.is(boost::sml::state<DribbleFSM>));
 
-    // goalie has ball, at the correct position and orientation to clear the ball
-    ::TestUtil::setBallPosition(world_ptr, clear_ball_origin,
+    // give possession (ball is near dribbler)
+    ::TestUtil::setBallPosition(world_ptr, goalie.position(),
                                 Timestamp::fromSeconds(123));
-    goalie.updateState(RobotState(clear_ball_origin, Vector(0, 0), clear_ball_direction,
-                                  AngularVelocity::zero()),
-                       Timestamp::fromSeconds(123));
 
-    // goalie should stay in PivotKickFSM but be ready to chip
+    // goalie should transition to PivotKickFSM once the ball is controlled
     fsm.process_event(GoalieFSM::Update(
         {}, TacticUpdate(goalie, world_ptr, [](std::shared_ptr<Primitive>) {})));
     EXPECT_TRUE(fsm.is(boost::sml::state<PivotKickFSM>));
@@ -162,10 +159,10 @@ TEST(GoalieFSMTest, test_transitions)
     ::TestUtil::setBallPosition(world_ptr, Point(-3.5, 1), Timestamp::fromSeconds(124));
     ::TestUtil::setBallVelocity(world_ptr, Vector(0, -0.1), Timestamp::fromSeconds(124));
 
-    // goalie should transition to PivotKickFSM
+    // goalie should transition to DribbleFSM to control the ball before chipping
     fsm.process_event(GoalieFSM::Update(
         {}, TacticUpdate(goalie, world_ptr, [](std::shared_ptr<Primitive>) {})));
-    EXPECT_TRUE(fsm.is(boost::sml::state<PivotKickFSM>));
+    EXPECT_TRUE(fsm.is(boost::sml::state<DribbleFSM>));
 
     // ball is stationary at the center of the field
     ::TestUtil::setBallPosition(world_ptr, Point(0, 0), Timestamp::fromSeconds(124));

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_tactic_test.py
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_tactic_test.py
@@ -9,10 +9,21 @@ from software.gameplay_tests.validation.friendly_has_ball_possession import *
 from software.gameplay_tests.validation.ball_speed_threshold import *
 from software.gameplay_tests.validation.robot_speed_threshold import *
 from software.gameplay_tests.validation.excessive_dribbling import *
+from software.gameplay_tests.validation.ball_is_off_ground import (
+    BallIsEventuallyOffGround,
+)
 from software.gameplay_tests.simulated_test_fixture import (
     pytest_main,
 )
 from proto.message_translation.tbots_protobuf import create_world_state
+from software.py_constants import ROBOT_MAX_RADIUS_METERS
+
+
+def get_no_chip_rectangle(field):
+    return tbots_cpp.Rectangle(
+        field.friendlyGoalpostNeg(),
+        field.friendlyGoalpostPos() + tbots_cpp.Vector(2 * ROBOT_MAX_RADIUS_METERS, 0),
+    )
 
 
 @pytest.mark.parametrize(
@@ -237,6 +248,68 @@ def test_goalie_clears_from_dead_zone(
                 ),
             ]
         ]
+
+    simulated_test_runner.run_test(
+        setup=setup,
+        test_timeout_s=8,
+        inv_eventually_validation_sequence_set=eventually_validation_sequence_set,
+        inv_always_validation_sequence_set=always_validation_sequence_set,
+        ag_eventually_validation_sequence_set=eventually_validation_sequence_set,
+        ag_always_validation_sequence_set=always_validation_sequence_set,
+    )
+
+
+@pytest.mark.parametrize(
+    "ball_offset_from_goal_center,robot_initial_position",
+    [
+        # ball stationary in no-chip rectangle, goalie far from ball
+        (
+            tbots_cpp.Vector(0.1, 0.1),
+            tbots_cpp.Point(-4, -1),
+        ),
+    ],
+)
+def test_goalie_controls_ball_before_chip(
+    ball_offset_from_goal_center,
+    robot_initial_position,
+    simulated_test_runner,
+):
+    field = tbots_cpp.Field.createSSLDivisionBField()
+    ball_initial_position = field.friendlyGoalCenter() + ball_offset_from_goal_center
+    no_chip_rectangle = get_no_chip_rectangle(field)
+
+    def setup(*args):
+        simulated_test_runner.set_world_state(
+            create_world_state(
+                [],
+                blue_robot_locations=[robot_initial_position],
+                ball_location=ball_initial_position,
+                ball_velocity=tbots_cpp.Vector(0, 0),
+            )
+        )
+
+        simulated_test_runner.set_tactics(
+            blue_tactics={
+                0: GoalieTactic(
+                    max_allowed_speed_mode=MaxAllowedSpeedMode.PHYSICAL_LIMIT
+                )
+            }
+        )
+
+    always_validation_sequence_set = [
+        [
+            BallNeverEntersRegion(regions=[field.friendlyGoal()]),
+            NeverExcessivelyDribbles(),
+        ]
+    ]
+
+    eventually_validation_sequence_set = [
+        [
+            FriendlyEventuallyHasBallPossession(robot_id=0, tolerance=0.05),
+            BallEventuallyExitsRegion(regions=[no_chip_rectangle]),
+            BallIsEventuallyOffGround(),
+        ]
+    ]
 
     simulated_test_runner.run_test(
         setup=setup,


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Previously when goalie chipped, it transitioned straight into `PivotKickFSM` even if the ball wasn't under control. Goalie was able to attempt chipping before securing ball. This PR adds `DribbleFSM` step that dribbles to control the ball and orient towards chip target before we hand off to PivotKickFSM. 

Added a new guard `controlBallForChip` action which drives `DribbleFSM` to position ball at a safe chip origin and orients towards target. 

Implemented new methods ballControlled and controlBallForChip. Updated `goalie_fsm_test.cpp` so FSM expects to land in DribbleFSM first and reaches PivotKickFSM after ball repositioned near dribbler (has possession). 

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->
So far only unit tests in `goalie_fsm_test.cpp` updated to assert new dribble state before chipping. It would be great to test on actual robot too. 

Additional pytests added to check that the goalie gets the ball and then has to leave the no chip rectangle before the ball gets chipped. What we see in this video is the seuence of DribbleFSM -> KickState -> terminate. It only checkes the world outcomes in order not the FSM states. It doesn't really show that the goalieFSM stayed in dribble until ballControlled before going into PivotKickFSM. The chip happened after repositioning. 

I would say the C++ unit tests should be what we use to test the fsm logic since we assert the states. 

https://github.com/user-attachments/assets/0d497e70-e4ee-4245-bf4d-b1548e3f2b6c





### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

resolves #2897 

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
