### PR TITLE
Refactor all play selection logic into PlaySelectionFSM

### DIFF
--- a/docs/fsm-diagrams.md
+++ b/docs/fsm-diagrams.md
@@ -11,16 +11,24 @@ direction LR
 Halt --> Stop : [gameStateStopped]\n<i>setupStopPlay</i>
 Halt --> Playing : [gameStatePlaying]\n<i>setupOffensePlay</i>
 Halt --> SetPlay : [gameStateSetupRestart]\n<i>setupSetPlay</i>
+Halt --> Halt : <i>setupOverridePlay</i>
+Halt --> Halt : <i>resetPlaySelection</i>
 Stop --> Halt : [gameStateHalted]\n<i>setupHaltPlay</i>
 Stop --> Playing : [gameStatePlaying]\n<i>setupOffensePlay</i>
 Stop --> SetPlay : [gameStateSetupRestart]\n<i>setupSetPlay</i>
+Stop --> Stop : <i>setupOverridePlay</i>
+Stop --> Halt : <i>resetPlaySelection</i>
 Playing --> Halt : [gameStateHalted]\n<i>setupHaltPlay</i>
 Playing --> Stop : [gameStateStopped]\n<i>setupStopPlay</i>
 Playing --> SetPlay : [gameStateSetupRestart]\n<i>setupSetPlay</i>
+Playing --> Playing : <i>setupOverridePlay</i>
+Playing --> Halt : <i>resetPlaySelection</i>
 SetPlay --> Halt : [gameStateHalted]\n<i>resetSetPlay, setupHaltPlay</i>
 SetPlay --> Stop : [gameStateStopped]\n<i>resetSetPlay, setupStopPlay</i>
 SetPlay --> Playing : [gameStatePlaying]\n<i>resetSetPlay, setupOffensePlay</i>
 SetPlay --> SetPlay : [gameStateSetupRestart]\n<i>setupSetPlay</i>
