### PR TITLE
Add ER-Force simulator realism options from upstream

### DIFF
--- a/src/extlibs/er_force_sim/src/amun/simulator/simrobot.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simrobot.cpp
@@ -527,9 +527,14 @@ void SimRobot::begin(SimBall& ball, double time)
     const float K_I_phi = /*0*0.2/1000; //*/ 0.f;
 
     const float a_phi = V_phi * omega + K_phi * error_omega + K_I_phi * m_error_sum_omega;
-    const float a_phi_bound =
-        bound(a_phi, omega, accelScale * m_specs.strategy().a_speedup_phi_max(),
-              accelScale * m_specs.strategy().a_brake_phi_max());
+
+    // A real robot does not drive perfectly straight; simulate that by turning part of
+    // the forward acceleration into rotational acceleration
+    const float a_phi_with_error = a_phi + m_rotationError * a_f;
+
+    const float a_phi_bound = bound(a_phi_with_error, omega,
+                                    accelScale * m_specs.strategy().a_speedup_phi_max(),
+                                    accelScale * m_specs.strategy().a_brake_phi_max());
     const btVector3 torque(0, 0, a_phi_bound * 0.007884f);
 
     if (force.length2() > 0 || torque.length2() > 0)

--- a/src/extlibs/er_force_sim/src/amun/simulator/simrobot.h
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simrobot.h
@@ -82,6 +82,17 @@ class camun::simulator::SimRobot
 
     void stopDribbling();
 
+    /**
+     * Sets how much the robot deviates from driving straight, as a fraction of its
+     * forward acceleration that is applied as rotational acceleration
+     *
+     * @param error the rotation error
+     */
+    void setRotationError(float error)
+    {
+        m_rotationError = error;
+    }
+
     const robot::Specs& specs() const
     {
         return m_specs;
@@ -130,6 +141,7 @@ class camun::simulator::SimRobot
     float m_error_sum_omega;
 
     bool m_perfectDribbler = false;
+    float m_rotationError  = 0.0f;
 
     int64_t m_lastSendTime = 0;
 };

--- a/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp
@@ -21,6 +21,7 @@
 #include "simulator.h"
 
 #include <algorithm>
+#include <array>
 #include <functional>
 
 #include "extlibs/er_force_sim/src/core/coordinates.h"
@@ -67,20 +68,25 @@ Simulator::Simulator(const amun::SimulatorSetup& setup)
     m_data->field = std::make_unique<SimField>(m_data->dynamicsWorld, m_data->geometry);
     m_data->ball  = std::make_shared<SimBall>(m_data->dynamicsWorld);
     m_data->flip  = false;
-    m_data->stddevBall               = 0.0f;
-    m_data->stddevBallArea           = 0.0f;
-    m_data->stddevRobot              = 0.0f;
-    m_data->stddevRobotPhi           = 0.0f;
-    m_data->ballDetectionsAtDribbler = 0.0f;
-    m_data->enableInvisibleBall      = true;
-    m_data->ballVisibilityThreshold  = 0.4;
-    m_data->cameraOverlap            = 0.3;
-    m_data->cameraPositionError      = 0;
-    m_data->objectPositionOffset     = 0;
-    m_data->robotCommandPacketLoss   = 0;
-    m_data->robotReplyPacketLoss     = 0;
-    m_data->missingBallDetections    = 0;
-    m_data->dribblePerfect           = false;
+    m_data->stddevBall                  = 0.0f;
+    m_data->stddevBallArea              = 0.0f;
+    m_data->stddevRobot                 = 0.0f;
+    m_data->stddevRobotPhi              = 0.0f;
+    m_data->ballDetectionsAtDribbler    = 0.0f;
+    m_data->enableInvisibleBall         = true;
+    m_data->ballVisibilityThreshold     = 0.4;
+    m_data->cameraOverlap               = 0.3;
+    m_data->cameraPositionError         = 0;
+    m_data->objectPositionOffset        = 0;
+    m_data->robotCommandPacketLoss      = 0;
+    m_data->robotReplyPacketLoss        = 0;
+    m_data->missingBallDetections       = 0;
+    m_data->dribblePerfect              = false;
+    m_data->missingRobotDetections      = 0;
+    m_data->commandDelay                = 0;
+    m_data->robotRotationError          = 0;
+    m_data->rotatedRobotDetectionsStart = 0;
+    m_data->rotatedRobotDetectionsStop  = 0;
 
     // no robots after initialisation
 }
