### PR TITLE
use perimeter stepping for crease defenders instead of shotcones

### DIFF
--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.cpp
@@ -29,8 +29,8 @@ std::optional<Point> CreaseDefenderFSM::findBlockThreatPoint(
     Angle center_angle = angle_to_positive_goalpost + shot_angle_sixth * 3.0;
 
     Ray center_ray(enemy_threat_origin, center_angle);
-    std::optional<Point> center_position = findDefenseAreaIntersection(
-        field, center_ray, robot_obstacle_inflation_factor);
+    std::optional<Point> center_position =
+        findDefenseAreaIntersection(field, center_ray, robot_obstacle_inflation_factor);
 
     if (!center_position.has_value())
     {
@@ -47,7 +47,7 @@ std::optional<Point> CreaseDefenderFSM::findBlockThreatPoint(
     Rectangle defense_perimeter =
         field.friendlyDefenseArea().expand(robot_radius_expansion);
 
-    double step_distance   = 2.0 * ROBOT_MAX_RADIUS_METERS;
+    double step_distance = 2.0 * ROBOT_MAX_RADIUS_METERS;
     // Positive stepAlongPerimeter follows the rectangle vertex order (CCW). On the
     // front of the crease that is toward -y (RIGHT); negative is toward +y (LEFT).
     double travel_distance = step_distance;

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.cpp
@@ -1,9 +1,11 @@
 #include "software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.h"
 
 #include "proto/message_translation/tbots_protobuf.h"
+#include "shared/constants.h"
 #include "software/ai/hl/stp/tactic/dribble/dribble_fsm.h"
 #include "software/geom/algorithms/contains.h"
 #include "software/geom/algorithms/distance.h"
+#include "software/geom/algorithms/step_along_perimeter.h"
 #include "software/geom/stadium.h"
 
 CreaseDefenderFSM::CreaseDefenderFSM(
@@ -17,27 +19,45 @@ std::optional<Point> CreaseDefenderFSM::findBlockThreatPoint(
     const TbotsProto::CreaseDefenderAlignment& crease_defender_alignment,
     double robot_obstacle_inflation_factor)
 {
-    // We increment the angle to positive goalpost by 1/6, 3/6, or 5/6 of the shot
-    // cone
+    // Anchor on the centre of the shot cone, then step LEFT/RIGHT along the
+    // inflated defense area perimeter for consistent robot spacing.
     Angle shot_angle_sixth = convexAngle(field.friendlyGoalpostPos(), enemy_threat_origin,
                                          field.friendlyGoalpostNeg()) /
                              6.0;
     Angle angle_to_positive_goalpost =
         (field.friendlyGoalpostPos() - enemy_threat_origin).orientation();
-    Angle angle_to_block = angle_to_positive_goalpost + shot_angle_sixth * 3.0;
+    Angle center_angle = angle_to_positive_goalpost + shot_angle_sixth * 3.0;
+
+    Ray center_ray(enemy_threat_origin, center_angle);
+    std::optional<Point> center_position = findDefenseAreaIntersection(
+        field, center_ray, robot_obstacle_inflation_factor);
+
+    if (!center_position.has_value())
+    {
+        return std::nullopt;
+    }
+
+    if (crease_defender_alignment == TbotsProto::CreaseDefenderAlignment::CENTRE)
+    {
+        return center_position;
+    }
+
+    double robot_radius_expansion =
+        ROBOT_MAX_RADIUS_METERS * robot_obstacle_inflation_factor;
+    Rectangle defense_perimeter =
+        field.friendlyDefenseArea().expand(robot_radius_expansion);
+
+    double step_distance   = 2.0 * ROBOT_MAX_RADIUS_METERS;
+    // Positive stepAlongPerimeter follows the rectangle vertex order (CCW). On the
+    // front of the crease that is toward -y (RIGHT); negative is toward +y (LEFT).
+    double travel_distance = step_distance;
     if (crease_defender_alignment == TbotsProto::CreaseDefenderAlignment::LEFT)
     {
-        angle_to_block = angle_to_positive_goalpost + shot_angle_sixth * 1.0;
-    }
-    else if (crease_defender_alignment == TbotsProto::CreaseDefenderAlignment::RIGHT)
-    {
-        angle_to_block = angle_to_positive_goalpost + shot_angle_sixth * 5.0;
+        travel_distance = -step_distance;
     }
 
-    // Shot ray to block
-    Ray ray(enemy_threat_origin, angle_to_block);
-
-    return findDefenseAreaIntersection(field, ray, robot_obstacle_inflation_factor);
+    return stepAlongPerimeter(defense_perimeter, center_position.value(),
+                              travel_distance);
 }
 
 bool CreaseDefenderFSM::isAnyEnemyInZone(const Update& event, const Stadium& zone)

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.cpp
@@ -21,18 +21,19 @@ std::optional<Point> CreaseDefenderFSM::findBlockThreatPoint(
 {
     // Anchor on the centre of the shot cone, then step LEFT/RIGHT along the
     // inflated defense area perimeter for consistent robot spacing.
-    Angle shot_angle_sixth = convexAngle(field.friendlyGoalpostPos(), enemy_threat_origin,
-                                         field.friendlyGoalpostNeg()) /
-                             6.0;
     Angle angle_to_positive_goalpost =
         (field.friendlyGoalpostPos() - enemy_threat_origin).orientation();
-    Angle center_angle = angle_to_positive_goalpost + shot_angle_sixth * 3.0;
+    Angle center_angle =
+        angle_to_positive_goalpost +
+        convexAngle(field.friendlyGoalpostPos(), enemy_threat_origin,
+                    field.friendlyGoalpostNeg()) /
+            2.0;
 
     Ray center_ray(enemy_threat_origin, center_angle);
     std::optional<Point> center_position =
         findDefenseAreaIntersection(field, center_ray, robot_obstacle_inflation_factor);
 
-    if (!center_position.has_value())
+    if (!center_position)
     {
         return std::nullopt;
     }
@@ -56,8 +57,24 @@ std::optional<Point> CreaseDefenderFSM::findBlockThreatPoint(
         travel_distance = -step_distance;
     }
 
-    return stepAlongPerimeter(defense_perimeter, center_position.value(),
-                              travel_distance);
+    Point block_point = stepAlongPerimeter(defense_perimeter, center_position.value(),
+                                           travel_distance);
+
+    // Stepping toward the goal can wrap onto the goal-line side of the crease. 
+    // Clamp perimiter stepping to the nearest back corner. 
+    Segment goal_line_side(defense_perimeter.negXPosYCorner(),
+                           defense_perimeter.negXNegYCorner());
+    if (contains(goal_line_side, block_point))
+    {
+        if (distance(block_point, defense_perimeter.negXPosYCorner()) <
+            distance(block_point, defense_perimeter.negXNegYCorner()))
+        {
+            return defense_perimeter.negXPosYCorner();
+        }
+        return defense_perimeter.negXNegYCorner();
+    }
+
+    return block_point;
 }
 
 bool CreaseDefenderFSM::isAnyEnemyInZone(const Update& event, const Stadium& zone)

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.cpp
@@ -23,11 +23,10 @@ std::optional<Point> CreaseDefenderFSM::findBlockThreatPoint(
     // inflated defense area perimeter for consistent robot spacing.
     Angle angle_to_positive_goalpost =
         (field.friendlyGoalpostPos() - enemy_threat_origin).orientation();
-    Angle center_angle =
-        angle_to_positive_goalpost +
-        convexAngle(field.friendlyGoalpostPos(), enemy_threat_origin,
-                    field.friendlyGoalpostNeg()) /
-            2.0;
+    Angle center_angle = angle_to_positive_goalpost +
+                         convexAngle(field.friendlyGoalpostPos(), enemy_threat_origin,
+                                     field.friendlyGoalpostNeg()) /
+                             2.0;
 
     Ray center_ray(enemy_threat_origin, center_angle);
     std::optional<Point> center_position =
@@ -57,11 +56,11 @@ std::optional<Point> CreaseDefenderFSM::findBlockThreatPoint(
         travel_distance = -step_distance;
     }
 
-    Point block_point = stepAlongPerimeter(defense_perimeter, center_position.value(),
-                                           travel_distance);
+    Point block_point =
+        stepAlongPerimeter(defense_perimeter, center_position.value(), travel_distance);
 
-    // Stepping toward the goal can wrap onto the goal-line side of the crease. 
-    // Clamp perimiter stepping to the nearest back corner. 
+    // Stepping toward the goal can wrap onto the goal-line side of the crease.
+    // Clamp perimiter stepping to the nearest back corner.
     Segment goal_line_side(defense_perimeter.negXPosYCorner(),
                            defense_perimeter.negXNegYCorner());
     if (contains(goal_line_side, block_point))

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm_test.cpp
@@ -145,6 +145,35 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_right_of_crease)
     EXPECT_GT(threat_point_centre.value().x(), threat_point_right.value().x());
 }
 
+TEST(CreaseDefenderFSMTest, test_find_block_threat_point_clamps_at_goal_line_corner)
+{
+    TbotsProto::RobotNavigationObstacleConfig config;
+    double robot_obstacle_inflation_factor = config.robot_obstacle_inflation_factor();
+    Field field                            = Field::createSSLDivisionBField();
+    Rectangle defense_perimeter            = field.friendlyDefenseArea().expand(
+        ROBOT_MAX_RADIUS_METERS * robot_obstacle_inflation_factor);
+
+    // Clamp +y side of goal
+    Point enemy_threat_origin = Point(-4.45, 2.0);
+
+    auto threat_point_left = CreaseDefenderFSM::findBlockThreatPoint(
+        field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::LEFT,
+        robot_obstacle_inflation_factor);
+    ASSERT_TRUE(threat_point_left);
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(
+        threat_point_left.value(), defense_perimeter.negXPosYCorner(), 1e-9));
+
+    // -y side: RIGHT would wrap without a clamp.
+    enemy_threat_origin = Point(-4.45, -2.0);
+
+    auto threat_point_right = CreaseDefenderFSM::findBlockThreatPoint(
+        field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::RIGHT,
+        robot_obstacle_inflation_factor);
+    ASSERT_TRUE(threat_point_right);
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(
+        threat_point_right.value(), defense_perimeter.negXNegYCorner(), 1e-9));
+}
+
 TEST(CreaseDefenderFSMTest, test_find_block_threat_point_threat_in_crease)
 {
     TbotsProto::RobotNavigationObstacleConfig config;

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm_test.cpp
@@ -151,7 +151,7 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_clamps_at_goal_line_cor
     double robot_obstacle_inflation_factor = config.robot_obstacle_inflation_factor();
     Field field                            = Field::createSSLDivisionBField();
     Rectangle defense_perimeter            = field.friendlyDefenseArea().expand(
-        ROBOT_MAX_RADIUS_METERS * robot_obstacle_inflation_factor);
+                   ROBOT_MAX_RADIUS_METERS * robot_obstacle_inflation_factor);
 
     // Clamp +y side of goal
     Point enemy_threat_origin = Point(-4.45, 2.0);
@@ -160,8 +160,8 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_clamps_at_goal_line_cor
         field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::LEFT,
         robot_obstacle_inflation_factor);
     ASSERT_TRUE(threat_point_left);
-    EXPECT_TRUE(TestUtil::equalWithinTolerance(
-        threat_point_left.value(), defense_perimeter.negXPosYCorner(), 1e-9));
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(threat_point_left.value(),
+                                               defense_perimeter.negXPosYCorner(), 1e-9));
 
     // -y side: RIGHT would wrap without a clamp.
     enemy_threat_origin = Point(-4.45, -2.0);
