### PR TITLE
Refactor MotorService: split poll() into helper functions

### DIFF
--- a/src/software/embedded/services/BUILD
+++ b/src/software/embedded/services/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "//software/physics:euclidean_to_wheel",
         "//software/util/scoped_timespec_timer",
         "@eigen",
+        "@tracy",
     ],
 )
 

--- a/src/software/embedded/services/motor.cpp
+++ b/src/software/embedded/services/motor.cpp
@@ -1,5 +1,7 @@
 #include "software/embedded/services/motor.h"
 
+#include <Tracy.hpp>
+
 #include "proto/tbots_software_msgs.pb.h"
 #include "software/embedded/motor_controller/stspin_motor_controller.h"
 #include "software/logger/logger.h"
@@ -12,6 +14,32 @@ MotorService::MotorService(const robot_constants::RobotConstants& robot_constant
       drive_motor_mps_per_rpm_(2 * M_PI * robot_constants.wheel_radius_meters / 60),
       num_tracked_motor_resets_(0)
 {
+}
+
+void MotorService::poll(const TbotsProto::DirectControlPrimitive& primitive,
+                        TbotsProto::RobotStatus& robot_status,
+                        const double time_elapsed_since_last_poll_s)
+{
+    ZoneNamedN(_tracy_motor_service_poll, "Thunderloop: Poll MotorService", true);
+
+    const auto poll_start = std::chrono::steady_clock::now();
+
+    resetMotorsIfNeeded();
+
+    const auto [current_wheel_velocities, dribbler_rpm] = driveMotors();
+
+    checkForMotorRunaway(current_wheel_velocities);
+
+    updateTargetVelocities(primitive, time_elapsed_since_last_poll_s);
+
+    updateMotorStatus(robot_status, current_wheel_velocities, dribbler_rpm);
+
+    const auto poll_end    = std::chrono::steady_clock::now();
+    using Millis           = std::chrono::duration<double, std::milli>;
+    const Millis poll_time = std::chrono::duration_cast<Millis>(poll_end - poll_start);
+
+    robot_status.mutable_thunderloop_status()->set_motor_service_poll_time_ms(
+        poll_time.count());
 }
 
 void MotorService::setup()
@@ -32,11 +60,143 @@ std::unique_ptr<MotorController> MotorService::setupMotorController()
     return std::make_unique<StSpinMotorController>(robot_constants_);
 }
 