@@ -98,6 +104,38 @@ std::vector<robot::RadioResponse> Simulator::acceptYellowRobotControlCommand(
 }
 
 std::vector<robot::RadioResponse> Simulator::acceptRobotControlCommand(
+    const SSLSimulationProto::RobotControl& control, bool isBlue)
+{
+    auto& pendingCommands = isBlue ? m_blueRadioCommands : m_yellowRadioCommands;
+
+    if (m_data->commandDelay <= 0 && pendingCommands.empty())
+    {
+        return applyRobotControlCommand(control, isBlue);
+    }
+
+    // The robots only receive the command after the command delay has passed. Note
+    // that the radio responses of a command are reported when it is applied, so they
+    // are delayed by the same amount.
+    pendingCommands.emplace_back(control, m_time);
+
+    std::vector<robot::RadioResponse> responses;
+    while (!pendingCommands.empty() &&
+           pendingCommands.front().second + m_data->commandDelay <= m_time)
+    {
+        const SSLSimulationProto::RobotControl pendingControl =
+            pendingCommands.front().first;
+        pendingCommands.pop_front();
+
+        const std::vector<robot::RadioResponse> pendingResponses =
+            applyRobotControlCommand(pendingControl, isBlue);
+        responses.insert(responses.end(), pendingResponses.begin(),
+                         pendingResponses.end());
+    }
+
+    return responses;
+}
+
+std::vector<robot::RadioResponse> Simulator::applyRobotControlCommand(
     const SSLSimulationProto::RobotControl& control, bool isBlue)
 {
     // collect responses from robots
@@ -146,7 +184,7 @@ void Simulator::resetFlipped(Simulator::RobotMap& robots, float side)
         {
             robot = std::make_unique<SimRobot>(robot->specs(), m_data->dynamicsWorld,
                                                btVector3(x, side * y, 0), 0.0f);
-            robot->setDribbleMode(m_data->dribblePerfect);
+            applyRobotRealism(*robot);
         }
         y -= 0.3;
     }
@@ -243,6 +281,126 @@ static btVector3 positionOffsetForCamera(float offsetStrength, btVector3 cameraP
     return btVector3(cameraPos.x(), cameraPos.y(), 0).normalized() * offsetStrength;
 }
 