@@ -170,8 +170,8 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_clamps_at_goal_line_cor
         field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::RIGHT,
         robot_obstacle_inflation_factor);
     ASSERT_TRUE(threat_point_right);
-    EXPECT_TRUE(TestUtil::equalWithinTolerance(
-        threat_point_right.value(), defense_perimeter.negXNegYCorner(), 1e-9));
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(threat_point_right.value(),
+                                               defense_perimeter.negXNegYCorner(), 1e-9));
 }
 
 TEST(CreaseDefenderFSMTest, test_find_block_threat_point_threat_in_crease)

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm_test.cpp
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm_test.cpp
@@ -3,8 +3,21 @@
 #include <gtest/gtest.h>
 
 #include "proto/parameters.pb.h"
+#include "shared/constants.h"
+#include "software/geom/algorithms/step_along_perimeter.h"
 #include "software/test_util/equal_within_tolerance.h"
 #include "software/test_util/test_util.h"
+
+namespace
+{
+Point expectedSteppedPoint(const Field& field, const Point& center_position,
+                           double robot_obstacle_inflation_factor, double travel_distance)
+{
+    Rectangle defense_perimeter = field.friendlyDefenseArea().expand(
+        ROBOT_MAX_RADIUS_METERS * robot_obstacle_inflation_factor);
+    return stepAlongPerimeter(defense_perimeter, center_position, travel_distance);
+}
+}  // namespace
 
 TEST(CreaseDefenderFSMTest, test_find_block_threat_point_in_front_of_crease)
 {
@@ -12,9 +25,11 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_in_front_of_crease)
     double robot_obstacle_inflation_factor = config.robot_obstacle_inflation_factor();
     Field field                            = Field::createSSLDivisionBField();
     Point enemy_threat_origin              = Point(2, 3);
