### PR TITLE
Enable implicit conversion warning

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -36,6 +36,7 @@ build --auto_cpu_environment_group=//toolchains/cc:cpus
 # Use Our Custom Toolchain
 build --crosstool_top=//toolchains/cc:toolchain
 common --features=external_include_paths
+common --features=generated_include_paths
 
 ################# Build Optimizations #################
 
@@ -68,10 +69,8 @@ common --enable_platform_specific_config
 build --incompatible_remove_legacy_whole_archive=False
 
 # Escalate Warnings to fail Compile for Thunderbots code
-build --features=external_include_paths
 build:linux --per_file_copt=proto/.*,proto/message_translation/.*,proto/primitive/.*,software/.*,shared/.*,-external/.*@-Wall,-Wextra,-Wno-unused-parameter,-Wno-deprecated,-Werror,-Wno-deprecated-declarations
-# TODO: #3492
-# build --per_file_copt=software/.*,shared/.*,-external/.*@-Wconversion
+build --per_file_copt=software/.*,shared/.*,-external/.*@-Wconversion
 
 build --cxxopt="-DG3_DYNAMIC_LOGGING"
 

--- a/src/software/embedded/motor_controller/stspin_motor_controller.cpp
+++ b/src/software/embedded/motor_controller/stspin_motor_controller.cpp
@@ -262,7 +262,7 @@ void StSpinMotorController::sendAndReceiveMessage(const MotorIndex motor,
                 *std::next(delimiter_pos, MESSAGE_DELIMITER.size());
 
             const uint8_t current_seq = motor_status_.at(motor).seq_num;
-            const uint8_t prev_seq    = current_seq - 1;
+            const uint8_t prev_seq    = static_cast<uint8_t>(current_seq - 1);
 
             // Accept responses where the sequence number is either the current
             // sequence number (ACK for the message we just sent) or the

--- a/src/software/embedded/motor_controller/tmc_motor_controller.cpp
+++ b/src/software/embedded/motor_controller/tmc_motor_controller.cpp
@@ -65,15 +65,19 @@ int TmcMotorController::readThenWriteVelocity(const MotorIndex motor,
     {
         const int velocity_erpm = readThenWriteValue(
             motor, TMC4671_PID_VELOCITY_ACTUAL, TMC4671_PID_VELOCITY_TARGET,
-            target_velocity * DRIBBLER_MOTOR_ELECTRICAL_RPM_PER_MECHANICAL_RPM);
-        return velocity_erpm * DRIBBLER_MOTOR_MECHANICAL_RPM_PER_ELECTRICAL_RPM;
+            static_cast<int>(target_velocity *
+                             DRIBBLER_MOTOR_ELECTRICAL_RPM_PER_MECHANICAL_RPM));
+        return static_cast<int>(velocity_erpm *
+                                DRIBBLER_MOTOR_MECHANICAL_RPM_PER_ELECTRICAL_RPM);
     }
     else
     {
         const int velocity_erpm = readThenWriteValue(
             motor, TMC4671_PID_VELOCITY_ACTUAL, TMC4671_PID_VELOCITY_TARGET,
-            target_velocity * DRIVE_MOTOR_ELECTRICAL_RPM_PER_MECHANICAL_RPM);
-        return velocity_erpm * DRIVE_MOTOR_MECHANICAL_RPM_PER_ELECTRICAL_RPM;
+            static_cast<int>(target_velocity *
+                             DRIVE_MOTOR_ELECTRICAL_RPM_PER_MECHANICAL_RPM));
+        return static_cast<int>(velocity_erpm *
+                                DRIVE_MOTOR_MECHANICAL_RPM_PER_ELECTRICAL_RPM);
     }
 }
 

--- a/src/software/embedded/services/imu.cpp
+++ b/src/software/embedded/services/imu.cpp
@@ -161,8 +161,9 @@ std::optional<int16_t> ImuService::readAndCombineByteData(uint8_t ls_reg, uint8_
         return std::nullopt;
     }
 
-    uint16_t combined = (static_cast<uint8_t>(most_significant) << 8) |
-                        static_cast<uint8_t>(least_significant);
+    uint16_t combined =
+        static_cast<uint16_t>((static_cast<uint8_t>(most_significant) << 8) |
+                              static_cast<uint8_t>(least_significant));
 
     return static_cast<int16_t>(combined);
 }
@@ -240,7 +241,7 @@ std::optional<Eigen::Vector2d> ImuService::pollLinearAcceleration()
         return std::nullopt;
     }
 
-    int16_t raw_x = -opt_y.value();
+    int16_t raw_x = static_cast<int16_t>(-opt_y.value());
     int16_t raw_y = opt_x.value();
 
     double a_x = (static_cast<double>(raw_x) / SHRT_MAX) * ACCELEROMETER_FULL_SCALE_G *

--- a/src/toolchains/cc/cc_toolchain_config.bzl
+++ b/src/toolchains/cc/cc_toolchain_config.bzl
@@ -332,6 +332,57 @@ def _make_common_features(ctx):
         ],
     )
 
+    result["external_include_paths"] = feature(
+        name = "external_include_paths",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-isystem", "%{external_include_paths}"],
+                        iterate_over = "external_include_paths",
+                        expand_if_available = "external_include_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Treat the bin directory (bazel-bin) as a system include directory.
+    # The purpose of this is to suppress warnings coming from generated headers
+    # (e.g. compiled protobufs) which are output in the bin directory.
+    # Our own headers are found through -iquote and are NOT affected by this,
+    # so our own code stays fully checked.
+    result["generated_include_paths"] = feature(
+        name = "generated_include_paths",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-isystem", ctx.bin_dir.path],
+                    ),
+                ],
+            ),
+        ],
+    )
+
     result["has_configured_linker_path_feature"] = feature(name = "has_configured_linker_path")
 
     result["copy_dynamic_libraries_to_binary_feature"] = \


### PR DESCRIPTION
### Description

Re-enables warnings for implicit conversions (`-Wconversion`). We had trouble in the past enabling this because the warnings were coming from headers from external dependencies. 

This PR makes two changes to suppress warnings from external deps:

- Pass include paths that point into external repos with `-isystem` (as system headers). gcc does not report warnings originating inside system headers, so this suppresses warnings from external deps' headers when included in our own code.

  We already had `--features=external_include_paths` enabled in `.bazelrc`, but we didn't actually define this feature in our C++ toolchain which is why it did nothing. The toolchain has been updated so that it actually takes the external include paths provided by Bazel and passes them to the compiler via the `-isystem` flag.

- Add the bazel bin directory (`bazel-bin`) as a system include path with `-isystem`. The purpose of this is to suppress warnings coming from generated headers (e.g. compiled protobufs) which are output in the bin directory. Our own headers are found through `-iquote` include paths and are not affected by this, so our own code stays fully checked.

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->
Resolves #3492 

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