+uint32_t Simulator::getRotatedRobotId(uint32_t id)
+{
+    // pink is 0, green is 1, starting from the top left side (dribbler is up) as the
+    // most significant bit, going clockwise to the least significant bit
+    static constexpr std::array<uint32_t, 16> PATTERNS = {
+        0b0001,  // 0
+        0b1001,  // 1
+        0b1101,  // 2
+        0b0101,  // 3
+        0b0010,  // 4
+        0b1010,  // 5
+        0b1110,  // 6
+        0b0110,  // 7
+        0b1111,  // 8
+        0b0000,  // 9
+        0b0011,  // 10
+        0b1100,  // 11
+        0b1011,  // 12
+        0b1000,  // 13
+        0b0111,  // 14
+        0b0100,  // 15
+    };
+
+    if (id >= PATTERNS.size())
+    {
+        return id;
+    }
+
+    const uint32_t pattern        = PATTERNS[id];
+    const uint32_t rotatedPattern = (pattern >> 1) | ((pattern << 3) & 0b1000);
+    const auto it = std::find(PATTERNS.begin(), PATTERNS.end(), rotatedPattern);
+    return static_cast<uint32_t>(std::distance(PATTERNS.begin(), it));
+}
+
+void Simulator::createRobotDetection(
+    SimRobot& robot, bool teamIsBlue,
+    std::vector<SSLProto::SSL_DetectionFrame>& detections)
+{
+    if (m_time - robot.getLastSendTime() < m_minRobotDetectionTime)
+    {
+        return;
+    }
+
+    const float timeDiff     = (m_time - robot.getLastSendTime()) * 1E-9;
+    const btVector3 robotPos = robot.position() / SIMULATOR_SCALE;
+
+    const std::size_t numCameras = m_data->reportedCameraSetup.size();
+    for (std::size_t cameraId = 0; cameraId < numCameras; ++cameraId)
+    {
+        if (!checkCameraID(cameraId, robotPos, m_data->cameraPositions,
+                           m_data->cameraOverlap))
+        {
+            continue;
+        }
+
+        const btVector3& cameraPos = m_data->cameraPositions[cameraId];
+        const btVector3 positionOffset =
+            positionOffsetForCamera(m_data->objectPositionOffset, cameraPos);
+        auto& cameraDetections = detections[cameraId];
+
+        const bool missingRobot =
+            m_data->missingRobotDetections > 0 &&
+            m_data->rng.uniformFloat(0, 1) <= m_data->missingRobotDetections;
+        if (!missingRobot)
+        {
+            auto& robotDetection = teamIsBlue ? *cameraDetections.add_robots_blue()
+                                              : *cameraDetections.add_robots_yellow();
+            robot.update(robotDetection, m_data->stddevRobot, m_data->stddevRobotPhi,
+                         m_time, positionOffset);
+        }
+
+        // Once in a while the vision misreads a robot's pattern as the one that it
+        // turns into when rotated by 90 degrees, and reports that second robot on top
+        // of the real one. Such a misdetection tends to persist for a few frames, so
+        // whether it starts and whether it stops are rolled separately.
+        const auto rotatedDetectionKey =
+            std::make_tuple(cameraId, robot.specs().id(), teamIsBlue);
+        const bool hadRotated        = m_hasRotatedDetection[rotatedDetectionKey];
+        const float rotatedThreshold = hadRotated
+                                           ? (1 - m_data->rotatedRobotDetectionsStop)
+                                           : m_data->rotatedRobotDetectionsStart;
+        const bool hasRotated        = m_data->rng.uniformFloat(0, 1) < rotatedThreshold;
+        m_hasRotatedDetection[rotatedDetectionKey] = hasRotated;
+
+        if (hasRotated)
+        {
+            auto& rotatedDetection = teamIsBlue ? *cameraDetections.add_robots_blue()
+                                                : *cameraDetections.add_robots_yellow();
+            robot.update(rotatedDetection, m_data->stddevRobot, m_data->stddevRobotPhi,
+                         m_time, positionOffset);
+            rotatedDetection.set_robot_id(getRotatedRobotId(rotatedDetection.robot_id()));
+            rotatedDetection.set_orientation(rotatedDetection.orientation() + M_PI_2);
+        }
+
+        // once in a while, add a ball mis-detection at a corner of the dribbler
+        // in real games, this happens because the ball detection light beam used by
+        // many teams is red
+        const float detectionProb = timeDiff * m_data->ballDetectionsAtDribbler;
+        if (m_data->ballDetectionsAtDribbler > 0 &&
+            m_data->rng.uniformFloat(0, 1) < detectionProb)
+        {
+            // always on the right side of the dribbler for now
+            if (!m_data->ball->addDetection(*cameraDetections.add_balls(),
+                                            robot.dribblerCorner(false) / SIMULATOR_SCALE,
+                                            m_data->stddevRobot, 0, cameraPos, false, 0,
+                                            positionOffset))
+            {
+                cameraDetections.mutable_balls()->DeleteSubrange(
+                    cameraDetections.balls_size() - 1, 1);
+            }
+        }
+    }
+}
+
+void Simulator::applyRobotRealism(SimRobot& robot) const
+{
+    robot.setDribbleMode(m_data->dribblePerfect);
+    robot.setRotationError(m_data->robotRotationError);
+}
+
 std::vector<SSLProto::SSL_WrapperPacket> Simulator::getWrapperPackets()
 {
     const std::size_t numCameras = m_data->reportedCameraSetup.size();
@@ -253,10 +411,8 @@ std::vector<SSLProto::SSL_WrapperPacket> Simulator::getWrapperPackets()
         initializeDetection(detections[i], i);
     }
 
-    bool missingBall = m_data->missingBallDetections > 0 &&
-                       m_data->rng.uniformFloat(0, 1) <= m_data->missingBallDetections;
     const btVector3 ballPosition = m_data->ball->position() / SIMULATOR_SCALE;
