### PR TITLE
Remove SMLFSM Macros and use functor classes instead of lambdas

### DIFF
--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.h
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.h
@@ -147,19 +147,20 @@ struct BallPlacementPlayFSM : public PlayFSM<BallPlacementPlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(StartState)
-        DEFINE_SML_STATE(KickOffWallState)
-        DEFINE_SML_STATE(AlignPlacementState)
-        DEFINE_SML_STATE(PlaceBallState)
-        DEFINE_SML_STATE(WaitState)
-        DEFINE_SML_STATE(RetreatState)
-        DEFINE_SML_EVENT(Update)
+        const auto StartState_S = boost::sml::state<StartState>;
+        const auto KickOffWallState_S = boost::sml::state<KickOffWallState>;
+        const auto AlignPlacementState_S = boost::sml::state<AlignPlacementState>;
+        const auto PlaceBallState_S = boost::sml::state<PlaceBallState>;
+        const auto WaitState_S = boost::sml::state<WaitState>;
+        const auto RetreatState_S = boost::sml::state<RetreatState>;
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(alignPlacement)
-        DEFINE_SML_ACTION(placeBall)
-        DEFINE_SML_ACTION(kickOffWall)
-        DEFINE_SML_ACTION(startWait)
-        DEFINE_SML_ACTION(retreat)
+        const auto alignPlacement_A =
+            SMLAction<&BallPlacementPlayFSM::alignPlacement>{this};
+        const auto placeBall_A   = SMLAction<&BallPlacementPlayFSM::placeBall>{this};
+        const auto kickOffWall_A = SMLAction<&BallPlacementPlayFSM::kickOffWall>{this};
+        const auto startWait_A   = SMLAction<&BallPlacementPlayFSM::startWait>{this};
+        const auto retreat_A     = SMLAction<&BallPlacementPlayFSM::retreat>{this};
 
         const auto shouldKickOffWall_G =
             SMLGuard<&BallPlacementPlayFSM::shouldKickOffWall>{this};

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.h
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.h
@@ -161,12 +161,13 @@ struct BallPlacementPlayFSM : public PlayFSM<BallPlacementPlayFSM>
         DEFINE_SML_ACTION(startWait)
         DEFINE_SML_ACTION(retreat)
 