-TbotsProto::MotorStatus MotorService::createMotorStatus(
-    const WheelSpace_t& current_wheel_velocities, const double dribbler_rpm) const
+void MotorService::resetMotorsIfNeeded()
+{
+    if (anyMotorRequiresReset())
+    {
+        LOG(INFO) << "Resetting motors due to fault indicators requiring reset";
+        trackMotorReset();
+        setup();
+    }
+}
+
+std::pair<WheelSpace_t, double> MotorService::driveMotors()
+{
+    const Eigen::Vector4<int> target_wheel_rpms =
+        (target_wheel_velocities_ / drive_motor_mps_per_rpm_).cast<int>();
+
+    const Eigen::Vector4<int> current_wheel_rpms = {
+        motor_controller_->readThenWriteVelocity(
+            MotorIndex::FRONT_RIGHT, target_wheel_rpms[FRONT_RIGHT_WHEEL_SPACE_INDEX]),
+        motor_controller_->readThenWriteVelocity(
+            MotorIndex::FRONT_LEFT, target_wheel_rpms[FRONT_LEFT_WHEEL_SPACE_INDEX]),
+        motor_controller_->readThenWriteVelocity(
+            MotorIndex::BACK_LEFT, target_wheel_rpms[BACK_LEFT_WHEEL_SPACE_INDEX]),
+        motor_controller_->readThenWriteVelocity(
+            MotorIndex::BACK_RIGHT, target_wheel_rpms[BACK_RIGHT_WHEEL_SPACE_INDEX]),
+    };
+
+    const double dribbler_rpm = motor_controller_->readThenWriteVelocity(
+        MotorIndex::DRIBBLER, dribbler_target_rpm_);
+
+    const WheelSpace_t current_wheel_velocities =
+        current_wheel_rpms.cast<double>() * drive_motor_mps_per_rpm_;
+
+    return {current_wheel_velocities, dribbler_rpm};
+}
+
+void MotorService::checkForMotorRunaway(const WheelSpace_t& current_wheel_velocities)
+{
+    if (std::abs(current_wheel_velocities[FRONT_RIGHT_WHEEL_SPACE_INDEX] -
+                 prev_wheel_velocities_[FRONT_RIGHT_WHEEL_SPACE_INDEX]) >
+        RUNAWAY_PROTECTION_THRESHOLD_MPS)
+    {
+        motor_controller_->immediatelyDisable();
+        LOG(FATAL) << "Front right motor runaway";
+    }
+    else if (std::abs(current_wheel_velocities[FRONT_LEFT_WHEEL_SPACE_INDEX] -
+                      prev_wheel_velocities_[FRONT_LEFT_WHEEL_SPACE_INDEX]) >
+             RUNAWAY_PROTECTION_THRESHOLD_MPS)
+    {
+        motor_controller_->immediatelyDisable();
+        LOG(FATAL) << "Front left motor runaway";
+    }
+    else if (std::abs(current_wheel_velocities[BACK_LEFT_WHEEL_SPACE_INDEX] -
+                      prev_wheel_velocities_[BACK_LEFT_WHEEL_SPACE_INDEX]) >
+             RUNAWAY_PROTECTION_THRESHOLD_MPS)
+    {
+        motor_controller_->immediatelyDisable();
+        LOG(FATAL) << "Back left motor runaway";
+    }
+    else if (std::abs(current_wheel_velocities[BACK_RIGHT_WHEEL_SPACE_INDEX] -
+                      prev_wheel_velocities_[BACK_RIGHT_WHEEL_SPACE_INDEX]) >
+             RUNAWAY_PROTECTION_THRESHOLD_MPS)
+    {
+        motor_controller_->immediatelyDisable();
+        LOG(FATAL) << "Back right motor runaway";
+    }
+}
+
+void MotorService::updateTargetVelocities(
+    const TbotsProto::DirectControlPrimitive& primitive,
+    const double time_elapsed_since_last_poll_s)
+{
+    const TbotsProto::MotorControl& motor_control = primitive.motor_control();
+
+    // Get target wheel velocities from the primitive
+    if (motor_control.has_direct_per_wheel_control())
+    {
+        const auto& direct_per_wheel = motor_control.direct_per_wheel_control();
+
+        target_wheel_velocities_ = {
+            direct_per_wheel.front_right_wheel_velocity(),
+            direct_per_wheel.front_left_wheel_velocity(),
+            direct_per_wheel.back_left_wheel_velocity(),
+            direct_per_wheel.back_right_wheel_velocity(),
+        };
+    }
+    else if (motor_control.has_direct_velocity_control())
+    {
+        const auto& direct_velocity = motor_control.direct_velocity_control();
+
+        const EuclideanSpace_t target_euclidean_velocity = {
+            direct_velocity.velocity().x_component_meters(),
+            direct_velocity.velocity().y_component_meters(),
+            direct_velocity.angular_velocity().radians_per_second()};
+
+        target_wheel_velocities_ =
+            euclidean_to_four_wheel_.getWheelVelocity(target_euclidean_velocity);
+    }
+
+    // Ramp the target velocities to keep acceleration compared to current velocities
+    // within safe bounds
+    target_wheel_velocities_ = euclidean_to_four_wheel_.rampWheelVelocity(
+        prev_wheel_velocities_, target_wheel_velocities_, time_elapsed_since_last_poll_s);
+
+    prev_wheel_velocities_ = target_wheel_velocities_;
+
+    // Get target dribbler rpm from the primitive
+    int target_dribbler_rpm;
+    if (motor_control.drive_control_case() ==
+        TbotsProto::MotorControl::DriveControlCase::DRIVE_CONTROL_NOT_SET)
+    {
+        target_dribbler_rpm = 0;
+    }
+    else
+    {
+        target_dribbler_rpm = motor_control.dribbler_speed_rpm();
+    }
+
+    // Ramp the dribbler velocity, clamping the max acceleration
+    int max_dribbler_delta_rpm = static_cast<int>(
+        DRIBBLER_ACCELERATION_THRESHOLD_RPM_PER_S_2 * time_elapsed_since_last_poll_s);
+    int delta_rpm = std::clamp(target_dribbler_rpm - dribbler_target_rpm_,
+                               -max_dribbler_delta_rpm, max_dribbler_delta_rpm);
+    dribbler_target_rpm_ += delta_rpm;
+
+    // Clamp to the max rpm
+    int max_dribbler_rpm = std::abs(robot_constants_.max_force_dribbler_speed_rpm);
+    dribbler_target_rpm_ =
+        std::clamp(dribbler_target_rpm_, -max_dribbler_rpm, max_dribbler_rpm);
+}
+
+void MotorService::updateMotorStatus(TbotsProto::RobotStatus& robot_status,
+                                     const WheelSpace_t& current_wheel_velocities,
+                                     const double dribbler_rpm)
 {
     TbotsProto::MotorStatus motor_status;
 
+    // Populate motor faults and current velocities
     for (const MotorIndex motor : reflective_enum::values<MotorIndex>())
     {
         const MotorFaultIndicator& motor_faults = motor_controller_->checkFaults(motor);
@@ -92,73 +252,7 @@ TbotsProto::MotorStatus MotorService::createMotorStatus(
     motor_status.mutable_back_right()->set_wheel_velocity(
         static_cast<float>(current_wheel_velocities[BACK_RIGHT_WHEEL_SPACE_INDEX]));
 
-    return motor_status;
-}
-
-void MotorService::poll(const TbotsProto::DirectControlPrimitive& primitive,
-                        TbotsProto::RobotStatus& robot_status,
-                        const double time_elapsed_since_last_poll_s)
-{
-    if (anyMotorRequiresReset())
-    {
-        LOG(INFO) << "Resetting motors due to fault indicators requiring reset";
-        trackMotorReset();
-        setup();
-    }
-
-    const Eigen::Vector4<int> target_wheel_rpms =
-        (target_wheel_velocities_ / drive_motor_mps_per_rpm_).cast<int>();
-
-    const Eigen::Vector4<int> current_wheel_rpms = {
-        motor_controller_->readThenWriteVelocity(
-            MotorIndex::FRONT_RIGHT, target_wheel_rpms[FRONT_RIGHT_WHEEL_SPACE_INDEX]),
-        motor_controller_->readThenWriteVelocity(
-            MotorIndex::FRONT_LEFT, target_wheel_rpms[FRONT_LEFT_WHEEL_SPACE_INDEX]),
-        motor_controller_->readThenWriteVelocity(
-            MotorIndex::BACK_LEFT, target_wheel_rpms[BACK_LEFT_WHEEL_SPACE_INDEX]),
-        motor_controller_->readThenWriteVelocity(
-            MotorIndex::BACK_RIGHT, target_wheel_rpms[BACK_RIGHT_WHEEL_SPACE_INDEX]),
-    };
-
-    const double dribbler_rpm = motor_controller_->readThenWriteVelocity(
-        MotorIndex::DRIBBLER, dribbler_target_rpm_);
-
-    const WheelSpace_t current_wheel_velocities =
-        current_wheel_rpms.cast<double>() * drive_motor_mps_per_rpm_;
-
-    TbotsProto::MotorStatus motor_status =
-        createMotorStatus(current_wheel_velocities, dribbler_rpm);
-
-    if (std::abs(current_wheel_velocities[FRONT_RIGHT_WHEEL_SPACE_INDEX] -
-                 prev_wheel_velocities_[FRONT_RIGHT_WHEEL_SPACE_INDEX]) >
-        RUNAWAY_PROTECTION_THRESHOLD_MPS)
-    {
-        motor_controller_->immediatelyDisable();
-        LOG(FATAL) << "Front right motor runaway";
-    }
-    else if (std::abs(current_wheel_velocities[FRONT_LEFT_WHEEL_SPACE_INDEX] -
-                      prev_wheel_velocities_[FRONT_LEFT_WHEEL_SPACE_INDEX]) >
-             RUNAWAY_PROTECTION_THRESHOLD_MPS)
-    {
-        motor_controller_->immediatelyDisable();
-        LOG(FATAL) << "Front left motor runaway";
-    }
-    else if (std::abs(current_wheel_velocities[BACK_LEFT_WHEEL_SPACE_INDEX] -
-                      prev_wheel_velocities_[BACK_LEFT_WHEEL_SPACE_INDEX]) >
-             RUNAWAY_PROTECTION_THRESHOLD_MPS)
-    {
-        motor_controller_->immediatelyDisable();
-        LOG(FATAL) << "Back left motor runaway";
-    }
-    else if (std::abs(current_wheel_velocities[BACK_RIGHT_WHEEL_SPACE_INDEX] -
-                      prev_wheel_velocities_[BACK_RIGHT_WHEEL_SPACE_INDEX]) >
-             RUNAWAY_PROTECTION_THRESHOLD_MPS)
-    {
-        motor_controller_->immediatelyDisable();
-        LOG(FATAL) << "Back right motor runaway";
-    }
-
-    // Convert to Euclidean velocity_delta
+    // Convert to Euclidean velocity
     const EuclideanSpace_t current_euclidean_velocity =
         euclidean_to_four_wheel_.getEuclideanVelocity(current_wheel_velocities);
 
@@ -169,38 +263,6 @@ void MotorService::poll(const TbotsProto::DirectControlPrimitive& primitive,
     motor_status.mutable_angular_velocity()->set_radians_per_second(
         current_euclidean_velocity[2]);
 
-    const TbotsProto::MotorControl& motor_control = primitive.motor_control();
-
-    // Get target wheel velocities from the primitive
-    if (motor_control.has_direct_per_wheel_control())
-    {
-        const auto& direct_per_wheel = motor_control.direct_per_wheel_control();
-
-        target_wheel_velocities_ = {
-            direct_per_wheel.front_right_wheel_velocity(),
-            direct_per_wheel.front_left_wheel_velocity(),
-            direct_per_wheel.back_left_wheel_velocity(),
-            direct_per_wheel.back_right_wheel_velocity(),
-        };
-    }
-    else if (motor_control.has_direct_velocity_control())
-    {
-        const auto& direct_velocity = motor_control.direct_velocity_control();
-
-        const EuclideanSpace_t target_euclidean_velocity = {
-            direct_velocity.velocity().x_component_meters(),
-            direct_velocity.velocity().y_component_meters(),
-            direct_velocity.angular_velocity().radians_per_second()};
-
-        target_wheel_velocities_ =
-            euclidean_to_four_wheel_.getWheelVelocity(target_euclidean_velocity);
-    }
-
-    // Ramp the target velocities to keep acceleration compared to current velocities
-    // within safe bounds
-    target_wheel_velocities_ = euclidean_to_four_wheel_.rampWheelVelocity(
-        prev_wheel_velocities_, target_wheel_velocities_, time_elapsed_since_last_poll_s);
-
     const EuclideanSpace_t target_euclidean_velocity =
         euclidean_to_four_wheel_.getEuclideanVelocity(target_wheel_velocities_);
 
@@ -210,33 +272,6 @@ void MotorService::poll(const TbotsProto::DirectControlPrimitive& primitive,
         target_euclidean_velocity[1]);
     motor_status.mutable_target_angular_velocity()->set_radians_per_second(
         target_euclidean_velocity[2]);
-
-    prev_wheel_velocities_ = target_wheel_velocities_;
-
-    // Get target dribbler rpm from the primitive
-    int target_dribbler_rpm;
-    if (motor_control.drive_control_case() ==
-        TbotsProto::MotorControl::DriveControlCase::DRIVE_CONTROL_NOT_SET)
-    {
-        target_dribbler_rpm = 0;
-    }
-    else
-    {
-        target_dribbler_rpm = motor_control.dribbler_speed_rpm();
-    }
-
-    // Ramp the dribbler velocity
-    // Clamp the max acceleration
-    int max_dribbler_delta_rpm = static_cast<int>(
-        DRIBBLER_ACCELERATION_THRESHOLD_RPM_PER_S_2 * time_elapsed_since_last_poll_s);
-    int delta_rpm = std::clamp(target_dribbler_rpm - dribbler_target_rpm_,
-                               -max_dribbler_delta_rpm, max_dribbler_delta_rpm);
-    dribbler_target_rpm_ += delta_rpm;
-
-    // Clamp to the max rpm
-    int max_dribbler_rpm = std::abs(robot_constants_.max_force_dribbler_speed_rpm);
-    dribbler_target_rpm_ =
-        std::clamp(dribbler_target_rpm_, -max_dribbler_rpm, max_dribbler_rpm);
 
     motor_status.mutable_dribbler()->set_dribbler_rpm(
         static_cast<float>(dribbler_target_rpm_));

--- a/src/software/embedded/services/motor.h
+++ b/src/software/embedded/services/motor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "proto/robot_status_msg.pb.h"
 #include "proto/tbots_software_msgs.pb.h"
@@ -10,18 +11,19 @@
 #include "software/physics/euclidean_to_wheel.h"
 
 /**
- * A service that interacts with the motors.
+ * A service that drives the robot's four wheel motors (and dribbler depending
+ * on the robot model).
  *
  * It is responsible for:
  * - Converting Euclidean velocities to wheel velocities
- * - Communicating with the motor
+ * - Communicating with the motor driver boards
  * - Detecting and handling faults
  */
 class MotorService
 {
    public:
     /**
-     * Service that interacts with the motors.
+     * Constructs a new MotorService.
      *
      * @param robot_constants The robot constants
      */
@@ -51,24 +53,55 @@ class MotorService
 
    private:
     /**
+     * Resets the motors if any of them reports a fault that requires a reset.
+     */
+    void resetMotorsIfNeeded();
+
+    /**
+     * Writes the target velocities to the motors and reads back the current velocities.
+     *
+     * @return the current wheel velocities in m/s and the dribbler RPM read from the
+     * dribbler motor
+     */
+    std::pair<WheelSpace_t, double> driveMotors();
+
+    /**
+     * Disables the motors and halts Thunderloop if any wheel velocity has changed by
+     * more than the runaway protection threshold since the previous step.
+     *
+     * @param current_wheel_velocities the current wheel velocities in m/s
+     */
+    void checkForMotorRunaway(const WheelSpace_t& current_wheel_velocities);
+
+    /**
+     * Updates the target wheel velocities and dribbler RPM from the primitive, ramping
+     * them toward the commanded values to respect acceleration limits.
+     *
+     * @param primitive DirectControlPrimitive to execute
+     * @param time_elapsed_since_last_poll_s The time since the last poll in seconds
+     */
+    void updateTargetVelocities(const TbotsProto::DirectControlPrimitive& primitive,
+                                double time_elapsed_since_last_poll_s);
+
+    /**
+     * Builds the motor status (motor faults, current and target velocities, and dribbler
+     * RPM) and assigns it to robot_status.
+     *
+     * @param robot_status RobotStatus message to modify with the current motor status
+     * @param current_wheel_velocities the current wheel velocities in m/s
+     * @param dribbler_rpm the current dribbler RPM read from the dribbler motor
+     */
+    void updateMotorStatus(TbotsProto::RobotStatus& robot_status,
+                           const WheelSpace_t& current_wheel_velocities,
+                           double dribbler_rpm);
+
+    /**
      * Creates a motor controller based on the motor board type specified at compile time.
      *
      * @return the instantiated motor controller implementation corresponding to the
      * motor board type specified at compile time
      */
     std::unique_ptr<MotorController> setupMotorController();
-
-    /**
-     * Return a MotorStatus proto filled with motor velocities and faults.
-     *
-     * @param current_wheel_velocities  the current wheel velocities in m/s
-     * @param dribbler_rpm             the dribbler motor's rotations per minute
-     *
-     * @return a MotorStatus proto with the velocity of each motor as well as their fault
-     * statuses (some faults may be cached)
-     */
-    TbotsProto::MotorStatus createMotorStatus(
-        const WheelSpace_t& current_wheel_velocities, double dribbler_rpm) const;
 
     /**
      * Tracks that a motor reset occurred just now.


### PR DESCRIPTION
Break the monolithic poll() into resetMotorsIfNeeded(), driveMotors(), checkForMotorRunaway(), updateTargetVelocities(), and updateMotorStatus().