-    if (m_time - m_lastBallSendTime >= m_minBallDetectionTime && !missingBall)
+    if (m_time - m_lastBallSendTime >= m_minBallDetectionTime)
     {
         m_lastBallSendTime = m_time;
 
@@ -265,6 +421,16 @@ std::vector<SSLProto::SSL_WrapperPacket> Simulator::getWrapperPackets()
             // at least one id is always valid
             if (!checkCameraID(cameraId, ballPosition, m_data->cameraPositions,
                                m_data->cameraOverlap))
+            {
+                continue;
+            }
+
+            // the ball is missed by each camera individually, rather than by all of
+            // them at once, which is what the real vision does
+            const bool missingBall =
+                m_data->missingBallDetections > 0 &&
+                m_data->rng.uniformFloat(0, 1) <= m_data->missingBallDetections;
+            if (missingBall)
             {
                 continue;
             }
@@ -291,54 +457,7 @@ std::vector<SSLProto::SSL_WrapperPacket> Simulator::getWrapperPackets()
     {
         for (auto& [robotId, robot] : team)
         {
-            if (m_time - robot->getLastSendTime() >= m_minRobotDetectionTime)
-            {
-                const float timeDiff     = (m_time - robot->getLastSendTime()) * 1E-9;
-                const btVector3 robotPos = robot->position() / SIMULATOR_SCALE;
-
-                for (std::size_t cameraId = 0; cameraId < numCameras; ++cameraId)
-                {
-                    if (!checkCameraID(cameraId, robotPos, m_data->cameraPositions,
-                                       m_data->cameraOverlap))
-                    {
-                        continue;
-                    }
-
-                    const btVector3 positionOffset = positionOffsetForCamera(
-                        m_data->objectPositionOffset, m_data->cameraPositions[cameraId]);
-                    if (teamIsBlue)
-                    {
-                        robot->update(*detections[cameraId].add_robots_blue(),
-                                      m_data->stddevRobot, m_data->stddevRobotPhi, m_time,
-                                      positionOffset);
-                    }
-                    else
-                    {
-                        robot->update(*detections[cameraId].add_robots_yellow(),
-                                      m_data->stddevRobot, m_data->stddevRobotPhi, m_time,
-                                      positionOffset);
-                    }
-
-                    // once in a while, add a ball mis-detection at a corner of the
-                    // dribbler in real games, this happens because the ball detection
-                    // light beam used by many teams is red
-                    float detectionProb = timeDiff * m_data->ballDetectionsAtDribbler;
-                    if (m_data->ballDetectionsAtDribbler > 0 &&
-                        m_data->rng.uniformFloat(0, 1) < detectionProb)
-                    {
-                        // always on the right side of the dribbler for now
-                        if (!m_data->ball->addDetection(
-                                *detections[cameraId].add_balls(),
-                                robot->dribblerCorner(false) / SIMULATOR_SCALE,
-                                m_data->stddevRobot, 0, m_data->cameraPositions[cameraId],
-                                false, 0, positionOffset))
-                        {
-                            detections[cameraId].mutable_balls()->DeleteSubrange(
-                                detections[cameraId].balls_size() - 1, 1);
-                        }
-                    }
-                }
-            }
+            createRobotDetection(*robot, teamIsBlue, detections);
         }
     }
 
@@ -472,7 +591,7 @@ void Simulator::setTeam(Simulator::RobotMap& robotMap, float side,
 
         robotMap[id] = std::make_unique<SimRobot>(teamSpecs[id], m_data->dynamicsWorld,
                                                   btVector3(x, side * y, 0), 0.f);
-        robotMap[id]->setDribbleMode(m_data->dribblePerfect);
+        applyRobotRealism(*robotMap[id]);
 
         y -= 0.3;
     }
@@ -557,7 +676,7 @@ void Simulator::moveRobot(const sslsim::TeleportRobot& robot)
                 robotMap[robot.id().id()] = std::make_unique<SimRobot>(
                     teamSpecs[robot.id().id()], m_data->dynamicsWorld,
                     btVector3(targetPos.x, targetPos.y, 0), 0.f);
-                robotMap[robot.id().id()]->setDribbleMode(m_data->dribblePerfect);
+                applyRobotRealism(*robotMap[robot.id().id()]);
             }
         }
         else if (!robot.present() && isPresent)
