### PR TITLE
Add opt-in per wheel acceleration limits to the ER-Force simulator

### DIFF
--- a/src/extlibs/er_force_sim/README.md
+++ b/src/extlibs/er_force_sim/README.md
@@ -3,6 +3,34 @@
 The simulator is adapted from [robotics-erlangen/framework](https://github.com/robotics-erlangen/framework). It contains several bug fixes and general code quality improvements, and it is modified so that time steps can be controlled by a `stepSimulation` function.
 
 
+## Upstream sync
+
+This is a fork, not a vendored copy. It was forked at upstream `73e139db` (2021-12-16)
+and individual upstream changes have been ported onto it by hand since, because the fork
+has diverged too far for cherry-picks to apply: Qt was removed (upstream is on Qt6), the
+API was made synchronous for our deterministic test runner, and the ball model was
+replaced with our own.
+
+Last sync: upstream `38563d11` (2026-07-27), covering every change to
+`src/amun/simulator` up to that commit.
+
+To find what is new upstream since then:
+
+```
+git clone https://github.com/robotics-erlangen/framework
+git -C framework log 38563d11..HEAD -- src/amun/simulator src/protobuf/protobuf/ssl_sim
+```
+
+Deliberately not ported:
+
+- the Qt6 migration, the protobuf folder reorganisation and compiler warning fixes,
+  which conflict with our own versions of the same code
+- `fastsimulator` and `erroraggregator`, which serve upstream's own tooling
+- `Specs.simulation_limits` in the upstream unit of wheel rotations; ours uses linear
+  units, matching our robot constants
+- everything outside of the simulator (Ra, strategy, tracking, logging)
+
+
 ## Copyright
 
 ```

--- a/src/extlibs/er_force_sim/src/amun/simulator/BUILD
+++ b/src/extlibs/er_force_sim/src/amun/simulator/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "//proto:ssl_simulation_cc_proto",
         "//shared:constants",
         "@bullet",
+        "@eigen",
     ],
     alwayslink = True,
 )

--- a/src/extlibs/er_force_sim/src/amun/simulator/simrobot.cpp
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simrobot.cpp
@@ -128,6 +128,8 @@ SimRobot::SimRobot(const robot::Specs& specs,
 
     m_shapes.push_back(std::move(wholeShape));
     m_shapes.push_back(std::move(dribblerShape));
+
+    generateVelocityCoupling();
 }
 
 SimRobot::~SimRobot()
@@ -506,16 +508,11 @@ void SimRobot::begin(SimBall& ball, double time)
     // as a certain part of the acceleration is required to compensate damping,
     // the robot will run into a speed limit! bound acceleration the speed limit
     // is acceleration * accelScale / V
-    float a_f = V * v_f + K * error_v_f + K_I * m_error_sum_v_f;
-    float a_s = V * v_s + K * error_v_s + K_I * m_error_sum_v_s;
+    const float a_f = V * v_f + K * error_v_f + K_I * m_error_sum_v_f;
+    const float a_s = V * v_s + K * error_v_s + K_I * m_error_sum_v_s;
 
     const float accelScale =
         2.f;  // let robot accelerate / brake faster than the accelerator does
-    a_f = bound(a_f, v_f, accelScale * m_specs.strategy().a_speedup_f_max(),
-                accelScale * m_specs.strategy().a_brake_f_max());
-    a_s = bound(a_s, v_s, accelScale * m_specs.strategy().a_speedup_s_max(),
-                accelScale * m_specs.strategy().a_brake_s_max());
-    const btVector3 force(a_s * m_specs.mass(), a_f * m_specs.mass(), 0);
 
     // localInertia.z() / SIMULATOR_SCALE^2 \approx
     // 1/12*mass*(robot_width^2+robot_depth^2)
@@ -532,9 +529,29 @@ void SimRobot::begin(SimBall& ball, double time)
     // the forward acceleration into rotational acceleration
     const float a_phi_with_error = a_phi + m_rotationError * a_f;
 
-    const float a_phi_bound = bound(a_phi_with_error, omega,
-                                    accelScale * m_specs.strategy().a_speedup_phi_max(),
-                                    accelScale * m_specs.strategy().a_brake_phi_max());
+    float a_f_bound, a_s_bound, a_phi_bound;
+    if (m_limitWheelAcceleration)
+    {
+        // Limit the acceleration of every wheel individually, which for example makes
+        // the robot accelerate slower diagonally than straight ahead
+        const Eigen::Vector3f limited =
+            limitAcceleration(a_f, a_s, a_phi_with_error, v_f, v_s, omega);
+        a_s_bound   = limited[0];
+        a_f_bound   = limited[1];
+        a_phi_bound = limited[2];
+    }
+    else
+    {
+        a_f_bound   = bound(a_f, v_f, accelScale * m_specs.strategy().a_speedup_f_max(),
+                            accelScale * m_specs.strategy().a_brake_f_max());
+        a_s_bound   = bound(a_s, v_s, accelScale * m_specs.strategy().a_speedup_s_max(),
+                            accelScale * m_specs.strategy().a_brake_s_max());
+        a_phi_bound = bound(a_phi_with_error, omega,
+                            accelScale * m_specs.strategy().a_speedup_phi_max(),
+                            accelScale * m_specs.strategy().a_brake_phi_max());
+    }
+
+    const btVector3 force(a_s_bound * m_specs.mass(), a_f_bound * m_specs.mass(), 0);
     const btVector3 torque(0, 0, a_phi_bound * 0.007884f);
 
     if (force.length2() > 0 || torque.length2() > 0)
@@ -543,6 +560,49 @@ void SimRobot::begin(SimBall& ball, double time)
         m_body->applyCentralForce(t * force * SIMULATOR_SCALE);
         m_body->applyTorque(torque * SIMULATOR_SCALE * SIMULATOR_SCALE);
     }
+}
+
+void SimRobot::generateVelocityCoupling()
+{
+    const auto& limits = m_specs.simulation_limits();
+    if (limits.wheel_velocity_coupling_size() !=
+        m_velocityCoupling.rows() * m_velocityCoupling.cols())
+    {
+        m_limitWheelAcceleration = false;
+        return;
+    }
+
+    for (int row = 0; row < m_velocityCoupling.rows(); row++)
+    {
+        for (int col = 0; col < m_velocityCoupling.cols(); col++)
+        {
+            m_velocityCoupling(row, col) =
+                limits.wheel_velocity_coupling(row * m_velocityCoupling.cols() + col);
+        }
+    }
+
+    m_inverseCoupling        = m_velocityCoupling.completeOrthogonalDecomposition();
+    m_limitWheelAcceleration = true;
+}
+
+Eigen::Vector3f SimRobot::limitAcceleration(float a_f, float a_s, float a_phi, float v_f,
+                                            float v_s, float omega) const
+{
+    const float wheelAccel = m_specs.simulation_limits().a_speedup_wheel_max();
+    const float wheelDecel = m_specs.simulation_limits().a_brake_wheel_max();
+
+    const Eigen::Vector3f speed{v_s, v_f, omega};
+    const Eigen::Vector4f wheelSpeed = m_velocityCoupling * speed;
+
+    const Eigen::Vector3f acceleration{a_s, a_f, a_phi};
+    Eigen::Vector4f limitedWheelAcceleration = m_velocityCoupling * acceleration;
+    for (int i = 0; i < limitedWheelAcceleration.size(); i++)
+    {
+        limitedWheelAcceleration[i] =
+            bound(limitedWheelAcceleration[i], wheelSpeed[i], wheelAccel, wheelDecel);
+    }
+
+    return m_inverseCoupling.solve(limitedWheelAcceleration);
 }
 
 // copy-paste from accelerator

--- a/src/extlibs/er_force_sim/src/amun/simulator/simrobot.h
+++ b/src/extlibs/er_force_sim/src/amun/simulator/simrobot.h
@@ -24,6 +24,9 @@
 #include <BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.h>
 #include <btBulletDynamicsCommon.h>
 
+#include <Eigen/Dense>
+#include <Eigen/QR>
+
 #include "extlibs/er_force_sim/src/core/rng.h"
 #include "extlibs/er_force_sim/src/protobuf/command.pb.h"
 #include "extlibs/er_force_sim/src/protobuf/robot.pb.h"
@@ -115,6 +118,28 @@ class camun::simulator::SimRobot
                                const btVector3 linVel, float omega);
     void dribble(const SimBall& ball, float speed);
 
+    /**
+     * Builds the matrix that maps the robot's local velocity to the speed of each of
+     * its wheels, and its inverse, from the robot's simulation limits
+     */
+    void generateVelocityCoupling();
+
+    /**
+     * Limits the given acceleration so that no single wheel accelerates faster than
+     * the robot's simulation limits allow
+     *
+     * @param a_f the forward acceleration
+     * @param a_s the sideways acceleration
+     * @param a_phi the rotational acceleration
+     * @param v_f the current forward velocity
+     * @param v_s the current sideways velocity
+     * @param omega the current rotational velocity
+     *
+     * @return the bounded {a_s, a_f, a_phi}
+     */
+    Eigen::Vector3f limitAcceleration(float a_f, float a_s, float a_phi, float v_f,
+                                      float v_s, float omega) const;
+
     RNG m_rng;
     robot::Specs m_specs;
     std::shared_ptr<btDiscreteDynamicsWorld> m_world;
@@ -142,6 +167,12 @@ class camun::simulator::SimRobot
 
     bool m_perfectDribbler = false;
     float m_rotationError  = 0.0f;
+
+    // Whether this robot limits the acceleration of each of its wheels individually,
+    // rather than just its acceleration as a whole
+    bool m_limitWheelAcceleration = false;
+    Eigen::Matrix<float, 4, 3> m_velocityCoupling;
+    Eigen::CompleteOrthogonalDecomposition<Eigen::Matrix<float, 4, 3>> m_inverseCoupling;
 
     int64_t m_lastSendTime = 0;
 };

--- a/src/extlibs/er_force_sim/src/protobuf/robot.proto
+++ b/src/extlibs/er_force_sim/src/protobuf/robot.proto
@@ -13,6 +13,20 @@ message LimitParameters
     optional float a_brake_phi_max   = 6;
 };
 
+message SimulationLimits
+{
+    // Limits the maximum acceleration of every wheel individually in the simulator,
+    // measured at the contact point of the wheel with the field [m/s^2].
+    // NOTE: upstream ER-Force specifies these per wheel rotation [rot/s^2]. We use
+    // linear units instead, because that is what our robot constants are given in.
+    optional float a_speedup_wheel_max = 1;
+    optional float a_brake_wheel_max   = 2;
+    // Row major 4x3 matrix that maps the robot's local velocity (v_s, v_f, omega),
+    // where v_s points to the right of the robot and v_f forwards, to the speed of
+    // each of its four wheels. The limits above are only applied if this is set.
+    repeated float wheel_velocity_coupling = 3;
+};
+
 message Specs
 {
     enum GenerationType
@@ -40,6 +54,9 @@ message Specs
     optional float shoot_radius    = 17;
     optional float dribbler_height = 18;
     reserved 20;
+    // If unset, the robot's acceleration is only limited by the 'acceleration' limits
+    // above (with an additional acceleration factor)
+    optional SimulationLimits simulation_limits = 21;
 };
 
 message Generation

--- a/src/software/er_force_simulator_main.cpp
+++ b/src/software/er_force_simulator_main.cpp
@@ -15,10 +15,11 @@ int main(int argc, char** argv)
 {
     struct CommandLineArgs
     {
-        bool help               = false;
-        std::string runtime_dir = "/tmp/tbots";
-        std::string division    = "div_b";
-        bool enable_realism     = false;  // realism flag
+        bool help                             = false;
+        std::string runtime_dir               = "/tmp/tbots";
+        std::string division                  = "div_b";
+        bool enable_realism                   = false;  // realism flag
+        bool enable_wheel_acceleration_limits = false;
     };
 
     CommandLineArgs args;
@@ -35,6 +36,10 @@ int main(int argc, char** argv)
     desc.add_options()("enable_realism",
                        boost::program_options::bool_switch(&args.enable_realism),
                        "realism simulator");  // install terminal flag
+    desc.add_options()(
+        "enable_wheel_acceleration_limits",
+        boost::program_options::bool_switch(&args.enable_wheel_acceleration_limits),
+        "limit how fast each wheel of a simulated robot may accelerate");
 
     boost::program_options::variables_map vm;
     boost::program_options::store(parse_command_line(argc, argv, desc), vm);
@@ -85,18 +90,12 @@ int main(int argc, char** argv)
             realism_config = ErForceSimulator::createDefaultRealismConfig();
         }
 
-        if (args.division == "div_a")
-        {
-            er_force_sim = std::make_shared<ErForceSimulator>(
-                TbotsProto::FieldType::DIV_A, robot_constants::createRobotConstants(),
-                realism_config);
-        }
-        else
-        {
-            er_force_sim = std::make_shared<ErForceSimulator>(
-                TbotsProto::FieldType::DIV_B, robot_constants::createRobotConstants(),
-                realism_config);
-        }
+        const TbotsProto::FieldType field_type = args.division == "div_a"
+                                                     ? TbotsProto::FieldType::DIV_A
+                                                     : TbotsProto::FieldType::DIV_B;
+        er_force_sim                           = std::make_shared<ErForceSimulator>(
+            field_type, robot_constants::createRobotConstants(), realism_config,
+            /*ramping=*/true, args.enable_wheel_acceleration_limits);
 
         std::mutex simulator_mutex;
 

--- a/src/software/simulation/er_force_simulator.cpp
+++ b/src/software/simulation/er_force_simulator.cpp
@@ -19,7 +19,8 @@
 ErForceSimulator::ErForceSimulator(const TbotsProto::FieldType& field_type,
                                    const robot_constants::RobotConstants& robot_constants,
                                    std::unique_ptr<RealismConfigErForce>& realism_config,
-                                   const bool ramping)
+                                   const bool ramping,
+                                   const bool wheel_acceleration_limits)
     : yellow_team_world_msg(std::make_unique<TbotsProto::World>()),
       blue_team_world_msg(std::make_unique<TbotsProto::World>()),
       frame_number(0),
@@ -28,7 +29,8 @@ ErForceSimulator::ErForceSimulator(const TbotsProto::FieldType& field_type,
       field(Field::createField(field_type)),
       blue_robot_with_ball(std::nullopt),
       yellow_robot_with_ball(std::nullopt),
-      ramping(ramping)
+      ramping(ramping),
+      wheel_acceleration_limits(wheel_acceleration_limits)
 {
     std::string full_filename = CONFIG_DIRECTORY;
 
@@ -208,6 +210,7 @@ void ErForceSimulator::setRobots(
 
     robot::Specs ERForce;
     robotSetDefault(&ERForce);
+    addSimulationLimits(ERForce);
 
     // Initialize Team Robots at the bottom of the field
     ::robot::Team* team;
@@ -304,6 +307,35 @@ void ErForceSimulator::setRobots(
                 std::make_shared<PrimitiveExecutor>(robot_constants, id);
             yellow_primitive_executor_map.insert({id, robot_primitive_executor});
         }
+    }
+}
+
+void ErForceSimulator::addSimulationLimits(robot::Specs& specs) const
+{
+    if (!wheel_acceleration_limits)
+    {
+        return;
+    }
+
+    auto* limits = specs.mutable_simulation_limits();
+    limits->set_a_speedup_wheel_max(robot_constants.motor_max_acceleration_m_per_s_2);
+    limits->set_a_brake_wheel_max(robot_constants.motor_max_acceleration_m_per_s_2);
+
+    // The simulator expects the coupling matrix in its own local frame, whose first
+    // axis points to the right of the robot and whose second axis points forwards,
+    // while ours has the first axis pointing forwards and the second one to the left.
+    const WheelSpace_t forward_column =
+        euclidean_to_four_wheel.getWheelVelocity(EuclideanSpace_t{1, 0, 0});
+    const WheelSpace_t left_column =
+        euclidean_to_four_wheel.getWheelVelocity(EuclideanSpace_t{0, 1, 0});
+    const WheelSpace_t angular_column =
+        euclidean_to_four_wheel.getWheelVelocity(EuclideanSpace_t{0, 0, 1});
+
+    for (Eigen::Index wheel = 0; wheel < forward_column.size(); wheel++)
+    {
+        limits->add_wheel_velocity_coupling(static_cast<float>(-left_column[wheel]));
+        limits->add_wheel_velocity_coupling(static_cast<float>(forward_column[wheel]));
+        limits->add_wheel_velocity_coupling(static_cast<float>(angular_column[wheel]));
     }
 }
 

--- a/src/software/simulation/er_force_simulator.h
+++ b/src/software/simulation/er_force_simulator.h
@@ -27,11 +27,22 @@ class ErForceSimulator
      * @param field_type The field type
      * @param robot_constants The robot constants
      * @param realism_config realism configuration
+     * @param ramping whether to ramp the commanded wheel velocities the way the motor
+     * service does on the real robot
+     * @param wheel_acceleration_limits whether the simulated robots limit how fast each
+     * of their wheels may accelerate. Note that this limits the robots inside the
+     * physics simulation, whereas ramping limits the commands sent to them.
+     * Off by default: the limit is applied to whatever the simulator's internal velocity
+     * controller asks for, and since that asks for far more acceleration than any robot
+     * can deliver, the limit ends up starving whichever of translation and rotation
+     * demands less of the wheels. A robot that is told to drive and spin at the same
+     * time therefore barely spins.
      */
     explicit ErForceSimulator(const TbotsProto::FieldType& field_type,
                               const robot_constants::RobotConstants& robot_constants,
                               std::unique_ptr<RealismConfigErForce>& realism_config,
-                              const bool ramping = true);
+                              const bool ramping                   = true,
+                              const bool wheel_acceleration_limits = false);
     ErForceSimulator()  = delete;
     ~ErForceSimulator() = default;
 
@@ -227,10 +238,19 @@ class ErForceSimulator
     robot_constants::RobotConstants robot_constants;
     Field field;
 
+    /**
+     * Sets the per wheel acceleration limits of the given robot specs from our robot
+     * constants, so that the simulated robots accelerate like ours do
+     *
+     * @param specs the robot specs to add the limits to
+     */
+    void addSimulationLimits(robot::Specs& specs) const;
+
     std::optional<RobotId> blue_robot_with_ball;
     std::optional<RobotId> yellow_robot_with_ball;
 
     bool ramping;
+    bool wheel_acceleration_limits;
 
     struct LocalVelocity
     {

--- a/src/software/simulation/er_force_simulator_test.cpp
+++ b/src/software/simulation/er_force_simulator_test.cpp
@@ -701,3 +701,80 @@ TEST_F(ErForceSimulatorTest, corner_blocks_keep_the_ball_out_of_the_field_corner
     // keeps its own radius of distance from each of the two walls
     EXPECT_GT(closest_approach_to_corner, CORNER_BLOCK_CATHETUS_METERS * 0.75);
 }
+
+class ErForceSimulatorWheelLimitTest : public ::testing::Test
+{
+   protected:
+    // Creates a simulator with a single yellow robot at the center of the field, either
+    // with or without per wheel acceleration limits
+    void createSimulator(bool wheel_acceleration_limits)
+    {
+        auto realism_config = ErForceSimulator::createDefaultRealismConfig();
+        simulator           = std::make_shared<ErForceSimulator>(
+            TbotsProto::FieldType::DIV_B, robot_constants, realism_config,
+            /*ramping=*/false, wheel_acceleration_limits);
+        simulator->resetCurrentTime();
+        simulator->setYellowRobots({RobotStateWithId{
+            .id          = 0,
+            .robot_state = RobotState(Point(0, 0), Vector(0, 0), Angle::zero(),
+                                      AngularVelocity::zero())}});
+    }
+
+    // Drives the robot with the given local velocity command and returns the speed it
+    // reaches after a short time
+    double reachedSpeed(const Vector& velocity, const AngularVelocity& angular_velocity)
+    {
+        TbotsProto::PrimitiveSet primitive_set;
+        (*primitive_set.mutable_robot_primitives())[0] = *createDirectControlPrimitive(
+            velocity, angular_velocity, /*dribbler_rpm=*/0, TbotsProto::AutoChipOrKick());
+        for (unsigned int step = 0; step < 10; step++)
+        {
+            simulator->setYellowRobotPrimitiveSet(primitive_set,
+                                                  std::make_unique<TbotsProto::World>());
+            simulator->stepSimulation(Duration::fromMilliseconds(5));
+        }
+
+        const auto& robot = simulator->getSimulatorState().yellow_robots(0);
+        return Vector(robot.v_x(), robot.v_y()).length();
+    }
+
+    std::shared_ptr<ErForceSimulator> simulator;
+    robot_constants::RobotConstants robot_constants =
+        robot_constants::createRobotConstants();
+};
+
+TEST_F(ErForceSimulatorWheelLimitTest, robots_accelerate_as_before_when_limits_are_off)
+{
+    const Vector target_velocity(2.0, 0);
+
+    createSimulator(/*wheel_acceleration_limits=*/false);
+    const double speed_without_limits =
+        reachedSpeed(target_velocity, AngularVelocity::zero());
+
+    createSimulator(/*wheel_acceleration_limits=*/true);
+    const double speed_with_limits =
+        reachedSpeed(target_velocity, AngularVelocity::zero());
+
+    // Driving straight ahead the wheels of our robots are the limiting factor well
+    // before the robot as a whole is, so the limits slow the robot down
+    EXPECT_GT(speed_without_limits, 0.1);
+    EXPECT_LT(speed_with_limits, speed_without_limits);
+}
+
+TEST_F(ErForceSimulatorWheelLimitTest, acceleration_depends_on_the_driving_direction)
+{
+    // Driving diagonally puts more of the load on a single wheel than driving straight
+    // ahead does, so a robot whose wheels limit its acceleration reaches a lower speed
+    // in the same time, even though both commands ask for the same speed
+    constexpr double TARGET_SPEED_METERS_PER_SECOND = 2.0;
+    const Vector straight(TARGET_SPEED_METERS_PER_SECOND, 0);
+    const Vector diagonal = straight.rotate(Angle::fromDegrees(45));
+
+    createSimulator(/*wheel_acceleration_limits=*/true);
+    const double straight_speed = reachedSpeed(straight, AngularVelocity::zero());
+
+    createSimulator(/*wheel_acceleration_limits=*/true);
+    const double diagonal_speed = reachedSpeed(diagonal, AngularVelocity::zero());
+
+    EXPECT_LT(diagonal_speed, straight_speed);
+}


### PR DESCRIPTION
### Description

## WIP Claude Template

Last of four stacked PRs porting upstream ER-Force simulator changes (#3912). Stacked on #3949.

Ports upstream's per wheel acceleration limit (upstream `3ad65ad6`, `7388a292`), which bounds how fast each wheel of a simulated robot may accelerate instead of bounding the acceleration of the robot as a whole. Upstream hardcodes their own wheel geometry and specifies the limits per wheel rotation; ours takes the coupling matrix from `EuclideanToWheel` so the limit reflects our drivetrain, and specifies the limits in m/s² at the wheel to match `motor_max_acceleration_m_per_s_2` in our robot constants.

**This is off by default**, both in the `ErForceSimulator` constructor and behind `--enable_wheel_acceleration_limits` on `er_force_simulator_main`. It composes with our existing wheel ramping (#3805) rather than replacing it: ramping limits the commands we send, this limits the robot inside the physics simulation.

It is off for a reason worth knowing before anyone turns it on, which I found while writing the tests: the limit is applied to whatever the simulator's internal velocity controller asks for, and that controller asks for far more acceleration than any robot can deliver (hundreds of m/s²). The clamp therefore ends up starving whichever of translation and rotation demands less of the wheels, and a robot told to drive and spin at the same time barely spins. That is upstream's behaviour too, not something introduced here, but it means this feature is not ready to be switched on without more work — reviewers may reasonably prefer we drop it.

Also records in the extlib README which upstream commit this fork is synced with (`38563d11`, 2026-07-27), and what was deliberately left unported, so the next sync is a `git log` away.

### Testing Done

- Two new `er_force_simulator_test` cases: with the limits off a robot accelerates exactly as before and with them on it accelerates more slowly, and with them on acceleration depends on the driving direction (diagonal is slower than straight, which is the per wheel limit binding in wheel space).
- The defaults path is unchanged, so the rest of the suite is the regression guard for "off by default".
- Same full suite runs as #3947.

### Stack testing summary

For the stack as a whole: 121/121 of the CI software tests pass, the 3 minute autoref'd AI vs AI game completes, and the simulated gameplay suite shows no regression. That last one deserves a caveat: across three full runs of the suite with the stack applied, 2, 0 and 1 test failed, a *different* test each time, and a baseline run on master also failed a fourth different test. Every individual failure passes 2–3 out of 3 times when run on its own, so this looks like the suite's known load sensitivity (CI runs it with `--flaky_test_attempts=3`), not a regression from these changes.

### Resolved Issues

resolves #3912

### Length Justification and Key Files to Review

323 lines. Key files: `src/extlibs/er_force_sim/src/amun/simulator/simrobot.cpp` and `src/software/simulation/er_force_simulator.cpp`.

### Review Checklist

- [x] **Function & Class comments**
- [x] **Remove all commented out code**
- [x] **Remove extra print statements**
- [x] **Resolve all TODO's**
