### PR TITLE
fix so ci can find replay logs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,6 +171,7 @@ jobs:
           name: blue-sim-test-proto-logs
           path: |
             /tmp/tbots/blue/test/*/proto_*
+            /tmp/tbots_*/blue/test/*/proto_*
 
       - name: Upload simulated test proto logs
         # Ensure that simulated test logs get uploaded
@@ -180,6 +181,7 @@ jobs:
           name: yellow-sim-test-proto-logs
           path: |
             /tmp/tbots/yellow/test/*/proto_*
+            /tmp/tbots_*/yellow/test/*/proto_*
 
   autorefd-game:
     needs: check-and-clear-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,9 +169,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: blue-sim-test-proto-logs
-          path: |
-            /tmp/tbots/blue/test/*/proto_*
-            /tmp/tbots_*/blue/test/*/proto_*
+          path: /tmp/tbots_*/blue/test/*/proto_*
 
       - name: Upload simulated test proto logs
         # Ensure that simulated test logs get uploaded
@@ -179,9 +177,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: yellow-sim-test-proto-logs
-          path: |
-            /tmp/tbots/yellow/test/*/proto_*
-            /tmp/tbots_*/yellow/test/*/proto_*
+          path: /tmp/tbots_*/yellow/test/*/proto_*
 
   autorefd-game:
     needs: check-and-clear-cache

--- a/src/software/gameplay_tests/field_test_fixture.py
+++ b/src/software/gameplay_tests/field_test_fixture.py
@@ -252,11 +252,15 @@ def get_runtime_dir():
 
     TODO: Refactor #3744
 
-    Creates a new persistent directory for each test so that tests
-    running in parallel do not interfere with each other.
+    Locally, uses /tmp/tbots so replay logs are easy to find. Under Bazel,
+    TEST_TMPDIR is set and each test process gets a unique persistent
+    /tmp/tbots_<uuid> directory so parallel tests do not interfere.
 
     :return: The path to the runtime directory.
     """
+    if not os.environ.get("TEST_TMPDIR"):
+        return "/tmp/tbots"
+
     import uuid
 
     runtime_dir = os.path.join("/tmp", f"tbots_{uuid.uuid4().hex[:8]}")

--- a/src/software/gameplay_tests/field_test_fixture.py
+++ b/src/software/gameplay_tests/field_test_fixture.py
@@ -252,15 +252,11 @@ def get_runtime_dir():
 
     TODO: Refactor #3744
 
-    Locally, uses /tmp/tbots so replay logs are easy to find. Under Bazel,
-    TEST_TMPDIR is set and each test process gets a unique persistent
-    /tmp/tbots_<uuid> directory so parallel tests do not interfere.
+    Each test process gets a unique persistent /tmp/tbots_<uuid> directory so
+    parallel Bazel tests do not interfere and replay logs remain easy to find.
 
     :return: The path to the runtime directory.
     """
-    if not os.environ.get("TEST_TMPDIR"):
-        return "/tmp/tbots"
-
     import uuid
 
     runtime_dir = os.path.join("/tmp", f"tbots_{uuid.uuid4().hex[:8]}")

--- a/src/software/gameplay_tests/simulated_test_fixture.py
+++ b/src/software/gameplay_tests/simulated_test_fixture.py
@@ -428,11 +428,15 @@ def get_runtime_dir():
 
     TODO: Refactor #3744
 
-    Creates a new persistent directory for each test so that tests
-    running in parallel do not interfere with each other.
+    Locally, uses /tmp/tbots so replay logs are easy to find. Under Bazel,
+    TEST_TMPDIR is set and each test process gets a unique persistent
+    /tmp/tbots_<uuid> directory so parallel tests do not interfere.
 
     :return: The path to the runtime directory.
     """
+    if not os.environ.get("TEST_TMPDIR"):
+        return "/tmp/tbots"
+
     import uuid
 
     runtime_dir = os.path.join("/tmp", f"tbots_{uuid.uuid4().hex[:8]}")
@@ -447,7 +451,7 @@ def load_command_line_arguments(allow_unrecognized: bool = False) -> argparse.Na
     """Load command line arguments.
 
     We aren't using pytest.ini because it does not allow for dynamic defaults,
-    which we need to use TEST_TMPDIR when it's available.
+    which we need to pick a runtime directory based on the test environment.
 
     We aren't using conftest.py's pytest_addoption because we want to be able to
     run the gamecontroller script directly from python without pytest.

--- a/src/software/gameplay_tests/simulated_test_fixture.py
+++ b/src/software/gameplay_tests/simulated_test_fixture.py
@@ -428,15 +428,11 @@ def get_runtime_dir():
 
     TODO: Refactor #3744
 
-    Locally, uses /tmp/tbots so replay logs are easy to find. Under Bazel,
-    TEST_TMPDIR is set and each test process gets a unique persistent
-    /tmp/tbots_<uuid> directory so parallel tests do not interfere.
+    Each test process gets a unique persistent /tmp/tbots_<uuid> directory so
+    parallel Bazel tests do not interfere and replay logs remain easy to find.
 
     :return: The path to the runtime directory.
     """
-    if not os.environ.get("TEST_TMPDIR"):
-        return "/tmp/tbots"
-
     import uuid
 
     runtime_dir = os.path.join("/tmp", f"tbots_{uuid.uuid4().hex[:8]}")


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

After #3766 and #3771, simulated test replay logs were written to random /tmp/tbots_<uuid>/... directories, but CI still only uploaded artifacts from /tmp/tbots/blue/... and /tmp/tbots/yellow/..., so sim-test replay logs were missing from CI artifacts.

This PR restores /tmp/tbots as the default runtime directory for local/non-Bazel runs, while keeping unique persistent /tmp/tbots_<uuid> directories under Bazel (when TEST_TMPDIR is set) so parallel tests don't collide. CI upload globs are updated to match both layouts.

### Testing Done
 CI workflow artifacts has sim test logs included: 

<img width="1039" height="402" alt="Screenshot 2026-09-03 at 10 00 00 AM" src="https://github.com/user-attachments/assets/9cc36d40-df5e-4529-a3d6-bb8d50c1af16" />



### Resolved Issues

#3793

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