@@ -602,7 +721,7 @@ void Simulator::moveRobot(const sslsim::TeleportRobot& robot)
 
 void Simulator::handleSimulatorSetupCommand(const std::unique_ptr<amun::Command>& command)
 {
-    bool teamOrPerfectDribbleChanged = false;
+    bool robotRealismChanged = false;
 
     if (command->has_simulator())
     {
@@ -695,8 +814,36 @@ void Simulator::handleSimulatorSetupCommand(const std::unique_ptr<amun::Command>
 
             if (realism.has_simulate_dribbling())
             {
-                m_data->dribblePerfect      = !realism.simulate_dribbling();
-                teamOrPerfectDribbleChanged = true;
+                m_data->dribblePerfect = !realism.simulate_dribbling();
+                robotRealismChanged    = true;
+            }
+
+            if (realism.has_missing_robot_detections())
+            {
+                m_data->missingRobotDetections = realism.missing_robot_detections();
+            }
+
+            if (realism.has_command_delay())
+            {
+                m_data->commandDelay = std::max<int64_t>(0l, realism.command_delay());
+            }
+
+            if (realism.has_robot_rotation_error())
+            {
+                m_data->robotRotationError = realism.robot_rotation_error();
+                robotRealismChanged        = true;
+            }
+
+            if (realism.has_rotated_robot_detections_start())
+            {
+                m_data->rotatedRobotDetectionsStart =
+                    realism.rotated_robot_detections_start();
+            }
+
+            if (realism.has_rotated_robot_detections_stop())
+            {
+                m_data->rotatedRobotDetectionsStop =
+                    realism.rotated_robot_detections_stop();
             }
         }
 
@@ -759,26 +906,26 @@ void Simulator::handleSimulatorSetupCommand(const std::unique_ptr<amun::Command>
 
     if (command->has_set_team_blue())
     {
-        teamOrPerfectDribbleChanged = true;
+        robotRealismChanged = true;
         setTeam(m_data->robotsBlue, 1.0f, command->set_team_blue(), m_data->specsBlue);
     }
 
     if (command->has_set_team_yellow())
     {
-        teamOrPerfectDribbleChanged = true;
+        robotRealismChanged = true;
         setTeam(m_data->robotsYellow, -1.0f, command->set_team_yellow(),
                 m_data->specsYellow);
     }
 
-    if (teamOrPerfectDribbleChanged)
+    if (robotRealismChanged)
     {
         for (auto& [robotId, robot] : m_data->robotsBlue)
         {
-            robot->setDribbleMode(m_data->dribblePerfect);
+            applyRobotRealism(*robot);
         }
         for (auto& [robotId, robot] : m_data->robotsYellow)
         {
-            robot->setDribbleMode(m_data->dribblePerfect);
+            applyRobotRealism(*robot);
         }
     }
 }

--- a/src/extlibs/er_force_sim/src/amun/simulator/simulator.h
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simulator.h
@@ -21,6 +21,8 @@
 #ifndef SIMULATOR_H
 #define SIMULATOR_H
 
+#include <deque>
+#include <map>
 #include <memory>
 #include <random>
 #include <utility>
@@ -120,6 +122,47 @@ class camun::simulator::Simulator
     std::vector<robot::RadioResponse> acceptRobotControlCommand(
         const SSLSimulationProto::RobotControl& control, bool isBlue);
 
+    /**
+     * Passes a robot control command on to the robots it addresses, without any
+     * command delay
+     *
+     * @param control the robot control command
+     * @param isBlue whether it's blue robots or not
+     *
+     * @return the radio response feedback from the simulator
+     */
+    std::vector<robot::RadioResponse> applyRobotControlCommand(
+        const SSLSimulationProto::RobotControl& control, bool isBlue);
+
+    /**
+     * Adds the detections of a single robot to the given detection frames, simulating
+     * missing and rotated detections as configured
+     *
+     * @param robot the robot to create detections for
+     * @param teamIsBlue whether the robot is on the blue team
+     * @param detections the detection frame of each camera, to add the detections to
+     */
+    void createRobotDetection(SimRobot& robot, bool teamIsBlue,
+                              std::vector<SSLProto::SSL_DetectionFrame>& detections);
+
+    /**
+     * Returns the id of the robot pattern that the given pattern turns into when it is
+     * rotated by 90 degrees clockwise
+     *
+     * @param id the robot id to rotate
+     *
+     * @return the rotated robot id
+     */
+    static uint32_t getRotatedRobotId(uint32_t id);
+
+    /**
+     * Applies the configured realism settings that are stored on the robots themselves
+     * to the given robot. Has to be called for every newly created robot.
+     *
+     * @param robot the robot to configure
+     */
+    void applyRobotRealism(SimRobot& robot) const;
+
     void resetFlipped(RobotMap& robots, float side);
     void setTeam(RobotMap& list, float side, const robot::Team& team,
                  std::map<uint32_t, robot::Specs>& specs);
@@ -141,6 +184,16 @@ class camun::simulator::Simulator
     int64_t m_lastBallSendTime      = 0;
 
     std::map<size_t, unsigned int> m_lastFrameNumber;
+
+    // robot control commands that have been received but are not applied yet, together
+    // with the time they were received at. Only used when a command delay is configured.
+    std::deque<std::pair<SSLSimulationProto::RobotControl, int64_t>> m_blueRadioCommands;
+    std::deque<std::pair<SSLSimulationProto::RobotControl, int64_t>>
+        m_yellowRadioCommands;
+
+    // (camera id, robot id, robot is blue) -> the robot had a rotated detection in the
+    // last frame
+    std::map<std::tuple<size_t, unsigned int, bool>, bool> m_hasRotatedDetection;
 
     std::mt19937 rand_shuffle_src = std::mt19937(std::random_device()());
 };
@@ -204,6 +257,11 @@ struct camun::simulator::SimulatorData
     float robotReplyPacketLoss;
     float missingBallDetections;
     bool dribblePerfect;
+    float missingRobotDetections;
+    int64_t commandDelay;
+    float robotRotationError;
+    float rotatedRobotDetectionsStart;
+    float rotatedRobotDetectionsStop;
 };
 
 #endif  // SIMULATOR_H