-    auto threat_point_centre               = CreaseDefenderFSM::findBlockThreatPoint(
-                      field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::CENTRE,
-                      robot_obstacle_inflation_factor);
+    double step_distance                   = 2.0 * ROBOT_MAX_RADIUS_METERS;
+
+    auto threat_point_centre = CreaseDefenderFSM::findBlockThreatPoint(
+        field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::CENTRE,
+        robot_obstacle_inflation_factor);
     ASSERT_TRUE(threat_point_centre);
     EXPECT_GT(threat_point_centre.value().x(), field.friendlyDefenseArea().xMax());
 
@@ -23,12 +38,22 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_in_front_of_crease)
         robot_obstacle_inflation_factor);
     ASSERT_TRUE(threat_point_left);
     EXPECT_GT(threat_point_left.value().x(), field.friendlyDefenseArea().xMax());
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(
+        threat_point_left.value(),
+        expectedSteppedPoint(field, threat_point_centre.value(),
+                             robot_obstacle_inflation_factor, -step_distance),
+        1e-9));
 
     auto threat_point_right = CreaseDefenderFSM::findBlockThreatPoint(
         field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::RIGHT,
         robot_obstacle_inflation_factor);
     ASSERT_TRUE(threat_point_right);
     EXPECT_GT(threat_point_right.value().x(), field.friendlyDefenseArea().xMax());
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(
+        threat_point_right.value(),
+        expectedSteppedPoint(field, threat_point_centre.value(),
+                             robot_obstacle_inflation_factor, step_distance),
+        1e-9));
 
     EXPECT_LT(threat_point_centre.value().y(), threat_point_left.value().y());
     EXPECT_GT(threat_point_centre.value().y(), threat_point_right.value().y());
