### PR TITLE
use ci_cmd_with_delay instead of threading.Timer

### DIFF
--- a/src/software/ai/hl/stp/play/kickoff_play_test.py
+++ b/src/software/ai/hl/stp/play/kickoff_play_test.py
@@ -33,6 +33,7 @@ from software.gameplay_tests.validation.robot_enters_region import (
 
 NORMAL_START_DELAY_S = 4.0
 
+
 @pytest.mark.parametrize("is_friendly_test", [True, False])
 def test_kickoff_play(simulated_test_runner, is_friendly_test):
     ball_initial_pos = tbots_cpp.Point(0, 0)

--- a/src/software/ai/hl/stp/play/kickoff_play_test.py
+++ b/src/software/ai/hl/stp/play/kickoff_play_test.py
@@ -12,8 +12,6 @@
 # +------------------+------------------+
 # After ball leaves center: half/CC rules no longer enforced here.
 
-import threading
-
 import proto.import_all_protos as protos
 import pytest
 import software.python_bindings as tbots_cpp
@@ -33,6 +31,7 @@ from software.gameplay_tests.validation.robot_enters_region import (
     RobotNeverEntersRegion,
 )
 
+NORMAL_START_DELAY_S = 4.0
 
 @pytest.mark.parametrize("is_friendly_test", [True, False])
 def test_kickoff_play(simulated_test_runner, is_friendly_test):
@@ -86,14 +85,6 @@ def test_kickoff_play(simulated_test_runner, is_friendly_test):
             )
             blue_play = protos.PlayName.KickoffEnemyPlay
             yellow_play = protos.PlayName.KickoffFriendlyPlay
-
-        # Let robots get ready before starting kickoff
-        threading.Timer(
-            4.0,
-            lambda: simulated_test_runner.send_gamecontroller_command(
-                gc_command=protos.Command.Type.NORMAL_START, team=SslTeam.BLUE
-            ),
-        ).start()
 
         simulated_test_runner.set_plays(blue_play=blue_play, yellow_play=yellow_play)
 
@@ -160,6 +151,9 @@ def test_kickoff_play(simulated_test_runner, is_friendly_test):
         setup=setup,
         inv_eventually_validation_sequence_set=eventually_validation_sequence_set,
         inv_always_validation_sequence_set=always_validation_sequence_set,
+        ci_cmd_with_delay=[
+            (NORMAL_START_DELAY_S, protos.Command.Type.NORMAL_START, SslTeam.BLUE),
+        ],
         test_timeout_s=10,
     )
 


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PRs, it should probably be added here to help save people time in the future.

Please fill out the following before requesting review on this PR!
-->

### Description

FIX from kickoff validation PR just merged: https://github.com/UBC-Thunderbots/Software/pull/3941
threading.Timer runs on real time, but the test's timeout and tick loop run in simulated time. In --ci_mode, the simulation can finish before that 4-second real-time timer even fires. ci_cmd_with_delay fixes this by scheduling NORMAL_START based on simulated elapsed time instead... so the setup delay stays consistent no matter how fast CI runs the simulation.



<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

ran kickoff_play_test with ci_mode flag: `bazel test //software/ai/hl/stp/play:kickoff_play_test --test_arg=--ci_mode`

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, closes #2, fixes #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification and Key Files to Review

<!-- 
    If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests and list the key files that contain the main content of your PR 
-->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