--- a/src/extlibs/er_force_sim/src/protobuf/ssl_simulation_custom_erforce_realism.proto
+++ b/src/extlibs/er_force_sim/src/protobuf/ssl_simulation_custom_erforce_realism.proto
@@ -53,4 +53,17 @@ message RealismConfigErForce
     // Simulates an offset of all reported object positions (robots, ball) at this
     // magnitude [m]
     optional float object_position_offset = 16;
+    // The percentage of times a robot is erroneously not "seen" by a camera [0-1]
+    optional float missing_robot_detections = 17;
+    // Robot control commands are only applied this long after they were received [ns]
+    optional int64 command_delay = 18;
+    // Simulates a robot that does not drive perfectly straight, by adding this
+    // fraction of the forward acceleration as rotational acceleration
+    optional float robot_rotation_error = 19;
+    // The probability per frame and camera that a robot starts being detected a
+    // second time, with its pattern misread as the one rotated by 90 degrees [0-1]
+    optional float rotated_robot_detections_start = 20;
+    // The probability per frame and camera that such a rotated detection stops
+    // again [0-1]
+    optional float rotated_robot_detections_stop = 21;
 }

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -94,8 +94,13 @@ std::unique_ptr<RealismConfigErForce> ErForceSimulator::createDefaultRealismConf
     realism_config->set_missing_ball_detections(0);
     realism_config->set_vision_delay(0);
     realism_config->set_vision_processing_time(0);
-    realism_config->set_missing_ball_detections(0);
     realism_config->set_simulate_dribbling(false);
+    realism_config->set_object_position_offset(0);
+    realism_config->set_missing_robot_detections(0);
+    realism_config->set_command_delay(0);
+    realism_config->set_robot_rotation_error(0);
+    realism_config->set_rotated_robot_detections_start(0);
+    realism_config->set_rotated_robot_detections_stop(0);
     return realism_config;
 }
 
@@ -116,11 +121,20 @@ std::unique_ptr<RealismConfigErForce> ErForceSimulator::createRealisticRealismCo
     realism_config->set_camera_position_error(0.1f);
     realism_config->set_robot_command_loss(0.03f);
     realism_config->set_robot_response_loss(0.1f);
-    realism_config->set_missing_ball_detections(0.05f);
+    // Upstream uses 0.05 here, but this config used to set the field twice and the
+    // second value won, so 0.02 is what this has actually been doing all along
+    realism_config->set_missing_ball_detections(0.02f);
     realism_config->set_vision_delay(35000000);
     realism_config->set_vision_processing_time(10000000);
-    realism_config->set_missing_ball_detections(0.02f);
+    // Upstream simulates dribbling here, but our simulated tests rely on the perfect
+    // dribbler, so we keep gluing the ball to the dribbler
     realism_config->set_simulate_dribbling(false);
+    realism_config->set_object_position_offset(0.02f);
+    realism_config->set_missing_robot_detections(0.02f);
+    realism_config->set_command_delay(3000000);
+    realism_config->set_robot_rotation_error(0.5f);
+    realism_config->set_rotated_robot_detections_start(0.001f);
+    realism_config->set_rotated_robot_detections_stop(0.3f);
     return realism_config;
 }
 