@@ -40,9 +65,11 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_left_of_crease)
     double robot_obstacle_inflation_factor = config.robot_obstacle_inflation_factor();
     Field field                            = Field::createSSLDivisionBField();
     Point enemy_threat_origin              = Point(-2.5, 3);
-    auto threat_point_centre               = CreaseDefenderFSM::findBlockThreatPoint(
-                      field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::CENTRE,
-                      robot_obstacle_inflation_factor);
+    double step_distance                   = 2.0 * ROBOT_MAX_RADIUS_METERS;
+
+    auto threat_point_centre = CreaseDefenderFSM::findBlockThreatPoint(
+        field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::CENTRE,
+        robot_obstacle_inflation_factor);
     ASSERT_TRUE(threat_point_centre);
     EXPECT_GE(threat_point_centre.value().y(), field.friendlyDefenseArea().yMax());
     EXPECT_LE(threat_point_centre.value().x(), field.friendlyDefenseArea().xMax());
@@ -53,6 +80,11 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_left_of_crease)
     ASSERT_TRUE(threat_point_left);
     EXPECT_GE(threat_point_left.value().y(), field.friendlyDefenseArea().yMax());
     EXPECT_LE(threat_point_left.value().x(), field.friendlyDefenseArea().xMax());
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(
+        threat_point_left.value(),
+        expectedSteppedPoint(field, threat_point_centre.value(),
+                             robot_obstacle_inflation_factor, -step_distance),
+        1e-9));
 
     auto threat_point_right = CreaseDefenderFSM::findBlockThreatPoint(
         field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::RIGHT,
@@ -60,6 +92,11 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_left_of_crease)
     ASSERT_TRUE(threat_point_right);
     EXPECT_GE(threat_point_right.value().y(), field.friendlyDefenseArea().yMax());
     EXPECT_LE(threat_point_right.value().x(), field.friendlyDefenseArea().xMax());
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(
+        threat_point_right.value(),
+        expectedSteppedPoint(field, threat_point_centre.value(),
+                             robot_obstacle_inflation_factor, step_distance),
+        1e-9));
 
     EXPECT_GT(threat_point_centre.value().x(), threat_point_left.value().x());
     EXPECT_LT(threat_point_centre.value().x(), threat_point_right.value().x());