-        DEFINE_SML_GUARD(shouldKickOffWall)
-        DEFINE_SML_GUARD(alignDone)
-        DEFINE_SML_GUARD(kickDone)
-        DEFINE_SML_GUARD(ballPlaced)
-        DEFINE_SML_GUARD(waitDone)
-        DEFINE_SML_GUARD(retreatDone)
+        const auto shouldKickOffWall_G =
+            SMLGuard<&BallPlacementPlayFSM::shouldKickOffWall>{this};
+        const auto alignDone_G   = SMLGuard<&BallPlacementPlayFSM::alignDone>{this};
+        const auto kickDone_G    = SMLGuard<&BallPlacementPlayFSM::kickDone>{this};
+        const auto ballPlaced_G  = SMLGuard<&BallPlacementPlayFSM::ballPlaced>{this};
+        const auto waitDone_G    = SMLGuard<&BallPlacementPlayFSM::waitDone>{this};
+        const auto retreatDone_G = SMLGuard<&BallPlacementPlayFSM::retreatDone>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.h
+++ b/src/software/ai/hl/stp/play/ball_placement/ball_placement_play_fsm.h
@@ -147,13 +147,13 @@ struct BallPlacementPlayFSM : public PlayFSM<BallPlacementPlayFSM>
     {
         using namespace boost::sml;
 
-        const auto StartState_S = boost::sml::state<StartState>;
-        const auto KickOffWallState_S = boost::sml::state<KickOffWallState>;
-        const auto AlignPlacementState_S = boost::sml::state<AlignPlacementState>;
-        const auto PlaceBallState_S = boost::sml::state<PlaceBallState>;
-        const auto WaitState_S = boost::sml::state<WaitState>;
-        const auto RetreatState_S = boost::sml::state<RetreatState>;
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto StartState_S          = boost::sml::state<StartState>;
+        constexpr auto KickOffWallState_S    = boost::sml::state<KickOffWallState>;
+        constexpr auto AlignPlacementState_S = boost::sml::state<AlignPlacementState>;
+        constexpr auto PlaceBallState_S      = boost::sml::state<PlaceBallState>;
+        constexpr auto WaitState_S           = boost::sml::state<WaitState>;
+        constexpr auto RetreatState_S        = boost::sml::state<RetreatState>;
+        constexpr auto Update_E              = boost::sml::event<Update>;
 
         const auto alignPlacement_A =
             SMLAction<&BallPlacementPlayFSM::alignPlacement>{this};

--- a/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_fsm.h
+++ b/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_fsm.h
@@ -49,11 +49,12 @@ struct CreaseDefensePlayFSM : PlayFSM<CreaseDefensePlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(DefenseState)
+        const auto DefenseState_S = boost::sml::state<DefenseState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(defendDefenseArea)
+        const auto defendDefenseArea_A =
+            SMLAction<&CreaseDefensePlayFSM::defendDefenseArea>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_fsm.h
+++ b/src/software/ai/hl/stp/play/crease_defense/crease_defense_play_fsm.h
@@ -49,9 +49,9 @@ struct CreaseDefensePlayFSM : PlayFSM<CreaseDefensePlayFSM>
     {
         using namespace boost::sml;
 
-        const auto DefenseState_S = boost::sml::state<DefenseState>;
+        constexpr auto DefenseState_S = boost::sml::state<DefenseState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto defendDefenseArea_A =
             SMLAction<&CreaseDefensePlayFSM::defendDefenseArea>{this};

--- a/src/software/ai/hl/stp/play/defense/defense_play_fsm.h
+++ b/src/software/ai/hl/stp/play/defense/defense_play_fsm.h
@@ -86,10 +86,11 @@ struct DefensePlayFSM : public DefensePlayFSMBase
     {
         using namespace boost::sml;
 
-        const auto DefenseState_S = boost::sml::state<DefenseState>;
-        const auto AggressiveDefenseState_S = boost::sml::state<AggressiveDefenseState>;
+        constexpr auto DefenseState_S = boost::sml::state<DefenseState>;
+        constexpr auto AggressiveDefenseState_S =
+            boost::sml::state<AggressiveDefenseState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto shouldDefendAggressively_G =
             SMLGuard<&DefensePlayFSM::shouldDefendAggressively>{this};

--- a/src/software/ai/hl/stp/play/defense/defense_play_fsm.h
+++ b/src/software/ai/hl/stp/play/defense/defense_play_fsm.h
@@ -91,7 +91,8 @@ struct DefensePlayFSM : public DefensePlayFSMBase
 
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(shouldDefendAggressively)
+        const auto shouldDefendAggressively_G =
+            SMLGuard<&DefensePlayFSM::shouldDefendAggressively>{this};
 
         DEFINE_SML_ACTION(blockShots)
         DEFINE_SML_ACTION(shadowAndBlockShots)

--- a/src/software/ai/hl/stp/play/defense/defense_play_fsm.h
+++ b/src/software/ai/hl/stp/play/defense/defense_play_fsm.h
@@ -86,16 +86,17 @@ struct DefensePlayFSM : public DefensePlayFSMBase
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(DefenseState)
-        DEFINE_SML_STATE(AggressiveDefenseState)
+        const auto DefenseState_S = boost::sml::state<DefenseState>;
+        const auto AggressiveDefenseState_S = boost::sml::state<AggressiveDefenseState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto shouldDefendAggressively_G =
             SMLGuard<&DefensePlayFSM::shouldDefendAggressively>{this};
 
-        DEFINE_SML_ACTION(blockShots)
-        DEFINE_SML_ACTION(shadowAndBlockShots)
+        const auto blockShots_A = SMLAction<&DefensePlayFSM::blockShots>{this};
+        const auto shadowAndBlockShots_A =
+            SMLAction<&DefensePlayFSM::shadowAndBlockShots>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_fsm.h
+++ b/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_fsm.h
@@ -104,11 +104,11 @@ struct EnemyBallPlacementPlayFSM : PlayFSM<EnemyBallPlacementPlayFSM>
     {
         using namespace boost::sml;
 
-        const auto WaitState_S = boost::sml::state<WaitState>;
-        const auto AvoidState_S = boost::sml::state<AvoidState>;
-        const auto DefenseState_S = boost::sml::state<DefenseState>;
+        constexpr auto WaitState_S    = boost::sml::state<WaitState>;
+        constexpr auto AvoidState_S   = boost::sml::state<AvoidState>;
+        constexpr auto DefenseState_S = boost::sml::state<DefenseState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto setPlacementPoint_A =
             SMLAction<&EnemyBallPlacementPlayFSM::setPlacementPoint>{this};

--- a/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_fsm.h
+++ b/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_fsm.h
@@ -104,15 +104,17 @@ struct EnemyBallPlacementPlayFSM : PlayFSM<EnemyBallPlacementPlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(WaitState)
-        DEFINE_SML_STATE(AvoidState)
-        DEFINE_SML_STATE(DefenseState)
+        const auto WaitState_S = boost::sml::state<WaitState>;
+        const auto AvoidState_S = boost::sml::state<AvoidState>;
+        const auto DefenseState_S = boost::sml::state<DefenseState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(setPlacementPoint)
-        DEFINE_SML_ACTION(avoid)
-        DEFINE_SML_ACTION(enterDefensiveFormation)
+        const auto setPlacementPoint_A =
+            SMLAction<&EnemyBallPlacementPlayFSM::setPlacementPoint>{this};
+        const auto avoid_A = SMLAction<&EnemyBallPlacementPlayFSM::avoid>{this};
+        const auto enterDefensiveFormation_A =
+            SMLAction<&EnemyBallPlacementPlayFSM::enterDefensiveFormation>{this};
 
         const auto hasPlacementPoint_G =
             SMLGuard<&EnemyBallPlacementPlayFSM::hasPlacementPoint>{this};

--- a/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_fsm.h
+++ b/src/software/ai/hl/stp/play/enemy_ball_placement/enemy_ball_placement_play_fsm.h
@@ -114,8 +114,10 @@ struct EnemyBallPlacementPlayFSM : PlayFSM<EnemyBallPlacementPlayFSM>
         DEFINE_SML_ACTION(avoid)
         DEFINE_SML_ACTION(enterDefensiveFormation)
 
-        DEFINE_SML_GUARD(hasPlacementPoint)
-        DEFINE_SML_GUARD(isNearlyPlaced)
+        const auto hasPlacementPoint_G =
+            SMLGuard<&EnemyBallPlacementPlayFSM::hasPlacementPoint>{this};
+        const auto isNearlyPlaced_G =
+            SMLGuard<&EnemyBallPlacementPlayFSM::isNearlyPlaced>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/enemy_free_kick/enemy_free_kick_play_fsm.h
+++ b/src/software/ai/hl/stp/play/enemy_free_kick/enemy_free_kick_play_fsm.h
@@ -42,9 +42,9 @@ struct EnemyFreeKickPlayFSM : public DefensePlayFSMBase
     {
         using namespace boost::sml;
 
-        const auto BlockEnemyKickerState_S = boost::sml::state<BlockEnemyKickerState>;
+        constexpr auto BlockEnemyKickerState_S = boost::sml::state<BlockEnemyKickerState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto blockEnemyKicker_A =
             SMLAction<&EnemyFreeKickPlayFSM::blockEnemyKicker>{this};

--- a/src/software/ai/hl/stp/play/enemy_free_kick/enemy_free_kick_play_fsm.h
+++ b/src/software/ai/hl/stp/play/enemy_free_kick/enemy_free_kick_play_fsm.h
@@ -42,11 +42,12 @@ struct EnemyFreeKickPlayFSM : public DefensePlayFSMBase
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(BlockEnemyKickerState)
+        const auto BlockEnemyKickerState_S = boost::sml::state<BlockEnemyKickerState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(blockEnemyKicker)
+        const auto blockEnemyKicker_A =
+            SMLAction<&EnemyFreeKickPlayFSM::blockEnemyKicker>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/example/example_play_fsm.h
+++ b/src/software/ai/hl/stp/play/example/example_play_fsm.h
@@ -39,9 +39,9 @@ struct ExamplePlayFSM : PlayFSM<ExamplePlayFSM>
     {
         using namespace boost::sml;
 
-        const auto MoveState_S = boost::sml::state<MoveState>;
+        constexpr auto MoveState_S = boost::sml::state<MoveState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto moveToPosition_A = SMLAction<&ExamplePlayFSM::moveToPosition>{this};
 

--- a/src/software/ai/hl/stp/play/example/example_play_fsm.h
+++ b/src/software/ai/hl/stp/play/example/example_play_fsm.h
@@ -39,11 +39,11 @@ struct ExamplePlayFSM : PlayFSM<ExamplePlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(MoveState)
+        const auto MoveState_S = boost::sml::state<MoveState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(moveToPosition)
+        const auto moveToPosition_A = SMLAction<&ExamplePlayFSM::moveToPosition>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/free_kick/free_kick_play_fsm.h
+++ b/src/software/ai/hl/stp/play/free_kick/free_kick_play_fsm.h
@@ -224,14 +224,14 @@ struct FreeKickPlayFSM : PlayFSM<FreeKickPlayFSM>
         DEFINE_SML_ACTION(passBall)
         DEFINE_SML_ACTION(chipBall)
 
-        DEFINE_SML_GUARD(setupDone)
-        DEFINE_SML_GUARD(shotFound)
-        DEFINE_SML_GUARD(shotDone)
-        DEFINE_SML_GUARD(shouldAbortPass)
-        DEFINE_SML_GUARD(passFound)
-        DEFINE_SML_GUARD(passDone)
-        DEFINE_SML_GUARD(chipDone)
-        DEFINE_SML_GUARD(timeExpired)
+        const auto setupDone_G       = SMLGuard<&FreeKickPlayFSM::setupDone>{this};
+        const auto shotFound_G       = SMLGuard<&FreeKickPlayFSM::shotFound>{this};
+        const auto shotDone_G        = SMLGuard<&FreeKickPlayFSM::shotDone>{this};
+        const auto shouldAbortPass_G = SMLGuard<&FreeKickPlayFSM::shouldAbortPass>{this};
+        const auto passFound_G       = SMLGuard<&FreeKickPlayFSM::passFound>{this};
+        const auto passDone_G        = SMLGuard<&FreeKickPlayFSM::passDone>{this};
+        const auto chipDone_G        = SMLGuard<&FreeKickPlayFSM::chipDone>{this};
+        const auto timeExpired_G     = SMLGuard<&FreeKickPlayFSM::timeExpired>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/free_kick/free_kick_play_fsm.h
+++ b/src/software/ai/hl/stp/play/free_kick/free_kick_play_fsm.h
@@ -209,13 +209,13 @@ struct FreeKickPlayFSM : PlayFSM<FreeKickPlayFSM>
     {
         using namespace boost::sml;
 
-        const auto SetupPositionState_S = boost::sml::state<SetupPositionState>;
-        const auto ShootState_S = boost::sml::state<ShootState>;
-        const auto AttemptPassState_S = boost::sml::state<AttemptPassState>;
-        const auto PassState_S = boost::sml::state<PassState>;
-        const auto ChipState_S = boost::sml::state<ChipState>;
+        constexpr auto SetupPositionState_S = boost::sml::state<SetupPositionState>;
+        constexpr auto ShootState_S         = boost::sml::state<ShootState>;
+        constexpr auto AttemptPassState_S   = boost::sml::state<AttemptPassState>;
+        constexpr auto PassState_S          = boost::sml::state<PassState>;
+        constexpr auto ChipState_S          = boost::sml::state<ChipState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto setupPosition_A = SMLAction<&FreeKickPlayFSM::setupPosition>{this};
         const auto shootBall_A     = SMLAction<&FreeKickPlayFSM::shootBall>{this};

--- a/src/software/ai/hl/stp/play/free_kick/free_kick_play_fsm.h
+++ b/src/software/ai/hl/stp/play/free_kick/free_kick_play_fsm.h
@@ -209,20 +209,21 @@ struct FreeKickPlayFSM : PlayFSM<FreeKickPlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(SetupPositionState)
-        DEFINE_SML_STATE(ShootState)
-        DEFINE_SML_STATE(AttemptPassState)
-        DEFINE_SML_STATE(PassState)
-        DEFINE_SML_STATE(ChipState)
+        const auto SetupPositionState_S = boost::sml::state<SetupPositionState>;
+        const auto ShootState_S = boost::sml::state<ShootState>;
+        const auto AttemptPassState_S = boost::sml::state<AttemptPassState>;
+        const auto PassState_S = boost::sml::state<PassState>;
+        const auto ChipState_S = boost::sml::state<ChipState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(setupPosition)
-        DEFINE_SML_ACTION(shootBall)
-        DEFINE_SML_ACTION(startLookingForPass)
-        DEFINE_SML_ACTION(lookForPass)
-        DEFINE_SML_ACTION(passBall)
-        DEFINE_SML_ACTION(chipBall)
+        const auto setupPosition_A = SMLAction<&FreeKickPlayFSM::setupPosition>{this};
+        const auto shootBall_A     = SMLAction<&FreeKickPlayFSM::shootBall>{this};
+        const auto startLookingForPass_A =
+            SMLAction<&FreeKickPlayFSM::startLookingForPass>{this};
+        const auto lookForPass_A = SMLAction<&FreeKickPlayFSM::lookForPass>{this};
+        const auto passBall_A    = SMLAction<&FreeKickPlayFSM::passBall>{this};
+        const auto chipBall_A    = SMLAction<&FreeKickPlayFSM::chipBall>{this};
 
         const auto setupDone_G       = SMLGuard<&FreeKickPlayFSM::setupDone>{this};
         const auto shotFound_G       = SMLGuard<&FreeKickPlayFSM::shotFound>{this};

--- a/src/software/ai/hl/stp/play/halt_play/halt_play_fsm.h
+++ b/src/software/ai/hl/stp/play/halt_play/halt_play_fsm.h
@@ -36,9 +36,9 @@ struct HaltPlayFSM : PlayFSM<HaltPlayFSM>
     {
         using namespace boost::sml;
 
-        const auto HaltState_S = boost::sml::state<HaltState>;
+        constexpr auto HaltState_S = boost::sml::state<HaltState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto updateStop_A = SMLAction<&HaltPlayFSM::updateStop>{this};
 

--- a/src/software/ai/hl/stp/play/halt_play/halt_play_fsm.h
+++ b/src/software/ai/hl/stp/play/halt_play/halt_play_fsm.h
@@ -36,11 +36,11 @@ struct HaltPlayFSM : PlayFSM<HaltPlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(HaltState)
+        const auto HaltState_S = boost::sml::state<HaltState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(updateStop)
+        const auto updateStop_A = SMLAction<&HaltPlayFSM::updateStop>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/kickoff_enemy/kickoff_enemy_play_fsm.h
+++ b/src/software/ai/hl/stp/play/kickoff_enemy/kickoff_enemy_play_fsm.h
@@ -90,9 +90,9 @@ struct KickoffEnemyPlayFSM : PlayFSM<KickoffEnemyPlayFSM>
     {
         using namespace boost::sml;
 
-        const auto SetupState_S = boost::sml::state<SetupState>;
+        constexpr auto SetupState_S = boost::sml::state<SetupState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto kickoff_A = SMLAction<&KickoffEnemyPlayFSM::kickoff>{this};
 

--- a/src/software/ai/hl/stp/play/kickoff_enemy/kickoff_enemy_play_fsm.h
+++ b/src/software/ai/hl/stp/play/kickoff_enemy/kickoff_enemy_play_fsm.h
@@ -90,11 +90,11 @@ struct KickoffEnemyPlayFSM : PlayFSM<KickoffEnemyPlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(SetupState)
+        const auto SetupState_S = boost::sml::state<SetupState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(kickoff)
+        const auto kickoff_A = SMLAction<&KickoffEnemyPlayFSM::kickoff>{this};
 
 
         return make_transition_table(

--- a/src/software/ai/hl/stp/play/kickoff_friendly/kickoff_friendly_play_fsm.h
+++ b/src/software/ai/hl/stp/play/kickoff_friendly/kickoff_friendly_play_fsm.h
@@ -88,13 +88,14 @@ struct KickoffFriendlyPlayFSM : PlayFSM<KickoffFriendlyPlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(SetupState)
-        DEFINE_SML_STATE(ChipState)
+        const auto SetupState_S = boost::sml::state<SetupState>;
+        const auto ChipState_S = boost::sml::state<ChipState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(setupKickoff)
-        DEFINE_SML_ACTION(chipBall)
+        const auto setupKickoff_A =
+            SMLAction<&KickoffFriendlyPlayFSM::setupKickoff>{this};
+        const auto chipBall_A = SMLAction<&KickoffFriendlyPlayFSM::chipBall>{this};
 
         const auto isSetupDone_G = SMLGuard<&KickoffFriendlyPlayFSM::isSetupDone>{this};
         const auto isPlaying_G   = SMLGuard<&KickoffFriendlyPlayFSM::isPlaying>{this};

--- a/src/software/ai/hl/stp/play/kickoff_friendly/kickoff_friendly_play_fsm.h
+++ b/src/software/ai/hl/stp/play/kickoff_friendly/kickoff_friendly_play_fsm.h
@@ -88,10 +88,10 @@ struct KickoffFriendlyPlayFSM : PlayFSM<KickoffFriendlyPlayFSM>
     {
         using namespace boost::sml;
 
-        const auto SetupState_S = boost::sml::state<SetupState>;
-        const auto ChipState_S = boost::sml::state<ChipState>;
+        constexpr auto SetupState_S = boost::sml::state<SetupState>;
+        constexpr auto ChipState_S  = boost::sml::state<ChipState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto setupKickoff_A =
             SMLAction<&KickoffFriendlyPlayFSM::setupKickoff>{this};

--- a/src/software/ai/hl/stp/play/kickoff_friendly/kickoff_friendly_play_fsm.h
+++ b/src/software/ai/hl/stp/play/kickoff_friendly/kickoff_friendly_play_fsm.h
@@ -75,14 +75,14 @@ struct KickoffFriendlyPlayFSM : PlayFSM<KickoffFriendlyPlayFSM>
      *
      * @param event the FreeKickPlayFSM Update event
      */
-    static bool isSetupDone(const Update& event);
+    bool isSetupDone(const Update& event);
 
     /**
      * Guard that checks if game has started (ball kicked).
      *
      * @param event the FreeKickPlayFSM Update event
      */
-    static bool isPlaying(const Update& event);
+    bool isPlaying(const Update& event);
 
     auto operator()()
     {
@@ -96,8 +96,8 @@ struct KickoffFriendlyPlayFSM : PlayFSM<KickoffFriendlyPlayFSM>
         DEFINE_SML_ACTION(setupKickoff)
         DEFINE_SML_ACTION(chipBall)
 
-        DEFINE_SML_GUARD(isSetupDone)
-        DEFINE_SML_GUARD(isPlaying)
+        const auto isSetupDone_G = SMLGuard<&KickoffFriendlyPlayFSM::isSetupDone>{this};
+        const auto isPlaying_G   = SMLGuard<&KickoffFriendlyPlayFSM::isPlaying>{this};
         return make_transition_table(
             *SetupState_S + Update_E[!isSetupDone_G] / setupKickoff_A = SetupState_S,
             SetupState_S + Update_E[isSetupDone_G]                    = ChipState_S,

--- a/src/software/ai/hl/stp/play/offense/offense_play_fsm.h
+++ b/src/software/ai/hl/stp/play/offense/offense_play_fsm.h
@@ -64,10 +64,10 @@ struct OffensePlayFSM : PlayFSM<OffensePlayFSM>
     {
         using namespace boost::sml;
 
-        const auto OffensiveState_S = boost::sml::state<OffensiveState>;
-        const auto DefensiveState_S = boost::sml::state<DefensiveState>;
+        constexpr auto OffensiveState_S = boost::sml::state<OffensiveState>;
+        constexpr auto DefensiveState_S = boost::sml::state<DefensiveState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto enemyHasPossession_G =
             SMLGuard<&OffensePlayFSM::enemyHasPossession>{this};

--- a/src/software/ai/hl/stp/play/offense/offense_play_fsm.h
+++ b/src/software/ai/hl/stp/play/offense/offense_play_fsm.h
@@ -64,16 +64,18 @@ struct OffensePlayFSM : PlayFSM<OffensePlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(OffensiveState)
-        DEFINE_SML_STATE(DefensiveState)
+        const auto OffensiveState_S = boost::sml::state<OffensiveState>;
+        const auto DefensiveState_S = boost::sml::state<DefensiveState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto enemyHasPossession_G =
             SMLGuard<&OffensePlayFSM::enemyHasPossession>{this};
 
-        DEFINE_SML_ACTION(setupOffensiveStrategy)
-        DEFINE_SML_ACTION(setupDefensiveStrategy)
+        const auto setupOffensiveStrategy_A =
+            SMLAction<&OffensePlayFSM::setupOffensiveStrategy>{this};
+        const auto setupDefensiveStrategy_A =
+            SMLAction<&OffensePlayFSM::setupDefensiveStrategy>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/offense/offense_play_fsm.h
+++ b/src/software/ai/hl/stp/play/offense/offense_play_fsm.h
@@ -69,7 +69,8 @@ struct OffensePlayFSM : PlayFSM<OffensePlayFSM>
 
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(enemyHasPossession)
+        const auto enemyHasPossession_G =
+            SMLGuard<&OffensePlayFSM::enemyHasPossession>{this};
 
         DEFINE_SML_ACTION(setupOffensiveStrategy)
         DEFINE_SML_ACTION(setupDefensiveStrategy)

--- a/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_fsm.h
+++ b/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_fsm.h
@@ -64,13 +64,13 @@ struct PenaltyKickPlayFSM : PlayFSM<PenaltyKickPlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(SetupPositionState)
-        DEFINE_SML_STATE(PerformKickState)
+        const auto SetupPositionState_S = boost::sml::state<SetupPositionState>;
+        const auto PerformKickState_S = boost::sml::state<PerformKickState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(setupPosition)
-        DEFINE_SML_ACTION(performKick)
+        const auto setupPosition_A = SMLAction<&PenaltyKickPlayFSM::setupPosition>{this};
+        const auto performKick_A   = SMLAction<&PenaltyKickPlayFSM::performKick>{this};
 
         const auto setupPositionDone_G =
             SMLGuard<&PenaltyKickPlayFSM::setupPositionDone>{this};

--- a/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_fsm.h
+++ b/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_fsm.h
@@ -72,8 +72,9 @@ struct PenaltyKickPlayFSM : PlayFSM<PenaltyKickPlayFSM>
         DEFINE_SML_ACTION(setupPosition)
         DEFINE_SML_ACTION(performKick)
 
-        DEFINE_SML_GUARD(setupPositionDone)
-        DEFINE_SML_GUARD(kickDone)
+        const auto setupPositionDone_G =
+            SMLGuard<&PenaltyKickPlayFSM::setupPositionDone>{this};
+        const auto kickDone_G = SMLGuard<&PenaltyKickPlayFSM::kickDone>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_fsm.h
+++ b/src/software/ai/hl/stp/play/penalty_kick/penalty_kick_play_fsm.h
@@ -64,10 +64,10 @@ struct PenaltyKickPlayFSM : PlayFSM<PenaltyKickPlayFSM>
     {
         using namespace boost::sml;
 
-        const auto SetupPositionState_S = boost::sml::state<SetupPositionState>;
-        const auto PerformKickState_S = boost::sml::state<PerformKickState>;
+        constexpr auto SetupPositionState_S = boost::sml::state<SetupPositionState>;
+        constexpr auto PerformKickState_S   = boost::sml::state<PerformKickState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto setupPosition_A = SMLAction<&PenaltyKickPlayFSM::setupPosition>{this};
         const auto performKick_A   = SMLAction<&PenaltyKickPlayFSM::performKick>{this};

--- a/src/software/ai/hl/stp/play/penalty_kick_enemy/penalty_kick_enemy_play_fsm.h
+++ b/src/software/ai/hl/stp/play/penalty_kick_enemy/penalty_kick_enemy_play_fsm.h
@@ -57,13 +57,14 @@ struct PenaltyKickEnemyPlayFSM : PlayFSM<PenaltyKickEnemyPlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(SetupPositionState)
-        DEFINE_SML_STATE(DefendKickState)
+        const auto SetupPositionState_S = boost::sml::state<SetupPositionState>;
+        const auto DefendKickState_S = boost::sml::state<DefendKickState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(setupPosition)
-        DEFINE_SML_ACTION(defendKick)
+        const auto setupPosition_A =
+            SMLAction<&PenaltyKickEnemyPlayFSM::setupPosition>{this};
+        const auto defendKick_A = SMLAction<&PenaltyKickEnemyPlayFSM::defendKick>{this};
 
         const auto setupPositionDone_G =
             SMLGuard<&PenaltyKickEnemyPlayFSM::setupPositionDone>{this};

--- a/src/software/ai/hl/stp/play/penalty_kick_enemy/penalty_kick_enemy_play_fsm.h
+++ b/src/software/ai/hl/stp/play/penalty_kick_enemy/penalty_kick_enemy_play_fsm.h
@@ -57,10 +57,10 @@ struct PenaltyKickEnemyPlayFSM : PlayFSM<PenaltyKickEnemyPlayFSM>
     {
         using namespace boost::sml;
 
-        const auto SetupPositionState_S = boost::sml::state<SetupPositionState>;
-        const auto DefendKickState_S = boost::sml::state<DefendKickState>;
+        constexpr auto SetupPositionState_S = boost::sml::state<SetupPositionState>;
+        constexpr auto DefendKickState_S    = boost::sml::state<DefendKickState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto setupPosition_A =
             SMLAction<&PenaltyKickEnemyPlayFSM::setupPosition>{this};

--- a/src/software/ai/hl/stp/play/penalty_kick_enemy/penalty_kick_enemy_play_fsm.h
+++ b/src/software/ai/hl/stp/play/penalty_kick_enemy/penalty_kick_enemy_play_fsm.h
@@ -65,7 +65,8 @@ struct PenaltyKickEnemyPlayFSM : PlayFSM<PenaltyKickEnemyPlayFSM>
         DEFINE_SML_ACTION(setupPosition)
         DEFINE_SML_ACTION(defendKick)
 
-        DEFINE_SML_GUARD(setupPositionDone)
+        const auto setupPositionDone_G =
+            SMLGuard<&PenaltyKickEnemyPlayFSM::setupPositionDone>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/shoot_or_chip/shoot_or_chip_play_fsm.h
+++ b/src/software/ai/hl/stp/play/shoot_or_chip/shoot_or_chip_play_fsm.h
@@ -28,8 +28,8 @@ struct ShootOrChipPlayFSM : PlayFSM<ShootOrChipPlayFSM>
     {
         using namespace boost::sml;
 
-        const auto ShootOrChipState_S = boost::sml::state<ShootOrChipState>;
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto ShootOrChipState_S = boost::sml::state<ShootOrChipState>;
+        constexpr auto Update_E           = boost::sml::event<Update>;
         const auto updateShootOrChip_A =
             SMLAction<&ShootOrChipPlayFSM::updateShootOrChip>{this};
         const auto attackerDone_G = SMLGuard<&ShootOrChipPlayFSM::attackerDone>{this};

--- a/src/software/ai/hl/stp/play/shoot_or_chip/shoot_or_chip_play_fsm.h
+++ b/src/software/ai/hl/stp/play/shoot_or_chip/shoot_or_chip_play_fsm.h
@@ -31,7 +31,7 @@ struct ShootOrChipPlayFSM : PlayFSM<ShootOrChipPlayFSM>
         DEFINE_SML_STATE(ShootOrChipState)
         DEFINE_SML_EVENT(Update)
         DEFINE_SML_ACTION(updateShootOrChip)
-        DEFINE_SML_GUARD(attackerDone)
+        const auto attackerDone_G = SMLGuard<&ShootOrChipPlayFSM::attackerDone>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/shoot_or_chip/shoot_or_chip_play_fsm.h
+++ b/src/software/ai/hl/stp/play/shoot_or_chip/shoot_or_chip_play_fsm.h
@@ -28,9 +28,10 @@ struct ShootOrChipPlayFSM : PlayFSM<ShootOrChipPlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(ShootOrChipState)
-        DEFINE_SML_EVENT(Update)
-        DEFINE_SML_ACTION(updateShootOrChip)
+        const auto ShootOrChipState_S = boost::sml::state<ShootOrChipState>;
+        const auto Update_E = boost::sml::event<Update>;
+        const auto updateShootOrChip_A =
+            SMLAction<&ShootOrChipPlayFSM::updateShootOrChip>{this};
         const auto attackerDone_G = SMLGuard<&ShootOrChipPlayFSM::attackerDone>{this};
 
         return make_transition_table(

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
@@ -113,10 +113,10 @@ struct ShootOrPassPlayFSM : PlayFSM<ShootOrPassPlayFSM>
     {
         using namespace boost::sml;
 
-        const auto AttemptShotState_S = boost::sml::state<AttemptShotState>;
-        const auto TakePassState_S = boost::sml::state<TakePassState>;
-        const auto StartState_S = boost::sml::state<StartState>;
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto AttemptShotState_S = boost::sml::state<AttemptShotState>;
+        constexpr auto TakePassState_S    = boost::sml::state<TakePassState>;
+        constexpr auto StartState_S       = boost::sml::state<StartState>;
+        constexpr auto Update_E           = boost::sml::event<Update>;
 
         const auto lookForPass_A = SMLAction<&ShootOrPassPlayFSM::lookForPass>{this};
         const auto startLookingForPass_A =

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
@@ -113,14 +113,15 @@ struct ShootOrPassPlayFSM : PlayFSM<ShootOrPassPlayFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(AttemptShotState)
-        DEFINE_SML_STATE(TakePassState)
-        DEFINE_SML_STATE(StartState)
-        DEFINE_SML_EVENT(Update)
+        const auto AttemptShotState_S = boost::sml::state<AttemptShotState>;
+        const auto TakePassState_S = boost::sml::state<TakePassState>;
+        const auto StartState_S = boost::sml::state<StartState>;
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(lookForPass)
-        DEFINE_SML_ACTION(startLookingForPass)
-        DEFINE_SML_ACTION(takePass)
+        const auto lookForPass_A = SMLAction<&ShootOrPassPlayFSM::lookForPass>{this};
+        const auto startLookingForPass_A =
+            SMLAction<&ShootOrPassPlayFSM::startLookingForPass>{this};
+        const auto takePass_A = SMLAction<&ShootOrPassPlayFSM::takePass>{this};
 
         const auto passFound_G = SMLGuard<&ShootOrPassPlayFSM::passFound>{this};
         const auto shouldAbortPass_G =

--- a/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
+++ b/src/software/ai/hl/stp/play/shoot_or_pass/shoot_or_pass_play_fsm.h
@@ -122,10 +122,11 @@ struct ShootOrPassPlayFSM : PlayFSM<ShootOrPassPlayFSM>
         DEFINE_SML_ACTION(startLookingForPass)
         DEFINE_SML_ACTION(takePass)
 
-        DEFINE_SML_GUARD(passFound)
-        DEFINE_SML_GUARD(shouldAbortPass)
-        DEFINE_SML_GUARD(passCompleted)
-        DEFINE_SML_GUARD(tookShot)
+        const auto passFound_G = SMLGuard<&ShootOrPassPlayFSM::passFound>{this};
+        const auto shouldAbortPass_G =
+            SMLGuard<&ShootOrPassPlayFSM::shouldAbortPass>{this};
+        const auto passCompleted_G = SMLGuard<&ShootOrPassPlayFSM::passCompleted>{this};
+        const auto tookShot_G      = SMLGuard<&ShootOrPassPlayFSM::tookShot>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/stop_play_fsm.h
+++ b/src/software/ai/hl/stp/play/stop_play_fsm.h
@@ -44,11 +44,12 @@ struct StopPlayFSM
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(StopState)
+        const auto StopState_S = boost::sml::state<StopState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(updateStopPosition)
+        const auto updateStopPosition_A =
+            SMLAction<&StopPlayFSM::updateStopPosition>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/play/stop_play_fsm.h
+++ b/src/software/ai/hl/stp/play/stop_play_fsm.h
@@ -44,9 +44,9 @@ struct StopPlayFSM
     {
         using namespace boost::sml;
 
-        const auto StopState_S = boost::sml::state<StopState>;
+        constexpr auto StopState_S = boost::sml::state<StopState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto updateStopPosition_A =
             SMLAction<&StopPlayFSM::updateStopPosition>{this};

--- a/src/software/ai/hl/stp/tactic/attacker/attacker_fsm.h
+++ b/src/software/ai/hl/stp/tactic/attacker/attacker_fsm.h
@@ -65,15 +65,15 @@ struct AttackerFSM : TacticFSM<AttackerFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(PivotKickFSM)
-        DEFINE_SML_STATE(KeepAwayFSM)
-        DEFINE_SML_STATE(DribbleFSM)
+        const auto PivotKickFSM_S = boost::sml::state<PivotKickFSM>;
+        const auto KeepAwayFSM_S = boost::sml::state<KeepAwayFSM>;
+        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto shouldKick_G = SMLGuard<&AttackerFSM::shouldKick>{this};
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(pivotKick, PivotKickFSM)
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(keepAway, KeepAwayFSM)
+        const auto pivotKick_A  = SMLSubFSMUpdateAction<&AttackerFSM::pivotKick>{this};
+        const auto keepAway_A   = SMLSubFSMUpdateAction<&AttackerFSM::keepAway>{this};
 
         return make_transition_table(
             *DribbleFSM_S + Update_E[shouldKick_G] / pivotKick_A = PivotKickFSM_S,

--- a/src/software/ai/hl/stp/tactic/attacker/attacker_fsm.h
+++ b/src/software/ai/hl/stp/tactic/attacker/attacker_fsm.h
@@ -71,7 +71,7 @@ struct AttackerFSM : TacticFSM<AttackerFSM>
 
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(shouldKick)
+        const auto shouldKick_G = SMLGuard<&AttackerFSM::shouldKick>{this};
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(pivotKick, PivotKickFSM)
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(keepAway, KeepAwayFSM)
 

--- a/src/software/ai/hl/stp/tactic/attacker/attacker_fsm.h
+++ b/src/software/ai/hl/stp/tactic/attacker/attacker_fsm.h
@@ -65,11 +65,11 @@ struct AttackerFSM : TacticFSM<AttackerFSM>
     {
         using namespace boost::sml;
 
-        const auto PivotKickFSM_S = boost::sml::state<PivotKickFSM>;
-        const auto KeepAwayFSM_S = boost::sml::state<KeepAwayFSM>;
-        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
+        constexpr auto PivotKickFSM_S = boost::sml::state<PivotKickFSM>;
+        constexpr auto KeepAwayFSM_S  = boost::sml::state<KeepAwayFSM>;
+        constexpr auto DribbleFSM_S   = boost::sml::state<DribbleFSM>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto shouldKick_G = SMLGuard<&AttackerFSM::shouldKick>{this};
         const auto pivotKick_A  = SMLSubFSMUpdateAction<&AttackerFSM::pivotKick>{this};

--- a/src/software/ai/hl/stp/tactic/chip/chip_fsm.h
+++ b/src/software/ai/hl/stp/tactic/chip/chip_fsm.h
@@ -66,9 +66,9 @@ struct ChipFSM : TacticFSM<ChipFSM>
     {
         using namespace boost::sml;
 
-        const auto GetBehindBallFSM_S = boost::sml::state<GetBehindBallFSM>;
-        const auto ChipState_S = boost::sml::state<ChipState>;
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto GetBehindBallFSM_S = boost::sml::state<GetBehindBallFSM>;
+        constexpr auto ChipState_S        = boost::sml::state<ChipState>;
+        constexpr auto Update_E           = boost::sml::event<Update>;
 
         const auto ballChicked_G = SMLGuard<&ChipFSM::ballChicked>{this};
         const auto shouldRealignWithBall_G =

--- a/src/software/ai/hl/stp/tactic/chip/chip_fsm.h
+++ b/src/software/ai/hl/stp/tactic/chip/chip_fsm.h
@@ -66,15 +66,16 @@ struct ChipFSM : TacticFSM<ChipFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(GetBehindBallFSM)
-        DEFINE_SML_STATE(ChipState)
-        DEFINE_SML_EVENT(Update)
+        const auto GetBehindBallFSM_S = boost::sml::state<GetBehindBallFSM>;
+        const auto ChipState_S = boost::sml::state<ChipState>;
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto ballChicked_G = SMLGuard<&ChipFSM::ballChicked>{this};
         const auto shouldRealignWithBall_G =
             SMLGuard<&ChipFSM::shouldRealignWithBall>{this};
-        DEFINE_SML_ACTION(updateChip)
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(updateGetBehindBall, GetBehindBallFSM)
+        const auto updateChip_A = SMLAction<&ChipFSM::updateChip>{this};
+        const auto updateGetBehindBall_A =
+            SMLSubFSMUpdateAction<&ChipFSM::updateGetBehindBall>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/chip/chip_fsm.h
+++ b/src/software/ai/hl/stp/tactic/chip/chip_fsm.h
@@ -70,8 +70,9 @@ struct ChipFSM : TacticFSM<ChipFSM>
         DEFINE_SML_STATE(ChipState)
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(ballChicked)
-        DEFINE_SML_GUARD(shouldRealignWithBall)
+        const auto ballChicked_G = SMLGuard<&ChipFSM::ballChicked>{this};
+        const auto shouldRealignWithBall_G =
+            SMLGuard<&ChipFSM::shouldRealignWithBall>{this};
         DEFINE_SML_ACTION(updateChip)
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(updateGetBehindBall, GetBehindBallFSM)
 

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.h
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.h
@@ -88,13 +88,15 @@ struct CreaseDefenderFSM : public DefenderFSMBase, TacticFSM<CreaseDefenderFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(MoveFSM)
-        DEFINE_SML_EVENT(Update)
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(blockThreat, MoveFSM)
-        DEFINE_SML_STATE(DribbleFSM)
+        const auto MoveFSM_S = boost::sml::state<MoveFSM>;
+        const auto Update_E = boost::sml::event<Update>;
+        const auto blockThreat_A =
+            SMLSubFSMUpdateAction<&CreaseDefenderFSM::blockThreat>{this};
+        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
         const auto ballNearbyWithoutThreat_G =
             SMLGuard<&CreaseDefenderFSM::ballNearbyWithoutThreat>{this};
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(prepareGetPossession, DribbleFSM)
+        const auto prepareGetPossession_A =
+            SMLSubFSMUpdateAction<&CreaseDefenderFSM::prepareGetPossession>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.h
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.h
@@ -88,11 +88,11 @@ struct CreaseDefenderFSM : public DefenderFSMBase, TacticFSM<CreaseDefenderFSM>
     {
         using namespace boost::sml;
 
-        const auto MoveFSM_S = boost::sml::state<MoveFSM>;
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto MoveFSM_S = boost::sml::state<MoveFSM>;
+        constexpr auto Update_E  = boost::sml::event<Update>;
         const auto blockThreat_A =
             SMLSubFSMUpdateAction<&CreaseDefenderFSM::blockThreat>{this};
-        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
+        constexpr auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
         const auto ballNearbyWithoutThreat_G =
             SMLGuard<&CreaseDefenderFSM::ballNearbyWithoutThreat>{this};
         const auto prepareGetPossession_A =

--- a/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.h
+++ b/src/software/ai/hl/stp/tactic/crease_defender/crease_defender_fsm.h
@@ -92,7 +92,8 @@ struct CreaseDefenderFSM : public DefenderFSMBase, TacticFSM<CreaseDefenderFSM>
         DEFINE_SML_EVENT(Update)
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(blockThreat, MoveFSM)
         DEFINE_SML_STATE(DribbleFSM)
-        DEFINE_SML_GUARD(ballNearbyWithoutThreat)
+        const auto ballNearbyWithoutThreat_G =
+            SMLGuard<&CreaseDefenderFSM::ballNearbyWithoutThreat>{this};
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(prepareGetPossession, DribbleFSM)
 
         return make_transition_table(

--- a/src/software/ai/hl/stp/tactic/dribble/dribble_fsm.h
+++ b/src/software/ai/hl/stp/tactic/dribble/dribble_fsm.h
@@ -173,17 +173,17 @@ struct DribbleFSM : TacticFSM<DribbleFSM>
     {
         using namespace boost::sml;
 
-        const auto GetPossession_S = boost::sml::state<GetPossession>;
-        const auto Dribble_S = boost::sml::state<Dribble>;
-        const auto LoseBall_S = boost::sml::state<LoseBall>;
-        const auto Update_E = boost::sml::event<Update>;
-        const auto havePossession_G = SMLGuard<&DribbleFSM::havePossession>{this};
-        const auto lostPossession_G = SMLGuard<&DribbleFSM::lostPossession>{this};
-        const auto dribblingDone_G  = SMLGuard<&DribbleFSM::dribblingDone>{this};
-        const auto shouldLoseBall_G = SMLGuard<&DribbleFSM::shouldLoseBall>{this};
-        const auto loseBall_A       = SMLAction<&DribbleFSM::loseBall>{this};
-        const auto getPossession_A  = SMLAction<&DribbleFSM::getPossession>{this};
-        const auto dribble_A        = SMLAction<&DribbleFSM::dribble>{this};
+        constexpr auto GetPossession_S = boost::sml::state<GetPossession>;
+        constexpr auto Dribble_S       = boost::sml::state<Dribble>;
+        constexpr auto LoseBall_S      = boost::sml::state<LoseBall>;
+        constexpr auto Update_E        = boost::sml::event<Update>;
+        const auto havePossession_G    = SMLGuard<&DribbleFSM::havePossession>{this};
+        const auto lostPossession_G    = SMLGuard<&DribbleFSM::lostPossession>{this};
+        const auto dribblingDone_G     = SMLGuard<&DribbleFSM::dribblingDone>{this};
+        const auto shouldLoseBall_G    = SMLGuard<&DribbleFSM::shouldLoseBall>{this};
+        const auto loseBall_A          = SMLAction<&DribbleFSM::loseBall>{this};
+        const auto getPossession_A     = SMLAction<&DribbleFSM::getPossession>{this};
+        const auto dribble_A           = SMLAction<&DribbleFSM::dribble>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/dribble/dribble_fsm.h
+++ b/src/software/ai/hl/stp/tactic/dribble/dribble_fsm.h
@@ -173,17 +173,17 @@ struct DribbleFSM : TacticFSM<DribbleFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(GetPossession)
-        DEFINE_SML_STATE(Dribble)
-        DEFINE_SML_STATE(LoseBall)
-        DEFINE_SML_EVENT(Update)
+        const auto GetPossession_S = boost::sml::state<GetPossession>;
+        const auto Dribble_S = boost::sml::state<Dribble>;
+        const auto LoseBall_S = boost::sml::state<LoseBall>;
+        const auto Update_E = boost::sml::event<Update>;
         const auto havePossession_G = SMLGuard<&DribbleFSM::havePossession>{this};
         const auto lostPossession_G = SMLGuard<&DribbleFSM::lostPossession>{this};
         const auto dribblingDone_G  = SMLGuard<&DribbleFSM::dribblingDone>{this};
         const auto shouldLoseBall_G = SMLGuard<&DribbleFSM::shouldLoseBall>{this};
-        DEFINE_SML_ACTION(loseBall)
-        DEFINE_SML_ACTION(getPossession)
-        DEFINE_SML_ACTION(dribble)
+        const auto loseBall_A       = SMLAction<&DribbleFSM::loseBall>{this};
+        const auto getPossession_A  = SMLAction<&DribbleFSM::getPossession>{this};
+        const auto dribble_A        = SMLAction<&DribbleFSM::dribble>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/dribble/dribble_fsm.h
+++ b/src/software/ai/hl/stp/tactic/dribble/dribble_fsm.h
@@ -177,10 +177,10 @@ struct DribbleFSM : TacticFSM<DribbleFSM>
         DEFINE_SML_STATE(Dribble)
         DEFINE_SML_STATE(LoseBall)
         DEFINE_SML_EVENT(Update)
-        DEFINE_SML_GUARD(havePossession)
-        DEFINE_SML_GUARD(lostPossession)
-        DEFINE_SML_GUARD(dribblingDone)
-        DEFINE_SML_GUARD(shouldLoseBall)
+        const auto havePossession_G = SMLGuard<&DribbleFSM::havePossession>{this};
+        const auto lostPossession_G = SMLGuard<&DribbleFSM::lostPossession>{this};
+        const auto dribblingDone_G  = SMLGuard<&DribbleFSM::dribblingDone>{this};
+        const auto shouldLoseBall_G = SMLGuard<&DribbleFSM::shouldLoseBall>{this};
         DEFINE_SML_ACTION(loseBall)
         DEFINE_SML_ACTION(getPossession)
         DEFINE_SML_ACTION(dribble)

--- a/src/software/ai/hl/stp/tactic/get_behind_ball/get_behind_ball_fsm.h
+++ b/src/software/ai/hl/stp/tactic/get_behind_ball/get_behind_ball_fsm.h
@@ -53,7 +53,7 @@ struct GetBehindBallFSM : TacticFSM<GetBehindBallFSM>
         DEFINE_SML_STATE(GetBehindBallState)
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(behindBall)
+        const auto behindBall_G = SMLGuard<&GetBehindBallFSM::behindBall>{this};
         DEFINE_SML_ACTION(updateMove)
 
 

--- a/src/software/ai/hl/stp/tactic/get_behind_ball/get_behind_ball_fsm.h
+++ b/src/software/ai/hl/stp/tactic/get_behind_ball/get_behind_ball_fsm.h
@@ -50,11 +50,11 @@ struct GetBehindBallFSM : TacticFSM<GetBehindBallFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(GetBehindBallState)
-        DEFINE_SML_EVENT(Update)
+        const auto GetBehindBallState_S = boost::sml::state<GetBehindBallState>;
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto behindBall_G = SMLGuard<&GetBehindBallFSM::behindBall>{this};
-        DEFINE_SML_ACTION(updateMove)
+        const auto updateMove_A = SMLAction<&GetBehindBallFSM::updateMove>{this};
 
 
         return make_transition_table(

--- a/src/software/ai/hl/stp/tactic/get_behind_ball/get_behind_ball_fsm.h
+++ b/src/software/ai/hl/stp/tactic/get_behind_ball/get_behind_ball_fsm.h
@@ -50,8 +50,8 @@ struct GetBehindBallFSM : TacticFSM<GetBehindBallFSM>
     {
         using namespace boost::sml;
 
-        const auto GetBehindBallState_S = boost::sml::state<GetBehindBallState>;
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto GetBehindBallState_S = boost::sml::state<GetBehindBallState>;
+        constexpr auto Update_E             = boost::sml::event<Update>;
 
         const auto behindBall_G = SMLGuard<&GetBehindBallFSM::behindBall>{this};
         const auto updateMove_A = SMLAction<&GetBehindBallFSM::updateMove>{this};

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
@@ -188,13 +188,13 @@ struct GoalieFSM : TacticFSM<GoalieFSM>
     {
         using namespace boost::sml;
 
-        const auto Panic_S = boost::sml::state<Panic>;
-        const auto PivotKickFSM_S = boost::sml::state<PivotKickFSM>;
-        const auto PositionToBlock_S = boost::sml::state<PositionToBlock>;
-        const auto MoveToGoalLine_S = boost::sml::state<MoveToGoalLine>;
-        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
+        constexpr auto Panic_S           = boost::sml::state<Panic>;
+        constexpr auto PivotKickFSM_S    = boost::sml::state<PivotKickFSM>;
+        constexpr auto PositionToBlock_S = boost::sml::state<PositionToBlock>;
+        constexpr auto MoveToGoalLine_S  = boost::sml::state<MoveToGoalLine>;
+        constexpr auto DribbleFSM_S      = boost::sml::state<DribbleFSM>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto ballInInflatedDefenseArea_G =
             SMLGuard<&GoalieFSM::ballInInflatedDefenseArea>{this};

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
@@ -188,13 +188,13 @@ struct GoalieFSM : TacticFSM<GoalieFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(Panic)
-        DEFINE_SML_STATE(PivotKickFSM)
-        DEFINE_SML_STATE(PositionToBlock)
-        DEFINE_SML_STATE(MoveToGoalLine)
-        DEFINE_SML_STATE(DribbleFSM)
+        const auto Panic_S = boost::sml::state<Panic>;
+        const auto PivotKickFSM_S = boost::sml::state<PivotKickFSM>;
+        const auto PositionToBlock_S = boost::sml::state<PositionToBlock>;
+        const auto MoveToGoalLine_S = boost::sml::state<MoveToGoalLine>;
+        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto ballInInflatedDefenseArea_G =
             SMLGuard<&GoalieFSM::ballInInflatedDefenseArea>{this};
@@ -207,11 +207,13 @@ struct GoalieFSM : TacticFSM<GoalieFSM>
             SMLGuard<&GoalieFSM::shouldMoveToGoalLine>{this};
         const auto retrieveDone_G = SMLGuard<&GoalieFSM::retrieveDone>{this};
 
-        DEFINE_SML_ACTION(panic)
-        DEFINE_SML_ACTION(positionToBlock)
-        DEFINE_SML_ACTION(moveToGoalLine)
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(updatePivotKick, PivotKickFSM)
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(retrieveFromDeadZone, DribbleFSM)
+        const auto panic_A           = SMLAction<&GoalieFSM::panic>{this};
+        const auto positionToBlock_A = SMLAction<&GoalieFSM::positionToBlock>{this};
+        const auto moveToGoalLine_A  = SMLAction<&GoalieFSM::moveToGoalLine>{this};
+        const auto updatePivotKick_A =
+            SMLSubFSMUpdateAction<&GoalieFSM::updatePivotKick>{this};
+        const auto retrieveFromDeadZone_A =
+            SMLSubFSMUpdateAction<&GoalieFSM::retrieveFromDeadZone>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
+++ b/src/software/ai/hl/stp/tactic/goalie/goalie_fsm.h
@@ -196,13 +196,16 @@ struct GoalieFSM : TacticFSM<GoalieFSM>
 
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(ballInInflatedDefenseArea)
-        DEFINE_SML_GUARD(panicDone)
-        DEFINE_SML_GUARD(shouldEvacuateCrease)
-        DEFINE_SML_GUARD(shouldPivotChip)
-        DEFINE_SML_GUARD(shouldPanic)
-        DEFINE_SML_GUARD(shouldMoveToGoalLine)
-        DEFINE_SML_GUARD(retrieveDone)
+        const auto ballInInflatedDefenseArea_G =
+            SMLGuard<&GoalieFSM::ballInInflatedDefenseArea>{this};
+        const auto panicDone_G = SMLGuard<&GoalieFSM::panicDone>{this};
+        const auto shouldEvacuateCrease_G =
+            SMLGuard<&GoalieFSM::shouldEvacuateCrease>{this};
+        const auto shouldPivotChip_G = SMLGuard<&GoalieFSM::shouldPivotChip>{this};
+        const auto shouldPanic_G     = SMLGuard<&GoalieFSM::shouldPanic>{this};
+        const auto shouldMoveToGoalLine_G =
+            SMLGuard<&GoalieFSM::shouldMoveToGoalLine>{this};
+        const auto retrieveDone_G = SMLGuard<&GoalieFSM::retrieveDone>{this};
 
         DEFINE_SML_ACTION(panic)
         DEFINE_SML_ACTION(positionToBlock)

--- a/src/software/ai/hl/stp/tactic/halt/halt_fsm.h
+++ b/src/software/ai/hl/stp/tactic/halt/halt_fsm.h
@@ -40,10 +40,10 @@ struct HaltFSM : TacticFSM<HaltFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(StopState)
-        DEFINE_SML_EVENT(Update)
-        const auto stopDone_G = SMLGuard<&HaltFSM::stopDone>{this};
-        DEFINE_SML_ACTION(updateStop)
+        const auto StopState_S = boost::sml::state<StopState>;
+        const auto Update_E = boost::sml::event<Update>;
+        const auto stopDone_G   = SMLGuard<&HaltFSM::stopDone>{this};
+        const auto updateStop_A = SMLAction<&HaltFSM::updateStop>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/halt/halt_fsm.h
+++ b/src/software/ai/hl/stp/tactic/halt/halt_fsm.h
@@ -40,10 +40,10 @@ struct HaltFSM : TacticFSM<HaltFSM>
     {
         using namespace boost::sml;
 
-        const auto StopState_S = boost::sml::state<StopState>;
-        const auto Update_E = boost::sml::event<Update>;
-        const auto stopDone_G   = SMLGuard<&HaltFSM::stopDone>{this};
-        const auto updateStop_A = SMLAction<&HaltFSM::updateStop>{this};
+        constexpr auto StopState_S = boost::sml::state<StopState>;
+        constexpr auto Update_E    = boost::sml::event<Update>;
+        const auto stopDone_G      = SMLGuard<&HaltFSM::stopDone>{this};
+        const auto updateStop_A    = SMLAction<&HaltFSM::updateStop>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/halt/halt_fsm.h
+++ b/src/software/ai/hl/stp/tactic/halt/halt_fsm.h
@@ -42,7 +42,7 @@ struct HaltFSM : TacticFSM<HaltFSM>
 
         DEFINE_SML_STATE(StopState)
         DEFINE_SML_EVENT(Update)
-        DEFINE_SML_GUARD(stopDone)
+        const auto stopDone_G = SMLGuard<&HaltFSM::stopDone>{this};
         DEFINE_SML_ACTION(updateStop)
 
         return make_transition_table(

--- a/src/software/ai/hl/stp/tactic/keep_away/keep_away_fsm.h
+++ b/src/software/ai/hl/stp/tactic/keep_away/keep_away_fsm.h
@@ -33,9 +33,9 @@ struct KeepAwayFSM : TacticFSM<KeepAwayFSM>
     auto operator()()
     {
         using namespace boost::sml;
-        DEFINE_SML_EVENT(Update)
-        DEFINE_SML_STATE(DribbleFSM)
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(keepAway, DribbleFSM)
+        const auto Update_E = boost::sml::event<Update>;
+        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
+        const auto keepAway_A = SMLSubFSMUpdateAction<&KeepAwayFSM::keepAway>{this};
 
         return make_transition_table(*DribbleFSM_S + Update_E / keepAway_A,
                                      DribbleFSM_S                             = X,

--- a/src/software/ai/hl/stp/tactic/keep_away/keep_away_fsm.h
+++ b/src/software/ai/hl/stp/tactic/keep_away/keep_away_fsm.h
@@ -33,9 +33,9 @@ struct KeepAwayFSM : TacticFSM<KeepAwayFSM>
     auto operator()()
     {
         using namespace boost::sml;
-        const auto Update_E = boost::sml::event<Update>;
-        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
-        const auto keepAway_A = SMLSubFSMUpdateAction<&KeepAwayFSM::keepAway>{this};
+        constexpr auto Update_E     = boost::sml::event<Update>;
+        constexpr auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
+        const auto keepAway_A       = SMLSubFSMUpdateAction<&KeepAwayFSM::keepAway>{this};
 
         return make_transition_table(*DribbleFSM_S + Update_E / keepAway_A,
                                      DribbleFSM_S                             = X,

--- a/src/software/ai/hl/stp/tactic/kick/kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/kick/kick_fsm.h
@@ -74,8 +74,9 @@ struct KickFSM : TacticFSM<KickFSM>
         DEFINE_SML_STATE(KickState)
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(ballChicked)
-        DEFINE_SML_GUARD(shouldRealignWithBall)
+        const auto ballChicked_G = SMLGuard<&KickFSM::ballChicked>{this};
+        const auto shouldRealignWithBall_G =
+            SMLGuard<&KickFSM::shouldRealignWithBall>{this};
         DEFINE_SML_ACTION(updateKick)
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(updateGetBehindBall, GetBehindBallFSM)
 

--- a/src/software/ai/hl/stp/tactic/kick/kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/kick/kick_fsm.h
@@ -70,15 +70,16 @@ struct KickFSM : TacticFSM<KickFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(GetBehindBallFSM)
-        DEFINE_SML_STATE(KickState)
-        DEFINE_SML_EVENT(Update)
+        const auto GetBehindBallFSM_S = boost::sml::state<GetBehindBallFSM>;
+        const auto KickState_S = boost::sml::state<KickState>;
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto ballChicked_G = SMLGuard<&KickFSM::ballChicked>{this};
         const auto shouldRealignWithBall_G =
             SMLGuard<&KickFSM::shouldRealignWithBall>{this};
-        DEFINE_SML_ACTION(updateKick)
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(updateGetBehindBall, GetBehindBallFSM)
+        const auto updateKick_A = SMLAction<&KickFSM::updateKick>{this};
+        const auto updateGetBehindBall_A =
+            SMLSubFSMUpdateAction<&KickFSM::updateGetBehindBall>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/kick/kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/kick/kick_fsm.h
@@ -70,9 +70,9 @@ struct KickFSM : TacticFSM<KickFSM>
     {
         using namespace boost::sml;
 
-        const auto GetBehindBallFSM_S = boost::sml::state<GetBehindBallFSM>;
-        const auto KickState_S = boost::sml::state<KickState>;
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto GetBehindBallFSM_S = boost::sml::state<GetBehindBallFSM>;
+        constexpr auto KickState_S        = boost::sml::state<KickState>;
+        constexpr auto Update_E           = boost::sml::event<Update>;
 
         const auto ballChicked_G = SMLGuard<&KickFSM::ballChicked>{this};
         const auto shouldRealignWithBall_G =

--- a/src/software/ai/hl/stp/tactic/move/move_fsm.h
+++ b/src/software/ai/hl/stp/tactic/move/move_fsm.h
@@ -67,7 +67,7 @@ struct MoveFSM : TacticFSM<MoveFSM>
         // Update_E is the _event_ that the MoveFSM responds to
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(moveDone)
+        const auto moveDone_G = SMLGuard<&MoveFSM::moveDone>{this};
         DEFINE_SML_ACTION(updateMove)
 
         return make_transition_table(

--- a/src/software/ai/hl/stp/tactic/move/move_fsm.h
+++ b/src/software/ai/hl/stp/tactic/move/move_fsm.h
@@ -63,9 +63,9 @@ struct MoveFSM : TacticFSM<MoveFSM>
         using namespace boost::sml;
 
         // MoveState_S is the _state_ used in the transition table
-        const auto MoveState_S = boost::sml::state<MoveState>;
+        constexpr auto MoveState_S = boost::sml::state<MoveState>;
         // Update_E is the _event_ that the MoveFSM responds to
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto moveDone_G   = SMLGuard<&MoveFSM::moveDone>{this};
         const auto updateMove_A = SMLAction<&MoveFSM::updateMove>{this};

--- a/src/software/ai/hl/stp/tactic/move/move_fsm.h
+++ b/src/software/ai/hl/stp/tactic/move/move_fsm.h
@@ -63,12 +63,12 @@ struct MoveFSM : TacticFSM<MoveFSM>
         using namespace boost::sml;
 
         // MoveState_S is the _state_ used in the transition table
-        DEFINE_SML_STATE(MoveState)
+        const auto MoveState_S = boost::sml::state<MoveState>;
         // Update_E is the _event_ that the MoveFSM responds to
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        const auto moveDone_G = SMLGuard<&MoveFSM::moveDone>{this};
-        DEFINE_SML_ACTION(updateMove)
+        const auto moveDone_G   = SMLGuard<&MoveFSM::moveDone>{this};
+        const auto updateMove_A = SMLAction<&MoveFSM::updateMove>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_fsm.h
+++ b/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_fsm.h
@@ -110,14 +110,15 @@ struct PassDefenderFSM : public DefenderFSMBase, TacticFSM<PassDefenderFSM>
 
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(passStarted)
-        DEFINE_SML_GUARD(ballDeflected)
+        const auto passStarted_G   = SMLGuard<&PassDefenderFSM::passStarted>{this};
+        const auto ballDeflected_G = SMLGuard<&PassDefenderFSM::ballDeflected>{this};
 
         DEFINE_SML_ACTION(blockPass)
         DEFINE_SML_ACTION(interceptBall)
 
         DEFINE_SML_STATE(DribbleFSM)
-        DEFINE_SML_GUARD(ballNearbyWithoutThreat)
+        const auto ballNearbyWithoutThreat_G =
+            SMLGuard<&PassDefenderFSM::ballNearbyWithoutThreat>{this};
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(prepareGetPossession, DribbleFSM)
 
         return make_transition_table(

--- a/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_fsm.h
+++ b/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_fsm.h
@@ -105,21 +105,22 @@ struct PassDefenderFSM : public DefenderFSMBase, TacticFSM<PassDefenderFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(BlockPassState)
-        DEFINE_SML_STATE(InterceptBallState)
+        const auto BlockPassState_S = boost::sml::state<BlockPassState>;
+        const auto InterceptBallState_S = boost::sml::state<InterceptBallState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto passStarted_G   = SMLGuard<&PassDefenderFSM::passStarted>{this};
         const auto ballDeflected_G = SMLGuard<&PassDefenderFSM::ballDeflected>{this};
 
-        DEFINE_SML_ACTION(blockPass)
-        DEFINE_SML_ACTION(interceptBall)
+        const auto blockPass_A     = SMLAction<&PassDefenderFSM::blockPass>{this};
+        const auto interceptBall_A = SMLAction<&PassDefenderFSM::interceptBall>{this};
 
-        DEFINE_SML_STATE(DribbleFSM)
+        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
         const auto ballNearbyWithoutThreat_G =
             SMLGuard<&PassDefenderFSM::ballNearbyWithoutThreat>{this};
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(prepareGetPossession, DribbleFSM)
+        const auto prepareGetPossession_A =
+            SMLSubFSMUpdateAction<&PassDefenderFSM::prepareGetPossession>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_fsm.h
+++ b/src/software/ai/hl/stp/tactic/pass_defender/pass_defender_fsm.h
@@ -105,10 +105,10 @@ struct PassDefenderFSM : public DefenderFSMBase, TacticFSM<PassDefenderFSM>
     {
         using namespace boost::sml;
 
-        const auto BlockPassState_S = boost::sml::state<BlockPassState>;
-        const auto InterceptBallState_S = boost::sml::state<InterceptBallState>;
+        constexpr auto BlockPassState_S     = boost::sml::state<BlockPassState>;
+        constexpr auto InterceptBallState_S = boost::sml::state<InterceptBallState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto passStarted_G   = SMLGuard<&PassDefenderFSM::passStarted>{this};
         const auto ballDeflected_G = SMLGuard<&PassDefenderFSM::ballDeflected>{this};
@@ -116,7 +116,7 @@ struct PassDefenderFSM : public DefenderFSMBase, TacticFSM<PassDefenderFSM>
         const auto blockPass_A     = SMLAction<&PassDefenderFSM::blockPass>{this};
         const auto interceptBall_A = SMLAction<&PassDefenderFSM::interceptBall>{this};
 
-        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
+        constexpr auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
         const auto ballNearbyWithoutThreat_G =
             SMLGuard<&PassDefenderFSM::ballNearbyWithoutThreat>{this};
         const auto prepareGetPossession_A =

--- a/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h
@@ -104,10 +104,10 @@ struct PenaltyKickFSM : TacticFSM<PenaltyKickFSM>
     {
         using namespace boost::sml;
 
-        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
-        const auto KickFSM_S = boost::sml::state<KickFSM>;
+        constexpr auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
+        constexpr auto KickFSM_S    = boost::sml::state<KickFSM>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto takePenaltyShot_G = SMLGuard<&PenaltyKickFSM::takePenaltyShot>{this};
         const auto timeOutApproach_G = SMLGuard<&PenaltyKickFSM::timeOutApproach>{this};

--- a/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h
@@ -109,8 +109,8 @@ struct PenaltyKickFSM : TacticFSM<PenaltyKickFSM>
 
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(takePenaltyShot)
-        DEFINE_SML_GUARD(timeOutApproach)
+        const auto takePenaltyShot_G = SMLGuard<&PenaltyKickFSM::takePenaltyShot>{this};
+        const auto timeOutApproach_G = SMLGuard<&PenaltyKickFSM::timeOutApproach>{this};
 
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(shoot, KickFSM)
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(updateApproachKeeper, DribbleFSM)

--- a/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/penalty_kick/penalty_kick_fsm.h
@@ -104,17 +104,19 @@ struct PenaltyKickFSM : TacticFSM<PenaltyKickFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(DribbleFSM)
-        DEFINE_SML_STATE(KickFSM)
+        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
+        const auto KickFSM_S = boost::sml::state<KickFSM>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto takePenaltyShot_G = SMLGuard<&PenaltyKickFSM::takePenaltyShot>{this};
         const auto timeOutApproach_G = SMLGuard<&PenaltyKickFSM::timeOutApproach>{this};
 
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(shoot, KickFSM)
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(updateApproachKeeper, DribbleFSM)
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(adjustOrientationForShot, DribbleFSM)
+        const auto shoot_A = SMLSubFSMUpdateAction<&PenaltyKickFSM::shoot>{this};
+        const auto updateApproachKeeper_A =
+            SMLSubFSMUpdateAction<&PenaltyKickFSM::updateApproachKeeper>{this};
+        const auto adjustOrientationForShot_A =
+            SMLSubFSMUpdateAction<&PenaltyKickFSM::adjustOrientationForShot>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest state

--- a/src/software/ai/hl/stp/tactic/pivot_kick/pivot_kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/pivot_kick/pivot_kick_fsm.h
@@ -61,10 +61,10 @@ struct PivotKickFSM : TacticFSM<PivotKickFSM>
     {
         using namespace boost::sml;
 
-        const auto StartState_S = boost::sml::state<StartState>;
-        const auto KickState_S = boost::sml::state<KickState>;
-        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto StartState_S = boost::sml::state<StartState>;
+        constexpr auto KickState_S  = boost::sml::state<KickState>;
+        constexpr auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
+        constexpr auto Update_E     = boost::sml::event<Update>;
 
         const auto ballKicked_G = SMLGuard<&PivotKickFSM::ballKicked>{this};
         const auto getPossessionAndPivot_A =

--- a/src/software/ai/hl/stp/tactic/pivot_kick/pivot_kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/pivot_kick/pivot_kick_fsm.h
@@ -66,7 +66,7 @@ struct PivotKickFSM : TacticFSM<PivotKickFSM>
         DEFINE_SML_STATE(DribbleFSM)
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(ballKicked)
+        const auto ballKicked_G = SMLGuard<&PivotKickFSM::ballKicked>{this};
         DEFINE_SML_SUB_FSM_UPDATE_ACTION(getPossessionAndPivot, DribbleFSM)
         DEFINE_SML_ACTION(kickBall)
 

--- a/src/software/ai/hl/stp/tactic/pivot_kick/pivot_kick_fsm.h
+++ b/src/software/ai/hl/stp/tactic/pivot_kick/pivot_kick_fsm.h
@@ -61,14 +61,15 @@ struct PivotKickFSM : TacticFSM<PivotKickFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(StartState)
-        DEFINE_SML_STATE(KickState)
-        DEFINE_SML_STATE(DribbleFSM)
-        DEFINE_SML_EVENT(Update)
+        const auto StartState_S = boost::sml::state<StartState>;
+        const auto KickState_S = boost::sml::state<KickState>;
+        const auto DribbleFSM_S = boost::sml::state<DribbleFSM>;
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto ballKicked_G = SMLGuard<&PivotKickFSM::ballKicked>{this};
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(getPossessionAndPivot, DribbleFSM)
-        DEFINE_SML_ACTION(kickBall)
+        const auto getPossessionAndPivot_A =
+            SMLSubFSMUpdateAction<&PivotKickFSM::getPossessionAndPivot>{this};
+        const auto kickBall_A = SMLAction<&PivotKickFSM::kickBall>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/receiver/receiver_fsm.h
+++ b/src/software/ai/hl/stp/tactic/receiver/receiver_fsm.h
@@ -145,10 +145,11 @@ struct ReceiverFSM : TacticFSM<ReceiverFSM>
     {
         using namespace boost::sml;
 
-        const auto ReceiveAndDribbleState_S = boost::sml::state<ReceiveAndDribbleState>;
-        const auto OneTouchShotState_S = boost::sml::state<OneTouchShotState>;
-        const auto WaitingForPassState_S = boost::sml::state<WaitingForPassState>;
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto ReceiveAndDribbleState_S =
+            boost::sml::state<ReceiveAndDribbleState>;
+        constexpr auto OneTouchShotState_S   = boost::sml::state<OneTouchShotState>;
+        constexpr auto WaitingForPassState_S = boost::sml::state<WaitingForPassState>;
+        constexpr auto Update_E              = boost::sml::event<Update>;
 
         const auto onetouchPossible_G = SMLGuard<&ReceiverFSM::onetouchPossible>{this};
         const auto passStarted_G      = SMLGuard<&ReceiverFSM::passStarted>{this};

--- a/src/software/ai/hl/stp/tactic/receiver/receiver_fsm.h
+++ b/src/software/ai/hl/stp/tactic/receiver/receiver_fsm.h
@@ -150,10 +150,10 @@ struct ReceiverFSM : TacticFSM<ReceiverFSM>
         DEFINE_SML_STATE(WaitingForPassState)
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(onetouchPossible)
-        DEFINE_SML_GUARD(passStarted)
-        DEFINE_SML_GUARD(passFinished)
-        DEFINE_SML_GUARD(strayPass)
+        const auto onetouchPossible_G = SMLGuard<&ReceiverFSM::onetouchPossible>{this};
+        const auto passStarted_G      = SMLGuard<&ReceiverFSM::passStarted>{this};
+        const auto passFinished_G     = SMLGuard<&ReceiverFSM::passFinished>{this};
+        const auto strayPass_G        = SMLGuard<&ReceiverFSM::strayPass>{this};
 
         DEFINE_SML_ACTION(updateOnetouch)
         DEFINE_SML_ACTION(updateReceive)

--- a/src/software/ai/hl/stp/tactic/receiver/receiver_fsm.h
+++ b/src/software/ai/hl/stp/tactic/receiver/receiver_fsm.h
@@ -145,19 +145,19 @@ struct ReceiverFSM : TacticFSM<ReceiverFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(ReceiveAndDribbleState)
-        DEFINE_SML_STATE(OneTouchShotState)
-        DEFINE_SML_STATE(WaitingForPassState)
-        DEFINE_SML_EVENT(Update)
+        const auto ReceiveAndDribbleState_S = boost::sml::state<ReceiveAndDribbleState>;
+        const auto OneTouchShotState_S = boost::sml::state<OneTouchShotState>;
+        const auto WaitingForPassState_S = boost::sml::state<WaitingForPassState>;
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto onetouchPossible_G = SMLGuard<&ReceiverFSM::onetouchPossible>{this};
         const auto passStarted_G      = SMLGuard<&ReceiverFSM::passStarted>{this};
         const auto passFinished_G     = SMLGuard<&ReceiverFSM::passFinished>{this};
         const auto strayPass_G        = SMLGuard<&ReceiverFSM::strayPass>{this};
 
-        DEFINE_SML_ACTION(updateOnetouch)
-        DEFINE_SML_ACTION(updateReceive)
-        DEFINE_SML_ACTION(adjustReceive)
+        const auto updateOnetouch_A = SMLAction<&ReceiverFSM::updateOnetouch>{this};
+        const auto updateReceive_A  = SMLAction<&ReceiverFSM::updateReceive>{this};
+        const auto adjustReceive_A  = SMLAction<&ReceiverFSM::adjustReceive>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/shadow_enemy/shadow_enemy_fsm.h
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy/shadow_enemy_fsm.h
@@ -132,22 +132,22 @@ struct ShadowEnemyFSM : TacticFSM<ShadowEnemyFSM>
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(MoveFSM)
-        DEFINE_SML_STATE(BlockPassState)
-        DEFINE_SML_STATE(GoAndStealState)
-        DEFINE_SML_STATE(StealAndPullState)
+        const auto MoveFSM_S = boost::sml::state<MoveFSM>;
+        const auto BlockPassState_S = boost::sml::state<BlockPassState>;
+        const auto GoAndStealState_S = boost::sml::state<GoAndStealState>;
+        const auto StealAndPullState_S = boost::sml::state<StealAndPullState>;
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
         const auto enemyThreatHasBall_G =
             SMLGuard<&ShadowEnemyFSM::enemyThreatHasBall>{this};
         const auto contestedBall_G = SMLGuard<&ShadowEnemyFSM::contestedBall>{this};
         const auto blockedShot_G   = SMLGuard<&ShadowEnemyFSM::blockedShot>{this};
 
-        DEFINE_SML_ACTION(blockPass)
-        DEFINE_SML_ACTION(goAndSteal)
-        DEFINE_SML_ACTION(stealAndPull)
-        DEFINE_SML_SUB_FSM_UPDATE_ACTION(blockShot, MoveFSM)
+        const auto blockPass_A    = SMLAction<&ShadowEnemyFSM::blockPass>{this};
+        const auto goAndSteal_A   = SMLAction<&ShadowEnemyFSM::goAndSteal>{this};
+        const auto stealAndPull_A = SMLAction<&ShadowEnemyFSM::stealAndPull>{this};
+        const auto blockShot_A = SMLSubFSMUpdateAction<&ShadowEnemyFSM::blockShot>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/ai/hl/stp/tactic/shadow_enemy/shadow_enemy_fsm.h
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy/shadow_enemy_fsm.h
@@ -139,9 +139,10 @@ struct ShadowEnemyFSM : TacticFSM<ShadowEnemyFSM>
 
         DEFINE_SML_EVENT(Update)
 
-        DEFINE_SML_GUARD(enemyThreatHasBall)
-        DEFINE_SML_GUARD(contestedBall)
-        DEFINE_SML_GUARD(blockedShot)
+        const auto enemyThreatHasBall_G =
+            SMLGuard<&ShadowEnemyFSM::enemyThreatHasBall>{this};
+        const auto contestedBall_G = SMLGuard<&ShadowEnemyFSM::contestedBall>{this};
+        const auto blockedShot_G   = SMLGuard<&ShadowEnemyFSM::blockedShot>{this};
 
         DEFINE_SML_ACTION(blockPass)
         DEFINE_SML_ACTION(goAndSteal)

--- a/src/software/ai/hl/stp/tactic/shadow_enemy/shadow_enemy_fsm.h
+++ b/src/software/ai/hl/stp/tactic/shadow_enemy/shadow_enemy_fsm.h
@@ -132,12 +132,12 @@ struct ShadowEnemyFSM : TacticFSM<ShadowEnemyFSM>
     {
         using namespace boost::sml;
 
-        const auto MoveFSM_S = boost::sml::state<MoveFSM>;
-        const auto BlockPassState_S = boost::sml::state<BlockPassState>;
-        const auto GoAndStealState_S = boost::sml::state<GoAndStealState>;
-        const auto StealAndPullState_S = boost::sml::state<StealAndPullState>;
+        constexpr auto MoveFSM_S           = boost::sml::state<MoveFSM>;
+        constexpr auto BlockPassState_S    = boost::sml::state<BlockPassState>;
+        constexpr auto GoAndStealState_S   = boost::sml::state<GoAndStealState>;
+        constexpr auto StealAndPullState_S = boost::sml::state<StealAndPullState>;
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto enemyThreatHasBall_G =
             SMLGuard<&ShadowEnemyFSM::enemyThreatHasBall>{this};

--- a/src/software/ai/play_selection_fsm.h
+++ b/src/software/ai/play_selection_fsm.h
@@ -72,10 +72,13 @@ struct PlaySelectionFSM
         DEFINE_SML_STATE(Playing)
         DEFINE_SML_STATE(Stop)
 
-        DEFINE_SML_GUARD(gameStateStopped)
-        DEFINE_SML_GUARD(gameStateHalted)
-        DEFINE_SML_GUARD(gameStatePlaying)
-        DEFINE_SML_GUARD(gameStateSetupRestart)
+        const auto gameStateStopped_G =
+            SMLGuard<&PlaySelectionFSM::gameStateStopped>{this};
+        const auto gameStateHalted_G = SMLGuard<&PlaySelectionFSM::gameStateHalted>{this};
+        const auto gameStatePlaying_G =
+            SMLGuard<&PlaySelectionFSM::gameStatePlaying>{this};
+        const auto gameStateSetupRestart_G =
+            SMLGuard<&PlaySelectionFSM::gameStateSetupRestart>{this};
 
         DEFINE_SML_EVENT(Update)
 

--- a/src/software/ai/play_selection_fsm.h
+++ b/src/software/ai/play_selection_fsm.h
@@ -67,10 +67,10 @@ struct PlaySelectionFSM
     {
         using namespace boost::sml;
 
-        const auto SetPlay_S = boost::sml::state<SetPlay>;
-        const auto Halt_S = boost::sml::state<Halt>;
-        const auto Playing_S = boost::sml::state<Playing>;
-        const auto Stop_S = boost::sml::state<Stop>;
+        constexpr auto SetPlay_S = boost::sml::state<SetPlay>;
+        constexpr auto Halt_S    = boost::sml::state<Halt>;
+        constexpr auto Playing_S = boost::sml::state<Playing>;
+        constexpr auto Stop_S    = boost::sml::state<Stop>;
 
         const auto gameStateStopped_G =
             SMLGuard<&PlaySelectionFSM::gameStateStopped>{this};
@@ -80,7 +80,7 @@ struct PlaySelectionFSM
         const auto gameStateSetupRestart_G =
             SMLGuard<&PlaySelectionFSM::gameStateSetupRestart>{this};
 
-        const auto Update_E = boost::sml::event<Update>;
+        constexpr auto Update_E = boost::sml::event<Update>;
 
         const auto setupSetPlay_A  = SMLAction<&PlaySelectionFSM::setupSetPlay>{this};
         const auto setupStopPlay_A = SMLAction<&PlaySelectionFSM::setupStopPlay>{this};

--- a/src/software/ai/play_selection_fsm.h
+++ b/src/software/ai/play_selection_fsm.h
@@ -67,10 +67,10 @@ struct PlaySelectionFSM
     {
         using namespace boost::sml;
 
-        DEFINE_SML_STATE(SetPlay)
-        DEFINE_SML_STATE(Halt)
-        DEFINE_SML_STATE(Playing)
-        DEFINE_SML_STATE(Stop)
+        const auto SetPlay_S = boost::sml::state<SetPlay>;
+        const auto Halt_S = boost::sml::state<Halt>;
+        const auto Playing_S = boost::sml::state<Playing>;
+        const auto Stop_S = boost::sml::state<Stop>;
 
         const auto gameStateStopped_G =
             SMLGuard<&PlaySelectionFSM::gameStateStopped>{this};
@@ -80,13 +80,14 @@ struct PlaySelectionFSM
         const auto gameStateSetupRestart_G =
             SMLGuard<&PlaySelectionFSM::gameStateSetupRestart>{this};
 
-        DEFINE_SML_EVENT(Update)
+        const auto Update_E = boost::sml::event<Update>;
 
-        DEFINE_SML_ACTION(setupSetPlay)
-        DEFINE_SML_ACTION(setupStopPlay)
-        DEFINE_SML_ACTION(setupHaltPlay)
-        DEFINE_SML_ACTION(setupOffensePlay)
-        DEFINE_SML_ACTION(resetSetPlay)
+        const auto setupSetPlay_A  = SMLAction<&PlaySelectionFSM::setupSetPlay>{this};
+        const auto setupStopPlay_A = SMLAction<&PlaySelectionFSM::setupStopPlay>{this};
+        const auto setupHaltPlay_A = SMLAction<&PlaySelectionFSM::setupHaltPlay>{this};
+        const auto setupOffensePlay_A =
+            SMLAction<&PlaySelectionFSM::setupOffensePlay>{this};
+        const auto resetSetPlay_A = SMLAction<&PlaySelectionFSM::resetSetPlay>{this};
 
         return make_transition_table(
             // src_state + event [guard] / action = dest_state

--- a/src/software/util/sml_fsm/sml_fsm.h
+++ b/src/software/util/sml_fsm/sml_fsm.h
@@ -30,13 +30,60 @@ using FSM = boost::sml::sm<T, boost::sml::process_queue<std::queue>>;
  */
 #define DEFINE_SML_EVENT(EVENT) const auto EVENT##_E = boost::sml::event<EVENT>;
 
-/**
- * Defines lambda wrapper around a function that can be used as an SML guard
- *
- * @param FUNCTION The function to turn into a lambda
- */
 #define DEFINE_SML_GUARD(FUNCTION)                                                       \
-    const auto FUNCTION##_G = [this](auto event) { return FUNCTION(event); };
+const auto FUNCTION##_G = [this](auto event) { return FUNCTION(event); };
+
+/**
+ * Unimplemented stub. Doesn't expose type so that use will throw an error.
+ *
+ * @tparam T Any type
+ */
+template <typename T>
+struct SMLCallbackTraits;
+
+/**
+ * Specializes against callback functions meant for Boost::SML and exposes their trait typenames
+ * The three template values make up the declaration of a function.
+ * const variant below
+ *
+ * @tparam FSMClass The FSM class the function belongs to
+ * @tparam Ret The return value
+ * @tparam Event The type of event being processed.
+ */
+template<typename FSMClass, typename Ret, typename Event>
+struct SMLCallbackTraits<Ret (FSMClass::*)(const Event&)> {
+    using FSMType = FSMClass;
+    using EventType = Event;
+    using ReturnType = Ret;
+};
+template<typename FSMClass, typename Ret, typename Event>
+struct SMLCallbackTraits<Ret (FSMClass::*)(const Event&) const> {
+    using FSMType = FSMClass;
+    using EventType = Event;
+    using ReturnType = Ret;
+};
+
+/**
+ * Callable wrapper around FSM member function that can be used as an SML guard.
+ *
+ * @tparam GuardFn The function to turn into a guard.
+ */
+template <auto GuardFn>
+class SMLGuard
+{
+    using Traits = SMLCallbackTraits<decltype(GuardFn)>;
+    static_assert(std::is_same_v<typename Traits::ReturnType, bool>,
+                  "an SML guard must return bool");
+
+  public:
+    explicit SMLGuard(Traits::FSMType* fsm) : fsm_(fsm) {}
+    bool operator()(const Traits::EventType& event) const {
+        return (fsm_->*GuardFn)(event);
+    }
+  private:
+    Traits::FSMType* fsm_;
+};
+
 
 /**
  * Defines lambda wrapper around a function that can be used as an SML action

--- a/src/software/util/sml_fsm/sml_fsm.h
+++ b/src/software/util/sml_fsm/sml_fsm.h
@@ -30,9 +30,6 @@ using FSM = boost::sml::sm<T, boost::sml::process_queue<std::queue>>;
  */
 #define DEFINE_SML_EVENT(EVENT) const auto EVENT##_E = boost::sml::event<EVENT>;
 
-#define DEFINE_SML_GUARD(FUNCTION)                                                       \
-const auto FUNCTION##_G = [this](auto event) { return FUNCTION(event); };
-
 /**
  * Unimplemented stub. Doesn't expose type so that use will throw an error.
  *

--- a/src/software/util/sml_fsm/sml_fsm.h
+++ b/src/software/util/sml_fsm/sml_fsm.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <include/boost/sml.hpp>
 #include <queue>
+#include <type_traits>
 
 #include "software/util/typename/typename.h"
 
@@ -81,26 +82,68 @@ class SMLGuard
     Traits::FSMType* fsm_;
 };
 
-
 /**
- * Defines lambda wrapper around a function that can be used as an SML action
+ * Callable wrapper around FSM member function that can be used as an SML action.
  *
- * @param FUNCTION The function to turn into a lambda
+ * @tparam ActionFn The function to turn into an action.
  */
-#define DEFINE_SML_ACTION(FUNCTION)                                                      \
-    const auto FUNCTION##_A = [this](auto event) { FUNCTION(event); };
+template <auto ActionFn>
+class SMLAction
+{
+    using Traits = SMLCallbackTraits<decltype(ActionFn)>;
+    static_assert(std::is_void_v<typename Traits::ReturnType>,
+                  "an SML action must return void");
+
+public:
+    explicit SMLAction(Traits::FSMType* fsm) : fsm_(fsm) {}
+    void operator()(const Traits::EventType& event) const { (fsm_->*ActionFn)(event); }
+
+private:
+    Traits::FSMType* fsm_;
+};
 
 /**
- * Defines lambda wrapper around a function that can be used as an SML action for updating
+ * Specializes against callback functions meant for Boost::SML and exposes their trait typenames
+ * The three template values make up the declaration of a function.
+ * In particular, this class is for actions that utilize subFSMs.
+ *
+ * @tparam FSMClass The FSM class the function belongs to.
+ * @tparam Event The type of event from the FSM that must be processed.
+ * @tparam SubEvent The type of event from the subFSM that must be processed.
+ */
+template <typename FSMClass, typename Event, typename SubEvent>
+struct SMLCallbackTraits<void (FSMClass::*)(const Event&,
+                                            boost::sml::back::process<SubEvent>)>
+{
+    using FSMType      = FSMClass;
+    using EventType    = Event;
+    using SubEventType = SubEvent;
+    using ReturnType   = void;
+};
+
+/**
+ * Callable wrapper around FSM member function that can be used as an SML action for updating
  * a sub fsm
- *
- * @param FUNCTION The function to turn into a lambda
- * @param SUB_FSM The sub fsm to update
+ * @tparam ActionFn The function to turn into an subFSM update action.
  */
-#define DEFINE_SML_SUB_FSM_UPDATE_ACTION(FUNCTION, SUB_FSM)                              \
-    const auto FUNCTION##_A =                                                            \
-        [this](auto event, back::process<SUB_FSM::Update> processEvent)                  \
-    { FUNCTION(event, processEvent); };
+template <auto ActionFn>
+class SMLSubFSMUpdateAction
+{
+    using Traits = SMLCallbackTraits<decltype(ActionFn)>;
+
+public:
+    explicit SMLSubFSMUpdateAction(Traits::FSMType* fsm) : fsm_(fsm) {}
+
+    void operator()(
+        const Traits::EventType& event,
+        boost::sml::back::process<typename Traits::SubEventType> processEvent) const
+    {
+        (fsm_->*ActionFn)(event, processEvent);
+    }
+
+private:
+    Traits::FSMType* fsm_;
+};
 
 /**
  * Strips extraneous information such as boost::sml template information to return

--- a/src/software/util/sml_fsm/sml_fsm.h
+++ b/src/software/util/sml_fsm/sml_fsm.h
@@ -18,20 +18,6 @@ template <class T>
 using FSM = boost::sml::sm<T, boost::sml::process_queue<std::queue>>;
 
 /**
- * Defines an SML state wrapper around a class/struct
- *
- * @param STATE The state class/struct
- */
-#define DEFINE_SML_STATE(STATE) const auto STATE##_S = boost::sml::state<STATE>;
-
-/**
- * Defines an SML event wrapper around a class/struct
- *
- * @param EVENT The event class/struct
- */
-#define DEFINE_SML_EVENT(EVENT) const auto EVENT##_E = boost::sml::event<EVENT>;
-
-/**
  * Unimplemented stub. Doesn't expose type so that use will throw an error.
  *
  * @tparam T Any type
@@ -40,24 +26,26 @@ template <typename T>
 struct SMLCallbackTraits;
 
 /**
- * Specializes against callback functions meant for Boost::SML and exposes their trait typenames
- * The three template values make up the declaration of a function.
- * const variant below
+ * Specializes against callback functions meant for Boost::SML and exposes their trait
+ * typenames The three template values make up the declaration of a function. const
+ * variant below
  *
  * @tparam FSMClass The FSM class the function belongs to
  * @tparam Ret The return value
  * @tparam Event The type of event being processed.
  */
-template<typename FSMClass, typename Ret, typename Event>
-struct SMLCallbackTraits<Ret (FSMClass::*)(const Event&)> {
-    using FSMType = FSMClass;
-    using EventType = Event;
+template <typename FSMClass, typename Ret, typename Event>
+struct SMLCallbackTraits<Ret (FSMClass::*)(const Event&)>
+{
+    using FSMType    = FSMClass;
+    using EventType  = Event;
     using ReturnType = Ret;
 };
-template<typename FSMClass, typename Ret, typename Event>
-struct SMLCallbackTraits<Ret (FSMClass::*)(const Event&) const> {
-    using FSMType = FSMClass;
-    using EventType = Event;
+template <typename FSMClass, typename Ret, typename Event>
+struct SMLCallbackTraits<Ret (FSMClass::*)(const Event&) const>
+{
+    using FSMType    = FSMClass;
+    using EventType  = Event;
     using ReturnType = Ret;
 };
 
@@ -73,12 +61,14 @@ class SMLGuard
     static_assert(std::is_same_v<typename Traits::ReturnType, bool>,
                   "an SML guard must return bool");
 
-  public:
+   public:
     explicit SMLGuard(Traits::FSMType* fsm) : fsm_(fsm) {}
-    bool operator()(const Traits::EventType& event) const {
+    bool operator()(const Traits::EventType& event) const
+    {
         return (fsm_->*GuardFn)(event);
     }
-  private:
+
+   private:
     Traits::FSMType* fsm_;
 };
 
@@ -94,18 +84,21 @@ class SMLAction
     static_assert(std::is_void_v<typename Traits::ReturnType>,
                   "an SML action must return void");
 
-public:
+   public:
     explicit SMLAction(Traits::FSMType* fsm) : fsm_(fsm) {}
-    void operator()(const Traits::EventType& event) const { (fsm_->*ActionFn)(event); }
+    void operator()(const Traits::EventType& event) const
+    {
+        (fsm_->*ActionFn)(event);
+    }
 
-private:
+   private:
     Traits::FSMType* fsm_;
 };
 
 /**
- * Specializes against callback functions meant for Boost::SML and exposes their trait typenames
- * The three template values make up the declaration of a function.
- * In particular, this class is for actions that utilize subFSMs.
+ * Specializes against callback functions meant for Boost::SML and exposes their trait
+ * typenames The three template values make up the declaration of a function. In
+ * particular, this class is for actions that utilize subFSMs.
  *
  * @tparam FSMClass The FSM class the function belongs to.
  * @tparam Event The type of event from the FSM that must be processed.
@@ -122,8 +115,8 @@ struct SMLCallbackTraits<void (FSMClass::*)(const Event&,
 };
 
 /**
- * Callable wrapper around FSM member function that can be used as an SML action for updating
- * a sub fsm
+ * Callable wrapper around FSM member function that can be used as an SML action for
+ * updating a sub fsm
  * @tparam ActionFn The function to turn into an subFSM update action.
  */
 template <auto ActionFn>
@@ -131,7 +124,7 @@ class SMLSubFSMUpdateAction
 {
     using Traits = SMLCallbackTraits<decltype(ActionFn)>;
 
-public:
+   public:
     explicit SMLSubFSMUpdateAction(Traits::FSMType* fsm) : fsm_(fsm) {}
 
     void operator()(
@@ -141,7 +134,7 @@ public:
         (fsm_->*ActionFn)(event, processEvent);
     }
 
-private:
+   private:
     Traits::FSMType* fsm_;
 };
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description
There is a set of macros defined in `sml_fsm.h` that are supposed to make using Boost::SML a bit easier for members. While it does simplify the context, it obfuscates a lot of what's going on under the hood, and makes debugging and logging more difficult. 

This PR removes all of those macros and replaces them with what they actually represent, in the case of State and Event macros.
It also defines a series of template classes to wrap action and guard functions into functor classes while preserving their context, to make logging and debugging easier (see #3489 for the potential applications of this).

This is a direct improvement over the macro I defined in #3489.
<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done
Compiles, thunderscope runs.
<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review
Most of the changes are just replacing the macro with an object initialization.
Please look at `software/util/sml_fsm/sml_fsm.h`.
<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [x] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**: for example, those just used for testing
- [x] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->