--- a/src/software/simulation/er_force_simulator_test.cpp
+++ b/src/software/simulation/er_force_simulator_test.cpp
@@ -534,3 +534,132 @@ TEST_F(ErForceSimulatorTest, simulator_state_rotation_matches_robot_orientation)
         Angle::fromRadians(2 * std::atan2(rotation.k(), rotation.real())), orientation,
         Angle::fromDegrees(1)));
 }
+
+class ErForceSimulatorRealismTest : public ::testing::Test
+{
+   protected:
+    // Creates a simulator whose realism config is the default one, with the given
+    // modification applied
+    void createSimulator(
+        const std::function<void(RealismConfigErForce&)>& configure_realism)
+    {
+        auto realism_config = ErForceSimulator::createDefaultRealismConfig();
+        configure_realism(*realism_config);
+        simulator = std::make_shared<ErForceSimulator>(TbotsProto::FieldType::DIV_B,
+                                                       robot_constants, realism_config);
+        simulator->resetCurrentTime();
+    }
+
+    // Adds a single stationary yellow robot at the center of the field
+    void addYellowRobot()
+    {
+        simulator->setYellowRobots({RobotStateWithId{
+            .id          = 0,
+            .robot_state = RobotState(Point(0, 0), Vector(0, 0), Angle::zero(),
+                                      AngularVelocity::zero())}});
+    }
+
+    // Returns all yellow robot detections across all cameras of the latest packets
+    std::vector<SSLProto::SSL_DetectionRobot> getYellowDetections()
+    {
+        std::vector<SSLProto::SSL_DetectionRobot> detections;
+        for (const auto& packet : simulator->getSSLWrapperPackets())
+        {
+            for (const auto& robot : packet.detection().robots_yellow())
+            {
+                detections.push_back(robot);
+            }
+        }
+        return detections;
+    }
+
+    std::shared_ptr<ErForceSimulator> simulator;
+    robot_constants::RobotConstants robot_constants =
+        robot_constants::createRobotConstants();
+};
+
+TEST_F(ErForceSimulatorRealismTest, robots_are_always_detected_by_default)
+{
+    createSimulator([](RealismConfigErForce&) {});
+    addYellowRobot();
+    simulator->stepSimulation(Duration::fromMilliseconds(5));
+
+    EXPECT_FALSE(getYellowDetections().empty());
+}
+
+TEST_F(ErForceSimulatorRealismTest, robots_are_never_detected_when_always_missing)
+{
+    createSimulator([](RealismConfigErForce& realism)
+                    { realism.set_missing_robot_detections(1.0f); });
+    addYellowRobot();
+    simulator->stepSimulation(Duration::fromMilliseconds(5));
+
+    EXPECT_TRUE(getYellowDetections().empty());
+}
+
+TEST_F(ErForceSimulatorRealismTest, rotated_robot_detections_are_reported_on_top)
+{
+    createSimulator(
+        [](RealismConfigErForce& realism)
+        {
+            realism.set_rotated_robot_detections_start(1.0f);
+            realism.set_rotated_robot_detections_stop(0.0f);
+        });
+    addYellowRobot();
+    simulator->stepSimulation(Duration::fromMilliseconds(5));
+
+    auto detections = getYellowDetections();
+    ASSERT_EQ(2, detections.size());
+
+    // The robot is reported once with its own id and once with the id of the pattern
+    // that its own pattern turns into when rotated by 90 degrees
+    EXPECT_EQ(0, detections[0].robot_id());
+    EXPECT_NE(detections[0].robot_id(), detections[1].robot_id());
+    EXPECT_NEAR(detections[1].x(), detections[0].x(), 1e-3);
+    EXPECT_NEAR(detections[1].y(), detections[0].y(), 1e-3);
+    EXPECT_NEAR(detections[1].orientation(), detections[0].orientation() + M_PI_2, 1e-3);
+}
+
+TEST_F(ErForceSimulatorRealismTest, commands_are_only_applied_after_the_command_delay)
+{
+    constexpr double COMMAND_DELAY_SECONDS         = 0.1;
+    constexpr double DRIVE_SPEED_METERS_PER_SECOND = 1.0;
+
+    TbotsProto::PrimitiveSet primitive_set;
+    (*primitive_set.mutable_robot_primitives())[0] = *createDirectControlPrimitive(
+        Vector(DRIVE_SPEED_METERS_PER_SECOND, 0), AngularVelocity::zero(),
+        /*dribbler_rpm=*/0, TbotsProto::AutoChipOrKick());
+
+    // Drives the robot forwards for the given duration and returns its forward velocity
+    const auto driveFor = [&](const Duration& duration)
+    {
+        for (unsigned int step = 0; step * 5 < duration.toMilliseconds(); step++)
+        {
+            simulator->setYellowRobotPrimitiveSet(primitive_set,
+                                                  std::make_unique<TbotsProto::World>());
+            simulator->stepSimulation(Duration::fromMilliseconds(5));
+        }
+        return simulator->getSimulatorState().yellow_robots(0).v_x();
+    };
+
+    // Without a command delay the robot starts driving right away
+    createSimulator([](RealismConfigErForce&) {});
+    addYellowRobot();
+    const double velocity_without_delay =
+        driveFor(Duration::fromSeconds(COMMAND_DELAY_SECONDS / 2));
+    EXPECT_GT(velocity_without_delay, 0.05);
+
+    // With a command delay the robot has not received anything yet at the same point in
+    // time, so it only drifts by the tiny amount it takes to settle onto the field
+    createSimulator(
+        [](RealismConfigErForce& realism)
+        {
+            realism.set_command_delay(
+                static_cast<int64_t>(COMMAND_DELAY_SECONDS * NANOSECONDS_PER_SECOND));
+        });
+    addYellowRobot();
+    EXPECT_NEAR(driveFor(Duration::fromSeconds(COMMAND_DELAY_SECONDS / 2)), 0.0, 0.01);
+
+    // Once the delay has passed, the robot drives just like it does without a delay
+    EXPECT_GT(driveFor(Duration::fromSeconds(1.0)), 0.1);
+}