@@ -71,9 +108,11 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_right_of_crease)
     double robot_obstacle_inflation_factor = config.robot_obstacle_inflation_factor();
     Field field                            = Field::createSSLDivisionBField();
     Point enemy_threat_origin              = Point(-4.25, -2);
-    auto threat_point_centre               = CreaseDefenderFSM::findBlockThreatPoint(
-                      field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::CENTRE,
-                      robot_obstacle_inflation_factor);
+    double step_distance                   = 2.0 * ROBOT_MAX_RADIUS_METERS;
+
+    auto threat_point_centre = CreaseDefenderFSM::findBlockThreatPoint(
+        field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::CENTRE,
+        robot_obstacle_inflation_factor);
     ASSERT_TRUE(threat_point_centre);
     EXPECT_LE(threat_point_centre.value().y(), field.friendlyDefenseArea().yMin());
     EXPECT_LE(threat_point_centre.value().x(), field.friendlyDefenseArea().xMax());
@@ -84,6 +123,11 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_right_of_crease)
     ASSERT_TRUE(threat_point_left);
     EXPECT_LE(threat_point_left.value().y(), field.friendlyDefenseArea().yMin());
     EXPECT_LE(threat_point_left.value().x(), field.friendlyDefenseArea().xMax());
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(
+        threat_point_left.value(),
+        expectedSteppedPoint(field, threat_point_centre.value(),
+                             robot_obstacle_inflation_factor, -step_distance),
+        1e-9));
 
     auto threat_point_right = CreaseDefenderFSM::findBlockThreatPoint(
         field, enemy_threat_origin, TbotsProto::CreaseDefenderAlignment::RIGHT,
@@ -91,6 +135,11 @@ TEST(CreaseDefenderFSMTest, test_find_block_threat_point_right_of_crease)
     ASSERT_TRUE(threat_point_right);
     EXPECT_LE(threat_point_right.value().y(), field.friendlyDefenseArea().yMin());
     EXPECT_LE(threat_point_right.value().x(), field.friendlyDefenseArea().xMax());
+    EXPECT_TRUE(TestUtil::equalWithinTolerance(
+        threat_point_right.value(),
+        expectedSteppedPoint(field, threat_point_centre.value(),
+                             robot_obstacle_inflation_factor, step_distance),
+        1e-9));
 
     EXPECT_LT(threat_point_centre.value().x(), threat_point_left.value().x());
     EXPECT_GT(threat_point_centre.value().x(), threat_point_right.value().x());
@@ -123,9 +172,11 @@ TEST(CreaseDefenderFSMTest, test_transitions)
     TbotsProto::AiConfig ai_config;
     TbotsProto::RobotNavigationObstacleConfig config =
         ai_config.robot_navigation_obstacle_config();
-    double robot_obstacle_inflation_factor = config.robot_obstacle_inflation_factor();
-    std::shared_ptr<World> world           = ::TestUtil::createBlankTestingWorld();
-    Robot robot                            = ::TestUtil::createRobotAtPos(Point(-2, -3));
+    // Match the inflation used in CreaseDefenderFSM::blockThreat
+    double robot_obstacle_inflation_factor =
+        config.robot_obstacle_inflation_factor() + 0.5;
+    std::shared_ptr<World> world = ::TestUtil::createBlankTestingWorld();
+    Robot robot                  = ::TestUtil::createRobotAtPos(Point(-2, -3));
     ::TestUtil::setBallPosition(world, Point(-0.5, 0), Timestamp::fromSeconds(123));
     CreaseDefenderFSM::ControlParams control_params{
         .enemy_threat_origin       = Point(2, 3),

--- a/src/software/geom/algorithms/step_along_perimeter.cpp
+++ b/src/software/geom/algorithms/step_along_perimeter.cpp
@@ -39,38 +39,41 @@ Point stepAlongPerimeter(const Polygon& polygon, const Point& start,
         travel_distance = perimeter - travel_distance;
     }
 
-    bool wrap_flag = false;
-    while (travel_distance > 0)
+    // First segment is traversed from closest_start toward the segment end; later
+    // segments are traversed from their start vertex.
+    bool on_first_segment = true;
+    while (travel_distance > FIXED_EPSILON)
     {
         Segment curr_segment = polygon_segments[segment_index];
-
+        Point from_point     = curr_segment.getStart();
         double segment_length = curr_segment.length();
-        if (segment_index == start_segment_index && !wrap_flag)
+
+        if (on_first_segment)
         {
-            segment_length = distance(closest_start, curr_segment.getEnd());
-            wrap_flag      = true;
+            from_point      = closest_start;
+            segment_length  = distance(closest_start, curr_segment.getEnd());
+            on_first_segment = false;
         }
 
-        // If the remaining distance to travel is less than or equal to the length
-        // of the current segment, calculate the final point and return it
+        if (segment_length < FIXED_EPSILON)
+        {
+            // End of segment. Advance to next. 
+            segment_index = (segment_index + 1) % polygon_segments.size();
+            continue;
+        }
+        
         if (travel_distance <= segment_length)
         {
             double ratio = travel_distance / segment_length;
-            double newX =
-                curr_segment.getStart().x() +
-                ratio * (curr_segment.getEnd().x() - curr_segment.getStart().x());
-            double newY =
-                curr_segment.getStart().y() +
-                ratio * (curr_segment.getEnd().y() - curr_segment.getStart().y());
-            return Point{newX, newY};
+            return Point(from_point.x() +
+                             ratio * (curr_segment.getEnd().x() - from_point.x()),
+                         from_point.y() +
+                             ratio * (curr_segment.getEnd().y() - from_point.y()));
         }
 
-        // Subtract the length of the current segment from the total distance
         travel_distance -= segment_length;
-
-        // Update the segment index
         segment_index = (segment_index + 1) % polygon_segments.size();
     }
 
-    return start;
+    return closest_start;
 }

--- a/src/software/geom/algorithms/step_along_perimeter.cpp
+++ b/src/software/geom/algorithms/step_along_perimeter.cpp
@@ -44,31 +44,30 @@ Point stepAlongPerimeter(const Polygon& polygon, const Point& start,
     bool on_first_segment = true;
     while (travel_distance > FIXED_EPSILON)
     {
-        Segment curr_segment = polygon_segments[segment_index];
-        Point from_point     = curr_segment.getStart();
+        Segment curr_segment  = polygon_segments[segment_index];
+        Point from_point      = curr_segment.getStart();
         double segment_length = curr_segment.length();
 
         if (on_first_segment)
         {
-            from_point      = closest_start;
-            segment_length  = distance(closest_start, curr_segment.getEnd());
+            from_point       = closest_start;
+            segment_length   = distance(closest_start, curr_segment.getEnd());
             on_first_segment = false;
         }
 
         if (segment_length < FIXED_EPSILON)
         {
-            // End of segment. Advance to next. 
+            // End of segment. Advance to next.
             segment_index = (segment_index + 1) % polygon_segments.size();
             continue;
         }
-        
+
         if (travel_distance <= segment_length)
         {
             double ratio = travel_distance / segment_length;
-            return Point(from_point.x() +
-                             ratio * (curr_segment.getEnd().x() - from_point.x()),
-                         from_point.y() +
-                             ratio * (curr_segment.getEnd().y() - from_point.y()));
+            return Point(
+                from_point.x() + ratio * (curr_segment.getEnd().x() - from_point.x()),
+                from_point.y() + ratio * (curr_segment.getEnd().y() - from_point.y()));
         }
 
         travel_distance -= segment_length;

--- a/src/software/geom/algorithms/step_along_perimeter_test.cpp
+++ b/src/software/geom/algorithms/step_along_perimeter_test.cpp
@@ -89,6 +89,18 @@ TEST(StepAlongPerimeterTest, positive_distance_starts_from_middle)
     EXPECT_EQ(result_point, expected_point);
 }
 
+TEST(StepAlongPerimeterTest, small_positive_distance_from_middle_of_segment)
+{
+    // travel must start from the closest point on the segment, not the
+    // segment's start vertex.
+    Polygon polygon({{0, 0}, {0, 2}, {2, 2}, {2, 0}});
+    Point start_point(1, 0);
+    double travel_distance = 0.5;
+    Point expected_point(0.5, 0);
+    Point result_point = stepAlongPerimeter(polygon, start_point, travel_distance);
+    EXPECT_EQ(result_point, expected_point);
+}
+
 TEST(StepAlongPerimeterTest, distance_equals_perimeter_returns_start)
 {
     Polygon polygon({{0, 0}, {0, 1}, {1, 1}, {1, 0}});


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Currently, CreaseDefensePlayFSM handles only 3 crease defenders to occupy 3 positions. We used shot cones to find where the robots should be positioned. However, when the shot cone angle is small there would be one robot clustered in the middle and not really doing much so want fewer sometimes. To do this, perimeter stepping along the defence area was implemented. 

There was a bug in stepAlongPerimeter where the mid-segment starts to interpolate from the segment start not the closest_start so the steps were wrong. Fix: first segment starts at closest point on perimeter. 
Tests were added for crease defender so LEFT and RIGHT matches +/- step from the centre. Also added perimeter stepping tests for bug. 

So far this seems to look like it fixed the issue of the shot cones always using up 3 robots. 

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Updated C++ tests and made sure they all passed. 
To visually see the change working i ran `./tbots.py run thunderscope_main --keyboard_estop` and tested placing the ball in a couple places like centre and the side where the shot cone caused different spacing of robots. Here I had 2 robots to demonstrate how the spacing was super close when the angle was smaller and the 2 crease defenders were further when enemy was in the centre causing a larger shotcone. 

This is before the fix. Notice crease defenders 1 and 2 are spaced further. 
<img width="552" height="327" alt="shotcone4" src="https://github.com/user-attachments/assets/e637c90a-6776-41f2-bac5-8bb9ef49731c" />

And when angle is close they are spaced super close. Since we can have up to 3, when there are 3 crease defenders, in this situation they cluster causing one to be very useless. (robots 1 and 5 are the crease defenders here)
<img width="478" height="337" alt="shotcone3" src="https://github.com/user-attachments/assets/0b236cc8-2f0d-4129-ba0f-b7507dfd6d7b" />



Here is the fix where the 2 crease defenders are always evenly spaced based on robot radius. 


https://github.com/user-attachments/assets/89be9633-9c38-4842-af8f-52a9c4284d00






### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

In my opinion doing the perimeter stepping solves the dynamic number of robots as crease defender? 
https://github.com/UBC-Thunderbots/Software/issues/3374
https://github.com/UBC-Thunderbots/Software/issues/2995

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
