### PR TITLE
Allow pre-passing in flags to interactive mode

### DIFF
--- a/src/tbots.py
+++ b/src/tbots.py
@@ -150,10 +150,6 @@ def main(
     :param robot_name: hostname of the robot targeted by an Ansible playbook
     :param ansible_playbook: name of the Ansible playbook to run
     """
-    if not action and not search_query:
-        start_interactive_cli()
-        return
-
     config = BuildConfig(
         action=action,
         search_query=search_query,
@@ -172,6 +168,10 @@ def main(
         robot_name=robot_name,
         ansible_playbook=ansible_playbook,
     )
+
+    if not action and not search_query:
+        start_interactive_cli(config)
+        return
 
     validate(config)
     command = create_command(config, ctx.args)
@@ -323,16 +323,18 @@ def execute_command(command: list[str], print_only: bool = False):
         sys.exit(1 if code != 0 else 0)
 
 
-def start_interactive_cli():
+def start_interactive_cli(config: BuildConfig):
     """Run the menu-driven interactive CLI.
 
     Walks the user through a series of questionary prompts to assemble a
-    :class:`BuildConfig`, then validates, builds, and executes the resulting
-    Bazel command. The menu choices (and their inline descriptions) live in
-    cli_params.py. Returns early without running anything if the user aborts
-    the top-level prompt.
+    :class:`BuildConfig` by modifying an existing config, then validates,
+    builds, and executes the resulting Bazel command. The menu choices (and
+    their inline descriptions) live in cli_params.py. Returns early without
+    running anything if the user aborts the top-level prompt.
+
+    :param config: The cli config to modify.
     """
-    config = BuildConfig(action=ActionArgument.run)  # Default action
+    config.action = ActionArgument.run  # Default action
     extra_args = []
 
     history = load_history()


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

<!--
    Give a high-level description of the changes in this PR
-->

Allows for stuff like `./tbots.py --jobs 4` to specify the jobs bazel option which might be useful for some users but not significant enough to justify being in the interactive cli. **This PR was originally was merged into robocup 2026 branch #3822**

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

Ran `./tbots.py --runs 3` and did interactive mode to run a test, resulting command: `bazel test --copt=-O3 --cache_test_results=false --runs_per_test=3 //software/ai/hl/stp/tactic/move:move_tactic_test`

Ran `./tbots.py --jobs 4` and did interactive mode to run thunderscope, resulting command: `bazel run --copt=-O3 --jobs=4 //software/thunderscope:thunderscope_main -- --enable_autoref`

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->