### PR DESCRIPTION
### Description

## WIP Claude Template

Second of four stacked PRs porting upstream ER-Force simulator changes (#3912). Stacked on #3947.

This PR ports the realism options upstream added since our fork. **All of them default to off**, so the simulator behaves exactly as it does today unless they are configured:

- `missing_robot_detections` (upstream `0f49e671`), and missing ball detections are now rolled per camera instead of for all cameras at once (upstream `6bb0bdce`), which is what the real vision does.
- `command_delay` (upstream `89158739`). Our fork applies robot control commands immediately rather than from a queue, so delayed commands are held in a per team queue and applied, with their radio responses, once the delay has passed.
- `robot_rotation_error` (upstream `b6c119de`), which makes a robot drift instead of driving perfectly straight.
- `rotated_robot_detections_start`/`stop` (upstream `2a94f56b`), which reports a robot a second time with its pattern misread as the one rotated by 90 degrees.

Two things worth a reviewer's attention:

- The robot detection code in `getWrapperPackets` moves into `createRobotDetection`, mirroring upstream. This is the bulk of the diff and is a straight extraction.
- Realism settings that live on the robots themselves are applied through `applyRobotRealism`, so robots created *after* the configuration arrives (`setTeam`, `moveRobot`, `resetFlipped`) get them too. Upstream only applies them to robots that already exist, which I believe is a bug on their side.

`createRealisticRealismConfig` is synced with upstream's `Realistic.txt`, keeping our perfect dribbler, and no longer sets `missing_ball_detections` twice (it set 0.05 then 0.02; 0.02 is what it has actually been doing, so that is what it keeps).

### Testing Done

- Four new realism tests in `er_force_simulator_test`: robots are always detected by default, never detected at `missing_robot_detections=1`, rotated detections are reported on top of the real one with the rotated pattern id, and commands only take effect after `command_delay`. The command delay test compares against an undelayed run and fails if the delay path is disabled.
- Defaults unchanged: the existing simulator and gameplay tests pass without modification.
- Same full suite runs as #3947.

### Resolved Issues

Part of #3912

### Length Justification and Key Files to Review

542 lines, of which roughly half is the `createRobotDetection` extraction and its tests. The options share that one code path, so splitting them into separate PRs would mean moving the same block repeatedly. Key files: `src/extlibs/er_force_sim/src/amun/simulator/simulator.cpp` and `simulator.h`.

### Review Checklist

- [x] **Function & Class comments**
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**
- [x] **Resolve all TODO's**