+SetPlay --> SetPlay : <i>setupOverridePlay</i>
+SetPlay --> Halt : <i>resetPlaySelection</i>
 Terminate:::terminate --> Terminate:::terminate
 
 ```

--- a/src/software/ai/ai.cpp
+++ b/src/software/ai/ai.cpp
@@ -2,7 +2,6 @@
 
 #include <Tracy.hpp>
 
-#include "software/ai/hl/stp/play/halt_play/halt_play.h"
 #include "software/ai/hl/stp/play/play_factory.h"
 #include "software/tracy/tracy_constants.h"
 
@@ -10,8 +9,6 @@
 Ai::Ai(std::shared_ptr<const TbotsProto::AiConfig> ai_config_ptr)
     : ai_config_ptr(ai_config_ptr),
       fsm(std::make_unique<FSM<PlaySelectionFSM>>(PlaySelectionFSM{ai_config_ptr})),
-      override_play(nullptr),
-      current_play(std::make_unique<HaltPlay>(ai_config_ptr)),
       ai_config_changed(false)
 {
     auto current_override = ai_config_ptr->ai_control_config().override_ai_play();
@@ -26,12 +23,11 @@ Ai::Ai(std::shared_ptr<const TbotsProto::AiConfig> ai_config_ptr)
 
 void Ai::overridePlay(std::unique_ptr<Play> play)
 {
-    override_play = std::move(play);
+    fsm->process_event(PlaySelectionFSM::Override(std::move(play)));
 }
 
 void Ai::overridePlayFromProto(TbotsProto::Play play_proto)
 {
-    current_override_play_proto = play_proto;
     overridePlay(std::move(createPlay(play_proto, ai_config_ptr)));
 }
 
@@ -44,23 +40,17 @@ void Ai::checkAiConfig()
 {
     if (ai_config_changed)
     {
-        ai_config_changed = false;
-
-        fsm = std::make_unique<FSM<PlaySelectionFSM>>(PlaySelectionFSM{ai_config_ptr});
-
         auto current_override = ai_config_ptr->ai_control_config().override_ai_play();
+        std::unique_ptr<Play> override_play;
         if (current_override != TbotsProto::PlayName::UseAiSelection)
         {
-            // Override to new play if we're not running Ai Selection
             TbotsProto::Play play_proto;
             play_proto.set_name(current_override);
-            overridePlayFromProto(play_proto);
+            override_play = createPlay(play_proto, ai_config_ptr);
         }
-        else
-        {
-            // Clear play override if we're running Ai Selection
-            overridePlay(nullptr);
-        }
+
+        fsm->process_event(PlaySelectionFSM::Reset(std::move(override_play)));
+        ai_config_changed = false;
     }
 }
 
@@ -70,25 +60,12 @@ std::unique_ptr<TbotsProto::PrimitiveSet> Ai::getPrimitives(const WorldPtr& worl
 
     checkAiConfig();
 
-    fsm->process_event(PlaySelectionFSM::Update([this](std::unique_ptr<Play> play)
-                                                { current_play = std::move(play); },
-                                                world_ptr->gameState(), *ai_config_ptr));
+    fsm->process_event(PlaySelectionFSM::Update(world_ptr->gameState(), *ai_config_ptr));
 
-    std::unique_ptr<TbotsProto::PrimitiveSet> primitive_set;
-    if (static_cast<bool>(override_play))
-    {
-        primitive_set = override_play->get(world_ptr, inter_play_communication,
-                                           [this](InterPlayCommunication comm) {
-                                               inter_play_communication = std::move(comm);
-                                           });
-    }
-    else
-    {
-        primitive_set = current_play->get(world_ptr, inter_play_communication,
-                                          [this](InterPlayCommunication comm) {
-                                              inter_play_communication = std::move(comm);
-                                          });
-    }
+    auto primitive_set = static_cast<PlaySelectionFSM&>(*fsm).getSelectedPlay().get(
+        world_ptr, inter_play_communication,
+        [this](InterPlayCommunication comm)
+        { inter_play_communication = std::move(comm); });
 
     FrameMarkEnd(TracyConstants::AI_FRAME_MARKER);
 
@@ -97,14 +74,9 @@ std::unique_ptr<TbotsProto::PrimitiveSet> Ai::getPrimitives(const WorldPtr& worl
 
 TbotsProto::PlayInfo Ai::getPlayInfo() const
 {
-    std::vector<std::string> play_state = current_play->getState();
-    auto tactic_robot_id_assignment     = current_play->getTacticRobotIdAssignment();
-
-    if (static_cast<bool>(override_play))
-    {
-        play_state                 = override_play->getState();
-        tactic_robot_id_assignment = override_play->getTacticRobotIdAssignment();
-    }
+    Play& selected_play = static_cast<const PlaySelectionFSM&>(*fsm).getSelectedPlay();
+    const std::vector<std::string> play_state = selected_play.getState();
+    auto tactic_robot_id_assignment = selected_play.getTacticRobotIdAssignment();
 
     TbotsProto::PlayInfo info;
 

--- a/src/software/ai/ai.h
+++ b/src/software/ai/ai.h
@@ -67,9 +67,6 @@ class Ai final
 
     std::shared_ptr<const TbotsProto::AiConfig> ai_config_ptr;
     std::unique_ptr<FSM<PlaySelectionFSM>> fsm;
-    std::unique_ptr<Play> override_play;
-    std::unique_ptr<Play> current_play;
-    TbotsProto::Play current_override_play_proto;
     bool ai_config_changed;
 
     // inter play communication

--- a/src/software/ai/play_selection_fsm.cpp
+++ b/src/software/ai/play_selection_fsm.cpp
@@ -24,7 +24,14 @@ PlaySelectionFSM::PlaySelectionFSM(
 
 Play& PlaySelectionFSM::getSelectedPlay() const
 {
-    return override_play ? *override_play : *current_play;
+    if (override_play)
+    {
+        return *override_play;
+    }
+    else
+    {
+        return *current_play;
+    }
 }
 
 bool PlaySelectionFSM::gameStateStopped(const Update& event)

--- a/src/software/ai/play_selection_fsm.cpp
+++ b/src/software/ai/play_selection_fsm.cpp
@@ -15,8 +15,16 @@
 
 PlaySelectionFSM::PlaySelectionFSM(
     std::shared_ptr<const TbotsProto::AiConfig> ai_config_ptr)
-    : ai_config_ptr(ai_config_ptr), current_set_play(std::nullopt)
+    : ai_config_ptr(ai_config_ptr),
+      current_set_play(std::nullopt),
+      current_play(std::make_shared<HaltPlay>(ai_config_ptr)),
+      override_play(nullptr)
 {
+}
+
+Play& PlaySelectionFSM::getSelectedPlay() const
+{
+    return override_play ? *override_play : *current_play;
 }
 
 bool PlaySelectionFSM::gameStateStopped(const Update& event)
@@ -39,6 +47,17 @@ bool PlaySelectionFSM::gameStateSetupRestart(const Update& event)
     return event.game_state.isSetupRestart();
 }
 
+void PlaySelectionFSM::setupOverridePlay(const Override& event)
+{
+    override_play = event.play;
+}
+
+void PlaySelectionFSM::resetPlaySelection(const Reset& event)
+{
+    current_set_play.reset();
+    setupOverridePlay(event);
+}
+
 void PlaySelectionFSM::setupSetPlay(const Update& event)
 {
     if (event.game_state.isOurBallPlacement())
@@ -46,7 +65,7 @@ void PlaySelectionFSM::setupSetPlay(const Update& event)
         if (current_set_play != TbotsProto::PlayName::BallPlacementPlay)
         {
             current_set_play = TbotsProto::PlayName::BallPlacementPlay;
-            event.set_current_play(std::make_unique<BallPlacementPlay>(ai_config_ptr));
+            setCurrentPlay(std::make_unique<BallPlacementPlay>(ai_config_ptr));
         }
     }
     else if (event.game_state.isTheirBallPlacement())
@@ -54,8 +73,7 @@ void PlaySelectionFSM::setupSetPlay(const Update& event)
         if (current_set_play != TbotsProto::PlayName::EnemyBallPlacementPlay)
         {
             current_set_play = TbotsProto::PlayName::EnemyBallPlacementPlay;
-            event.set_current_play(
-                std::make_unique<EnemyBallPlacementPlay>(ai_config_ptr));
+            setCurrentPlay(std::make_unique<EnemyBallPlacementPlay>(ai_config_ptr));
         }
     }
     else if (event.game_state.isOurKickoff())
@@ -63,7 +81,7 @@ void PlaySelectionFSM::setupSetPlay(const Update& event)
         if (current_set_play != TbotsProto::PlayName::KickoffFriendlyPlay)
         {
             current_set_play = TbotsProto::PlayName::KickoffFriendlyPlay;
-            event.set_current_play(std::make_unique<KickoffFriendlyPlay>(ai_config_ptr));
+            setCurrentPlay(std::make_unique<KickoffFriendlyPlay>(ai_config_ptr));
         }
     }
     else if (event.game_state.isTheirKickoff())
@@ -71,7 +89,7 @@ void PlaySelectionFSM::setupSetPlay(const Update& event)
         if (current_set_play != TbotsProto::PlayName::KickoffEnemyPlay)
         {
             current_set_play = TbotsProto::PlayName::KickoffEnemyPlay;
-            event.set_current_play(std::make_unique<KickoffEnemyPlay>(ai_config_ptr));
+            setCurrentPlay(std::make_unique<KickoffEnemyPlay>(ai_config_ptr));
         }
     }
     else if (event.game_state.isOurPenalty())
@@ -79,7 +97,7 @@ void PlaySelectionFSM::setupSetPlay(const Update& event)
         if (current_set_play != TbotsProto::PlayName::PenaltyKickPlay)
         {
             current_set_play = TbotsProto::PlayName::PenaltyKickPlay;
-            event.set_current_play(std::make_unique<PenaltyKickPlay>(ai_config_ptr));
+            setCurrentPlay(std::make_unique<PenaltyKickPlay>(ai_config_ptr));
         }
     }
     else if (event.game_state.isTheirPenalty())
@@ -87,7 +105,7 @@ void PlaySelectionFSM::setupSetPlay(const Update& event)
         if (current_set_play != TbotsProto::PlayName::PenaltyKickEnemyPlay)
         {
             current_set_play = TbotsProto::PlayName::PenaltyKickEnemyPlay;
-            event.set_current_play(std::make_unique<PenaltyKickEnemyPlay>(ai_config_ptr));
+            setCurrentPlay(std::make_unique<PenaltyKickEnemyPlay>(ai_config_ptr));
         }
     }
     else if (event.game_state.isOurDirectFree() || event.game_state.isOurIndirectFree())
@@ -95,7 +113,7 @@ void PlaySelectionFSM::setupSetPlay(const Update& event)
         if (current_set_play != TbotsProto::PlayName::FreeKickPlay)
         {
             current_set_play = TbotsProto::PlayName::FreeKickPlay;
-            event.set_current_play(std::make_unique<FreeKickPlay>(ai_config_ptr));
+            setCurrentPlay(std::make_unique<FreeKickPlay>(ai_config_ptr));
         }
     }
     else if (event.game_state.isTheirDirectFree() ||
@@ -104,27 +122,32 @@ void PlaySelectionFSM::setupSetPlay(const Update& event)
         if (current_set_play != TbotsProto::PlayName::EnemyFreeKickPlay)
         {
             current_set_play = TbotsProto::PlayName::EnemyFreeKickPlay;
-            event.set_current_play(std::make_unique<EnemyFreeKickPlay>(ai_config_ptr));
+            setCurrentPlay(std::make_unique<EnemyFreeKickPlay>(ai_config_ptr));
         }
     }
 }
 
 void PlaySelectionFSM::setupStopPlay(const Update& event)
 {
-    event.set_current_play(std::make_unique<StopPlay>(ai_config_ptr));
+    setCurrentPlay(std::make_unique<StopPlay>(ai_config_ptr));
 }
 
 void PlaySelectionFSM::setupHaltPlay(const Update& event)
 {
-    event.set_current_play(std::make_unique<HaltPlay>(ai_config_ptr));
+    setCurrentPlay(std::make_unique<HaltPlay>(ai_config_ptr));
 }
 
 void PlaySelectionFSM::setupOffensePlay(const Update& event)
 {
-    event.set_current_play(std::make_unique<OffensePlay>(ai_config_ptr));
+    setCurrentPlay(std::make_unique<OffensePlay>(ai_config_ptr));
 }
 
 void PlaySelectionFSM::resetSetPlay(const Update& event)
 {
     current_set_play.reset();
+}
+
+void PlaySelectionFSM::setCurrentPlay(std::unique_ptr<Play> play)
+{
+    current_play = std::move(play);
 }

--- a/src/software/ai/play_selection_fsm.h
+++ b/src/software/ai/play_selection_fsm.h
@@ -10,20 +10,26 @@ struct PlaySelectionFSM
     class Playing;
     class Stop;
     class SetPlay;
-    class OverridePlay;
 
     struct Update
     {
-        Update(const std::function<void(std::unique_ptr<Play>)>& set_current_play,
-               const GameState& game_state, const TbotsProto::AiConfig& ai_config)
-            : set_current_play(set_current_play),
-              game_state(game_state),
-              ai_config(ai_config)
+        Update(const GameState& game_state, const TbotsProto::AiConfig& ai_config)
+            : game_state(game_state), ai_config(ai_config)
         {
         }
-        std::function<void(std::unique_ptr<Play>)> set_current_play;
         GameState game_state;
         TbotsProto::AiConfig ai_config;
+    };
+
+    struct Override
+    {
+        explicit Override(std::unique_ptr<Play> play) : play(std::move(play)) {}
+        std::shared_ptr<Play> play;
+    };
+
+    struct Reset : Override
+    {
+        using Override::Override;
     };
 
     /**
@@ -32,6 +38,13 @@ struct PlaySelectionFSM
      * @param ai_config_ptr pointer to the default play config for this play fsm
      */
     explicit PlaySelectionFSM(std::shared_ptr<const TbotsProto::AiConfig> ai_config_ptr);
+
+    /**
+     * Gets the currently selected play
+     *
+     * @return the override play if one exists, otherwise the current play
+     */
+    Play& getSelectedPlay() const;
 
     /**
      * Guards for whether the game state is stopped, halted, playing, or in set up
@@ -46,7 +59,21 @@ struct PlaySelectionFSM
     bool gameStateSetupRestart(const Update& event);
 
     /**
-     * Action to set up the OverridePlay, SetPlay, StopPlay, HaltPlay, or OffensePlay
+     * Action to set up the override play
+     *
+     * @param event The PlaySelection::Override event
+     */
+    void setupOverridePlay(const Override& event);
+
+    /**
+     * Action to reset play selection and set up the override play
+     *
+     * @param event The PlaySelection::Reset event
+     */
+    void resetPlaySelection(const Reset& event);
+
+    /**
+     * Action to set up the SetPlay, StopPlay, HaltPlay, or OffensePlay
      *
      * @param event The PlaySelection::Update event
      *
@@ -63,6 +90,13 @@ struct PlaySelectionFSM
      */
     void resetSetPlay(const Update& event);
 
+    /**
+     * Sets the current play
+     *
+     * @param play the new current play
+     */
+    void setCurrentPlay(std::unique_ptr<Play> play);
+
     auto operator()()
     {
         using namespace boost::sml;
@@ -78,7 +112,11 @@ struct PlaySelectionFSM
         DEFINE_SML_GUARD(gameStateSetupRestart)
 
         DEFINE_SML_EVENT(Update)
+        DEFINE_SML_EVENT(Override)
+        DEFINE_SML_EVENT(Reset)
 
+        DEFINE_SML_ACTION(setupOverridePlay)
+        DEFINE_SML_ACTION(resetPlaySelection)
         DEFINE_SML_ACTION(setupSetPlay)
         DEFINE_SML_ACTION(setupStopPlay)
         DEFINE_SML_ACTION(setupHaltPlay)
@@ -93,18 +131,24 @@ struct PlaySelectionFSM
             *Halt_S + Update_E[gameStateStopped_G] / setupStopPlay_A    = Stop_S,
             Halt_S + Update_E[gameStatePlaying_G] / setupOffensePlay_A  = Playing_S,
             Halt_S + Update_E[gameStateSetupRestart_G] / setupSetPlay_A = SetPlay_S,
+            Halt_S + Override_E / setupOverridePlay_A,
+            Halt_S + Reset_E / resetPlaySelection_A = Halt_S,
 
             // Check for transitions to other states, if not then default to running the
             // current play
             Stop_S + Update_E[gameStateHalted_G] / setupHaltPlay_A      = Halt_S,
             Stop_S + Update_E[gameStatePlaying_G] / setupOffensePlay_A  = Playing_S,
             Stop_S + Update_E[gameStateSetupRestart_G] / setupSetPlay_A = SetPlay_S,
+            Stop_S + Override_E / setupOverridePlay_A,
+            Stop_S + Reset_E / resetPlaySelection_A = Halt_S,
 
             // Check for transitions to other states, if not then default to running the
             // current play
             Playing_S + Update_E[gameStateHalted_G] / setupHaltPlay_A      = Halt_S,
             Playing_S + Update_E[gameStateStopped_G] / setupStopPlay_A     = Stop_S,
             Playing_S + Update_E[gameStateSetupRestart_G] / setupSetPlay_A = SetPlay_S,
+            Playing_S + Override_E / setupOverridePlay_A,
+            Playing_S + Reset_E / resetPlaySelection_A = Halt_S,
 
             // Check for transitions to other states, if not then default to running the
             // current play
@@ -115,6 +159,8 @@ struct PlaySelectionFSM
             SetPlay_S + Update_E[gameStatePlaying_G] /
                             (resetSetPlay_A, setupOffensePlay_A) = Playing_S,
             SetPlay_S + Update_E[gameStateSetupRestart_G] / setupSetPlay_A,
+            SetPlay_S + Override_E / setupOverridePlay_A,
+            SetPlay_S + Reset_E / resetPlaySelection_A = Halt_S,
 
             X + Update_E = X);
     }
@@ -122,4 +168,6 @@ struct PlaySelectionFSM
    private:
     std::shared_ptr<const TbotsProto::AiConfig> ai_config_ptr;
     std::optional<TbotsProto::PlayName> current_set_play;
+    std::shared_ptr<Play> current_play;
+    std::shared_ptr<Play> override_play;
 };

--- a/src/software/ai/play_selection_fsm_test.cpp
+++ b/src/software/ai/play_selection_fsm_test.cpp
@@ -17,257 +17,247 @@ class PlaySelectionFSMTest : public ::testing::Test
     std::unique_ptr<FSM<PlaySelectionFSM>> fsm =
         std::make_unique<FSM<PlaySelectionFSM>>(PlaySelectionFSM{ai_config_ptr});
     GameState game_state;
+
+    Play& selectedPlay() const
+    {
+        return static_cast<const PlaySelectionFSM&>(*fsm).getSelectedPlay();
+    }
+
+    void update()
+    {
+        fsm->process_event(PlaySelectionFSM::Update(game_state, ai_config));
+    }
 };
+
+TEST_F(PlaySelectionFSMTest, test_override_preserves_ai_selection_state)
+{
+    // Stop
+    game_state.updateRefereeCommand(RefereeCommand::STOP);
+    update();
+    EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Stop>));
+    EXPECT_EQ("StopPlay", objectTypeName(selectedPlay()));
+
+    // Override stop play with halt
+    fsm->process_event(
+        PlaySelectionFSM::Override(std::make_unique<HaltPlay>(ai_config_ptr)));
+    EXPECT_EQ("HaltPlay", objectTypeName(selectedPlay()));
+
+    // Play selection should continue while overridden
+    game_state.updateRefereeCommand(RefereeCommand::FORCE_START);
+    update();
+    EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Playing>));
+    EXPECT_EQ("HaltPlay", objectTypeName(selectedPlay()));
+
+    // Remove override, should show new selected play from previous step
+    fsm->process_event(PlaySelectionFSM::Override(nullptr));
+    EXPECT_EQ("OffensePlay", objectTypeName(selectedPlay()));
+}
+
+TEST_F(PlaySelectionFSMTest, test_reset_clears_override_and_resets_selection_state)
+{
+    // Start
+    game_state.updateRefereeCommand(RefereeCommand::FORCE_START);
+    update();
+    EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Playing>));
+
+    // Override offense play with halt
+    fsm->process_event(
+        PlaySelectionFSM::Override(std::make_unique<HaltPlay>(ai_config_ptr)));
+    EXPECT_EQ("HaltPlay", objectTypeName(selectedPlay()));
+
+    // Play selection should be reset
+    fsm->process_event(PlaySelectionFSM::Reset(nullptr));
+    EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Halt>));
+    EXPECT_EQ("OffensePlay", objectTypeName(selectedPlay()));
+}
 
 TEST_F(PlaySelectionFSMTest, test_transition_out_of_penalty_kick)
 {
-    std::unique_ptr<Play> current_play = std::make_unique<HaltPlay>(ai_config_ptr);
-
     // Start in halt
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Halt>));
-    EXPECT_EQ("HaltPlay", objectTypeName(*current_play));
+    EXPECT_EQ("HaltPlay", objectTypeName(selectedPlay()));
 
     // Stop
     game_state.updateRefereeCommand(RefereeCommand::STOP);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Stop>));
-    EXPECT_EQ("StopPlay", objectTypeName(*current_play));
+    EXPECT_EQ("StopPlay", objectTypeName(selectedPlay()));
 
     // Penalty kick preparation
     game_state.updateRefereeCommand(RefereeCommand::PREPARE_PENALTY_US);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("PenaltyKickPlay", objectTypeName(*current_play));
+    EXPECT_EQ("PenaltyKickPlay", objectTypeName(selectedPlay()));
 
     // Normal start
     game_state.updateRefereeCommand(RefereeCommand::NORMAL_START);
     EXPECT_TRUE(game_state.isReadyState());
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("PenaltyKickPlay", objectTypeName(*current_play));
+    EXPECT_EQ("PenaltyKickPlay", objectTypeName(selectedPlay()));
 
     // Playing
     game_state.updateRefereeCommand(RefereeCommand::HALT);
     game_state.updateRefereeCommand(RefereeCommand::FORCE_START);
     EXPECT_TRUE(game_state.isPlaying());
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Playing>));
-    EXPECT_EQ("OffensePlay", objectTypeName(*current_play));
+    EXPECT_EQ("OffensePlay", objectTypeName(selectedPlay()));
 }
 
 TEST_F(PlaySelectionFSMTest, test_transition_out_of_penalty_kick_enemy_when_goal_conceded)
 {
-    std::unique_ptr<Play> current_play = std::make_unique<HaltPlay>(ai_config_ptr);
-
     // Start in halt
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Halt>));
-    EXPECT_EQ("HaltPlay", objectTypeName(*current_play));
+    EXPECT_EQ("HaltPlay", objectTypeName(selectedPlay()));
 
     // Stop
     game_state.updateRefereeCommand(RefereeCommand::STOP);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Stop>));
-    EXPECT_EQ("StopPlay", objectTypeName(*current_play));
+    EXPECT_EQ("StopPlay", objectTypeName(selectedPlay()));
 
     // Penalty kick preparation
     game_state.updateRefereeCommand(RefereeCommand::PREPARE_PENALTY_THEM);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isTheirPenalty());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("PenaltyKickEnemyPlay", objectTypeName(*current_play));
+    EXPECT_EQ("PenaltyKickEnemyPlay", objectTypeName(selectedPlay()));
 
     // Normal start
     game_state.updateRefereeCommand(RefereeCommand::NORMAL_START);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isReadyState());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("PenaltyKickEnemyPlay", objectTypeName(*current_play));
+    EXPECT_EQ("PenaltyKickEnemyPlay", objectTypeName(selectedPlay()));
 
     // Goal conceded
     game_state.updateRefereeCommand(RefereeCommand::GOAL_THEM);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isStopped());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Stop>));
-    EXPECT_EQ("StopPlay", objectTypeName(*current_play));
+    EXPECT_EQ("StopPlay", objectTypeName(selectedPlay()));
 
     // Kickoff preparation
     game_state.updateRefereeCommand(RefereeCommand::PREPARE_KICKOFF_US);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isSetupState());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("KickoffFriendlyPlay", objectTypeName(*current_play));
+    EXPECT_EQ("KickoffFriendlyPlay", objectTypeName(selectedPlay()));
 
     // Normal start
     game_state.updateRefereeCommand(RefereeCommand::NORMAL_START);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isReadyState());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("KickoffFriendlyPlay", objectTypeName(*current_play));
+    EXPECT_EQ("KickoffFriendlyPlay", objectTypeName(selectedPlay()));
 
     // Ball is kicked and restart state is cleared, enter playing state
     game_state.setRestartCompleted();
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isPlaying());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Playing>));
-    EXPECT_EQ("OffensePlay", objectTypeName(*current_play));
+    EXPECT_EQ("OffensePlay", objectTypeName(selectedPlay()));
 }
 
 TEST_F(PlaySelectionFSMTest,
        test_transition_out_of_penalty_kick_enemy_when_no_goal_conceded)
 {
-    std::unique_ptr<Play> current_play = std::make_unique<HaltPlay>(ai_config_ptr);
-
     // Start in halt
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Halt>));
-    EXPECT_EQ("HaltPlay", objectTypeName(*current_play));
+    EXPECT_EQ("HaltPlay", objectTypeName(selectedPlay()));
 
     // Stop
     game_state.updateRefereeCommand(RefereeCommand::STOP);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Stop>));
-    EXPECT_EQ("StopPlay", objectTypeName(*current_play));
+    EXPECT_EQ("StopPlay", objectTypeName(selectedPlay()));
 
     // Penalty kick preparation
     game_state.updateRefereeCommand(RefereeCommand::PREPARE_PENALTY_THEM);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isTheirPenalty());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("PenaltyKickEnemyPlay", objectTypeName(*current_play));
+    EXPECT_EQ("PenaltyKickEnemyPlay", objectTypeName(selectedPlay()));
 
     // Normal start
     game_state.updateRefereeCommand(RefereeCommand::NORMAL_START);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isReadyState());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("PenaltyKickEnemyPlay", objectTypeName(*current_play));
+    EXPECT_EQ("PenaltyKickEnemyPlay", objectTypeName(selectedPlay()));
 
     // Stop because no goal
     game_state.updateRefereeCommand(RefereeCommand::STOP);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isStopped());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Stop>));
-    EXPECT_EQ("StopPlay", objectTypeName(*current_play));
+    EXPECT_EQ("StopPlay", objectTypeName(selectedPlay()));
 
     // Free kick
     game_state.updateRefereeCommand(RefereeCommand::DIRECT_FREE_US);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isOurDirectFree());
     EXPECT_TRUE(game_state.isReadyState());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("FreeKickPlay", objectTypeName(*current_play));
+    EXPECT_EQ("FreeKickPlay", objectTypeName(selectedPlay()));
 
     // Ball is kicked and restart state is cleared, enter playing state
     game_state.setRestartCompleted();
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isPlaying());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Playing>));
-    EXPECT_EQ("OffensePlay", objectTypeName(*current_play));
+    EXPECT_EQ("OffensePlay", objectTypeName(selectedPlay()));
 }
 
 TEST_F(PlaySelectionFSMTest, test_transition_between_ball_placement_and_free_kick)
 {
-    std::unique_ptr<Play> current_play = std::make_unique<HaltPlay>(ai_config_ptr);
-
     // Start in halt
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Halt>));
-    EXPECT_EQ("HaltPlay", objectTypeName(*current_play));
+    EXPECT_EQ("HaltPlay", objectTypeName(selectedPlay()));
 
     // Stop
     game_state.updateRefereeCommand(RefereeCommand::STOP);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Stop>));
-    EXPECT_EQ("StopPlay", objectTypeName(*current_play));
+    EXPECT_EQ("StopPlay", objectTypeName(selectedPlay()));
 
     // Friendly ball placement
     game_state.updateRefereeCommand(RefereeCommand::BALL_PLACEMENT_US);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isOurBallPlacement());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("BallPlacementPlay", objectTypeName(*current_play));
+    EXPECT_EQ("BallPlacementPlay", objectTypeName(selectedPlay()));
 
     // Friendly free kick
     game_state.updateRefereeCommand(RefereeCommand::DIRECT_FREE_US);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isOurDirectFree());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("FreeKickPlay", objectTypeName(*current_play));
+    EXPECT_EQ("FreeKickPlay", objectTypeName(selectedPlay()));
 
     // Enemy ball placement
     game_state.updateRefereeCommand(RefereeCommand::BALL_PLACEMENT_THEM);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isTheirBallPlacement());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("EnemyBallPlacementPlay", objectTypeName(*current_play));
+    EXPECT_EQ("EnemyBallPlacementPlay", objectTypeName(selectedPlay()));
 
     // Enemy free kick
     game_state.updateRefereeCommand(RefereeCommand::DIRECT_FREE_THEM);
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isTheirDirectFree());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::SetPlay>));
-    EXPECT_EQ("EnemyFreeKickPlay", objectTypeName(*current_play));
+    EXPECT_EQ("EnemyFreeKickPlay", objectTypeName(selectedPlay()));
 
     // Ball is kicked and restart state is cleared, enter playing state
     game_state.setRestartCompleted();
-    fsm->process_event(PlaySelectionFSM::Update(
-        [&current_play](std::unique_ptr<Play> play) { current_play = std::move(play); },
-        game_state, ai_config));
+    update();
     EXPECT_TRUE(game_state.isPlaying());
     EXPECT_TRUE(fsm->is(boost::sml::state<PlaySelectionFSM::Playing>));
-    EXPECT_EQ("OffensePlay", objectTypeName(*current_play));
+    EXPECT_EQ("OffensePlay", objectTypeName(selectedPlay()));
 }


### PR DESCRIPTION
### Description

Moved the remaining play selection logic that was in `Ai` (override, reset) into `PlaySelectionFSM`. `Ai` only calls the play selection now and doesn't perform any of it itself.

### Testing Done

Added two new tests to test override/reset behavior. Existing tests passing

### Resolved Issues

Closes #3099

### Review Checklist

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [X] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [X] **Remove all commented out code**
- [X] **Remove extra print statements**: for example, those just used for testing
- [X] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue